### PR TITLE
build: update copyright year to 2026

### DIFF
--- a/build/flyweight-maven-plugin/src/main/antlr4/io/aklivity/zilla/build/maven/plugins/flyweight/internal/parser/Flyweight.g4
+++ b/build/flyweight-maven-plugin/src/main/antlr4/io/aklivity/zilla/build/maven/plugins/flyweight/internal/parser/Flyweight.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/AbstractMojo.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/AbstractMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojo.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/Generator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/Parser.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/TestGenerateMojo.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/TestGenerateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ValidateMojo.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ValidateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstAbstractMemberNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstAbstractMemberNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstByteOrder.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstByteOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstEnumNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstEnumNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstListMemberNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstListMemberNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstListNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstListNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstMapNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstMapNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstNamedNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstNamedNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstScopeNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstScopeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstSpecificationNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstSpecificationNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstStructMemberNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstStructMemberNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstStructNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstStructNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstType.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstTypedefNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstTypedefNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstUnionCaseNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstUnionCaseNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstUnionNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstUnionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstValueNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstValueNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstVariantCaseNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstVariantCaseNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstVariantNode.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/AstVariantNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/parse/AstParser.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/parse/AstParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/EnumVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/EnumVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/ListVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/ListVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/ScopeVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/ScopeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/StructVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/StructVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/UnionVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/UnionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/VariantVisitor.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/visit/VariantVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array16FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array16FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array32FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array32FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array8FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Array8FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ArrayFWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ArrayFWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ArrayFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ArrayFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets16FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets16FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets32FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets32FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets8FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctets8FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctetsFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/BoundedOctetsFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ClassSpecGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ClassSpecGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ClassSpecMixinGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ClassSpecMixinGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/EnumFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/EnumFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/EnumTypeGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/EnumTypeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List0FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List0FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List32FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List32FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List8FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/List8FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ListFWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ListFWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ListFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ListFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map16FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map16FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map32FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map32FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map8FWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Map8FWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MapFWGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MapFWGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MapFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MapFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MethodSpecGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/MethodSpecGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/OctetsFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/OctetsFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/PackagedTypeSpec.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/PackagedTypeSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ParameterizedTypeSpecGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/ParameterizedTypeSpecGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String16FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String16FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String32FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String32FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String8FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/String8FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StringFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StringFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StructFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/StructFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeNames.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeResolver.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeSpecGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/TypeSpecGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/UnionFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/UnionFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/VarStringFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/VarStringFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/VariantFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/VariantFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varint32FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varint32FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varint64FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varint64FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varuint32FlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varuint32FlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varuint32nFlyweightGenerator.java
+++ b/build/flyweight-maven-plugin/src/main/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generate/Varuint32nFlyweightGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/moditect/module-info.java
+++ b/build/flyweight-maven-plugin/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/build/flyweight-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2021-2024 Aklivity Inc.
+    Copyright 2021-2026 Aklivity Inc.
 
     Aklivity licenses this file to you under the Apache License,
     version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojoRule.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojoRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojoTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/GenerateMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/parse/AstParserTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/ast/parse/AstParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/bench/FlyweightBM.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/bench/FlyweightBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Array8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/BoundedOctets8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ConstrainedMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ConstrainedMapFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ContiguousSizeFieldsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ContiguousSizeFieldsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt64FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithInt8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithString8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint64FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithUint8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithVariantOfUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/EnumWithVariantOfUint64FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithArrayFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlatWithOctetsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlyweightTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/FlyweightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFixedArraysFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerFixedArraysFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerVariableArraysFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/IntegerVariableArraysFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List0FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List0FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/List8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListFromVariantOfListFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListFromVariantOfListFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayOfStructFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithArrayOfStructFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithConstrainedMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithConstrainedMapFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumAndVariantWithDefaultFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumAndVariantWithDefaultFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithEnumFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMapFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMissingFieldByteFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithMissingFieldByteFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFW.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithOctetsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithPhysicalAndLogicalLengthFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithPhysicalAndLogicalLengthFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithTypedefFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithTypedefFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithUnionFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithUnionFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithVariantFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/ListWithVariantFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Map8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/NestedFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/NestedFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsDefaultedNoAnchorFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsDefaultedNoAnchorFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/OctetsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/PotentialNameConflitsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/PotentialNameConflitsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/RollFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/RollFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/String8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/StructWithNonPrimitiveFieldsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/StructWithNonPrimitiveFieldsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefFromTypedefFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefFromTypedefFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/TypedefUint32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionChildFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionOctetsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionStringFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionStringFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionWithEnumFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/UnionWithEnumFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfInt8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfStringFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfStringFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint16FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint16FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint8FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindOfUint8FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindWithInt32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantEnumKindWithInt32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfArrayFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfArrayFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfListFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfListFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfMapFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfMapFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfOctetsFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantOfOctetsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindOfUint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindOfUint64FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithInt64TypeFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithInt64TypeFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithString32TypeFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantUint8KindWithString32TypeFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithFourTypesFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithFourTypesFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithVariantCaseFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithVariantCaseFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithoutOfFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/VariantWithoutOfFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint64FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varint64FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32FWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32FWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32nFWTest.java
+++ b/build/flyweight-maven-plugin/src/test/java/io/aklivity/zilla/build/maven/plugins/flyweight/internal/generated/Varuint32nFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayLengthHasDefault.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayLengthHasDefault.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayLengthNotUnsigned.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayLengthNotUnsigned.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayWithDefaultLengthNotSigned.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidIntArrayWithDefaultLengthNotSigned.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidOctetsNotLast.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidOctetsNotLast.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidOctetsNotLastNested.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidOctetsNotLastNested.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/invalidUnrecognizedType.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/invalidUnrecognizedType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/pom.xml
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2021-2024 Aklivity Inc.
+    Copyright 2021-2026 Aklivity Inc.
 
     Aklivity licenses this file to you under the Apache License,
     version 2.0 (the "License"); you may not use this file except in compliance

--- a/build/flyweight-maven-plugin/src/test/resources/test-project/test.idl
+++ b/build/flyweight-maven-plugin/src/test/resources/test-project/test.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/cloud/docker-image/src/main/docker/Dockerfile
+++ b/cloud/docker-image/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/cloud/docker-image/src/main/docker/alpine.Dockerfile
+++ b/cloud/docker-image/src/main/docker/alpine.Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/cloud/docker-image/src/main/docker/assembly.xml
+++ b/cloud/docker-image/src/main/docker/assembly.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2021-2024 Aklivity Inc
+    Copyright 2021-2026 Aklivity Inc
 
     Licensed under the Aklivity Community License (the "License"); you may not use
     this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-amqp.spec/src/main/java/io/aklivity/zilla/specs/binding/amqp/internal/AmqpFunctions.java
+++ b/incubator/binding-amqp.spec/src/main/java/io/aklivity/zilla/specs/binding/amqp/internal/AmqpFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/moditect/module-info.java
+++ b/incubator/binding-amqp.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/resources/META-INF/zilla/amqp.idl
+++ b/incubator/binding-amqp.spec/src/main/resources/META-INF/zilla/amqp.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.when.address.receive.only.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.when.address.receive.only.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.when.address.send.only.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.when.address.send.only.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.when.address.receive.only.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.when.address.receive.only.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.when.address.send.only.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.when.address.send.only.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.yaml
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/abort.after.sending.first.fragment/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/abort.after.sending.first.fragment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/abort.after.sending.first.fragment/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/abort.after.sending.first.fragment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.and.reset/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.and.reset/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.only/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.only/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.abort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.abort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.sender/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.sender/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.sender/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.receiver.then.sender/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.only/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.only/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.abort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.abort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.receiver/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.receiver/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.receiver/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/connect.as.sender.then.receiver/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/disconnect/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/disconnect/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.reduced/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.reduced/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.reduced/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/incoming.window.reduced/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/link.credit.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/link.credit.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/link.credit.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/link.credit.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/max.frame.size.exceeded.with.multiple.sessions.and.links/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/max.frame.size.exceeded.with.multiple.sessions.and.links/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/max.frame.size.exceeded.with.multiple.sessions.and.links/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/max.frame.size.exceeded.with.multiple.sessions.and.links/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.at.least.once/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.at.least.once/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.at.least.once/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.at.least.once/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.through.multiple.sessions/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.through.multiple.sessions/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.through.multiple.sessions/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.through.multiple.sessions/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.first.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.first.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.first.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.first.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.last.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.last.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.last.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.last.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved.and.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.links.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.middle.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.middle.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.middle.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.middle.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.when.sessions.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.application.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.application.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.application.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.application.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.array8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.boolean/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.boolean/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.boolean/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.boolean/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.byte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.byte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.byte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.byte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.char/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.char/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.char/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.char/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.delivery.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.delivery.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.delivery.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.delivery.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.false/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.false/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.false/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.false/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.footer/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.footer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.footer/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.footer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.headers/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.headers/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.int/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.int/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.int/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.int/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.list8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.long/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.long/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.map8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.multiple.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.null/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.null/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.short/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.short/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.short/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.short/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.single.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalllong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalllong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalllong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalllong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalluint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalluint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalluint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smalluint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.smallulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str32utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str32utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str32utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str32utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str8utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str8utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str8utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.str8utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.sym8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.timestamp/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.timestamp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.timestamp/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.timestamp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.true/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.true/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.true/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.true/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ubyte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ubyte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ubyte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ubyte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.uint0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ulong0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ushort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ushort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ushort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.ushort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.client.with.vbin8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.at.least.once/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.at.least.once/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.at.least.once/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.at.least.once/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.then.flow.with.echo/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.then.flow.with.echo/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.then.flow.with.echo/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.then.flow.with.echo/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.first.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.first.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.first.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.first.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.last.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.last.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.last.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.last.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.links.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.middle.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.middle.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.middle.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.middle.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.when.sessions.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.application.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.application.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.application.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.application.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.array8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.boolean/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.boolean/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.boolean/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.boolean/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.byte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.byte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.byte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.byte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.char/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.char/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.char/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.char/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.delivery.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.delivery.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.delivery.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.delivery.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.false/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.false/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.false/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.false/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.footer/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.footer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.footer/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.footer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.headers/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.headers/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.int/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.int/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.int/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.int/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.invalid.delivery.id/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.invalid.delivery.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.invalid.delivery.id/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.invalid.delivery.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.large.delivery.count/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.large.delivery.count/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.large.delivery.count/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.large.delivery.count/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.list8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.long/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.long/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.map8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.multiple.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.null/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.null/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.short/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.short/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.short/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.short/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.single.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalllong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalllong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalllong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalllong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalluint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalluint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalluint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smalluint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.smallulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str32utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str32utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str32utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str32utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str8utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str8utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str8utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.str8utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.sym8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.timestamp/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.timestamp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.timestamp/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.timestamp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.true/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.true/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.true/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.true/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ubyte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ubyte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ubyte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ubyte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.uint0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ulong0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ushort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ushort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ushort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.ushort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/send.to.server.with.vbin8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/server.sent.flush/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/server.sent.flush/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/application/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.does.not.expire/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.does.not.expire/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.does.not.expire/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.does.not.expire/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.expires/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.expires/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.expires/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/client.idle.timeout.expires/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.server.abandoned/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.server.abandoned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.server.abandoned/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.server.abandoned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.simultaneous/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.simultaneous/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.simultaneous/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange.simultaneous/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/close.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/header.exchange/handshake.client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/header.exchange/handshake.client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/header.exchange/handshake.server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/header.exchange/handshake.server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange.pipelined/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange.pipelined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange.pipelined/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange.pipelined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.default/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.default/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.default/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.default/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.non.default/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.non.default/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.non.default/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/open.with.outgoing.locales.negotiated.non.default/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/protocol.header.unmatched/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/protocol.header.unmatched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/protocol.header.unmatched/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/protocol.header.unmatched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/reject.incorrect.fields.key.type/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/reject.incorrect.fields.key.type/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/reject.incorrect.fields.key.type/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/reject.incorrect.fields.key.type/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange.then.open.exchange.pipelined/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange.then.open.exchange.pipelined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange.then.open.exchange.pipelined/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange.then.open.exchange.pipelined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/sasl.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.does.not.expire/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.does.not.expire/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.does.not.expire/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.does.not.expire/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.expires/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.expires/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.expires/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/connection/server.idle.timeout.expires/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.only/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.only/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.detach.with.error.then.flow/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.detach.with.error.then.flow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.detach.with.error.then.flow/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.detach.with.error.then.flow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.sender/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.sender/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.sender/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.then.sender/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.when.source.does.not.exist/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.when.source.does.not.exist/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.when.source.does.not.exist/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.receiver.when.source.does.not.exist/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.only/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.only/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.then.receiver/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.then.receiver/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.then.receiver/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.then.receiver/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.when.target.does.not.exist/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.when.target.does.not.exist/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.when.target.does.not.exist/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/attach.as.sender.when.target.does.not.exist/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/detach.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/detach.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/detach.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/detach.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.with.unattached.handle/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.with.unattached.handle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.with.unattached.handle/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.with.unattached.handle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.without.handle/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.without.handle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.without.handle/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/flow.without.handle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/handle.max.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/handle.max.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/handle.max.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/handle.max.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/link.credit.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/link.credit.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/link.credit.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/link.credit.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/max.frame.size.exceeded.with.multiple.sessions.and.links/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/max.frame.size.exceeded.with.multiple.sessions.and.links/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/max.frame.size.exceeded.with.multiple.sessions.and.links/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/max.frame.size.exceeded.with.multiple.sessions.and.links/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.attach.when.handle.in.use/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.attach.when.handle.in.use/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.attach.when.handle.in.use/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.attach.when.handle.in.use/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.durable.message.when.durable.not.supported/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.durable.message.when.durable.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.durable.message.when.durable.not.supported/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.durable.message.when.durable.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.flow.with.inconsistent.fields/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.flow.with.inconsistent.fields/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.flow.with.inconsistent.fields/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.flow.with.inconsistent.fields/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.transfer.with.more.inconsistent.fields/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.transfer.with.more.inconsistent.fields/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.transfer.with.more.inconsistent.fields/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/reject.transfer.with.more.inconsistent.fields/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/server.sent.flush/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/server.sent.flush/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.at.least.once/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.at.least.once/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.at.least.once/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.at.least.once/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.max.message.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.max.message.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.max.message.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.max.message.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.first.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.first.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.first.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.first.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.last.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.last.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.last.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.last.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved.and.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.links.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.middle.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.middle.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.middle.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.when.middle.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.application.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.application.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.application.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.application.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.array8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.boolean/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.boolean/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.boolean/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.boolean/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.byte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.byte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.byte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.byte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.char/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.char/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.char/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.char/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.delivery.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.delivery.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.delivery.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.delivery.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.false/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.false/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.false/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.false/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.footer/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.footer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.footer/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.footer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.headers/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.headers/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.int/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.int/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.int/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.int/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.list8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.long/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.long/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.map8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.multiple.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.null/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.null/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.short/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.short/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.short/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.short/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.single.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalllong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalllong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalllong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalllong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalluint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalluint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalluint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smalluint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.smallulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str32utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str32utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str32utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str32utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str8utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str8utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str8utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.str8utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.sym8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.timestamp/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.timestamp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.timestamp/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.timestamp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.true/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.true/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.true/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.true/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ubyte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ubyte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ubyte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ubyte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.uint0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ulong0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ushort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ushort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ushort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.ushort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.client.with.vbin8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.at.least.once/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.at.least.once/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.at.least.once/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.at.least.once/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.max.message.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.max.message.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.max.message.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.max.message.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.link/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.link/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.link/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.link/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.session/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.session/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.session/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.then.flow.with.echo.on.session/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.first.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.first.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.first.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.first.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.last.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.last.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.last.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.last.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.links.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.middle.fragment.aborted/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.middle.fragment.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.middle.fragment.aborted/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.when.middle.fragment.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.application.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.application.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.application.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.application.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.array8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.boolean/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.boolean/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.boolean/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.boolean/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.byte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.byte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.byte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.byte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.char/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.char/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.char/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.char/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.delivery.annotations/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.delivery.annotations/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.delivery.annotations/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.delivery.annotations/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.false/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.false/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.false/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.false/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.footer/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.footer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.footer/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.footer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.headers/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.headers/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.int/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.int/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.int/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.int/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.invalid.delivery.id/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.invalid.delivery.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.invalid.delivery.id/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.invalid.delivery.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.delivery.count/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.delivery.count/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.delivery.count/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.delivery.count/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.next.incoming.id/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.next.incoming.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.next.incoming.id/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.large.next.incoming.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.list8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.long/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.long/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.map8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.multiple.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.null/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.null/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.properties/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.properties/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.short/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.short/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.short/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.short/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.data/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.data/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.sequence/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.sequence/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.sequence/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.single.sequence/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalllong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalllong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalllong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalllong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalluint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalluint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalluint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smalluint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.smallulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str32utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str32utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str32utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str32utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str8utf8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str8utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str8utf8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.str8utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.sym8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.timestamp/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.timestamp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.timestamp/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.timestamp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.true/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.true/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.true/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.true/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ubyte/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ubyte/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ubyte/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ubyte/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.uint0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong0/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong0/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ulong0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ushort/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ushort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ushort/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.ushort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin32/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin32/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin32/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin32/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin8/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin8/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/link/transfer.to.server.with.vbin8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.channel.max.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.channel.max.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.channel.max.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.channel.max.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.multiple.sessions/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.multiple.sessions/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.multiple.sessions/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.multiple.sessions/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.then.close/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.then.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.then.close/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/begin.then.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/discard.after.end/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/discard.after.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/discard.after.end/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/discard.after.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange.simultaneous/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange.simultaneous/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange.simultaneous/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange.simultaneous/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/end.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.reduced/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.reduced/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.reduced/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/incoming.window.reduced/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/reject.errant.link/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/reject.errant.link/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/reject.errant.link/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/reject.errant.link/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/send.to.client.multiple.sessions/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/send.to.client.multiple.sessions/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/send.to.client.multiple.sessions/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/send.to.client.multiple.sessions/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved.and.max.frame.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.client.when.sessions.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved.and.fragmented/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved.and.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved.and.fragmented/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved.and.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved/client.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved/server.rpt
+++ b/incubator/binding-amqp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/amqp/streams/network/session/transfer.to.server.when.sessions.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/config/SchemaTest.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/internal/AmqpFunctionsTest.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/internal/AmqpFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/application/StreamIT.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/application/StreamIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/ConnectionIT.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/LinkIT.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/LinkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/SessionIT.java
+++ b/incubator/binding-amqp.spec/src/test/java/io/aklivity/zilla/specs/binding/amqp/streams/network/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/config/AmqpConditionConfig.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/config/AmqpConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBinding.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBindingContext.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBindingFactorySpi.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpConfiguration.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/AmqpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionConfigAdapter.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionMatcher.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpRouteConfig.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpConnectionState.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpConnectionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpSessionState.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpSessionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpState.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpStreamFactory.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpTransferFlags.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpTransferFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/util/AmqpTypeUtil.java
+++ b/incubator/binding-amqp/src/main/java/io/aklivity/zilla/runtime/binding/amqp/internal/util/AmqpTypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/moditect/module-info.java
+++ b/incubator/binding-amqp/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/main/zilla/protocol.idl
+++ b/incubator/binding-amqp/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionConfigAdapterTest.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConfigurationTest.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/config/AmqpConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpConnectionStateTest.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpConnectionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpSessionStateTest.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/AmqpSessionStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/server/AdvisoryIT.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/server/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/server/AmqpServerIT.java
+++ b/incubator/binding-amqp/src/test/java/io/aklivity/zilla/runtime/binding/amqp/internal/stream/server/AmqpServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/binding-pgsql-kafka.spec/src/main/moditect/module-info.java
+++ b/incubator/binding-pgsql-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.alter.yaml
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.alter.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.generated.as.yaml
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.generated.as.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.yaml
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/create.topic/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/create.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/create.topic/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/create.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/drop.topic/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/drop.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/drop.topic/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/kafka/drop.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.add.column/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.add.column/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.add.column/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.add.column/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.modify.column.rejected/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.modify.column.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.modify.column.rejected/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/alter.topic.modify.column.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic.with.generated.as/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic.with.generated.as/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic.with.generated.as/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic.with.generated.as/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/create.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/drop.topic/client.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/drop.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/drop.topic/server.rpt
+++ b/incubator/binding-pgsql-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/pgsql/drop.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/KafkaIT.java
+++ b/incubator/binding-pgsql-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/KafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/PgsqlIT.java
+++ b/incubator/binding-pgsql-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/kafka/streams/PgsqlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBinding.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBindingContext.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBindingFactorySpi.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaConfiguration.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/PgsqlKafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/config/PgsqlKafkaBindingConfig.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/config/PgsqlKafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/config/PgsqlKafkaRouteConfig.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/config/PgsqlKafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroField.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroPayload.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroSchema.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/AvroSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaAvroSchemaTemplate.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaAvroSchemaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaKeyAvroSchemaTemplate.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaKeyAvroSchemaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaValueAvroSchemaTemplate.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/schema/PgsqlKafkaValueAvroSchemaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaCommandType.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaCommandType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaCompletionCommand.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaCompletionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaProxyFactory.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaState.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaStreamFactory.java
+++ b/incubator/binding-pgsql-kafka/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/PgsqlKafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/main/moditect/module-info.java
+++ b/incubator/binding-pgsql-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql-kafka/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/ProxyIT.java
+++ b/incubator/binding-pgsql-kafka/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/kafka/internal/stream/ProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/java/io/aklivity/zilla/specs/binding/pgsql/PgsqlFunctions.java
+++ b/incubator/binding-pgsql.spec/src/main/java/io/aklivity/zilla/specs/binding/pgsql/PgsqlFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/moditect/module-info.java
+++ b/incubator/binding-pgsql.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/resources/META-INF/zilla/pgsql.idl
+++ b/incubator/binding-pgsql.spec/src/main/resources/META-INF/zilla/pgsql.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/config/client.yaml
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/config/server.yaml
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/cancel.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/cancel.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/cancel.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/cancel.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.read.abort/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.read.abort/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.write.abort/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.write.abort/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.fragmented/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.fragmented/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.with.primary.key/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.with.primary.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.with.primary.key/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.table.with.primary.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.view.with.notice/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.view.with.notice/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.view.with.notice/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/create.view.with.notice/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/gss.encrypt.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/gss.encrypt.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/gss.encrypt.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/gss.encrypt.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table.with.error/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table.with.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table.with.error/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table.with.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/select.table/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/ssl.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/ssl.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/ssl.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/ssl.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/termination.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/termination.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/termination.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/application/termination.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/cancel.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/cancel.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/cancel.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/cancel.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.read.abort/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.read.abort/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.write.abort/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.write.abort/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.fragmented/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.fragmented/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.with.primary.key/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.with.primary.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.with.primary.key/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.table.with.primary.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.view.with.notice/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.view.with.notice/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.view.with.notice/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/create.view.with.notice/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/gss.encrypt.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/gss.encrypt.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/gss.encrypt.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/gss.encrypt.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table.with.error/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table.with.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table.with.error/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table.with.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/select.table/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/ssl.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/ssl.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/ssl.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/ssl.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/termination.request/client.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/termination.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/termination.request/server.rpt
+++ b/incubator/binding-pgsql.spec/src/main/scripts/io/aklivity/zilla/specs/binding/pgsql/streams/network/termination.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/ApplicationIT.java
+++ b/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/NetworkIT.java
+++ b/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/internal/PgsqlFunctionsTest.java
+++ b/incubator/binding-pgsql.spec/src/test/java/io/aklivity/zilla/specs/binding/pgsql/streams/internal/PgsqlFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/antlr4/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlLexer.g4
+++ b/incubator/binding-pgsql/src/main/antlr4/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlLexer.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/antlr4/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlParser.g4
+++ b/incubator/binding-pgsql/src/main/antlr4/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlParser.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBinding.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBindingContext.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBindingFactorySpi.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlConfiguration.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/PgsqlConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/config/PgsqlBindingConfig.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/config/PgsqlBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/config/PgsqlRouteConfig.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/config/PgsqlRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlClientFactory.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlServerFactory.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlState.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlStreamFactory.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/PgsqlStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/LexerDispatchingErrorListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/LexerDispatchingErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/ParserDispatchingErrorListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/ParserDispatchingErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PgsqlParser.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PgsqlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlLexerBase.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlLexerBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlParserBase.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PostgreSqlParserBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlAlterZtableTopicListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlAlterZtableTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCommandListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCommandListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateFunctionListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateFunctionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZfunctionListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZfunctionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZtableTopicListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZtableTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZviewListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlCreateZviewListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlDropListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlDropListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlShowListener.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/listener/SqlShowListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Alter.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Alter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/AlterExpression.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/AlterExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateFunction.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZfunction.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZfunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZtable.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZview.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/CreateZview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Drop.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Drop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/FunctionArgument.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/FunctionArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Operation.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Select.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/Select.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/ZtableColumn.java
+++ b/incubator/binding-pgsql/src/main/java/io/aklivity/zilla/runtime/binding/pgsql/parser/model/ZtableColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/moditect/module-info.java
+++ b/incubator/binding-pgsql/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/main/zilla/protocol.idl
+++ b/incubator/binding-pgsql/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/ClientIT.java
+++ b/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/ClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/ServerIT.java
+++ b/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/internal/stream/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PgsqlParserTest.java
+++ b/incubator/binding-pgsql/src/test/java/io/aklivity/zilla/runtime/binding/pgsql/parser/PgsqlParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/moditect/module-info.java
+++ b/incubator/binding-risingwave.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.function.yaml
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.function.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.risingwave.yaml
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.risingwave.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.yaml
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/alter.ztable.add.column/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/alter.ztable.add.column/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/alter.ztable.add.column/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/alter.ztable.add.column/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/client.stream.established/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/client.stream.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/client.stream.established/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/client.stream.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded.python/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded.python/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded.python/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded.python/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.embedded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.python/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.python/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.python/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.python/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.struct/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.struct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.struct/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.struct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.table/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.table/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.table/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function.return.table/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.function/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zfunction/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zfunction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zfunction/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zfunction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.double.quote.name/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.double.quote.name/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.double.quote.name/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.double.quote.name/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.generated.as/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.generated.as/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.generated.as/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.generated.as/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.primary.key/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.primary.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.primary.key/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.ztable.with.primary.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zview/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zview/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zview/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/create.zview/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zfunction/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zfunction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zfunction/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zfunction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.ztable/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.ztable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.ztable/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.ztable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zview/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zview/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zview/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/drop.zview/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements.errored/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements.errored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements.errored/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements.errored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/query.with.multiple.statements/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/set.variable/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/set.variable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/set.variable/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/set.variable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.materialized.views/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.materialized.views/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.materialized.views/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.materialized.views/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.tables/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.tables/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.tables/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.tables/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zfunctions/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zfunctions/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zfunctions/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zfunctions/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.ztables/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.ztables/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.ztables/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.ztables/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zviews/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zviews/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zviews/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/effective/show.zviews/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.add.column/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.add.column/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.add.column/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.add.column/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.modify.column.rejected/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.modify.column.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.modify.column.rejected/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/alter.ztable.modify.column.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded.python/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded.python/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded.python/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded.python/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.embedded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.python/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.python/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.python/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.python/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.struct/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.struct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.struct/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.struct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.table/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.table/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.table/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function.return.table/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.function/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zfunction/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zfunction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zfunction/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zfunction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.double.quote.name/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.double.quote.name/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.double.quote.name/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.double.quote.name/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.generated.as/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.generated.as/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.generated.as/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.generated.as/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.primary.key/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.primary.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.primary.key/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.ztable.with.primary.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zview/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zview/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zview/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/create.zview/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zfunction/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zfunction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zfunction/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zfunction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.ztable/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.ztable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.ztable/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.ztable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zview/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zview/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zview/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/drop.zview/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements.errored/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements.errored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements.errored/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements.errored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/query.with.multiple.statements/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/set.variable/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/set.variable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/set.variable/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/set.variable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.materialized.views/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.materialized.views/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.materialized.views/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.materialized.views/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.tables.with.newline/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.tables.with.newline/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.tables.with.newline/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.tables.with.newline/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zfunctions/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zfunctions/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zfunctions/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zfunctions/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.ztables/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.ztables/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.ztables/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.ztables/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zviews/client.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zviews/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zviews/server.rpt
+++ b/incubator/binding-risingwave.spec/src/main/scripts/io/aklivity/zilla/specs/binding/risingwave/streams/pgsql/show.zviews/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/config/SchemaTest.java
+++ b/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/streams/EffectiveIT.java
+++ b/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/streams/EffectiveIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/streams/PgsqlIT.java
+++ b/incubator/binding-risingwave.spec/src/test/java/io/aklivity/zilla/specs/binding/risingwave/streams/PgsqlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveConditionConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveConditionConfigBuilder.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaConfigBuilder.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaPropertiesConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaPropertiesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaPropertiesConfigBuilder.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveKafkaPropertiesConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveOptionConfigBuilder.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveOptionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveOptionsConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveUdfConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveUdfConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveUdfConfigBuilder.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/config/RisingwaveUdfConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBinding.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBindingContext.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBindingFactorySpi.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveConfiguration.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/RisingwaveConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveBindingConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveCommandType.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveCommandType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveConditionConfigAdapter.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveConditionMatcher.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveKafkaConfigAdapter.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveKafkaConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveKafkaPropertiesConfigAdapter.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveKafkaPropertiesConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapter.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveRouteConfig.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveUdfConfigAdapter.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveUdfConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveAlterZtableMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveAlterZtableMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateFunctionMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateFunctionMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZfunctionMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZfunctionMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZtableMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZtableMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZviewMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveCreateZviewMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZfunctionMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZfunctionMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZtableMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZtableMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZviewMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveDropZviewMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroBase.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroHandler.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroState.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveMacroState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwavePgsqlTypeMapping.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwavePgsqlTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowCommandMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowCommandMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowZcommandMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowZcommandMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowZfunctionCommandMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveShowZfunctionCommandMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveUnknownMacro.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/macro/RisingwaveUnknownMacro.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveCompletionCommand.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveCompletionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveProxyFactory.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveState.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveStreamFactory.java
+++ b/incubator/binding-risingwave/src/main/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/RisingwaveStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/moditect/module-info.java
+++ b/incubator/binding-risingwave/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/main/zilla/protocol.idl
+++ b/incubator/binding-risingwave/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapterTest.java
+++ b/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/config/RisingwaveOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/ProxyIT.java
+++ b/incubator/binding-risingwave/src/test/java/io/aklivity/zilla/runtime/binding/risingwave/internal/stream/ProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/ZillaDumpCommandSpi.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/ZillaDumpCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommand.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommandPathConverterProvider.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/ZillaDumpCommandPathConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/labels/LabelManager.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/labels/LabelManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/Info.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/Info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/Layout.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/Layout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/StreamsLayout.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/layouts/StreamsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/OneToOneRingBufferSpy.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/OneToOneRingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/RingBufferSpy.java
+++ b/incubator/command-dump/src/main/java/io/aklivity/zilla/runtime/command/dump/internal/airline/spy/RingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/moditect/module-info.java
+++ b/incubator/command-dump/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/resources/META-INF/zilla/pcap.idl
+++ b/incubator/command-dump/src/main/resources/META-INF/zilla/pcap.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
+++ b/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
@@ -1,6 +1,6 @@
 --[[
 
-    Copyright 2021-2024 Aklivity Inc
+    Copyright 2021-2026 Aklivity Inc
 
     Licensed under the Aklivity Community License (the "License"); you may not use
     this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/application/connect.as.receiver.only/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/application/connect.as.receiver.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/application/connect.as.receiver.only/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/application/connect.as.receiver.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/network/link/attach.as.receiver.only/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/network/link/attach.as.receiver.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/network/link/attach.as.receiver.only/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/amqp/streams/network/link/attach.as.receiver.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/filesystem/streams/application/read.file.extension/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/filesystem/streams/application/read.file.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/filesystem/streams/application/read.file.extension/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/filesystem/streams/application/read.file.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/grpc/streams/application/server.stream.rpc/message.exchange/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/grpc/streams/application/server.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/grpc/streams/application/server.stream.rpc/message.exchange/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/grpc/streams/application/server.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/describe/topic.config.info/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/describe/topic.config.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/describe/topic.config.info/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/describe/topic.config.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/fetch/partition.offset/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/fetch/partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/fetch/partition.offset/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/fetch/partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/group/rebalance.sync.group/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/group/rebalance.sync.group/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/group/rebalance.sync.group/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/group/rebalance.sync.group/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/init.producer.id/produce.new.id/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/init.producer.id/produce.new.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/init.producer.id/produce.new.id/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/init.producer.id/produce.new.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/merged/merged.fetch.filter.sync/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/merged/merged.fetch.filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/merged/merged.fetch.filter.sync/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/merged/merged.fetch.filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/meta/topic.partition.info/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/meta/topic.partition.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/meta/topic.partition.info/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/meta/topic.partition.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.fetch/topic.offset.info/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.fetch/topic.offset.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.fetch/topic.offset.info/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/offset.fetch/topic.offset.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/produce/message.producer.id/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/produce/message.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/produce/message.producer.id/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/application/produce/message.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/network/describe.configs.v0/topic.config.info/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/network/describe.configs.v0/topic.config.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/network/describe.configs.v0/topic.config.info/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/kafka/streams/network/describe.configs.v0/topic.config.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/publish.one.message.properties/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/publish.one.message.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/publish.one.message.properties/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/publish.one.message.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/subscribe.one.message/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/subscribe.one.message/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/application/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/network/v5/publish.one.message.properties/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/network/v5/publish.one.message.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/network/v5/publish.one.message.properties/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/mqtt/streams/network/v5/publish.one.message.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/proxy/streams/application/connected.local.client.sent.begin.ext/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/proxy/streams/application/connected.local.client.sent.begin.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/proxy/streams/application/connected.local.client.sent.begin.ext/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/proxy/streams/application/connected.local.client.sent.begin.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/sse/streams/application/data/non.empty/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/sse/streams/application/data/non.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/sse/streams/application/data/non.empty/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/sse/streams/application/data/non.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/application/connection.established/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/application/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/application/connection.established/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/application/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/network/connection.established/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/network/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/network/connection.established/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/tls/streams/network/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.challenge/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.challenge/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
+++ b/incubator/command-dump/src/main/scripts/io/aklivity/zilla/runtime/command/dump/binding/ws/streams/application/advise/client.sent.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/DumpCommandRunner.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/DumpCommandRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/DumpRule.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/DumpRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/TsharkRunner.java
+++ b/incubator/command-dump/src/test/java/io/aklivity/zilla/runtime/command/dump/internal/test/TsharkRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/test/Dockerfile
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/test/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogBudgetsCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogBudgetsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogBuffersCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogBuffersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCountersCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogCountersCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogQueueDepthCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogQueueDepthCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LogStreamsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/LoggableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/Logger.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/labels/LabelManager.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/labels/LabelManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/BudgetsLayout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/BudgetsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/BufferPoolLayout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/BufferPoolLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/Layout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/Layout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/MetricsLayout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/MetricsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/RoutesLayout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/RoutesLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/StreamsLayout.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/layouts/StreamsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/spy/OneToOneRingBufferSpy.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/spy/OneToOneRingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/spy/RingBufferSpy.java
+++ b/incubator/command-log/src/main/java/io/aklivity/zilla/runtime/command/log/internal/spy/RingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-log/src/main/moditect/module-info.java
+++ b/incubator/command-log/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/ZillaTuneCommandSpi.java
+++ b/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/ZillaTuneCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/airline/ZillaTuneCommand.java
+++ b/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/airline/ZillaTuneCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/airline/labels/LabelManager.java
+++ b/incubator/command-tune/src/main/java/io/aklivity/zilla/runtime/command/tune/internal/airline/labels/LabelManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/incubator/command-tune/src/main/moditect/module-info.java
+++ b/incubator/command-tune/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmCli.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmCli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmCommand.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmMain.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/ZpmMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/clean/ZpmClean.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/clean/ZpmClean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmConfiguration.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmDependency.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmRepository.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/adapters/ZpmDependencyAdapter.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/adapters/ZpmDependencyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/adapters/ZpmRepositoryAdapter.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/adapters/ZpmRepositoryAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmArtifact.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmArtifactId.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmArtifactId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmModule.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/wrap/ZpmWrap.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/wrap/ZpmWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/types/ZpmPathConverterProvider.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/types/ZpmPathConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/main/moditect/module-info.java
+++ b/manager/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/clean/ZpmCleanTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/clean/ZpmCleanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmConfigurationTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/wrap/ZpmWrapTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/wrap/ZpmWrapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
           <configuration>
             <header>COPYRIGHT</header>
             <properties>
-              <copyrightYears>${project.inceptionYear}-2024</copyrightYears>
+              <copyrightYears>${project.inceptionYear}-2026</copyrightYears>
             </properties>
             <includes>
               <include>src/**</include>

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiCatalogConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiCatalogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiCatalogConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiCatalogConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiChannelsConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiChannelsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiChannelsConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiChannelsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiMqttKafkaConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiMqttKafkaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiMqttKafkaConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiMqttKafkaConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiOptionsConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiOptionsConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSchemaConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSchemaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiServerConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiServerConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiServerConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSpecificationConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSpecificationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSpecificationConfigBuilder.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/config/AsyncapiSpecificationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBindingContext.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBindingFactorySpi.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiConfiguration.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiBindingConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeConditionConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeRouteConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeWithConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiCompositeWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiRouteConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiClientGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiClientGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeId.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiCompositeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiProxyGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiProxyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiServerGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiServerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventContext.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventFormatter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventFormatterFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/event/AsyncapiEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AbstractAsyncapiResolvable.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AbstractAsyncapiResolvable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/Asyncapi.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/Asyncapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiAddress.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiChannel.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiComponents.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiCorrelationId.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiCorrelationId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiMessage.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiMultiFormatSchema.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiMultiFormatSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiOperation.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiParameter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiReply.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiReply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchema.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemaItem.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemaItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemaPayloadDeserializer.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemaPayloadDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemasPayloadDeserializer.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSchemasPayloadDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSecurityScheme.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiSecurityScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiServer.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiServerVariable.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiServerVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiTrait.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/AsyncapiTrait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiMessageBindings.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiMessageBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiOperationBindings.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiOperationBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiServerBindings.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/AsyncapiServerBindings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/AsyncapiHttpOperationBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/AsyncapiHttpOperationBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/kafka/AsyncapiHttpKafkaFilter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/kafka/AsyncapiHttpKafkaFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/kafka/AsyncapiHttpKafkaOperationBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/http/kafka/AsyncapiHttpKafkaOperationBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/kafka/AsyncapiKafkaMessageBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/kafka/AsyncapiKafkaMessageBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/kafka/AsyncapiKafkaServerBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/kafka/AsyncapiKafkaServerBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/AsyncapiSseOperationBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/AsyncapiSseOperationBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/kafka/AsyncapiSseKafkaFilter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/kafka/AsyncapiSseKafkaFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/kafka/AsyncapiSseKafkaOperationBinding.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/bindings/sse/kafka/AsyncapiSseKafkaOperationBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/parser/AsyncapiParser.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/parser/AsyncapiParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AbstractAsyncapiResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AbstractAsyncapiResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiChannelResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiChannelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiCorrelationIdResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiCorrelationIdResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiMessageResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiMessageResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiMessageTraitResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiMessageTraitResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiOperationResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiOperationResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiSchemaResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiSchemaResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiSecuritySchemeResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiSecuritySchemeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiServerVariableResolver.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/model/resolver/AsyncapiServerVariableResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiState.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiStreamFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiChannelView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiChannelView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiComponentsView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiComponentsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiCorrelationIdView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiCorrelationIdView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiKafkaMessageBindingView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiKafkaMessageBindingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMessageBindingsView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMessageBindingsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMessageView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMessageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMultiFormatSchemaView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiMultiFormatSchemaView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiOperationView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiOperationView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiParameterView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiParameterView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiReplyView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiReplyView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSchemaItemView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSchemaItemView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSchemaView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSchemaView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSecuritySchemeView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiSecuritySchemeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiServerVariableView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiServerVariableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiServerView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiServerView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiTraitView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiTraitView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiView.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/main/moditect/module-info.java
+++ b/runtime/binding-asyncapi/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiConfigurationTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/AsyncapiConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientIT.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyIT.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerIT.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiViewTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/view/AsyncapiViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBinding.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBindingContext.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBindingFactorySpi.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoConfiguration.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoRouter.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/EchoRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/stream/EchoServerFactory.java
+++ b/runtime/binding-echo/src/main/java/io/aklivity/zilla/runtime/binding/echo/internal/stream/EchoServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/main/moditect/module-info.java
+++ b/runtime/binding-echo/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoHandshakeBM.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoHandshakeBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/streams/ServerIT.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/streams/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBinding.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBindingContext.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBindingFactorySpi.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanConfiguration.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/FanConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanState.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanStreamFactory.java
+++ b/runtime/binding-fan/src/main/java/io/aklivity/zilla/runtime/binding/fan/internal/stream/FanStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/main/moditect/module-info.java
+++ b/runtime/binding-fan/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-fan/src/test/java/io/aklivity/zilla/runtime/binding/fan/internal/streams/ServerIT.java
+++ b/runtime/binding-fan/src/test/java/io/aklivity/zilla/runtime/binding/fan/internal/streams/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/config/FileSystemOptionsConfig.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/config/FileSystemOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/config/FileSystemSymbolicLinksConfig.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/config/FileSystemSymbolicLinksConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBinding.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBindingContext.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBindingFactorySpi.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemConfiguration.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemWatcher.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/FileSystemWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapter.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerFactory.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemState.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemStreamFactory.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/model/FileSystemObject.java
+++ b/runtime/binding-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/filesystem/model/FileSystemObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/main/moditect/module-info.java
+++ b/runtime/binding-filesystem/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
+++ b/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerIT.java
+++ b/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemStateTest.java
+++ b/runtime/binding-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/filesystem/internal/stream/FileSystemStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaConditionConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaCorrelationConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaCorrelationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaIdempotencyConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaIdempotencyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaMetadataValueConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaMetadataValueConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaOptionsConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaReliabilityConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/config/GrpcKafkaReliabilityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBinding.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBindingContext.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBindingFactorySpi.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaConfiguration.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/GrpcKafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaCapability.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaConditionConfigAdapter.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaConditionMatcher.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapter.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaRouteConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithConfigAdapter.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchConfigAdapter.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterHeaderConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterHeaderResult.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterHeaderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterResult.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchFilterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchResult.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithFetchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceConfigAdapter.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceHash.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceOverrideConfig.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceOverrideConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceOverrideResult.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceOverrideResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceResult.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithProduceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithResolver.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/config/GrpcKafkaWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaIdHelper.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaIdHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaProxyFactory.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaState.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaStreamFactory.java
+++ b/runtime/binding-grpc-kafka/src/main/java/io/aklivity/zilla/runtime/binding/grpc/kafka/internal/stream/GrpcKafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-grpc-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaConditionConfigAdapterTest.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaWithConfigAdapterTest.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/config/GrpcKafkaWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaFetchProxyIT.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaFetchProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaProduceProxyIT.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaProduceProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/antlr4/io/aklivity/zilla/runtime/binding/grpc/internal/parser/Protobuf3.g4
+++ b/runtime/binding-grpc/src/main/antlr4/io/aklivity/zilla/runtime/binding/grpc/internal/parser/Protobuf3.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcConditionConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcMetadataValueConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcMetadataValueConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcMethodConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcMethodConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcOptionsConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcProtobufConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcProtobufConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcServiceConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/config/GrpcServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBinding.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBindingContext.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBindingFactorySpi.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcConfiguration.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/GrpcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcConditionConfigAdapter.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcConditionMatcher.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcMethodResult.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcMethodResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapter.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcProtobufParser.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcProtobufParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcRouteConfig.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcServiceDefinitionListener.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcServiceDefinitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcClientFactory.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcServerFactory.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcState.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcStreamFactory.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/GrpcStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/HttpGrpcResponseHeaderHelper.java
+++ b/runtime/binding-grpc/src/main/java/io/aklivity/zilla/runtime/binding/grpc/internal/stream/HttpGrpcResponseHeaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/moditect/module-info.java
+++ b/runtime/binding-grpc/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/main/zilla/protocol.idl
+++ b/runtime/binding-grpc/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapterTest.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/config/GrpcOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/BidiStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/BidiStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/ClientStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/ClientStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/ServerStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/ServerStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/UnaryRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/client/UnaryRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/BidiStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/BidiStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/ClientStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/ClientStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/RejectedRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/RejectedRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/ServerStreamRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/ServerStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/UnaryRpcIT.java
+++ b/runtime/binding-grpc/src/test/java/io/aklivity/zilla/runtime/binding/grpc/internal/streams/server/UnaryRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/config/HttpFileSystemConditionConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/config/HttpFileSystemConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/config/HttpFileSystemConditionConfigBuilder.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/config/HttpFileSystemConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBinding.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBindingContext.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBindingFactorySpi.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemConfiguration.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/HttpFileSystemConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionConfigAdapter.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionMatcher.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemRouteConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfig.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigAdapter.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigBuilder.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithResolver.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithResult.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyFactory.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemState.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemStreamFactory.java
+++ b/runtime/binding-http-filesystem/src/main/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/main/moditect/module-info.java
+++ b/runtime/binding-http-filesystem/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionConfigAdapterTest.java
+++ b/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigAdapterTest.java
+++ b/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/config/HttpFileSystemWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyIT.java
+++ b/runtime/binding-http-filesystem/src/test/java/io/aklivity/zilla/runtime/binding/http/filesystem/internal/stream/HttpFileSystemProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaConditionConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaConditionConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaCorrelationConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaCorrelationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaCorrelationConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaCorrelationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaIdempotencyConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaIdempotencyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaIdempotencyConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaIdempotencyConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaOptionsConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaOptionsConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterHeaderConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterHeaderConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchFilterHeaderConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchMergeConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchMergeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchMergeConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithFetchMergeConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceAsyncHeaderConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceAsyncHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceAsyncHeaderConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceAsyncHeaderConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceOverrideConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceOverrideConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceOverrideConfigBuilder.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/config/HttpKafkaWithProduceOverrideConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBinding.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBindingContext.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBindingFactorySpi.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaConfiguration.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/HttpKafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaCapability.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionConfigAdapter.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionMatcher.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapter.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaRouteConfig.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithConfigAdapter.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchConfigAdapter.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchFilterHeaderResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchFilterHeaderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchFilterResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchFilterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchMergeResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchMergeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithFetchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceAsyncHeaderResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceAsyncHeaderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceConfigAdapter.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceHash.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceOverrideResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceOverrideResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceResult.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithProduceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithResolver.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaEtagHelper.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaEtagHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaState.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaStreamFactory.java
+++ b/runtime/binding-http-kafka/src/main/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-http-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-http-kafka/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionConfigAdapterTest.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithConfigAdapterTest.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/config/HttpKafkaWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
+++ b/runtime/binding-http-kafka/src/test/java/io/aklivity/zilla/runtime/binding/http/kafka/internal/stream/HttpKafkaProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAccessControlConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAllowConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpAuthorizationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpCredentialsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpExposeConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpParamConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpParamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpParamConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpParamConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPatternConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPolicyConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpPolicyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpRequestConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpRequestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpRequestConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpRequestConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpResponseConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpResponseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpResponseConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpResponseConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpVersion.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfigBuilder.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBinding.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBindingContext.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBindingFactorySpi.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventContext.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventFormatter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventFormatterFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ContinuationFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ContinuationFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2DataFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2DataFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ErrorCode.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameInfoFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameInfoFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameType.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2FrameType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2GoawayFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2GoawayFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2HeadersFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2HeadersFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PingFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PingFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PrefaceFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PrefaceFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PriorityFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PriorityFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PushPromiseFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PushPromiseFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2RstStreamFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2RstStreamFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2Setting.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2Setting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingsFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingsFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2WindowUpdateFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2WindowUpdateFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/UnboundedListFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/codec/UnboundedListFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionMatcher.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpQueryStringComparator.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpQueryStringComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestConfigAdapter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestType.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpResponseConfigAdapter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpResponseConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRouteAffinity.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRouteAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRouteConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithConfigAdapter.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithResolver.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackContext.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderBlockFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderBlockFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderFieldFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderFieldFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHuffman.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHuffman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackIntegerFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackIntegerFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackLiteralHeaderFieldFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackLiteralHeaderFieldFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackStringFW.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackStringFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/Http2Flags.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/Http2Flags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/Http2Settings.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/Http2Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpState.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpStreamFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/BufferUtil.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/BufferUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/HttpUtil.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/function/ObjectIntBiConsumer.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/util/function/ObjectIntBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/moditect/module-info.java
+++ b/runtime/binding-http/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/main/zilla/internal.idl
+++ b/runtime/binding-http/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfigTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/config/HttpWithConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfigurationTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ContinuationFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2ContinuationFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2DataFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2DataFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2GoawayFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2GoawayFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2HeadersFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2HeadersFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PingFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PingFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PriorityFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PriorityFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PushPromiseFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2PushPromiseFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2RstStreamFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2RstStreamFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingsFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2SettingsFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2WindowUpdateFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/codec/Http2WindowUpdateFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpQueryStringComparatorTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpQueryStringComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestTypeTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpRequestTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithConfigAdapterTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackContextTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderBlockFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderBlockFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderFieldFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHeaderFieldFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHuffmanTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackHuffmanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackIntegerFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackIntegerFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackStringFWTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/hpack/HpackStringFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/AdvisoryIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ArchitectureIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ArchitectureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/FlowControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/FlowControlLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/TransferCodingsIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/TransferCodingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ValidationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AccessControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AdvisoryIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ArchitectureIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ArchitectureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AuthorizationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/EventIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/FlowControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/FlowControlLimitsIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/FlowControlLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/RedirectIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/RedirectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/TransferCodingsIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/TransferCodingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ValidationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/server/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/AbortIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/AbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConfigIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/FlowControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/StartingIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/StartingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ValidationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/client/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AbortIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AccessControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AuthorizationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConfigIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConnectionManagementIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/EventIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/FlowControlIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/MessageFormatIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/RedirectIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/RedirectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/SettingsIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/SettingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/StartingIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/StartingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ValidationIT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7540/server/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/test/SystemPropertiesRule.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/test/SystemPropertiesRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/BufferUtilTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/BufferUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/HttpUtilTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/HttpUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/function/ObjectIntBiConsumerTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/util/function/ObjectIntBiConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcConditionConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcCorrelationConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcCorrelationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcIdempotencyConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcIdempotencyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcOptionsConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/config/KafkaGrpcOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingFactorySpi.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcConfiguration.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/KafkaGrpcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionConfigAdapter.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResolver.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResult.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcFetchFilterHeaderResult.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcFetchFilterHeaderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcFetchFilterResult.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcFetchFilterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapter.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcFetchHeaderHelper.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcFetchHeaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcState.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcStreamFactory.java
+++ b/runtime/binding-kafka-grpc/src/main/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/moditect/module-info.java
+++ b/runtime/binding-kafka-grpc/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/main/zilla/internal.idl
+++ b/runtime/binding-kafka-grpc/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionConfigAdapterTest.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/config/KafkaGrpcWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerIT.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaConditionConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaOptionsConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaOptionsConfigBuilder.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaSaslConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaSaslConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaSaslConfigBuilder.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaSaslConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaServerConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaServerConfigBuilder.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaServerConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicConfigBuilder.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicHeaderConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicTransformsConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicTransformsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicTransformsConfigBuilder.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/config/KafkaTopicTransformsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplier.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierFactorySpi.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierSpi.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBinding.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBindingContext.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBindingFactorySpi.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaCacheClientBudget.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaCacheClientBudget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudget.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetAccountant.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetAccountant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetCreditor.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetDebitor.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/KafkaMergedBudgetDebitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/MergedBudgetCreditor.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/budget/MergedBudgetCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCache.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCleanupPolicy.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCleanupPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorRecord.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFile.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexFile.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexRecord.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheObject.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegment.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopic.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopicConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionConfigAdapter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionMatcher.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaRouteConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaScramMechanism.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaScramMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicConfigAdapter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicHeaderType.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicHeaderType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicTransformsConfigAdapter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicTransformsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicTransformsType.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicTransformsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicType.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaTopicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfig.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfigAdapter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaApiKey.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaApiKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventContext.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventFormatter.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventFormatterFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/events/KafkaEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/identity/KafkaConfluentClientIdSupplier.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/identity/KafkaConfluentClientIdSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/identity/KafkaConfluentClientIdSupplierFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/identity/KafkaConfluentClientIdSupplierFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheBootstrapFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheBootstrapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientConsumerFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientDescribeFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientDescribeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheInitProducerIdFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheInitProducerIdFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheMetaFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheMetaFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheOffsetCommitFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheOffsetCommitFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheOffsetFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheOffsetFetchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheRoute.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerAddressFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerAddressFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerConsumerFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerDescribeFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerDescribeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerProduceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaChecksum.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaChecksum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientAlterConfigsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientAlterConfigsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDeleteTopicsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDeleteTopicsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeClusterFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeClusterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFetchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientInitProducerIdFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientInitProducerIdFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientMetaFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientMetaFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetCommitFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetCommitFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetFetchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientRequestFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientRoute.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaMergedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaPartitionOffset.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaPartitionOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaState.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaStreamFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-kafka/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/main/zilla/protocol.idl
+++ b/runtime/binding-kafka/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/identity/KafkaClientIdSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfigurationTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/KafkaConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCleanupPolicyTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCleanupPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorRecordTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheCursorRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFileTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexFileTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexRecordTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheIndexRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheObjectTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegmentTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheSegmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopicTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionConfigAdapterTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfigAdapterTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/config/KafkaWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/AlterConfigsIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/AlterConfigsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/AlterConfigsSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/AlterConfigsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheBootstrapIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheBootstrapIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheConsumerIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheConsumerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheDescribeIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheDescribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheGroupIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheGroupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheMergedIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheMergedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheMetaIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheMetaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheOffsetCommitIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheOffsetCommitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheOffsetFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheOffsetFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientDescribeIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientDescribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientDescribeSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientDescribeSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientFetchSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientFetchSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientGroupSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientInitProducerIdIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientInitProducerIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientInitProducerIdSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientInitProducerIdSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMergedIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMergedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMetaIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMetaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMetaSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientMetaSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetCommitIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetCommitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetCommitSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetCommitSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetFetchSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientOffsetFetchSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientProduceIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientProduceSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/ClientProduceSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CreateTopicsIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CreateTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CreateTopicsSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CreateTopicsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DeleteTopicsIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DeleteTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DeleteTopicsSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DeleteTopicsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/EventIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpAuthorizationConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpAuthorizationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpAuthorizationConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpAuthorizationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpElicitationConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpElicitationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpElicitationConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpElicitationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpOptionsConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpOptionsConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpPromptConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpPromptConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpWithConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpWithConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBinding.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingContext.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingFactorySpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpClientCapabilities.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpClientCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpImplementationInfo.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpImplementationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpInitializeRequestParams.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpInitializeRequestParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpNotifyCanceledParams.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpNotifyCanceledParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpServerCapabilities.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/codec/McpServerCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRoutePrefix.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRoutePrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpWithConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpState.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpStreamFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionConfigBuilder.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionKind.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaConditionKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaOptionsConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaOptionsConfigBuilder.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaPublishConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaPublishConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaPublishConfigBuilder.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaPublishConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaRouteConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaTopicsConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaTopicsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaTopicsConfigBuilder.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaTopicsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaWithConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaWithConfigBuilder.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/config/MqttKafkaWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/InstanceId.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/InstanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBinding.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBindingContext.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBindingFactorySpi.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaConfiguration.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventContext.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventFormatter.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventFormatterFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaBindingConfig.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionConfigAdapter.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionMatcher.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaHeaderHelper.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaHeaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapter.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithConfigAdapter.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithResolver.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaProxyFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishMetadata.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaState.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaStreamFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-mqtt-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-mqtt-kafka/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaConfigurationTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/MqttKafkaConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionConfigAdapterTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionMatcherTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaConditionMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapterTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithConfigAdapterTest.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/config/MqttKafkaWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaPublishProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttAuthorizationConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttAuthorizationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttAuthorizationConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttAuthorizationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttConditionConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttConditionConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttCredentialsConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttCredentialsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttCredentialsConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttCredentialsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttOptionsConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttOptionsConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPatternConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPatternConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPatternConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPatternConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPublishConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPublishConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPublishConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttPublishConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSessionConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSessionConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSessionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSubscribeConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSubscribeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSubscribeConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttSubscribeConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicParamConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicParamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicParamConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttTopicParamConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttUserPropertyConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttUserPropertyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttUserPropertyConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttUserPropertyConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfigBuilder.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBinding.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBindingContext.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBindingFactorySpi.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttConfiguration.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventContext.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventFormatter.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventFormatterFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttReasonCodes.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttReasonCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttValidator.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionConfigAdapter.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionMatcher.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapter.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttRouteConfig.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttTopicConfigAdapter.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttTopicConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttVersion.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttState.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttStreamFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/moditect/module-info.java
+++ b/runtime/binding-mqtt/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/main/zilla/protocol.idl
+++ b/runtime/binding-mqtt/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfigTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/config/MqttWithConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttConfigurationTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/MqttConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/ValidatorTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/ValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionConfigAdapterTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapterTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/ConnectionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/PingIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/PingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/PublishIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/SubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/UnsubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/client/v5/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/ConnectionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/PingIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/PingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/PublishIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/SubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/UnsubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v4/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/ConnectionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/PingIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/PingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/PublishIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/UnsubscribeIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/config/OpenapiAsyncapiOptionsConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/config/OpenapiAsyncapiOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/config/OpenapiAsyncapiSpecConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/config/OpenapiAsyncapiSpecConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBinding.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBindingContext.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBindingFactorySpi.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiConfiguration.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/OpenapiAsyncapiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiBindingConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeConditionConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeRouteConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeWithConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiCompositeWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiRouteConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiCompositeGenerator.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiCompositeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiCompositeId.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiCompositeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiProxyFactory.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiState.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiStreamFactory.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/main/moditect/module-info.java
+++ b/runtime/binding-openapi-asyncapi/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiIT.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiCatalogConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiCatalogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiCatalogConfigBuilder.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiCatalogConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiOptionsConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiOptionsConfigBuilder.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiParser.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiSchemaConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiSchemaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiServerConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiServerConfigBuilder.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiServerConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiSpecificationConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/config/OpenapiSpecificationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBinding.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBindingContext.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBindingFactorySpi.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiConfiguration.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiBindingConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeConditionConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeRouteConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeWithConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiCompositeWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiConditionConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiNamespaceConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiNamespaceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapter.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiRouteConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiWithConfig.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiClientGenerator.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiClientGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeGenerator.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeId.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiServerGenerator.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiServerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventContext.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventFormatter.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventFormatterFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/event/OpenapiEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/AbstractOpenapiResolvable.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/AbstractOpenapiResolvable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/Openapi.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/Openapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiComponents.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiEncoding.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiHeader.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiLink.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiMediaType.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiMediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiOperation.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiParameter.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiPath.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiRequestBody.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiRequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiResponse.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiSchema.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiSecurityScheme.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiSecurityScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiServer.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiServerVariable.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/OpenapiServerVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/extensions/http/kafka/OpenapiHttpKafkaFilter.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/extensions/http/kafka/OpenapiHttpKafkaFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/extensions/http/kafka/OpenapiHttpKafkaOperationExtension.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/extensions/http/kafka/OpenapiHttpKafkaOperationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/AbstractOpenapiResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/AbstractOpenapiResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiHeaderResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiHeaderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiLinkResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiLinkResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiParameterResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiParameterResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiRequestBodyResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiRequestBodyResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiResponseResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiResponseResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiSchemaResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiSchemaResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiSecuritySchemeResolver.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/model/resolver/OpenapiSecuritySchemeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiState.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiStreamFactory.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiComponentsView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiComponentsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiEncodingView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiEncodingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiHeaderView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiHeaderView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiLinkView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiLinkView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiMediaTypeView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiMediaTypeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiOperationView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiOperationView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiParameterView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiParameterView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiPathView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiPathView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiRequestBodyView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiRequestBodyView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiResponseView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiResponseView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSchemaView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSchemaView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSecurityRequirementView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSecurityRequirementView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSecuritySchemeView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiSecuritySchemeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiServerView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiServerView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiVariableView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiVariableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiView.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/main/moditect/module-info.java
+++ b/runtime/binding-openapi/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiConfigurationTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/OpenapiConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientIT.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerIT.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/streams/OpenapiServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiViewTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/view/OpenapiViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyAddressConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyAddressConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyConditionConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyInfoConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyInfoConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyOptionsConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/config/ProxyOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBinding.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBindingContext.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBindingFactorySpi.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyConfiguration.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/ProxyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyAddressConfigAdapter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyAddressConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionConfigAdapter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionMatcher.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyInfoConfigAdapter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyInfoConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyRouteConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxySecureInfoConfig.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxySecureInfoConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxySecureInfoConfigAdapter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxySecureInfoConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyClientFactory.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyRouter.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyServerFactory.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyState.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyStreamFactory.java
+++ b/runtime/binding-proxy/src/main/java/io/aklivity/zilla/runtime/binding/proxy/internal/stream/ProxyStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/moditect/module-info.java
+++ b/runtime/binding-proxy/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/main/zilla/internal.idl
+++ b/runtime/binding-proxy/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionConfigAdapterTest.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyMatcherTest.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapterTest.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/config/ProxyOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/streams/ProxyClientIT.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/streams/ProxyClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/streams/ProxyServerIT.java
+++ b/runtime/binding-proxy/src/test/java/io/aklivity/zilla/runtime/binding/proxy/internal/streams/ProxyServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaConditionConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaConditionConfigBuilder.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithConfigBuilder.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterConfigBuilder.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterHeaderConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterHeaderConfigBuilder.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/config/SseKafkaWithFilterHeaderConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBinding.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBindingContext.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBindingFactorySpi.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaConfiguration.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionConfigAdapter.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionMatcher.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaRouteConfig.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfigAdapter.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithFilterHeaderResult.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithFilterHeaderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithFilterResult.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithFilterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResolver.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResult.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelper.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyFactory.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaState.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaStreamFactory.java
+++ b/runtime/binding-sse-kafka/src/main/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-sse-kafka/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/main/zilla/internal.idl
+++ b/runtime/binding-sse-kafka/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaConfigurationTest.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/SseKafkaConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionConfigAdapterTest.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfigAdapterTest.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/config/SseKafkaWithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelperTest.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaIdHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyIT.java
+++ b/runtime/binding-sse-kafka/src/test/java/io/aklivity/zilla/runtime/binding/sse/kafka/internal/stream/SseKafkaProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseConditionConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseConditionConfigBuilder.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseOptionsConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseOptionsConfigBuilder.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SsePathConfigBuilder.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SsePathConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseRequestConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseRequestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfigBuilder.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBinding.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBindingContext.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBindingFactorySpi.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfiguration.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionConfigAdapter.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionMatcher.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapter.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseRequestConfigAdapter.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseRequestConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseRouteConfig.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseClientFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseState.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseStreamFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFW.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/util/Flags.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/util/Flags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/main/moditect/module-info.java
+++ b/runtime/binding-sse/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfigTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/config/SseWithConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfigurationTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/SseConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionConfigAdapterTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapterTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/AdvisoryIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ByteOrderMarkIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ByteOrderMarkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/DataIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/DataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/EndOfLineIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/EndOfLineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ErrorIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/HandshakeIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/HandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ReconnectIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/ReconnectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/TypeIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/client/TypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/AdvisoryIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ChallengeIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ChallengeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/DataIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/DataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ErrorIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/HandshakeIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/HandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdleIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/IdleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ReconnectIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/ReconnectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/TimestampIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/TimestampIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/TypeIT.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/streams/server/TypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFWTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/types/codec/SseEventFWTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfigBuilder.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfigBuilder.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/config/TcpOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBinding.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingContext.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingController.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingFactorySpi.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpConfiguration.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventContext.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventFormatter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventFormatterFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpUsageTracker.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/TcpUsageTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionMatcher.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapter.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpRouteConfig.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpState.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpStreamFactory.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/stream/TcpStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/Cidr.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/Cidr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/IpUtil.java
+++ b/runtime/binding-tcp/src/main/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/IpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/main/moditect/module-info.java
+++ b/runtime/binding-tcp/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/SocketChannelHelper.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/SocketChannelHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/bench/TcpServerBM.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/bench/TcpServerBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapterTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/config/TcpOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIOExceptionFromReadIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIOExceptionFromReadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIOExceptionFromWriteIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIOExceptionFromWriteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientLimitsIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientPartialWriteIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientPartialWriteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientPartialWriteLimitsIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientPartialWriteLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientResetAndAbortIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientResetAndAbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientRoutingIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientRoutingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/EventIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIOExceptionFromReadIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIOExceptionFromReadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIOExceptionFromWriteIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIOExceptionFromWriteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerLimitsIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerPartialWriteIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerPartialWriteIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerPartialWriteLimitsIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerPartialWriteLimitsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerResetAndAbortIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerResetAndAbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerRoutingIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ServerRoutingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/CidrTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/CidrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/IpUtilTest.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/util/IpUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfigBuilder.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsConditionConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsMutualConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsMutualConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBinding.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBindingContext.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBindingFactorySpi.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfiguration.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventContext.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatter.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatterFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapter.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionMatcher.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapter.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsRouteConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/identity/TlsClientX509ExtendedKeyManager.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/identity/TlsClientX509ExtendedKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsProxyFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsState.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsStreamFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/moditect/module-info.java
+++ b/runtime/binding-tls/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/main/zilla/protocol.idl
+++ b/runtime/binding-tls/src/main/zilla/protocol.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfigurationTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/TlsConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsHandshakeBM.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsHandshakeBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapterTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/BridgeIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/BridgeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ClientFragmentedIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ClientFragmentedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ClientIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ProxyIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ServerFragmentedIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ServerFragmentedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ServerIT.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/streams/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/config/WsConditionConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/config/WsConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/config/WsOptionsConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/config/WsOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBinding.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBindingContext.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBindingFactorySpi.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsConfiguration.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/WsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionConfigAdapter.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionMatcher.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapter.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsRouteConfig.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsClientFactory.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsServerFactory.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsState.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsStreamFactory.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/stream/WsStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/types/codec/WsHeaderFW.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/types/codec/WsHeaderFW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/util/WsMaskUtil.java
+++ b/runtime/binding-ws/src/main/java/io/aklivity/zilla/runtime/binding/ws/internal/util/WsMaskUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/main/moditect/module-info.java
+++ b/runtime/binding-ws/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionConfigAdapterTest.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapterTest.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/config/WsOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/AdvisoryIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/BaseFramingIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/BaseFramingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/ControlIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/ControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/FlowControlIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/OpeningHandshakeIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/client/OpeningHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/AdvisoryIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/BaseFramingIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/BaseFramingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/ClosingHandshakeIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/ClosingHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/ControlIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/ControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/FlowControlIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/FragmentationIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/FragmentationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/OpeningHandshakeIT.java
+++ b/runtime/binding-ws/src/test/java/io/aklivity/zilla/runtime/binding/ws/internal/streams/server/OpeningHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfig.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfigBuilder.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/config/ApicurioOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCache.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalog.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogContext.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogFactorySpi.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventContext.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventFormatter.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventFormatterFactory.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/CachedArtifact.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/CachedArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/CachedArtifactId.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/CachedArtifactId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapter.java
+++ b/runtime/catalog-apicurio/src/main/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/moditect/module-info.java
+++ b/runtime/catalog-apicurio/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/main/zilla/internal.idl
+++ b/runtime/catalog-apicurio/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogFactoryTest.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandlerTest.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogIT.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/ApicurioCatalogIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
+++ b/runtime/catalog-apicurio/src/test/java/io/aklivity/zilla/runtime/catalog/apicurio/internal/config/ApicurioOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalog.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogContext.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogFactorySpi.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogHandler.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventContext.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventFormatter.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventFormatterFactory.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfig.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapter.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigBuilder.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemSchemaConfig.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemSchemaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemSchemaConfigBuilder.java
+++ b/runtime/catalog-filesystem/src/main/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemSchemaConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/main/moditect/module-info.java
+++ b/runtime/catalog-filesystem/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/EventIT.java
+++ b/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogFactoryTest.java
+++ b/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemCatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemIT.java
+++ b/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/FilesystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapterTest.java
+++ b/runtime/catalog-filesystem/src/test/java/io/aklivity/zilla/runtime/catalog/filesystem/internal/config/FilesystemOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfig.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapter.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigBuilder.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineSchemaConfig.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineSchemaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineSchemaConfigBuilder.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineSchemaConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalog.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogContext.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogFactorySpi.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandler.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/main/moditect/module-info.java
+++ b/runtime/catalog-inline/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/InlineCatalogFactoryTest.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/InlineCatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapterTest.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/config/InlineOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineIT.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/config/KarapaceOptionsConfig.java
+++ b/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/config/KarapaceOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/config/KarapaceOptionsConfigBuilder.java
+++ b/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/config/KarapaceOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceCatalogFactorySpi.java
+++ b/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapter.java
+++ b/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/events/KarapaceEventFormatterFactory.java
+++ b/runtime/catalog-karapace/src/main/java/io/aklivity/zilla/runtime/catalog/karapace/internal/events/KarapaceEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/moditect/module-info.java
+++ b/runtime/catalog-karapace/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/main/zilla/internal.idl
+++ b/runtime/catalog-karapace/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceCatalogFactoryTest.java
+++ b/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceCatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceIT.java
+++ b/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/KarapaceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapterTest.java
+++ b/runtime/catalog-karapace/src/test/java/io/aklivity/zilla/runtime/catalog/karapace/internal/config/KarapaceOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryCatalogFactorySpi.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryEventFormatterFactory.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryOptionsConfigAdapter.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/AbstractSchemaRegistryOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/AbstractSchemaRegistryOptionsConfig.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/AbstractSchemaRegistryOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/AbstractSchemaRegistryOptionsConfigBuilder.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/AbstractSchemaRegistryOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/SchemaRegistryOptionsConfig.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/SchemaRegistryOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/SchemaRegistryOptionsConfigBuilder.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/config/SchemaRegistryOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalog.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogContext.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogFactorySpi.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryCatalogConfig.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryCatalogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapter.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventContext.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventFormatter.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventFormatterFactory.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/events/SchemaRegistryEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/CachedSchema.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/CachedSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/CachedSchemaId.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/CachedSchemaId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCache.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/handler/SchemaRegistryCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/RegisterSchemaRequest.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/RegisterSchemaRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/UnregisterSchemaRequest.java
+++ b/runtime/catalog-schema-registry/src/main/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/UnregisterSchemaRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/moditect/module-info.java
+++ b/runtime/catalog-schema-registry/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/main/zilla/internal.idl
+++ b/runtime/catalog-schema-registry/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogFactoryTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogHandlerTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryCatalogHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryIT.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/SchemaRegistryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapterTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/config/SchemaRegistryOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/RegisterSchemaRequestTest.java
+++ b/runtime/catalog-schema-registry/src/test/java/io/aklivity/zilla/runtime/catalog/schema/registry/internal/serializer/RegisterSchemaRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/ZillaMetricsCommandSpi.java
+++ b/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/ZillaMetricsCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/airline/ZillaMetricsCommand.java
+++ b/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/airline/ZillaMetricsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/printer/MetricsPrinter.java
+++ b/runtime/command-metrics/src/main/java/io/aklivity/zilla/runtime/command/metrics/internal/printer/MetricsPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-metrics/src/main/moditect/module-info.java
+++ b/runtime/command-metrics/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-metrics/src/test/java/io/aklivity/zilla/runtime/command/metrics/internal/printer/MetricsPrinterTest.java
+++ b/runtime/command-metrics/src/test/java/io/aklivity/zilla/runtime/command/metrics/internal/printer/MetricsPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/ZillaStartCommandSpi.java
+++ b/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/ZillaStartCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
+++ b/runtime/command-start/src/main/java/io/aklivity/zilla/runtime/command/start/internal/airline/ZillaStartCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-start/src/main/moditect/module-info.java
+++ b/runtime/command-start/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-stop/src/main/java/io/aklivity/zilla/runtime/command/stop/internal/ZillaStopCommandSpi.java
+++ b/runtime/command-stop/src/main/java/io/aklivity/zilla/runtime/command/stop/internal/ZillaStopCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-stop/src/main/java/io/aklivity/zilla/runtime/command/stop/internal/airline/ZillaStopCommand.java
+++ b/runtime/command-stop/src/main/java/io/aklivity/zilla/runtime/command/stop/internal/airline/ZillaStopCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-stop/src/main/moditect/module-info.java
+++ b/runtime/command-stop/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-version/src/main/java/io/aklivity/zilla/runtime/command/version/internal/ZillaVersionCommandSpi.java
+++ b/runtime/command-version/src/main/java/io/aklivity/zilla/runtime/command/version/internal/ZillaVersionCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-version/src/main/java/io/aklivity/zilla/runtime/command/version/internal/airline/ZillaVersionCommand.java
+++ b/runtime/command-version/src/main/java/io/aklivity/zilla/runtime/command/version/internal/airline/ZillaVersionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command-version/src/main/moditect/module-info.java
+++ b/runtime/command-version/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/ZillaCommand.java
+++ b/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/ZillaCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/ZillaCommandSpi.java
+++ b/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/ZillaCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/internal/ZillaMain.java
+++ b/runtime/command/src/main/java/io/aklivity/zilla/runtime/command/internal/ZillaMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/main/moditect/module-info.java
+++ b/runtime/command/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaMainTest.java
+++ b/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaTestCommand.java
+++ b/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaTestCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaTestCommandSpi.java
+++ b/runtime/command/src/test/java/io/aklivity/zilla/runtime/command/internal/ZillaTestCommandSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/DirectBufferInputStreamEx.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/DirectBufferInputStreamEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/StreamingJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonLocation.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactory.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/main/moditect/module-info.java
+++ b/runtime/common-json/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/DirectBufferInputStreamExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/DirectBufferInputStreamExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonLocationTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonParserTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/StreamingJsonParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactoryTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonParserFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/StreamingJsonTokenizerPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/common/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
+++ b/runtime/common/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/common/src/main/java/io/aklivity/zilla/runtime/common/feature/Incubating.java
+++ b/runtime/common/src/main/java/io/aklivity/zilla/runtime/common/feature/Incubating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/common/src/main/moditect/module-info.java
+++ b/runtime/common/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Configuration.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineAffinity.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineAffinity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineController.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/Binding.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingController.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/BindingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageConsumer.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessagePredicate.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessagePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageReader.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/function/MessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetCreditor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebitor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/budget/BudgetDebitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/buffer/BufferPool.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/buffer/BufferPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/Catalog.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/Catalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/concurrent/Signaler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/concurrent/Signaler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/AttributeConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/BindingConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConditionConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConditionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConditionConfigAdapterSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConditionConfigAdapterSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigAdapterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigAdapterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigException.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ConfigException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigAnnotator.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigAnnotator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigReader.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigWriter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/EngineConfigWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ExporterConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/GuardedConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/KindConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/KindConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/MetricRefConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfigAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfigAdapterSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/ModelConfigAdapterSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/NamespaceConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfigAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfigAdapterSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/OptionsConfigAdapterSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouteConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouterConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouterConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/RouterConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfigAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/SchemaConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/StoreConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/StoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/StoreConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/StoreConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/TelemetryRefConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfigBuilder.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/VaultConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/WithConfig.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/WithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/WithConfigAdapterSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/config/WithConfigAdapterSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/diagnostic/EngineDiagnosticsTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/diagnostic/EngineDiagnosticsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/event/EventFormatterSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/Exporter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/Exporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/exporter/ExporterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/ext/EngineExtSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/Aliasable.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/Aliasable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/Factory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/Factory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/FactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/factory/FactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/Guard.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/Guard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/LabelManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/LabelManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Tuning.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Tuning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetCreditor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetDebitor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetDebitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/AtomicBufferEx.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/AtomicBufferEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DirectBufferEx.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/DirectBufferEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/MutableDirectBufferEx.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/buffer/MutableDirectBufferEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/concurent/ManyToOneRingBuffer.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/concurent/ManyToOneRingBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/concurent/SafeBuffer.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/concurent/SafeBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/AttributeAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/AttributeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/CatalogAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/CatalogAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/CatalogedAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/CatalogedAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/ExporterAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/ExporterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/GuardAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/GuardAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/KindAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/KindAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/MetricAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/MetricAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/MetricRefAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/MetricRefAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/RouteAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/RouteAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/StoreAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/StoreAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryRefAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryRefAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/VaultAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/VaultAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/WithAdapter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/WithAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/schema/SchemaDecorator.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/schema/SchemaDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/schema/UniquePropertyKeysSchema.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/config/schema/UniquePropertyKeysSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatterFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventAccessor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventReader.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/exporter/ExporterAgent.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/exporter/ExporterAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BindingsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BindingsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BudgetsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BudgetsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BufferPoolLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/BufferPoolLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/StreamsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/StreamsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/MetricsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/MetricsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/ScalarsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/ScalarsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroup.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroupFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineMetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersCapacityMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersCapacityMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersCountMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersCountMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersUsageMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/metrics/EngineWorkersUsageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/Poller.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/Poller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/PollerKeyImpl.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/poller/PollerKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/BindingRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/BindingRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/CatalogRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/CatalogRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineBoss.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineBoss.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouteable.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouteable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ExporterRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/ExporterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/GuardRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/GuardRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/MetricHandlerKind.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/MetricHandlerKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/MetricRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/MetricRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/NamespaceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/StoreRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/StoreRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/VaultRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/VaultRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/spy/OneToOneRingBufferSpy.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/spy/OneToOneRingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/spy/RingBufferSpy.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/spy/RingBufferSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/BudgetId.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/BudgetId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/StreamId.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/StreamId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/Target.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/stream/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatchTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatcher.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/watcher/EngineConfigWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Collector.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Collector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/CollectorContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/CollectorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroup.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestCounterMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestCounterMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestGaugeMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestGaugeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestHistogramMetric.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/TestHistogramMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecord.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricRecord.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricRecordHelper.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricRecordHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricsReader.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecord.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ConverterHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/Model.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ValidatorHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/function/ValueConsumer.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/function/ValueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/namespace/NamespacedId.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/namespace/NamespacedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/poller/PollerKey.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/poller/PollerKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/reader/BindingsLayoutReader.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/reader/BindingsLayoutReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/Resolver.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/Resolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/ResolverFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/ResolverFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/ResolverSpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/resolver/ResolverSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouteableContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouteableContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/Router.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/Router.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/security/RevocationStrategy.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/security/RevocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/security/Trusted.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/security/Trusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/Store.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/store/StoreHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/IntIntFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/IntIntFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntIntFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongIntIntFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongLongFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongLongFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiConsumer.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectPredicate.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/ObjectLongIntIntFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/ObjectLongIntIntFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/ObjectLongLongFunction.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/util/function/ObjectLongLongFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/Vault.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/Vault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultFactory.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultFactorySpi.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/moditect/module-info.java
+++ b/runtime/engine/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/main/resources/config/local.server.yaml
+++ b/runtime/engine/src/main/resources/config/local.server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/ConfigurationTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/BindingFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/BindingFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/function/MessageConsumerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/function/MessageConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/function/MessagePredicateTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/binding/function/MessagePredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/catalog/CatalogFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfigTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/CatalogedConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/EngineConfigAnnotatorTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/EngineConfigAnnotatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/EngineConfigWriterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/config/EngineConfigWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/diagnostic/EngineDiagnosticsTaskTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/diagnostic/EngineDiagnosticsTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/exporter/ExporterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineContextIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineContextIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineMetricsIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineMetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/ReconfigureFileIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/ReconfigureFileIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/ReconfigureHttpIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/ReconfigureHttpIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetCreditorTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetCreditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetDebitorTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/budget/DefaultBudgetDebitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPoolTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/buffer/DefaultBufferPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurent/SafeBufferTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurent/SafeBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/ManyToOneRingBufferTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/ManyToOneRingBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/BufferBM.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/BufferBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/TimestampBM.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/concurrent/bench/TimestampBM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/BindingConfigsAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/ConditionConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/KindConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/KindConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/NamespaceConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/OptionsConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/OptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/RouteConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/RouteConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryConfigsAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/TelemetryConfigsAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/WithConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/config/WithConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/EngineEventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/CountersLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/GaugesLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/layouts/metrics/HistogramsLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/ModelFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/ModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/ModelTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/config/ModelConfigAdapterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/model/config/ModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/MetricGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecordTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/HistogramRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricsReaderTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/MetricsReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecordTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/metrics/reader/ScalarRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/function/ValueConsumerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/function/ValueConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/reader/BindingsLayoutReaderTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/reader/BindingsLayoutReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/resolver/ResolverTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/resolver/ResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/router/RouterFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/router/RouterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/security/TrustedTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/security/TrustedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRuleParameterizedTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRuleParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRuleTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EngineRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EventIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/Services.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/Services.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configuration.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configure.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configures.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/annotation/Configures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/DuplexIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/DuplexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/HalfDuplexIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/HalfDuplexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/SimplexIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/SimplexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBinding.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestAuthorizationConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestAuthorizationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestRouteConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/config/TestRouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/DecoderTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/DecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/EncoderTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/EncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalog.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/TestCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/ValidatorTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/ValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/catalog/config/TestCatalogOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventFormatter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventFormatterFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/event/TestEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/TestExporterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/exporter/config/TestExporterOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuard.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaBootstrapFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaBootstrapFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaChannelAddressFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaChannelAddressFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaExtConfiguration.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/ZillaExtConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/LabelManager.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/LabelManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/NullChannelBuffer.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/NullChannelBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBehaviorSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBehaviorSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBootstrapFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBootstrapFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaByteOrder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaByteOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddress.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddressFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelAddressFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChildChannel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChildChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChildChannelSink.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChildChannelSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannelFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannelSink.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaClientChannelSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaCorrelation.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaCorrelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEngine.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEnginePool.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaEnginePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaExtensionKind.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaExtensionKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaPartition.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaScope.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelSink.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaServerChannelSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaSource.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaStreamFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaThrottleMode.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaThrottleMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTransmission.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTransmission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaUpdateMode.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaUpdateMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/AbstractReadExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/AbstractReadExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadAbortExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadAbortExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadAckOptionHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadAckOptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadBeginExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadBeginExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadDataExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadDataExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadEmptyDataHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadEmptyDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadEndExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadEndExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadFlagsOptionHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadFlagsOptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadNullDataHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadNullDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteAbortedExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteAbortedExtHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteEmptyDataHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteEmptyDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteFlagsOptionHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/WriteFlagsOptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ZillaExtensionDecoder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ZillaExtensionDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ZillaExtensionEncoder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ZillaExtensionEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/Layout.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/Layout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/StreamsLayout.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/StreamsLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/StreamsLayoutTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/layout/StreamsLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/el/Functions.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/el/Functions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/el/FunctionsTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/el/FunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/util/Conversions.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/util/Conversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/util/function/LongObjectBiConsumer.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/util/function/LongObjectBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/metrics/TestMetricGroup.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/metrics/TestMetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/metrics/TestMetricGroupFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/metrics/TestMetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestConverterHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModel.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestValidatorHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/config/TestModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/resolver/TestResolverFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/resolver/TestResolverFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/resolver/TestResolverSpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/resolver/TestResolverSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStore.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/store/TestStoreHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVault.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultFactorySpi.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/TestVaultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultEntryConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultEntryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultEntryConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultEntryConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigAdapter.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/config/TestVaultOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiConsumerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiFunctionTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectBiFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectPredicateTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/util/function/LongObjectPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/vault/VaultFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/vault/VaultFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-expression-invalid.yaml
+++ b/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-expression-invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-expression.yaml
+++ b/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-expression.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-multiple.yaml
+++ b/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-multiple.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.default/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.default/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.default/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.default/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.native/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.native/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.native/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.native/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.network/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.network/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.network/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/byteorder.network/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.null.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.null.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.null.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.flush.null.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.receive.null.data.with.ext.and.expression/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.receive.null.data.with.ext.and.expression/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.receive.null.data.with.ext.and.expression/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.receive.null.data.with.ext.and.expression/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.missing.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.missing.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.missing.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data.missing.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.incomplete/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.incomplete/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.no.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.no.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.no.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.no.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.skip/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.skip/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.skip/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.skip/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.then.reset.flags/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.then.reset.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.then.reset.flags/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.option.flags.then.reset.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.overflow/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.overflow/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.server.replied.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.server.replied.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.server.replied.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.server.replied.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.and.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.and.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.and.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.read.and.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only.message.aligned/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only.message.aligned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only.message.aligned/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only.message.aligned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.initial.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.message/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.message/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.throttle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort.server.replied.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort.server.replied.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort.server.replied.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort.server.replied.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.empty.data.and.server.read.empty.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.empty.data.and.server.read.empty.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.empty.data.and.server.read.empty.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/client.write.empty.data.and.server.read.empty.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.authorized/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.authorized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.authorized/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.authorized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.budget.id/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.budget.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.budget.id/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.budget.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.unequal.authorization/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.unequal.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.unequal.authorization/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.unequal.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.null.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.null.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.null.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.flush.null.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.missing.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.missing.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.missing.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data.missing.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.ack/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.ack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.ack/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.ack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.incomplete/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.incomplete/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.no.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.no.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.no.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.no.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.skip/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.skip/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.skip/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.skip/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.then.reset.flags/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.then.reset.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.then.reset.flags/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.option.flags.then.reset.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow.padding/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow.padding/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.and.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.and.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.and.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.read.and.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only.message.aligned/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only.message.aligned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only.message.aligned/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only.message.aligned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.initial.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.message/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.message/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.throttle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.and.client.read.empty.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.and.client.read.empty.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.and.client.read.empty.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.and.client.read.empty.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/server.write.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/timestamps.false/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.null.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.null.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.null.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.flush.null.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.missing.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.missing.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.missing.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data.missing.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.incomplete/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.incomplete/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.no.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.no.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.no.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.no.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.skip/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.skip/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.skip/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.skip/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.then.reset.flags/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.then.reset.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.then.reset.flags/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.option.flags.then.reset.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.overflow/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.overflow/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.before.reply/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.before.reply/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.before.reply/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.before.reply/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.server.replied.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.server.replied.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.server.replied.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort.server.replied.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only.message.aligned/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only.message.aligned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only.message.aligned/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only.message.aligned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.initial.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.message/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.message/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.throttle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort.server.replied.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.empty.data.and.server.read.empty.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.empty.data.and.server.read.empty.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.empty.data.and.server.read.empty.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.sent.write.empty.data.and.server.read.empty.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/client.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.authorized/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.authorized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.authorized/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.authorized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.budget.id/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.budget.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.budget.id/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.budget.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.unequal.authorization/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.unequal.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.unequal.authorization/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.unequal.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.null.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.null.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.null.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.flush.null.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.missing.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.missing.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.missing.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data.missing.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.ack/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.ack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.ack/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.ack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.incomplete/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.incomplete/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.no.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.no.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.no.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.no.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.skip/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.skip/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.skip/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.skip/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.then.reset.flags/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.then.reset.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.then.reset.flags/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.option.flags.then.reset.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.overflow/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.overflow/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.and.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.and.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.and.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.read.and.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only.message.aligned/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only.message.aligned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only.message.aligned/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only.message.aligned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.initial.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.message/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.message/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.throttle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.empty.data.and.client.read.empty.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.empty.data.and.client.read.empty.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.empty.data.and.client.read.empty.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.sent.write.empty.data.and.client.read.empty.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.abort.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.abort.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.abort.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.abort.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/server.write.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.null.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.null.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.null.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.flush.null.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.missing.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.missing.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.missing.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data.missing.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.incomplete/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.incomplete/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.no.fragmentation/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.no.fragmentation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.no.fragmentation/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.no.fragmentation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.skip/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.skip/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.skip/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.skip/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.then.reset.flags/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.then.reset.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.then.reset.flags/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.option.flags.then.reset.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.and.server.read.empty.data/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.and.server.read.empty.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.and.server.read.empty.data/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.and.server.read.empty.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.with.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.with.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.with.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/client.write.empty.data.with.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.affinity/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.affinity/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.affinity/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.affinity/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.authorized/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.authorized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.authorized/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.authorized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.budget.id/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.budget.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.budget.id/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.budget.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.rejected/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.unequal.authorization/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.unequal.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.unequal.authorization/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.unequal.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.option.ack/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.option.ack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.option.ack/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.option.ack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.overflow/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.overflow/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.abort/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.abort/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.redirect.ext/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.redirect.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.redirect.ext/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.read.advise.redirect.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.message.aligned/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.message.aligned/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.message.aligned/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.message.aligned/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.update.none/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.update.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.update.none/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only.update.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.initial.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.message/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.message/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle/server.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/server.sent.throttle/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpEndpointConfig.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpEndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpEndpointConfigBuilder.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpEndpointConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOptionsConfig.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOptionsConfigBuilder.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOverridesConfig.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOverridesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOverridesConfigBuilder.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/config/OtlpOverridesConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OltpConfiguration.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OltpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OltpExporterHandler.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OltpExporterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporter.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterContext.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterFactorySpi.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpEndpointAdapter.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpEndpointAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpExporterConfig.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOptionsConfigAdapter.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOverridesAdapter.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpOverridesAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpSignalsAdapter.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpSignalsAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/EventReader.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/EventReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/OtlpLogsSerializer.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/OtlpLogsSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/OtlpMetricsSerializer.java
+++ b/runtime/exporter-otlp/src/main/java/io/aklivity/zilla/runtime/exporter/otlp/internal/serializer/OtlpMetricsSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/main/moditect/module-info.java
+++ b/runtime/exporter-otlp/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/EventIT.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/MetricsIT.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/MetricsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterFactoryTest.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/OtlpExporterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OltpOptionsConfigAdapterTest.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OltpOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpExporterConfigTest.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/OtlpExporterConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/SchemaTest.java
+++ b/runtime/exporter-otlp/src/test/java/io/aklivity/zilla/runtime/exporter/otlp/internal/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporter.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterContext.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterFactorySpi.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandler.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusEndpointAdapter.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusEndpointAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusEndpointConfig.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusEndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusExporterConfig.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfig.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapter.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptor.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinter.java
+++ b/runtime/exporter-prometheus/src/main/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/main/moditect/module-info.java
+++ b/runtime/exporter-prometheus/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterFactoryTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandlerTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/PrometheusExporterHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapterTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/config/PrometheusOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptorTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinterTest.java
+++ b/runtime/exporter-prometheus/src/test/java/io/aklivity/zilla/runtime/exporter/prometheus/internal/printer/PrometheusMetricsPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutConfiguration.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporter.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterContext.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterFactorySpi.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterHandler.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutExporterConfig.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfig.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapter.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/stream/StdoutEventsStream.java
+++ b/runtime/exporter-stdout/src/main/java/io/aklivity/zilla/runtime/exporter/stdout/internal/stream/StdoutEventsStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/main/moditect/module-info.java
+++ b/runtime/exporter-stdout/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterConfigurationTest.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterFactoryTest.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/StdoutExporterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapterTest.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/config/StdoutOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/EventIT.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/StdoutOutputRule.java
+++ b/runtime/exporter-stdout/src/test/java/io/aklivity/zilla/runtime/exporter/stdout/internal/events/StdoutOutputRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/application/client.rpt
+++ b/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/application/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/application/server.rpt
+++ b/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/application/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/network/client.rpt
+++ b/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/network/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/network/server.rpt
+++ b/runtime/exporter-stdout/src/test/scripts/io/aklivity/zilla/runtime/exporter/stdout/streams/network/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/HttpFilesystemEnvironment.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/HttpFilesystemEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystem.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystemConfiguration.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystemConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystemProvider.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpPath.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpWatchService.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpWatchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpsFileSystemProvider.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/HttpsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/ReadOnlyByteArrayChannel.java
+++ b/runtime/filesystem-http/src/main/java/io/aklivity/zilla/runtime/filesystem/http/internal/ReadOnlyByteArrayChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/main/moditect/module-info.java
+++ b/runtime/filesystem-http/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemIT.java
+++ b/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemTest.java
+++ b/runtime/filesystem-http/src/test/java/io/aklivity/zilla/runtime/filesystem/http/HttpFileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfig.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfigBuilder.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeyConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeySetConfig.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtKeySetConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfig.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfigBuilder.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/config/JwtOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventContext.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventFormatter.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventFormatterFactory.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuard.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardContext.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardFactorySpi.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeyConfigAdapter.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeyConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeySetConfigAdapter.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeySetConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapter.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/main/moditect/module-info.java
+++ b/runtime/guard-jwt/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/EventIT.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardIT.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeySetConfigAdapterTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtKeySetConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapterTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/config/JwtOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/keys/JwtKeyConfigs.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/keys/JwtKeyConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcActiveRequestsMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcActiveRequestsMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcActiveRequestsMetricContext.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcActiveRequestsMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcCountPerRpcContext.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcCountPerRpcContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcDurationMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcDurationMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcDurationMetricContext.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcDurationMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricConsumer.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroup.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupFactorySpi.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcRequestSizeMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcRequestSizeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcRequestsPerRpcMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcRequestsPerRpcMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcResponseSizeMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcResponseSizeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcResponsesPerRpcMetric.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcResponsesPerRpcMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcSizeMetricContext.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcSizeMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcUtils.java
+++ b/runtime/metrics-grpc/src/main/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/main/moditect/module-info.java
+++ b/runtime/metrics-grpc/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/test/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupFactoryTest.java
+++ b/runtime/metrics-grpc/src/test/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-grpc/src/test/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupTest.java
+++ b/runtime/metrics-grpc/src/test/java/io/aklivity/zilla/runtime/metrics/grpc/internal/GrpcMetricGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetric.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpActiveRequestsMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpAttributeHelper.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpAttributeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpDurationMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricConsumer.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroup.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupFactorySpi.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpRequestSizeMetric.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpRequestSizeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpResponseSizeMetric.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpResponseSizeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpSizeMetricContext.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpSizeMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
+++ b/runtime/metrics-http/src/main/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/main/moditect/module-info.java
+++ b/runtime/metrics-http/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupFactoryTest.java
+++ b/runtime/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
+++ b/runtime/metrics-http/src/test/java/io/aklivity/zilla/runtime/metrics/http/internal/HttpMetricGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveMetricContext.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveReceivedMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveReceivedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveSentMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamActiveSentMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesMetricContext.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesReceivedMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesReceivedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesSentMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamClosesSentMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataMetricContext.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataReceivedMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataReceivedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataSentMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamDataSentMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsMetricContext.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsReceivedMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsReceivedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsSentMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamErrorsSentMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroup.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupFactorySpi.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensMetricContext.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensMetricContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensReceivedMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensReceivedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensSentMetric.java
+++ b/runtime/metrics-stream/src/main/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamOpensSentMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/main/moditect/module-info.java
+++ b/runtime/metrics-stream/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/test/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupFactoryTest.java
+++ b/runtime/metrics-stream/src/test/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/metrics-stream/src/test/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupTest.java
+++ b/runtime/metrics-stream/src/test/java/io/aklivity/zilla/runtime/metrics/stream/internal/StreamMetricGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/config/AvroModelConfig.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/config/AvroModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/config/AvroModelConfigBuilder.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/config/AvroModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroField.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModel.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelConfiguration.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelContext.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventContext.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatter.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatterFactory.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelFactorySpi.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroReadConverterHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroReadConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroValidatorHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroWriteConverterHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroWriteConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/config/AvroModelConfigAdapter.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/config/AvroModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/org/apache/avro/io/CanonicalJsonDecoder.java
+++ b/runtime/model-avro/src/main/java/org/apache/avro/io/CanonicalJsonDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/org/apache/avro/io/CanonicalJsonEncoder.java
+++ b/runtime/model-avro/src/main/java/org/apache/avro/io/CanonicalJsonEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/runtime/model-avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/java/org/apache/avro/io/JsonEncoder.java
+++ b/runtime/model-avro/src/main/java/org/apache/avro/io/JsonEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/moditect/module-info.java
+++ b/runtime/model-avro/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/main/zilla/internal.idl
+++ b/runtime/model-avro/src/main/zilla/internal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelFactorySpiTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelFactorySpiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroValidatorTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/EventIT.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/config/AvroModelConfigAdapterTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/config/AvroModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/BooleanModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/BooleanModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/BooleanModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/BooleanModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/DoubleModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/DoubleModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/DoubleModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/DoubleModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/FloatModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/FloatModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/FloatModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/FloatModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int32ModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int32ModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int32ModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int32ModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int64ModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int64ModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int64ModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/Int64ModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/RangeConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/RangeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringModelConfig.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringModelConfigBuilder.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringPattern.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/config/StringPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModel.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BooleanValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventFormatter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventFormatterFactory.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleFormat.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModel.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleState.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/DoubleValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatFormat.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModel.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatState.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/FloatValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32Format.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32Model.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32State.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int32ValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64Format.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64Format.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64Model.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64State.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/Int64ValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringConverterHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringEncoding.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModel.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModelContext.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModelFactorySpi.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringState.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorEncoding.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/BooleanModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/BooleanModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/DoubleModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/DoubleModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/FloatModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/FloatModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/Int32ModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/Int32ModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/Int64ModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/Int64ModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/RangeConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/RangeConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/StringModelConfigAdapter.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/config/StringModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/main/moditect/module-info.java
+++ b/runtime/model-core/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleConverterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/EventIT.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatConverterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ConverterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ConverterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringConverterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringEncodingTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelFactoryTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/BooleanModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/BooleanModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/DoubleModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/DoubleModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/FloatModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/FloatModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/Int32ModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/Int32ModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/Int64ModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/Int64ModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/StringModelConfigAdapterTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/StringModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/StringPatternTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/config/StringPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/config/JsonModelConfig.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/config/JsonModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/config/JsonModelConfigBuilder.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/config/JsonModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModel.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelContext.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventContext.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatter.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatterFactory.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelFactorySpi.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonReadConverterHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonReadConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonValidatorHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonValidatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonWriteConverterHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonWriteConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/config/JsonModelConfigAdapter.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/config/JsonModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/main/moditect/module-info.java
+++ b/runtime/model-json/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/EventIT.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonConverterTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelFactorySpiTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelFactorySpiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonValidatorTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/config/JsonModelConfigAdapterTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/config/JsonModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf2.g4
+++ b/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf2.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf3.g4
+++ b/runtime/model-protobuf/src/main/antlr4/io/aklivity/zilla/runtime/model/protobuf/internal/parser/Protobuf3.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfig.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfigBuilder.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/config/ProtobufModelConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/DescriptorTree.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/DescriptorTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2Listener.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto2Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3Listener.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/Proto3Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufField.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModel.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelContext.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventContext.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatter.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatterFactory.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEventFormatterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelFactorySpi.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufParser.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufReadConverterHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufReadConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufWriteConverterHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufWriteConverterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapter.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/main/moditect/module-info.java
+++ b/runtime/model-protobuf/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/EventIT.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/EventIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelFactorySpiTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelFactorySpiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufParserTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapterTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/config/ProtobufModelConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/resolver-env/src/main/java/io/aklivity/zilla/runtime/resolver/env/internal/EnvironmentResolverFactorySpi.java
+++ b/runtime/resolver-env/src/main/java/io/aklivity/zilla/runtime/resolver/env/internal/EnvironmentResolverFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/resolver-env/src/main/java/io/aklivity/zilla/runtime/resolver/env/internal/EnvironmentResolverSpi.java
+++ b/runtime/resolver-env/src/main/java/io/aklivity/zilla/runtime/resolver/env/internal/EnvironmentResolverSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/resolver-env/src/main/moditect/module-info.java
+++ b/runtime/resolver-env/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryEntry.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStore.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreConfiguration.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreContext.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreFactorySpi.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandler.java
+++ b/runtime/store-memory/src/main/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/main/moditect/module-info.java
+++ b/runtime/store-memory/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreConfigurationTest.java
+++ b/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
+++ b/runtime/store-memory/src/test/java/io/aklivity/zilla/runtime/store/memory/internal/MemoryStoreHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfig.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfigBuilder.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemOptionsConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfig.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfigBuilder.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/config/FileSystemStoreConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemContext.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVault.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultFactorySpi.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultFactorySpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultHandler.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapter.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemStoreConfigAdapter.java
+++ b/runtime/vault-filesystem/src/main/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemStoreConfigAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/main/moditect/module-info.java
+++ b/runtime/vault-filesystem/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultIT.java
+++ b/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultTest.java
+++ b/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/FileSystemVaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
+++ b/runtime/vault-filesystem/src/test/java/io/aklivity/zilla/runtime/vault/filesystem/internal/config/FileSystemOptionsConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiFunctions.java
+++ b/specs/binding-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiSpecs.java
+++ b/specs/binding-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/moditect/module-info.java
+++ b/specs/binding-asyncapi.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/resources/META-INF/zilla/asyncapi.idl
+++ b/specs/binding-asyncapi.spec/src/main/resources/META-INF/zilla/asyncapi.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.http.secure.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.http.secure.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.http.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.http.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.kafka.sasl.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.kafka.sasl.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.kafka.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.mqtt.secure.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.mqtt.secure.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.mqtt.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.mqtt.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.sse.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/client.sse.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.async.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.mqtt.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.mqtt.kafka.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.sse.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.sse.kafka.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.http.secure.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.http.secure.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.http.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.http.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.mqtt.secure.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.mqtt.secure.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.mqtt.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.mqtt.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.multi.protocol.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.multi.protocol.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.sse.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.sse.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.unresolved.ref.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/server.unresolved.ref.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/create.pet/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/create.pet/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/verify.customer.async/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/verify.customer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/verify.customer.async/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/http/verify.customer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/create.pet/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/create.pet/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/produce.message/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/produce.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/produce.message/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/produce.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/publish/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/publish/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/server.sent.messages/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/server.sent.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/server.sent.messages/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/server.sent.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/verify.customer/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/verify.customer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/verify.customer/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/kafka/verify.customer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish.and.subscribe/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish.and.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish.and.subscribe/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish.and.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/mqtt/publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/data.multiple/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/data.multiple/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/data.multiple/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/data.multiple/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/server.sent.messages/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/server.sent.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/server.sent.messages/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/asyncapi/sse/server.sent.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/http/create.pet/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/http/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/http/create.pet/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/http/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/kafka/produce.message/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/kafka/produce.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/kafka/produce.message/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/kafka/produce.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/mqtt/publish.and.subscribe/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/mqtt/publish.and.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/mqtt/publish.and.subscribe/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/mqtt/publish.and.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/sse/data.multiple/client.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/sse/data.multiple/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/sse/data.multiple/server.rpt
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/streams/composite/sse/data.multiple/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiFunctionsTest.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/AsyncapiFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/config/SchemaTest.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiHttpIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiHttpIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiKafkaIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiKafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiMqttIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiMqttIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiSseIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/AsyncapiSseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeHttpIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeHttpIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeKafkaIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeKafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeMqttIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeMqttIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeSseIT.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/streams/CompositeSseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/moditect/module-info.java
+++ b/specs/binding-echo.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/resources/META-INF/zilla/echo.idl
+++ b/specs/binding-echo.spec/src/main/resources/META-INF/zilla/echo.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/config/server.yaml
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.challenge/client.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.challenge/server.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.data/client.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.data/server.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.flush/client.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.flush/server.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/connection.established/client.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/connection.established/server.rpt
+++ b/specs/binding-echo.spec/src/main/scripts/io/aklivity/zilla/specs/binding/echo/streams/rfc862/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/test/java/io/aklivity/zilla/specs/binding/echo/config/SchemaTest.java
+++ b/specs/binding-echo.spec/src/test/java/io/aklivity/zilla/specs/binding/echo/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-echo.spec/src/test/java/io/aklivity/zilla/specs/binding/echo/streams/rfc862/ServerIT.java
+++ b/specs/binding-echo.spec/src/test/java/io/aklivity/zilla/specs/binding/echo/streams/rfc862/ServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/moditect/module-info.java
+++ b/specs/binding-fan.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/resources/META-INF/zilla/fan.idl
+++ b/specs/binding-fan.spec/src/main/resources/META-INF/zilla/fan.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/config/server.yaml
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.connected/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.connected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.connected/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.connected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.received.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.received.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.and.received.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.and.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.and.received.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.and.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.flush/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.flush/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/server.sent.flush/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/server.sent.flush/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/application/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.connected/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.connected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.connected/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.connected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.received.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.received.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.and.received.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.and.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.and.received.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.and.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.data/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.data/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.flush/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.flush/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/server.sent.flush/client.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/server.sent.flush/server.rpt
+++ b/specs/binding-fan.spec/src/main/scripts/io/aklivity/zilla/specs/binding/fan/streams/network/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/config/SchemaTest.java
+++ b/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/streams/ApplicationIT.java
+++ b/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/streams/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/streams/NetworkIT.java
+++ b/specs/binding-fan.spec/src/test/java/io/aklivity/zilla/specs/binding/fan/streams/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-filesystem.spec/src/main/java/io/aklivity/zilla/specs/binding/filesystem/internal/FileSystemFunctions.java
+++ b/specs/binding-filesystem.spec/src/main/java/io/aklivity/zilla/specs/binding/filesystem/internal/FileSystemFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/moditect/module-info.java
+++ b/specs/binding-filesystem.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/resources/META-INF/zilla/filesystem.idl
+++ b/specs/binding-filesystem.spec/src/main/resources/META-INF/zilla/filesystem.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/config/server.yaml
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/config/server_symlinks.yaml
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/config/server_symlinks.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.abort/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.abort/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.begin.not.modified/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.begin.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.begin.not.modified/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.begin.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.file.not.found/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.file.not.found/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.file.not.found/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.read.file.not.found/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.write.abort/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.write.abort/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/client.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.directory/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.directory/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.directory/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.directory/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.file.payload/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.file.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.file.payload/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/create.file.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.directory/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.directory/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.directory/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.directory/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload.failed/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload.failed/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/delete.file.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.empty/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.empty/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.failed/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.failed/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.directory/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension.default/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension.default/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension.default/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension.default/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.empty/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.empty/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.extension/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.extension/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlink.changes/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlink.changes/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlink.changes/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlink.changes/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlinks/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlinks/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlinks/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.follow.symlinks/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.multi.client/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.multi.client/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.multi.client/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified.multi.client/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.tag.not.matched/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.tag.not.matched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.tag.not.matched/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload.tag.not.matched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/read.file.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.interrupt/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.interrupt/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.interrupt/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.interrupt/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified.abort/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified.abort/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified/client.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified/server.rpt
+++ b/specs/binding-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/filesystem/streams/application/write.file.payload.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/config/SchemaTest.java
+++ b/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/internal/FileSystemFunctionsTest.java
+++ b/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/internal/FileSystemFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/streams/application/FileSystemIT.java
+++ b/specs/binding-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/filesystem/streams/application/FileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctions.java
+++ b/specs/binding-grpc-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/moditect/module-info.java
+++ b/specs/binding-grpc-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/resources/META-INF/zilla/grpc_kafka.idl
+++ b/specs/binding-grpc-kafka.spec/src/main/resources/META-INF/zilla/grpc_kafka.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/fetch.proxy.rpc.yaml
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/fetch.proxy.rpc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/produce.proxy.rpc.oneway.yaml
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/produce.proxy.rpc.oneway.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/produce.proxy.rpc.yaml
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/config/produce.proxy.rpc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.read.abort.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.read.abort.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.read.abort.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.read.abort.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.write.abort.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.write.abort.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.write.abort.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/client.sent.write.abort.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reject.request.body.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reject.request.body.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reject.request.body.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reject.request.body.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/reliable.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/fetch/unreliable.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/bidi.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.oneway/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.oneway/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.oneway/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.oneway/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/client.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc.read.aborted/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc.read.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc.read.aborted/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc.read.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/server.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.error/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.error/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.message.value.100k/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.message.value.100k/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.oneway/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.oneway/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.oneway/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.oneway/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.rejected/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.rejected/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.sent.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.sent.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/grpc/produce/unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.read.abort.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.read.abort.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.read.abort.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.read.abort.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.write.abort.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.write.abort.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.write.abort.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/client.sent.write.abort.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reject.request.body.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reject.request.body.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reject.request.body.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reject.request.body.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reliable.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reliable.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reliable.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/reliable.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/unreliable.unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/unreliable.unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/unreliable.unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/fetch/unreliable.unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/bidi.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.oneway/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.oneway/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.oneway/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.oneway/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/client.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc.read.aborted/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc.read.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc.read.aborted/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc.read.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/server.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.error/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.error/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.message.value.100k/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.message.value.100k/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.oneway/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.oneway/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.oneway/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.oneway/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.rejected/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.rejected/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.sent.write.abort/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.sent.write.abort/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc/client.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc/server.rpt
+++ b/specs/binding-grpc-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/kafka/streams/kafka/produce/unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctionsTest.java
+++ b/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/internal/GrpcKafkaFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/GrpcFetchIT.java
+++ b/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/GrpcFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/GrpcProduceIT.java
+++ b/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/GrpcProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/KafkaFetchIT.java
+++ b/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/KafkaFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/KafkaProduceIT.java
+++ b/specs/binding-grpc-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/kafka/streams/KafkaProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/internal/GrpcFunctions.java
+++ b/specs/binding-grpc.spec/src/main/java/io/aklivity/zilla/specs/binding/grpc/internal/GrpcFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/moditect/module-info.java
+++ b/specs/binding-grpc.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/resources/META-INF/zilla/grpc.idl
+++ b/specs/binding-grpc.spec/src/main/resources/META-INF/zilla/grpc.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.when.binary.metadata.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.when.binary.metadata.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.when.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/protobuf/echo.proto
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/protobuf/echo.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/protobuf/oneway.proto
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/protobuf/oneway.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.binary.metadata.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.binary.metadata.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.catalog.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.yaml
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/bidirectional.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/bidirectional.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/bidirectional.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/bidirectional.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/client.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/client.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/client.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/client.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/server.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/server.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/server.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/server.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/binary.metadata/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/binary.metadata/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/binary.metadata/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/binary.metadata/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/empty.message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/empty.message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/empty.message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/empty.message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange.100k/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange.100k/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.missing.grpc.status/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.missing.grpc.status/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.missing.grpc.status/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.missing.grpc.status/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.timeout/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.timeout/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/response.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.read.abort.on.open.request/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.read.abort.on.open.request/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.response/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.response/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/application/unary.rpc/server.send.write.abort.on.open.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/bidirectional.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/bidirectional.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/bidirectional.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/bidirectional.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/client.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/client.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/client.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/client.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/method.not.post/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/method.not.post/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/method.not.post/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/method.not.post/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/missing.te.trailers/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/missing.te.trailers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/missing.te.trailers/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/missing.te.trailers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unrecognized.rpc/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unrecognized.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unrecognized.rpc/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unrecognized.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unsupported.content.type/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unsupported.content.type/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unsupported.content.type/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/rejected.rpc/unsupported.content.type/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/server.stream.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/server.stream.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/server.stream.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/server.stream.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/binary.metadata/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/binary.metadata/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/binary.metadata/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/binary.metadata/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/empty.message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/empty.message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/empty.message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/empty.message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/grpc.web/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/grpc.web/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/grpc.web/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/grpc.web/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange.100k/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange.100k/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/message.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.missing.grpc.status/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.missing.grpc.status/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.missing.grpc.status/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.missing.grpc.status/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.timeout/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.timeout/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.with.grpc.error/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.with.grpc.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.with.grpc.error/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/response.with.grpc.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.read.abort.on.open.request/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.read.abort.on.open.request/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.response/client.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.response/server.rpt
+++ b/specs/binding-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/grpc/streams/network/unary.rpc/server.send.write.abort.on.open.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/config/SchemaTest.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/internal/GrpcFunctionsTest.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/internal/GrpcFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/BidiStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/BidiStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/ClientStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/ClientStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/ServerStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/ServerStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/UnaryRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/application/UnaryRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/BidiStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/BidiStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/ClientStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/ClientStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/RejectedRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/RejectedRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/ServerStreamRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/ServerStreamRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/UnaryRpcIT.java
+++ b/specs/binding-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/grpc/streams/network/UnaryRpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/moditect/module-info.java
+++ b/specs/binding-http-filesystem.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.directory.dynamic.yaml
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.directory.dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.path.dynamic.yaml
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.path.dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.path.yaml
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/config/proxy.with.path.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.existing.file.failed/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.existing.file.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.existing.file.failed/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.existing.file.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.create.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.non.existent.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.non.existent.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.non.existent.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.delete.non.existent.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.directory/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.directory/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.directory/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.directory/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.info/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.info/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.not.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.not.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file.map.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.read.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.abort/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.abort/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.reset/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.reset/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file.failed/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file.failed/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/client.write.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.abort/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.abort/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.flush/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.flush/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.reset/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.reset/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/filesystem/server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.existing.file.failed/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.existing.file.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.existing.file.failed/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.existing.file.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.create.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.non.existent.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.non.existent.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.non.existent.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.delete.non.existent.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.directory/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.directory/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.directory/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.directory/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.info/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.info/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.map.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file.with.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.read.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.rejected/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.rejected/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.abort/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.abort/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.message/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.message/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.reset/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.reset/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file.failed/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file.failed/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/client.write.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.abort/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.abort/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.flush/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.flush/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.reset/client.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.reset/server.rpt
+++ b/specs/binding-http-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/filesystem/streams/http/server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/config/SchemaTest.java
+++ b/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/streams/FileSystemIT.java
+++ b/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/streams/FileSystemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/streams/HttpIT.java
+++ b/specs/binding-http-filesystem.spec/src/test/java/io/aklivity/zilla/specs/binding/http/filesystem/streams/HttpIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/moditect/module-info.java
+++ b/specs/binding-http-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.async.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.no.reply.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.no.reply.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.delete.item.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.item.child.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.item.child.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.item.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.item.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.items.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.get.items.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.invalid.path.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.invalid.path.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.patch.item.async.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.patch.item.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.patch.item.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.patch.item.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.item.command.async.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.item.command.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.item.command.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.item.command.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.async.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.with.correlationId.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.with.correlationId.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.post.items.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.async.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.no.reply.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.no.reply.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.put.item.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.with.topic.dynamic.yaml
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/config/proxy.with.topic.dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.no.etag/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.no.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.no.etag/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match.no.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.ignored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.ignored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.rejected/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.rejected/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.wait.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.with.body/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.prefer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.rejected/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.rejected/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/delete.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.attribute.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.attribute.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.attribute.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.attribute.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.child/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.child/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.child/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.child/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.empty/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.empty/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match.not.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match.not.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.if.none.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag.if.none.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag.if.none.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag.if.none.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag.if.none.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.implicit.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.not.found/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.not.found/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.not.found/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.not.found/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait.not.found/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait.not.found/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait.not.found/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait.not.found/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.prefer.wait/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.with.body/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.with.body/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.with.body/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.with.body/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.empty/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.empty/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match.not.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match.not.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.if.none.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait.not.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait.not.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.prefer.wait/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.with.body/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.with.body/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.with.body/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.with.body/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.items/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.my.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.my.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.my.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/get.my.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.ignored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async.ignored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item.prefer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/patch.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.10k/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.10k/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.ignored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async.ignored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command.prefer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.item.command/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async.ignored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items.prefer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/post.items/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.ignored/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.ignored/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.ignored/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async.ignored/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item.prefer.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.my.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.my.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.my.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/http/put.my.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.no.reply/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.no.reply/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.no.reply/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.no.reply/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected.no.reply/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected.no.reply/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected.no.reply/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected.no.reply/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.wait.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/delete.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.attribute.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.attribute.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.attribute.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.attribute.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.child/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.child/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.child/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.child/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.deleted/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.deleted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.deleted/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.deleted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.empty/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.empty/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modifying/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modifying/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modifying/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.modifying/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.no.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.found/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.found/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.found/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.found/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait.timeout/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait.timeout/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.wait/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.empty/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.empty/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.not.modified/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.not.modified/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.read.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.read.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.abort/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.abort/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.flush/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.flush/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items.write.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.items/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.my.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.my.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.my.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/get.my.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/patch.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.async.command/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.async.command/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.async.command/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.async.command/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.10k/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.10k/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.async.replayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.async.replayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.async.replayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.async.replayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.replayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.replayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.replayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command.replayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.item.command/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.with.correlationId/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.with.correlationId/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.with.correlationId/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items.with.correlationId/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/post.items/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.async/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.async/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.async/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.async/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.delayed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.if.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.no.reply/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.no.reply/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.no.reply/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item.no.reply/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.my.item/client.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.my.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.my.item/server.rpt
+++ b/specs/binding-http-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/kafka/streams/kafka/put.my.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/config/SchemaTest.java
+++ b/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/HttpIT.java
+++ b/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/HttpIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/KafkaIT.java
+++ b/specs/binding-http-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/http/kafka/streams/KafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
+++ b/specs/binding-http.spec/src/main/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/moditect/module-info.java
+++ b/specs/binding-http.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/resources/META-INF/zilla/http.idl
+++ b/specs/binding-http.spec/src/main/resources/META-INF/zilla/http.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/upgrade/client.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/upgrade/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/upgrade/server.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/upgrade/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.validation.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.validation.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.credentials.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.credentials.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.credentials.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.credentials.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.explicit.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.explicit.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.explicit.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.allow.explicit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.expose.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.expose.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.cross.origin.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.same.origin.implicit.ports.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.same.origin.implicit.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.same.origin.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.access.control.same.origin.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authority.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authority.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authorization.credentials.basic.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authorization.credentials.basic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authorization.credentials.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.authorization.credentials.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.event.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.event.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.event.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.model.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.with.affinity.invalid.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.with.affinity.invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.with.route.header.overrides.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.with.route.header.overrides.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v1.1/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.authority.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.authority.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.path.prefix.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.path.prefix.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.path.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.path.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.validation.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.validation.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.credentials.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.credentials.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.credentials.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.credentials.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.explicit.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.explicit.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.explicit.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.allow.explicit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.cached.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.cached.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.expose.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.expose.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.cross.origin.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.same.origin.implicit.ports.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.same.origin.implicit.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.same.origin.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.access.control.same.origin.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authority.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authority.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authorization.credentials.basic.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authorization.credentials.basic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authorization.credentials.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.authorization.credentials.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.event.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.event.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.event.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.model.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.override.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.override.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.path.prefix.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.path.prefix.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.path.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.path.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.with.route.header.overrides.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.with.route.header.overrides.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.yaml
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/config/v2/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.methods/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.methods/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.methods/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.methods/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.omitted/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.omitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.omitted/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.omitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.present/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.present/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.present/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.present/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/allow.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/expose.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/expose.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/expose.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/access.control/expose.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/advisory/request.and.flush/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/advisory/request.and.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/advisory/request.and.flush/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/advisory/request.and.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.uri.with.percent.chars/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.uri.with.percent.chars/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.uri.with.percent.chars/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.uri.with.percent.chars/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.version.1.2+/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.version.1.2+/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.version.1.2+/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/request.version.1.2+/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/response.version.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/response.version.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/response.version.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/architecture/response.version.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header.basic/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header.basic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header.basic/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header.basic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/authorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/challenge.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/expire.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/authorization/reauthorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/503.with.retry.after/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/503.with.retry.after/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/503.with.retry.after/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/503.with.retry.after/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.and.reuse/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.and.reuse/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.and.reuse/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.and.reuse/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.with.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.with.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.with.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests.with.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.requests/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/first.pipelined.response.has.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/first.pipelined.response.has.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/first.pipelined.response.has.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/first.pipelined.response.has.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/http.patch.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/http.patch.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/http.patch.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/http.patch.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.same.connection/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.same.connection/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.same.connection/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.same.connection/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.serialized/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.serialized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.serialized/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/multiple.requests.serialized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pending.request.second.request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pending.request.second.request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pending.request.second.request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pending.request.second.request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/backend.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/backend.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.forward.connection.header/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/backend.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/backend.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/proxy.must.not.retry.non.idempotent.requests/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response.with.retry/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response.with.retry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response.with.retry/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response.with.retry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.503.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice.awaiting.barrier/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice.awaiting.barrier/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice.awaiting.barrier/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice.awaiting.barrier/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.twice/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.end/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.end/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.response.with.incomplete.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.upgrade.required.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.upgrade.required.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.upgrade.required.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.and.upgrade.required.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.authority.with.no.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.authority.with.no.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.authority.with.no.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.authority.with.no.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.receive.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.receive.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.receive.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.receive.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.rejected/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.rejected/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.send.abort.after.response.received/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.send.abort.after.response.received/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.send.abort.after.response.received/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.send.abort.after.response.received/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.route.header.overrides/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.route.header.overrides/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.route.header.overrides/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/request.with.route.header.overrides/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.400.and.reset.next.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.400.and.reset.next.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.400.and.reset.next.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.400.and.reset.next.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.content.length.is.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.content.length.is.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.content.length.is.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/response.with.content.length.is.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/backend.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/backend.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/reverse.proxy.connection.established/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/send.end.after.upgrade.request.completed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/send.end.after.upgrade.request.completed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/send.end.after.upgrade.request.completed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/send.end.after.upgrade.request.completed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response.with.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/upgrade.request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.headers.too.long/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.headers.too.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.headers.too.long/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.headers.too.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/request.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.first.fragment.maximum.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.first.fragment.maximum.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.first.fragment.maximum.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.first.fragment.maximum.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.fragmented.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.fragmented.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.fragmented.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.fragmented.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/client.no.response.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/client.no.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/client.response.reset.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/client.response.reset.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/server.no.response.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/server.no.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/server.response.reset.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.too.long/server.response.reset.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.headers.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.content.exceeding.window/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.content.exceeding.window/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.content.exceeding.window/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.content.exceeding.window/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/flow.control/response.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/head.request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/post.request.with.no.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/post.request.with.no.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/post.request.with.no.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/post.request.with.no.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/proxy.should.preserve.unrecognized.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.extra.CRLF.before.request.line/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.extra.CRLF.before.request.line/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.extra.CRLF.before.request.line/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.extra.CRLF.before.request.line/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/request.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/message.format/response.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/redirect/request.redirect/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/redirect/request.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/request.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/invalid.response.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/validation/valid.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.methods/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.methods/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.methods/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.methods/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.omitted/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.omitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.omitted/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.omitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.present/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.present/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.present/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.present/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/allow.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/expose.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/expose.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/expose.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/access.control/expose.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header.basic/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header.basic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header.basic/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header.basic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/authorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/challenge.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/expire.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/authorization/reauthorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/server.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/server.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/server.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/server.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/user.agent.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/user.agent.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/user.agent.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/config/user.agent.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.read.abort.on.open.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/client.sent.write.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.abort/server.sent.write.abort.on.open.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.close.before.response.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.close.before.response.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.close.before.response.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.close.before.response.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/client.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/connection.has.two.streams/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/connection.has.two.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/connection.has.two.streams/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/connection.has.two.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.authority.default.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.authority.default.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.authority.default.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.authority.default.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.get.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.patch.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.patch.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.patch.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.patch.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.prefix/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.prefix/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.prefix/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.prefix/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.with.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.with.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.with.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.path.with.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.before.settings.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.before.settings.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.before.settings.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.before.settings.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.streaming/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.streaming/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.streaming/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange.streaming/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.post.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.push.promise/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.response.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.response.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.response.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.response.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.authority/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.authority/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.authority/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.authority/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.path/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.path/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.path/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/http.unknown.path/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.client.rst.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.client.rst.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.client.rst.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.client.rst.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.server.rst.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.server.rst.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.server.rst.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/ignore.server.rst.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/multiple.data.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/multiple.data.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/multiple.data.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/multiple.data.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/reset.client.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/reset.client.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/reset.client.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/reset.client.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.close.before.response.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.close.before.response.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.close.before.response.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.close.before.response.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.end.stream.before.payload/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.end.stream.before.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.end.stream.before.payload/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.end.stream.before.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.before.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.before.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.before.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.before.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.rst.frame.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.rst.frame.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.rst.frame.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/server.sent.write.rst.frame.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/streams.on.same.connection/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/streams.on.same.connection/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/streams.on.same.connection/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/connection.management/streams.on.same.connection/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.rst.stream.last.frame/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.rst.stream.last.frame/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.rst.stream.last.frame/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.rst.stream.last.frame/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/client.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.rst.stream.last.frame/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.rst.stream.last.frame/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.rst.stream.last.frame/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.rst.stream.last.frame/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/server.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/stream.flow/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/stream.flow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/stream.flow/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/flow.control/stream.flow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.error.frame.with.request.payload/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.error.frame.with.request.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.error.frame.with.request.payload/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.error.frame.with.request.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/client.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/connection.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/continuation.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/continuation.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/continuation.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/continuation.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/dynamic.table.requests/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/dynamic.table.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/dynamic.table.requests/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/dynamic.table.requests/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.zilla.data.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.zilla.data.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.zilla.data.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/max.zilla.data.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/priority.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/priority.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/priority.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/priority.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/request.and.503.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/request.and.503.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/request.and.503.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/request.and.503.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/rst.stream.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/rst.stream.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/rst.stream.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/rst.stream.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.continuation.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.continuation.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.continuation.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.continuation.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/server.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/stream.id.order/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/stream.id.order/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/stream.id.order/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/stream.id.order/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/window.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/window.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/window.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/message.format/window.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/redirect/request.redirect/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/redirect/request.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/settings/client.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/settings/client.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/settings/client.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/settings/client.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.http/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.http/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.https/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.https/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.https/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.https/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.multiple.requests.pipelined/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.multiple.requests.pipelined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.multiple.requests.pipelined/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/starting/upgrade.multiple.requests.pipelined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/invalid.response.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/validation/valid.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.headers.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.methods.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.cross.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.cross.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.cross.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.cross.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.omitted.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.present/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.present/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.present/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.present/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/allow.origin.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/expose.headers.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.header.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.header.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.header.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.header.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.method.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.method.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.method.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.method.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.omitted/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.omitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.omitted/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/access.control/reject.origin.omitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/advisory/request.and.flush/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/advisory/request.and.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/advisory/request.and.flush/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/advisory/request.and.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.header.host.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.header.host.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.header.host.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.header.host.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.percent.chars/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.percent.chars/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.percent.chars/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.percent.chars/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.user.info/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.user.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.user.info/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.uri.with.user.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.1.2+/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.1.2+/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.1.2+/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.1.2+/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.invalid/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.invalid/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.not.1.x/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.not.1.x/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.not.1.x/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/request.version.not.1.x/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/response.version.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/response.version.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/response.version.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/architecture/response.version.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header.basic/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header.basic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header.basic/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header.basic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/authorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/challenge.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/expire.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reauthorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/authorization/reject.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/503.with.retry.after/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/503.with.retry.after/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/503.with.retry.after/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/503.with.retry.after/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.and.reuse/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.and.reuse/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.and.reuse/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.and.reuse/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.connections/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.connections/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.connections/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.requests.different.connections/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/concurrent.upgrade.requests.and.responses.with.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/first.pipelined.response.has.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/first.pipelined.response.has.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/first.pipelined.response.has.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/first.pipelined.response.has.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/http.patch.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/http.patch.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/http.patch.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/http.patch.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined.with.retry/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined.with.retry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined.with.retry/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined.with.retry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.pipelined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.same.connection/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.same.connection/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.same.connection/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/multiple.requests.same.connection/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/partial.request.receive.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/partial.request.receive.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/partial.request.receive.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/partial.request.receive.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pending.request.second.request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pending.request.second.request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pending.request.second.request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pending.request.second.request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.upgrade.required.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.upgrade.required.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.upgrade.required.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.and.upgrade.required.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.mismatch/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.mismatch/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.no.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.no.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.no.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.no.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.authority.with.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.end/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.end/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.incomplete.response.headers.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.end/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.end/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.no.response.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.rejected/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.rejected/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.end/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.end/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.end/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.end/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.response.headers.incomplete.data.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.send.abort.after.response.received/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.send.abort.after.response.received/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.send.abort.after.response.received/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.send.abort.after.response.received/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.route.header.overrides/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.route.header.overrides/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.route.header.overrides/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/request.with.route.header.overrides/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.400.and.reset.next.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.400.and.reset.next.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.400.and.reset.next.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.400.and.reset.next.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.connection.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.connection.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.connection.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.connection.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.content.length.is.reset/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.content.length.is.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.content.length.is.reset/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/response.with.content.length.is.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/send.end.after.upgrade.request.completed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/send.end.after.upgrade.request.completed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/send.end.after.upgrade.request.completed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/send.end.after.upgrade.request.completed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.rejected.when.not.requested/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.rejected.when.not.requested/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.rejected.when.not.requested/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.rejected.when.not.requested/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.abort/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.abort/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.then.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data.and.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response.with.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/upgrade.request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.pipelined.fragmented/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.pipelined.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.pipelined.fragmented/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.pipelined.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.with.content.length.pipelined.fragmented/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.with.content.length.pipelined.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.with.content.length.pipelined.fragmented/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/multiple.requests.with.content.length.pipelined.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.content.length.and.transport.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.content.length.and.transport.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.content.length.and.transport.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.content.length.and.transport.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/request.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.chunked.with.extensions.filling.maximum.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.first.fragment.maximum.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.first.fragment.maximum.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.first.fragment.maximum.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.first.fragment.maximum.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/client.5xx.response.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/client.5xx.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/client.response.reset.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/client.response.reset.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/server.5xx.response.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/server.5xx.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/server.response.reset.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.too.long/server.response.reset.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.headers.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.exceeding.window/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.exceeding.window/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.exceeding.window/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.exceeding.window/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.length.and.transport.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.length.and.transport.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.length.and.transport.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.content.length.and.transport.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.padding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.padding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/flow.control/response.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/head.request.and.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/incomplete.request.with.unimplemented.method/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/incomplete.request.with.unimplemented.method/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/incomplete.request.with.unimplemented.method/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/incomplete.request.with.unimplemented.method/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.missing.target/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.missing.target/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.missing.target/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.missing.target/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.multiple.content.lengths/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.multiple.content.lengths/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.multiple.content.lengths/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.multiple.content.lengths/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.not.http/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.not.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.not.http/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.not.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.space.before.colon.in.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.space.before.colon.in.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.space.before.colon.in.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.space.before.colon.in.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.whitespace.after.start.line/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.whitespace.after.start.line/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.whitespace.after.start.line/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/invalid.request.whitespace.after.start.line/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/on.response.proxy.must.remove.space.in.header.with.space.between.header.name.and.colon/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/post.request.with.no.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/post.request.with.no.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/post.request.with.no.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/post.request.with.no.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.gets.response.with.multiple.content.lengths/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.or.gateway.must.reject.obs.in.header.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/proxy.should.preserve.unrecongnized.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.extra.CRLF.before.request.line/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.extra.CRLF.before.request.line/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.extra.CRLF.before.request.line/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.extra.CRLF.before.request.line/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.header.value.too.long/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.header.value.too.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.header.value.too.long/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.header.value.too.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.obsolete.line.folding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.obsolete.line.folding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.obsolete.line.folding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.obsolete.line.folding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.start.line.too.long/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.start.line.too.long/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.start.line.too.long/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.start.line.too.long/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unimplemented.method/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unimplemented.method/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unimplemented.method/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unimplemented.method/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unknown.transfer.encoding/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unknown.transfer.encoding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unknown.transfer.encoding/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/request.with.unknown.transfer.encoding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.content.length/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.content.length/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.content.length/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.content.length/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.format/response.with.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/firewall.intermediary.should.replace.host.in.via.header.with.pseudonym/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/gateway.must.attach.appropriate.via.header.on.request.and.may.attach.on.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.host.header.should.follow.request.line/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.host.header.should.follow.request.line/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.host.header.should.follow.request.line/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.host.header.should.follow.request.line/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.absolute.form/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.absolute.form/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.absolute.form/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.absolute.form/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.asterick.form.options.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.asterick.form.options.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.asterick.form.options.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.asterick.form.options.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.origin.form/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.origin.form/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.origin.form/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.accept.origin.form/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.does.not.match.uri/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.does.not.match.uri/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.does.not.match.uri/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.does.not.match.uri/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.occurs.more.than.once/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.occurs.more.than.once/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.occurs.more.than.once/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.host.header.occurs.more.than.once/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.missing.host.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.missing.host.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.missing.host.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/inbound.must.reject.request.with.400.if.missing.host.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/intermediary.must.accept.authority.form.connect.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/intermediary.must.accept.authority.form.connect.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/intermediary.must.accept.authority.form.connect.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/intermediary.must.accept.authority.form.connect.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/last.proxy.must.convert.options.in.absolute.form.to.asterick.form/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/last.proxy.must.convert.options.in.absolute.form.to.asterick.form/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/last.proxy.must.convert.options.in.absolute.form.to.asterick.form/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/last.proxy.must.convert.options.in.absolute.form.to.asterick.form/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.attach.appropriate.via.headers.even.when.others/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.modify.query.or.absolute.path.of.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.modify.query.or.absolute.path.of.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.modify.query.or.absolute.path.of.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.modify.query.or.absolute.path.of.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.request.that.contains.a.no.transform.cache.control/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.request.that.contains.a.no.transform.cache.control/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.request.that.contains.a.no.transform.cache.control/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.request.that.contains.a.no.transform.cache.control/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.response.that.contains.a.no.transform.cache.control/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.response.that.contains.a.no.transform.cache.control/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.response.that.contains.a.no.transform.cache.control/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.must.not.transform.the.payload.of.a.response.that.contains.a.no.transform.cache.control/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/proxy.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/proxy.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/message.routing/proxy.should.rewrite.host.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/redirect/request.redirect/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/redirect/request.redirect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/redirect/request.redirect/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/redirect/request.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/invalid.chunked.request.no.crlf.at.end.of.chunk/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/multiple.requests.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked.with.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/request.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked.with.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/transfer.codings/response.transfer.encoding.chunked/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/invalid.response.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/validation/valid.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.headers.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard.cached/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard.cached/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard.cached/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard.cached/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.methods.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.cross.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.cross.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.cross.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.cross.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.omitted.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.present/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.present/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.present/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.present/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.http.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin.implicit.https.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.same.origin/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/allow.origin.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.credentials/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.credentials/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.credentials/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.credentials/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.explicit/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.explicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.explicit/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.explicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.wildcard/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.wildcard/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/expose.headers.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.header.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.header.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.header.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.header.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.method.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.method.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.method.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.method.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.not.allowed/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.not.allowed/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.omitted/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.omitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.omitted/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/access.control/reject.origin.omitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header.basic/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header.basic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header.basic/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header.basic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/authorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/challenge.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/expire.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reauthorize.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.cookie/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.cookie/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.cookie/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.cookie/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.missing/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.missing/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/authorization/reject.credentials.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/server.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/server.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/server.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/server.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/user.agent.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/user.agent.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/user.agent.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/config/user.agent.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.read.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.rst/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.rst/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.rst/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.rst/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/client.sent.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.abort/server.sent.write.abort.on.open.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.close.before.response.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.close.before.response.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.close.before.response.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.close.before.response.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.before.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.before.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.before.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.before.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.open.request.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.open.request.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.open.request.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.rst.stream.on.open.request.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.abort.then.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/client.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.established/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.established/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.has.two.streams/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.has.two.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.has.two.streams/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/connection.has.two.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.authority.default.port/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.authority.default.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.authority.default.port/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.authority.default.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange.with.route.header.overrides/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.get.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.patch.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.patch.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.patch.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.patch.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.prefix/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.prefix/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.prefix/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.prefix/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.with.query/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.with.query/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.with.query/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.path.with.query/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.before.settings.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.before.settings.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.before.settings.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.before.settings.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.streaming/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.streaming/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.streaming/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange.streaming/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.post.exchange/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.header.override/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.header.override/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.header.override/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.header.override/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.none.cacheable.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.none.cacheable.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.none.cacheable.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise.none.cacheable.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.push.promise/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.response.trailer/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.response.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.response.trailer/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.response.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.authority/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.authority/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.authority/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.authority/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.path/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.path/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.path/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/http.unknown.path/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.client.rst.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.client.rst.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.client.rst.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.client.rst.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.server.rst.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.server.rst.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.server.rst.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/ignore.server.rst.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/multiple.data.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/multiple.data.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/multiple.data.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/multiple.data.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.close.before.response.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.close.before.response.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.close.before.response.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.close.before.response.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.end.stream.before.payload/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.end.stream.before.payload/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.end.stream.before.payload/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.end.stream.before.payload/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.before.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.before.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.before.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.before.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.close/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.close/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/server.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/streams.on.same.connection/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/streams.on.same.connection/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/streams.on.same.connection/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/connection.management/streams.on.same.connection/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.rst.stream.last.frame/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.rst.stream.last.frame/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.rst.stream.last.frame/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.rst.stream.last.frame/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.stream.flow/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.stream.flow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.stream.flow/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/client.stream.flow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.rst.stream.last.frame/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.rst.stream.last.frame/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.rst.stream.last.frame/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.rst.stream.last.frame/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.stream.flow/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.stream.flow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.stream.flow/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/flow.control/server.stream.flow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.connection.window.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.connection.window.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.connection.window.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.connection.window.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.invalid.hpack.index/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.invalid.hpack.index/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.invalid.hpack.index/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.invalid.hpack.index/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.ping.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.ping.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.ping.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.ping.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.priority.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.priority.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.priority.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.priority.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.rst.stream.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.rst.stream.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.rst.stream.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.rst.stream.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.window.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.window.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.window.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/client.window.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.headers/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.headers/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.window.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.window.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.window.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/connection.window.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/continuation.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/continuation.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/continuation.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/continuation.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/dynamic.table.requests/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/dynamic.table.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/dynamic.table.requests/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/dynamic.table.requests/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/invalid.hpack.index/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/invalid.hpack.index/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/invalid.hpack.index/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/invalid.hpack.index/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.zilla.data.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.zilla.data.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.zilla.data.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/max.zilla.data.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/ping.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/ping.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/ping.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/ping.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/priority.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/priority.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/priority.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/priority.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/rst.stream.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/rst.stream.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/rst.stream.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/rst.stream.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.continuation.frames/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.continuation.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.continuation.frames/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.continuation.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/server.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/stream.id.order/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/stream.id.order/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/stream.id.order/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/stream.id.order/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/window.frame.size.error/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/window.frame.size.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/window.frame.size.error/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/message.format/window.frame.size.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/redirect/request.redirect/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/redirect/request.redirect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/redirect/request.redirect/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/redirect/request.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/client.max.frame.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/client.max.frame.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/client.max.frame.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/client.max.frame.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.concurrent.streams/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.concurrent.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.concurrent.streams/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.concurrent.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.header.list.size/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.header.list.size/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.header.list.size/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/settings/max.header.list.size/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.extra.settings/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.extra.settings/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.extra.settings/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.extra.settings/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.multiple.requests.pipelined/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.multiple.requests.pipelined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.multiple.requests.pipelined/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.multiple.requests.pipelined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.settings/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.tls/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.tls/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.tls/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.no.tls/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.h2/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.h2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.h2/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.h2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.http1.1/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.http1.1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.http1.1/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.alpn.http1.1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.no.alpn/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.no.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.no.alpn/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.h2c.with.tls.and.no.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.no.tls/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.no.tls/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.no.tls/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.no.tls/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.h2/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.h2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.h2/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.h2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.http1.1/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.http1.1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.http1.1/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.alpn.http1.1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.no.alpn/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.no.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.no.alpn/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/starting/upgrade.pri.with.tls.and.no.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.content/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.content/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.content/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.content/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.header/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.header/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/invalid.response.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.request/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.request/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.request/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.request/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/validation/valid.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/config/SchemaTest.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctionsTest.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/internal/HttpFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AccessControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AdvisoryIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ArchitectureIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ArchitectureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AuthorizationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/FlowControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/TransferCodingsIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/TransferCodingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ValidationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AbortIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AccessControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AuthorizationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ConfigIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/FlowControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/SettingsIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/SettingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/StartingIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/StartingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ValidationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7540/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AccessControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AdvisoryIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ArchitectureIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ArchitectureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AuthorizationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/FlowControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/RedirectIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/RedirectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/TransferCodingsIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/TransferCodingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ValidationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AbortIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AbortIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AccessControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AccessControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AuthorizationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/AuthorizationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ConfigIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ConnectionManagementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/FlowControlIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/MessageFormatIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/MessageFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/RedirectIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/RedirectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/SettingsIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/SettingsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/StartingIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/StartingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ValidationIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7540/ValidationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka-grpc.spec/src/main/moditect/module-info.java
+++ b/specs/binding-kafka-grpc.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/config/remote.server.rpc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/bidi.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/bidi.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/bidi.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/bidi.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.sent.write.abort/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.sent.write.abort/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/client.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/retry.on.unavailable.server/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/retry.on.unavailable.server/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/retry.on.unavailable.server/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/retry.on.unavailable.server/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/server.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/server.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/server.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/server.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc.message.value.100k/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc.message.value.100k/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/grpc/unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/bidi.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/bidi.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/bidi.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/bidi.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.sent.write.abort/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.sent.write.abort/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/client.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/missing.service.and.method.headers/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/missing.service.and.method.headers/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/missing.service.and.method.headers/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/missing.service.and.method.headers/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/server.stream.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/server.stream.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/server.stream.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/server.stream.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc.message.value.100k/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc.message.value.100k/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc/client.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc/server.rpt
+++ b/specs/binding-kafka-grpc.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/grpc/streams/kafka/unary.rpc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/grpc/internal/streams/GrpcIT.java
+++ b/specs/binding-kafka-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/grpc/internal/streams/GrpcIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/grpc/internal/streams/KafkaIT.java
+++ b/specs/binding-kafka-grpc.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/grpc/internal/streams/KafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctions.java
+++ b/specs/binding-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/moditect/module-info.java
+++ b/specs/binding-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/resources/META-INF/zilla/kafka.idl
+++ b/specs/binding-kafka.spec/src/main/resources/META-INF/zilla/kafka.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.client.options.validate.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.client.options.validate.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.bootstrap.live.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.bootstrap.live.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.bootstrap.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.bootstrap.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.convert.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.convert.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.delta.type.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.delta.type.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.headers.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.headers.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.key.and.headers.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.key.and.headers.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.key.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.extract.key.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.live.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.live.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.merged.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.merged.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.parameterized.topic.validate.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.parameterized.topic.validate.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.validate.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.options.validate.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.when.topic.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.when.topic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.api.version.rejected.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.api.version.rejected.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.cluster.authorization.failed.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.cluster.authorization.failed.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.sasl.authentication.failed.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.sasl.authentication.failed.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.topic.authorization.failed.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.event.topic.authorization.failed.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.merged.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.merged.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.plain.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.plain.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.scram.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.scram.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.when.topic.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.when.topic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.when.topics.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.when.topics.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/alter.configs/alter.topics.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/alter.configs/alter.topics.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/alter.configs/alter.topics.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/alter.configs/alter.topics.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/group.fetch.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/group.fetch.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/group.fetch.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/group.fetch.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/partition.offsets.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/partition.offsets.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/partition.offsets.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/partition.offsets.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/unmerged.group.fetch.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/unmerged.group.fetch.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/unmerged.group.fetch.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/bootstrap/unmerged.group.fetch.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/acknowledge.message.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/acknowledge.message.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/acknowledge.message.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/acknowledge.message.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/commit.acknowledge.message.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/commit.acknowledge.message.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/commit.acknowledge.message.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/commit.acknowledge.message.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/partition.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/partition.assignment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/partition.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/partition.assignment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/reassign.new.topic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/reassign.new.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/reassign.new.topic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/consumer/reassign.new.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/create.topics/create.topics/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/create.topics/create.topics/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/create.topics/create.topics/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/create.topics/create.topics/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/delete.topics/delete.topics/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/delete.topics/delete.topics/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/delete.topics/delete.topics/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/delete.topics/delete.topics/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.partial/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.partial/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.partial/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.partial/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.synonyms/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.synonyms/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.synonyms/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info.synonyms/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.config.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe/topic.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.tombstone/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.tombstone/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.tombstone/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.message.with.tombstone/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.tombstone/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.tombstone/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.tombstone/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compact.tombstone.with.tombstone/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.tombstone/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.tombstone/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.tombstone/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.message.with.tombstone/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.tombstone/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.tombstone/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.tombstone/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/compacted.tombstone.with.tombstone/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change.none/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change.none/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.change/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.extracted.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.extracted.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.extracted.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.extracted.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.and.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.and.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.and.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.and.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.json.patch/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.json.patch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.json.patch/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.json.patch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header.eager/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header.eager/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header.eager/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header.eager/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header.or.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.eager/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.eager/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.eager/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.eager/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.empty/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.empty/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.many/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one.empty/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one.empty/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.one/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.many/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.many/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.many/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.many/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.one/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.one/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.one/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.one/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.two/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.two/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.two/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.headers.skip.two/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.json.patch/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.json.patch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.json.patch/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.json.patch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.or.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.or.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.or.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header.or.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.not.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.not.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.not.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.and.not.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header.and.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header.and.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header.and.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header.and.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key.or.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json.patch/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json.patch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json.patch/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json.patch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none.json/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.not.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync.with.data/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync.with.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync.with.data/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync.with.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/follow.message.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/follow.message.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/follow.message.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/follow.message.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/followed.message.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/followed.message.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/followed.message.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/followed.message.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborting/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborting/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborting/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.aborting/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.committing/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.committing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.committing/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed.committing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.committed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborting/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborting/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborting/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.aborting/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.committing/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.committing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.committing/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/isolation.read.uncommitted.committing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.headers.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.json.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.json.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.json.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.json.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.extracted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.extracted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.extracted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.extracted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key.with.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.empty/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.empty/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/messages.after.retention.max/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/messages.after.retention.max/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/messages.after.retention.max/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/messages.after.retention.max/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/no.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/no.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/no.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/no.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.not.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.not.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.not.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.not.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.latest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.latest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.latest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.latest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.zero/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.zero/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.zero/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset.zero/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.missing/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.missing/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.not.routed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.not.routed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/topic.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.read.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.read.abort.after.sync.group.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.read.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.read.abort.after.sync.group.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.join.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.join.group.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.join.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.join.group.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.sync.group.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.after.sync.group.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.before.coordinator.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.before.coordinator.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.before.coordinator.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/client.sent.write.abort.before.coordinator.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/group.authorization.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/group.authorization.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/group.authorization.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/group.authorization.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/ignore.heartbeat.before.handshake/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/ignore.heartbeat.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/ignore.heartbeat.before.handshake/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/ignore.heartbeat.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config.cluster.authorization.error/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config.cluster.authorization.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config.cluster.authorization.error/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config.cluster.authorization.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.describe.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.session.timeout/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.session.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.session.timeout/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/invalid.session.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/leader.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/leader.assignment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/leader.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/leader.assignment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/multiple.find.coordinator.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/multiple.find.coordinator.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/multiple.find.coordinator.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/multiple.find.coordinator.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/partition.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/partition.assignment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/partition.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/partition.assignment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/reassign.new.topic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/reassign.new.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/reassign.new.topic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/reassign.new.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.multiple.members.with.same.group.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.multiple.members.with.same.group.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.multiple.members.with.same.group.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.multiple.members.with.same.group.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander.migrate.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.highlander/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.protocol.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.sync.group/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.sync.group/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.sync.group/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/rebalance.sync.group/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/server.sent.read.abort.after.join.group/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/server.sent.read.abort.after.join.group/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/server.sent.read.abort.after.join.group/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/server.sent.read.abort.after.join.group/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/topics.partition.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/topics.partition.assignment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/topics.partition.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/group/topics.partition.assignment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/init.producer.id/produce.new.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/init.producer.id/produce.new.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/init.producer.id/produce.new.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/init.producer.id/produce.new.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.historical/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.historical/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.historical/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.historical/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.live/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.live/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.live/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.age.live/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.change/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.change/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.change/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.change/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.and.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.and.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.and.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.and.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.or.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.or.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.or.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.or.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.with.compaction/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.with.compaction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.with.compaction/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header.with.compaction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many.empty/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many.empty/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.many/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one.empty/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one.empty/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.one/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.many/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.many/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.many/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.many/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.one/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.one/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.one/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.one/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.two/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.two/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.two/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.headers.skip.two/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.not.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.not.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.not.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.and.not.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header.eager/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header.eager/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header.eager/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header.eager/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key.or.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none.read.uncommitted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none.read.uncommitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none.read.uncommitted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none.read.uncommitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.not.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.sync/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.sync/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.from.parameterized.topic.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.isolation.read.committed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.isolation.read.committed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.isolation.read.committed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.isolation.read.committed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.ack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.convert/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.convert/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.convert/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.convert/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.values/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.values/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.values/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.message.values/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.aborted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.aborted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.leader.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest.overflow/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest.overflow/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.latest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.latest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.latest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.partition.offsets.latest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.unsubscribe/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.unsubscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.unsubscribe/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.fetch.unsubscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.invalid.partition/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.invalid.partition/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.invalid.partition/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.invalid.partition/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.group.produce.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.and.fetch.get.cleanup.policy/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.and.fetch.get.cleanup.policy/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.and.fetch.get.cleanup.policy/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.and.fetch.get.cleanup.policy/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic.hashed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic.hashed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic.hashed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic.hashed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.flags.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.flags.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.partition.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.partition.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.partition.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.partition.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hash.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hash.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hash.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hash.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hashed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hashed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hashed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic.hashed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/merged.produce.message.values/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.age.historical/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.age.historical/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.age.historical/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.age.historical/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.change/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.change/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.change/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.change/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none.with.compaction/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none.with.compaction/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none.with.compaction/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none.with.compaction/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.sync/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.sync/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.from.parameterized.topic.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.convert/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.convert/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.convert/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.convert/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values.live/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values.live/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values.live/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values.live/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.message.values/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.aborted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.aborted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.leader.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.latest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.latest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.latest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.partition.offsets.latest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset.and.abort.with.message/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset.and.abort.with.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset.and.abort.with.message/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset.and.abort.with.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.assignment.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.assignment.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.assignment.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.assignment.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.ack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.unsubscribe/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.unsubscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.unsubscribe/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.fetch.unsubscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.invalid.partition/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.invalid.partition/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.invalid.partition/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.invalid.partition/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.group.produce.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.and.fetch.get.cleanup.policy/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.and.fetch.get.cleanup.policy/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.and.fetch.get.cleanup.policy/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.and.fetch.get.cleanup.policy/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic.hashed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic.hashed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic.hashed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic.hashed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.flags.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.flags.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.flags.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.flags.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.partition.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.partition.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.partition.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.partition.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.valid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.valid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.value.valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hash.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hash.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hash.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hash.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hashed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hashed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hashed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic.hashed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.produce.message.values/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/sasl.authentication.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/sasl.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/sasl.authentication.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/sasl.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.authorization.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.authorization.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.authorization.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.authorization.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.partition.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unreachable/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unreachable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unreachable/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/meta/topic.unreachable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offsets/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offsets/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offsets/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.topic.partition.offsets/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.unknown.topic.partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.unknown.topic.partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.unknown.topic.partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.commit/update.unknown.topic.partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.no.partition/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.no.partition/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.no.partition/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/offset.fetch/topic.offset.no.partition/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/idle.no.error.reconnect.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/idle.no.error.reconnect.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/idle.no.error.reconnect.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/idle.no.error.reconnect.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.empty.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.empty.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.empty.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.empty.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.headers.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key.with.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.null.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.null.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.null.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.null.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailer/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailer/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailers.overlap/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailers.overlap/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailers.overlap/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.trailers.overlap/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.rejected/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.rejected/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated.fragmented/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated.fragmented/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.sequential/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.sequential/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.sequential/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.100k.sequential/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.changes/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.changes/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.changes/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.changes/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.replay/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.replay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.replay/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id.replay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.rejected/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.rejected/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.sequential/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.sequential/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.sequential/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.sequential/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/messages.fragmented.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/messages.fragmented.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/messages.fragmented.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/messages.fragmented.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.not.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/partition.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.missing/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.missing/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.not.routed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.not.routed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/topic.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1.sasl.handshake.v1/alter.topics.config.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1/alter.topics.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1/alter.topics.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1/alter.topics.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/alter.configs.v1/alter.topics.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3.sasl.handshake.v1/create.topics.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3/create.topics/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3/create.topics/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3/create.topics/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/create.topics.v3/create.topics/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3.sasl.handshake.v1/delete.topics.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3/delete.topics/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3/delete.topics/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3/delete.topics/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/delete.topics.v3/delete.topics/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0/cluster.brokers.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0/cluster.brokers.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0/cluster.brokers.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0/cluster.brokers.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1.sasl.handshake.v1/topic.config.info.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.partial/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.partial/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.partial/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.partial/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.synonyms/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.synonyms/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.synonyms/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info.synonyms/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.config.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.configs.v1/topic.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5.sasl.handshake.v1/partition.offset.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.none/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.none/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.none/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.none/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.sync/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.sync/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.committed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.committed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.committed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.committed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborting/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborting/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborting/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.aborting/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.committing/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.committing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.committing/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/isolation.read.uncommitted.committing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.headers.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key.with.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/no.message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/no.message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/no.message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/no.message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.leader.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.leader.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.leader.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.leader.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.not.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.not.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.not.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.not.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.latest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.latest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.latest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.latest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.zero/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.zero/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.zero/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset.zero/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/fetch.v5/partition.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.read.abort.after.sync.group.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.after.sync.group.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.before.coordinator.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.before.coordinator.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.before.coordinator.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/client.sent.write.abort.before.coordinator.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.not.available/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/coordinator.reject.invalid.consumer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/group.authorization.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/group.authorization.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/group.authorization.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/group.authorization.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/ignore.heartbeat.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/initial.delay.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config.cluster.authorization.error/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config.cluster.authorization.error/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config.cluster.authorization.error/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config.cluster.authorization.error/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.describe.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/invalid.session.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/multiple.find.coordinator.response/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/multiple.find.coordinator.response/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/multiple.find.coordinator.response/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/multiple.find.coordinator.response/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.multiple.members.with.same.group.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.fragmented/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.fragmented/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.heartbeat.unknown.member/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader.in.parallel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.migrate.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander.unknown.member.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.highlander/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.protocol.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/rebalance.sync.group/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.f1.j5.s3.l3.h3/topics.partition.assignment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/initial.delay.config.with.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/group.sasl.f1.j5.s3.l3.h3.handshake.v1/leader.assignment.with.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4.sasl.handshake.v1/produce.new.id.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4/produce.new.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4/produce.new.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4/produce.new.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/init.producer.id.v4/produce.new.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/sasl.authentication.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/sasl.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/sasl.authentication.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/sasl.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5.sasl.handshake.v1/topic.partition.info.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.authorization.failed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.authorization.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.authorization.failed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.authorization.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.invalid/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.invalid/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.changed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.changed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.partition.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/metadata.v5/topic.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7.sasl.handshake.v1/update.topic.partition.offset.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offsets/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offsets/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offsets/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.topic.partition.offsets/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.unknown.topic.partition.offset/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.unknown.topic.partition.offset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.unknown.topic.partition.offset/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.commit.v7/update.unknown.topic.partition.offset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5.sasl.handshake.v1/topic.offset.info.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info.incomplete/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info.incomplete/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info.incomplete/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info.incomplete/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.info/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.no.partition/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.no.partition/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.no.partition/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/offset.fetch.v5/topic.offset.no.partition/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.scram/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.scram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.scram/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3.sasl.handshake.v1/message.value.sasl.scram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.empty.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.empty.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.empty.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.empty.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.headers.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.header/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.header/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.header/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.header/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key.with.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.null.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.null.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.null.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.null.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.repeated/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.repeated/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.value/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.changes/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.changes/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.changes/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.changes/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.replay/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.replay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.replay/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id.replay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.producer.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.sequential/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.sequential/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.sequential/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/message.values.sequential/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/messages.fragmented.crc/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/messages.fragmented.crc/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/messages.fragmented.crc/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/messages.fragmented.crc/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.not.leader/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.not.leader/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.not.leader/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.not.leader/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/produce.v3/partition.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/sasl.handshake.v1/mechanism.plain/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/sasl.handshake.v1/mechanism.plain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/sasl.handshake.v1/mechanism.plain/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/sasl.handshake.v1/mechanism.plain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.committed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.committed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.committed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.committed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.uncommitted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.uncommitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.uncommitted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.none.read.uncommitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.sync/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.sync/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.sync/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.filter.sync/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.committed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.committed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.committed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.committed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.uncommitted/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.uncommitted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.uncommitted/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.message.values.read.uncommitted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.partition.offsets.earliest/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.partition.offsets.earliest/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.partition.offsets.earliest/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.fetch.partition.offsets.earliest/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.100k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.100k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.10k/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.10k/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.value.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic.hashed/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic.hashed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic.hashed/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic.hashed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.null/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.null/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/unmerged.p3.f5.d1.m5/unmerged.produce.message.values/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/config/SchemaTest.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctionsTest.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/internal/KafkaFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/AlterConfigsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/AlterConfigsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/BootstrapIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/BootstrapIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ConsumerIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ConsumerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/CreateTopicsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/CreateTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DeleteTopicsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DeleteTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeClusterIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/FetchIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/FetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/GroupIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/GroupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/InitProducerIdIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/InitProducerIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MergedIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MergedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MetaIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MetaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/OffsetCommitIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/OffsetCommitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/OffsetFetchIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/OffsetFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/AlterConfigsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/AlterConfigsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/AlterConfigsSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/AlterConfigsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/CreateTopicsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/CreateTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/CreateTopicsSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/CreateTopicsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DeleteTopicsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DeleteTopicsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DeleteTopicsSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DeleteTopicsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeConfigsIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeConfigsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeConfigsSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeConfigsSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/FetchIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/FetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/FetchSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/FetchSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/GroupIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/GroupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/GroupSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/GroupSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/InitProducerIdIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/InitProducerIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/InitProducerIdSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/InitProducerIdSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/MetadataIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/MetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/MetadataSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/MetadataSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetCommitIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetCommitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetCommitSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetCommitSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetFetchIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetFetchIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetFetchSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/OffsetFetchSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/ProduceIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/ProduceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/ProduceSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/ProduceSaslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/UnmergedIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/UnmergedIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
+++ b/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/moditect/module-info.java
+++ b/specs/binding-mcp.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.multi.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/server.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.evict/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.keepalive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.open/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.duplicate/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.unsupported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.prompts.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.resources.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.ping/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspend.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.suspended.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.before.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.array/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.params.before.method/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.elicit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.evict/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.keepalive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.open/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.session.unknown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.unsupported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.prompts.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.resources.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.notify.tools.list.changed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.ping/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.requests/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspend.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.suspended.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.events/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.get/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/prompts.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.accept.unsupported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.auth.callback.unknown.elicitation/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.auth.callback.unknown.elicitation/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.auth.callback.unknown.elicitation/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.auth.callback.unknown.elicitation/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.method.not.allowed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.before.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.read/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined.proxied/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.declined/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.resume/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspend/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress.suspended/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.with.progress/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.aborted/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list.canceled/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.list/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/kafka/internal/MqttKafkaFunctions.java
+++ b/specs/binding-mqtt-kafka.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/kafka/internal/MqttKafkaFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/moditect/module-info.java
+++ b/specs/binding-mqtt-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/resources/META-INF/zilla/mqtt_kafka.idl
+++ b/specs/binding-mqtt-kafka.spec/src/main/resources/META-INF/zilla/mqtt_kafka.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.log.event.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.log.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.options.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.options.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.publish.qos.max.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.publish.qos.max.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.client.topic.space.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.client.topic.space.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.invalid.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.with.messages.params.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.with.messages.params.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.with.messages.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.publish.topic.with.messages.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.invalid.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.with.messages.params.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.with.messages.params.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.with.messages.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.subscribe.topic.with.messages.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.topic.valid.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.when.topic.valid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.yaml
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.10k/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.10k/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.client.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.empty.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.empty.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.empty.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.empty.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.mixture.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.mixture.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.clients/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.clients/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.clients/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.clients/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.messages/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.messages/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.multiple.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.changed.topic.name/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.changed.topic.name/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.changed.topic.name/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.changed.topic.name/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.resolve.topic.params/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.resolve.topic.params/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.resolve.topic.params/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message.resolve.topic.params/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.init.producer.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.init.producer.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.init.producer.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.init.producer.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.meta.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.meta.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.meta.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.meta.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.commit.abort.phase2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.fetch.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.fetch.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.fetch.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.offset.fetch.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.recovery/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.recovery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.recovery/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.recovery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.retained/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.retained/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.large.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.large.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.large.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.large.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.reject.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.10k/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.10k/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space.with.params/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space.with.params/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space.with.params/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space.with.params/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.distinct/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.distinct/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.repeated/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.repeated/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.properties.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.property/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.property/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/publish.with.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.expire.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.expire.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.expire.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.expire.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.abort.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.cancel.session.expiry/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.cancel.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.cancel.session.expiry/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.cancel.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.takeover/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.takeover/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.client.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.close.expire.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.close.expire.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.close.expire.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.close.expire.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.max.session.expiry/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.max.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.max.session.expiry/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.max.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.min.session.expiry/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.min.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.min.session.expiry/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.connect.override.min.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.exists.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.exists.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.exists.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.exists.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.expiry.after.signal.stream.restart/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.expiry.after.signal.stream.restart/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.expiry.after.signal.stream.restart/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.expiry.after.signal.stream.restart/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.describe.config/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.describe.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.describe.config/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.describe.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.session.timeout/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.session.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.session.timeout/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.invalid.session.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.not.authorized/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.not.authorized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.not.authorized/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.reset.not.authorized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.group.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.redirect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.redirect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.redirect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.reject.non.compacted.sessions.topic/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.reject.non.compacted.sessions.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.reject.non.compacted.sessions.topic/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.reject.non.compacted.sessions.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.session.expiry.fragmented/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.session.expiry.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.session.expiry.fragmented/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.session.expiry.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.unsubscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.cancel.delivery/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.cancel.delivery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.cancel.delivery/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.cancel.delivery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.takeover.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.takeover.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.takeover.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.takeover.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.abort.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.abort.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.abort.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.abort.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.end.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.end.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.end.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.end.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.reset.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.reset.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.reset.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.stream.reset.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.abort.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.abort.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.abort.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.abort.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.end.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.end.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.end.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.end.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.reset.reconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.reset.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.reset.reconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.bootstrap.stream.reset.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.client.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.deferred.filter.change.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.deferred.filter.change.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.deferred.filter.change.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.deferred.filter.change.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message.fragmented/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message.fragmented/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.expire.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.buffer/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.buffer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.buffer/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.buffer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.resubscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.resubscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.resubscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain.resubscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.filter.change.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.multiple.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.multiple.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.multiple.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.multiple.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.changed.topic.name/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.changed.topic.name/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.changed.topic.name/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.changed.topic.name/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.fragmented/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.fragmented/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.resolve.topic.params/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.resolve.topic.params/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.resolve.topic.params/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.resolve.topic.params/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.user.properties.unaltered/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.user.properties.unaltered/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.user.properties.unaltered/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message.user.properties.unaltered/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.publish.no.local/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.publish.no.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.publish.no.local/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.publish.no.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.qos2.version1.offset.metadata/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.qos2.version1.offset.metadata/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.qos2.version1.offset.metadata/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.qos2.version1.offset.metadata/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.overlapping.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1.published.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1.published.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1.published.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1.published.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.message.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.messages.mixture.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.messages.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.messages.mixture.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.receive.messages.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.replay.retained.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain.fragmented/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain.fragmented/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.retained.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.flush/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.flush/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.two.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.two.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.two.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filter.two.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.both.exact/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.both.exact/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.both.exact/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.both.exact/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.overlapping.wildcards/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.overlapping.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.overlapping.wildcards/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.filters.overlapping.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/subscribe.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.topic.filter.single/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.topic.filter.single/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.topic.filter.single/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/unsubscribe.topic.filter.single/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.10k/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.10k/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.client.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.empty.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.empty.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.empty.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.empty.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.mixture.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.mixture.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.clients/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.clients/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.clients/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.clients/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.messages/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.messages/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.multiple.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.one.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.one.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.offset.commit.abort.phase2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.recovery/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.recovery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.recovery/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.recovery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.retained/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.retained/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.large.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.large.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.large.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.large.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.reject.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.10k/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.10k/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space.with.params/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space.with.params/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space.with.params/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space.with.params/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.distinct/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.distinct/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.repeated/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.repeated/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.properties.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.property/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.property/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/publish.with.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.expire.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.expire.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.expire.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.expire.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.abort.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.takeover/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.takeover/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.client.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.close.expire.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.close.expire.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.close.expire.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.close.expire.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.max.session.expiry/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.max.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.max.session.expiry/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.max.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.min.session.expiry/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.min.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.min.session.expiry/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.connect.override.min.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.exists.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.exists.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.exists.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.exists.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.describe.config/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.describe.config/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.describe.config/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.describe.config/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.session.timeout/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.session.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.session.timeout/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.invalid.session.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.not.authorized/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.not.authorized/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.not.authorized/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.group.reset.not.authorized/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.redirect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.redirect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.redirect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.redirect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.reject.non.compacted.sessions.topic/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.reject.non.compacted.sessions.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.reject.non.compacted.sessions.topic/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.reject.non.compacted.sessions.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.unsubscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.10k.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.10k.abort.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.10k.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.10k.abort.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.abort.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.normal.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.normal.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.takeover.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.takeover.deliver.will/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.takeover.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.takeover.deliver.will/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.client.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.deferred.filter.change.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.deferred.filter.change.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.deferred.filter.change.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.deferred.filter.change.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.expire.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.expire.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.expire.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.expire.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain.resubscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain.resubscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain.resubscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain.resubscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.filter.change.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.multiple.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.multiple.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.multiple.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.multiple.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.user.properties.unaltered/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.user.properties.unaltered/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.user.properties.unaltered/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message.user.properties.unaltered/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.publish.no.local/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.publish.no.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.publish.no.local/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.publish.no.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.qos2.version1.offset.metadata/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.qos2.version1.offset.metadata/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.qos2.version1.offset.metadata/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.qos2.version1.offset.metadata/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.overlapping.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1.published.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1.published.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1.published.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1.published.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.message.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.messages.mixture.qos/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.messages.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.messages.mixture.qos/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.receive.messages.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos1/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos1/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos2/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos2/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.replay.retained.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain.as.published/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain.as.published/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.flush/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.flush/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.retained.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.flush/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.flush/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.reset/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.reset/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.two.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.two.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.two.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filter.two.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.both.exact/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.both.exact/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.both.exact/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.both.exact/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.overlapping.wildcards/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.overlapping.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.overlapping.wildcards/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.filters.overlapping.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.space/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.space/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.space/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/subscribe.topic.space/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.topic.filter.single/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.topic.filter.single/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.topic.filter.single/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/unsubscribe.topic.filter.single/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/config/SchemaTest.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/internal/MqttKafkaFunctionsTest.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/internal/MqttKafkaFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-mqtt.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctions.java
+++ b/specs/binding-mqtt.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/moditect/module-info.java
+++ b/specs/binding-mqtt.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/resources/META-INF/zilla/mqtt.idl
+++ b/specs/binding-mqtt.spec/src/main/resources/META-INF/zilla/mqtt.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.credentials.password.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.credentials.password.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.credentials.username.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.credentials.username.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.when.topic.or.sessions.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.when.topic.or.sessions.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.when.topic.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.when.topic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.password.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.password.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.username.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.username.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.log.event.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.log.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.protocol.version.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.protocol.version.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.route.non.default.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.route.non.default.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.user.properties.validator.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.user.properties.validator.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.validator.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.validator.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.publish.topic.invalid.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.publish.topic.invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.subscribe.topic.invalid.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.subscribe.topic.invalid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.params.attribute.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.params.attribute.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.params.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.params.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.valid.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.when.topic.valid.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.close/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.close/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/client.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.delegate.connack.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.delegate.connack.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.delegate.connack.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.delegate.connack.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.exceeded/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.exceeded/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.server.ignores.exceeding.publish.packet/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.server.ignores.exceeding.publish.packet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.server.ignores.exceeding.publish.packet/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.max.packet.size.server.ignores.exceeding.publish.packet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.maximum.qos.0/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.maximum.qos.0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.maximum.qos.0/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.maximum.qos.0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.non.successful.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.reject.will.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.reject.will.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.reject.will.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.reject.will.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/disconnect.after.subscribe.and.publish/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/disconnect.after.subscribe.and.publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/disconnect.after.subscribe.and.publish/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/disconnect.after.subscribe.and.publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.10k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.10k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.retained.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.retained.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.retained.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.empty.retained.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.message.with.topic.alias/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.message.with.topic.alias/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.message.with.topic.alias/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.message.with.topic.alias/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.distinct/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.distinct/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.invalid.scope/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.invalid.scope/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.invalid.scope/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.invalid.scope/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.replaced/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.replaced/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.replaced/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.messages.with.topic.alias.replaced/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.clients/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.clients/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.clients/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.clients/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages.timeout/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages.timeout/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.multiple.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.one.message.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.one.message.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.one.message.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.one.message.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos1.dup.after.puback/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos1.dup.after.puback/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos1.dup.after.puback/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos1.dup.after.puback/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.ack.with.reasoncode/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.ack.with.reasoncode/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.ack.with.reasoncode/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.ack.with.reasoncode/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.no.dupicate.before.pubrel/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.no.dupicate.before.pubrel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.no.dupicate.before.pubrel/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.no.dupicate.before.pubrel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.recovery/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.recovery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.recovery/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.qos2.recovery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.large.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.large.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.large.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.large.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.qos.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.qos.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.qos.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.qos.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.reject.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained.multiple.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained.multiple.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained.multiple.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained.multiple.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.session.takeover/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.session.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.session.takeover/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.session.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.subscribe.batched/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.subscribe.batched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.subscribe.batched/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.subscribe.batched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.user.property/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.user.property/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.valid.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.distinct/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.distinct/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.properties.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.property/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.property/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/publish.with.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.abort.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.abort.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.abort.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.abort.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.client.takeover/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.client.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.client.takeover/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.client.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.authorization/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.authorization/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.override.session.expiry/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.override.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.override.session.expiry/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.override.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.redirect.support/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.redirect.support/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.redirect.support/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.redirect.support/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.with.session.expiry/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.with.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.with.session.expiry/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect.with.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.exists.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.exists.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.exists.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.exists.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.after.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.after.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.after.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.after.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.before.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.before.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.before.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.invalid.session.timeout.before.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.publish/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.publish/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.reject.non.compacted.sessions.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.reject.non.compacted.sessions.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.reject.non.compacted.sessions.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.reject.non.compacted.sessions.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.after.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.after.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.after.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.after.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.before.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.before.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.before.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.redirect.before.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.sent.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.sent.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.invalid.state/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.invalid.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.invalid.state/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.invalid.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.multiple.isolated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.multiple.isolated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.multiple.isolated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.multiple.isolated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.publish.routing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.publish.routing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.publish.routing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.publish.routing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe.deferred/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe.deferred/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe.deferred/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe.deferred/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.unsubscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.10k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.10k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.normal.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.normal.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.retain/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.retain/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.get.retained.as.published/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.get.retained.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.get.retained.as.published/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.get.retained.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.user.properties.unaltered/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.user.properties.unaltered/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.user.properties.unaltered/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message.user.properties.unaltered/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.invalid.affinity/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.invalid.affinity/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.invalid.affinity/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.invalid.affinity/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.no.local/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.no.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.no.local/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.publish.no.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.publish.retained.no.replay/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.publish.retained.no.replay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.publish.retained.no.replay/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.publish.retained.no.replay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.replay.retained.no.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.replay.retained.no.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.replay.retained.no.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.qos0.replay.retained.no.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.overlapping.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos0.published.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1.published.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1.published.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1.published.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1.published.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.topic.alias.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.topic.alias.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.topic.alias.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.receive.messages.topic.alias.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.publish.no.subscription/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.publish.no.subscription/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.publish.no.subscription/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.publish.no.subscription/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.shared.subscriptions.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.shared.subscriptions.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.shared.subscriptions.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.shared.subscriptions.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.subscription.ids.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.subscription.ids.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.subscription.ids.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.subscription.ids.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.wildcard.subscriptions.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.wildcard.subscriptions.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.wildcard.subscriptions.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.reject.wildcard.subscriptions.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1.v4/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1.v4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1.v4/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1.v4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2.v4/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2.v4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2.v4/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2.v4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.replay.retained.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.retain.as.published/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.retain.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.retain.as.published/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.retain.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.two.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.two.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.two.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filter.two.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.disjoint.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.disjoint.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.disjoint.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.disjoint.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.both.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.overlapping.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.overlapping.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.overlapping.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.filters.overlapping.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/subscribe.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.publish.unfragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.publish.unfragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.publish.unfragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.publish.unfragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filter.single/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filter.single/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filter.single/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filter.single/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/unsubscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.close/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.close/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.reset/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.reset/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/close.network.after.keep.alive.timeout/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/close.network.after.keep.alive.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/close.network.after.keep.alive.timeout/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/close.network.after.keep.alive.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.protocol.version/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.protocol.version/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.protocol.version/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.invalid.protocol.version/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.non.successful.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.non.successful.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.non.successful.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.non.successful.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.failed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.failed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.password.authentication.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.exceeding.max.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.exceeding.max.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.exceeding.max.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.exceeding.max.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.missing.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.missing.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.missing.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.missing.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.no.client.id.no.clean.session/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.no.client.id.no.clean.session/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.no.client.id.no.clean.session/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.no.client.id.no.clean.session/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.other.packet.before.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.other.packet.before.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.other.packet.before.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.other.packet.before.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.password/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.password/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.password/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.password/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.username.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.username.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.username.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.password.flag.no.username.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.second.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.second.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.second.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.second.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.username.flag.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.username.flag.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.username.flag.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.username.flag.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.payload.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.payload.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.payload.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.payload.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.topic.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.topic.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.topic.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.reject.will.topic.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.server.assigned.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.server.assigned.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.server.assigned.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.server.assigned.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.subscribe.batched/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.subscribe.batched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.subscribe.batched/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.subscribe.batched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful.fragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful.fragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.timeout.before.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.timeout.before.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.timeout.before.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.timeout.before.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.failed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.failed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.username.authentication.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.invalid.will.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.invalid.will.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.invalid.will.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.invalid.will.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.1.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.1.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.1.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.1.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.2.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.2.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.2.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.qos.2.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.retain.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.retain.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.retain.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/connect.will.reject.will.retain.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect.after.subscribe.and.publish/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect.after.subscribe.and.publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect.after.subscribe.and.publish/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect.after.subscribe.and.publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.no.pingresp/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.no.pingresp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.no.pingresp/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping.no.pingresp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ping/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.10k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.10k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.retained.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.retained.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.retained.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.empty.retained.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.unfragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.unfragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.unfragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.unfragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.with.delay/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.with.delay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.with.delay/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages.with.delay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.multiple.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos1.dup.after.puback/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos1.dup.after.puback/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos1.dup.after.puback/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos1.dup.after.puback/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos2.no.dupicate.before.pubrel/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos2.no.dupicate.before.pubrel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos2.no.dupicate.before.pubrel/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.qos2.no.dupicate.before.pubrel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos0.with.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos0.with.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos0.with.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos0.with.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos1.without.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos1.without.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos1.without.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos1.without.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos2.without.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos2.without.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos2.without.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.reject.qos2.without.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained.multiple.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained.multiple.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained.multiple.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained.multiple.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.subscribe.batched/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.subscribe.batched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.subscribe.batched/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.subscribe.batched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.not.routed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.not.routed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.topic.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.valid.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.valid.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.valid.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/publish.valid.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.abort.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.abort.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.abort.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.abort.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.client.takeover/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.client.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.client.takeover/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.client.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.connect.payload.fragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.connect.payload.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.connect.payload.fragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.connect.payload.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.exists.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.exists.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.exists.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.exists.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.reject.non.compacted.sessions.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.reject.non.compacted.sessions.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.reject.non.compacted.sessions.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.reject.non.compacted.sessions.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.multiple.isolated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.multiple.isolated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.multiple.isolated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.multiple.isolated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.publish.routing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.publish.routing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.publish.routing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.publish.routing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe.deferred/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe.deferred/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe.deferred/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe.deferred/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.no.ping.within.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.no.ping.within.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.no.ping.within.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.no.ping.within.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.normal.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.normal.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.retain/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.retain/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/session.will.message.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.fixed.header.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.fixed.header.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.fixed.header.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.fixed.header.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.filter/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.filter/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.filter/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.filter/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.one.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.one.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.overlapping.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos0.published.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos0.published.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos0.published.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos0.published.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.messages.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.messages.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.messages.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.receive.messages.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.malformed.subscription.options/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.malformed.subscription.options/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.malformed.subscription.options/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.malformed.subscription.options/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.missing.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.missing.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.missing.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.reject.missing.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.replay.retained.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.retain.as.published/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.retain.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.retain.as.published/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.retain.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.two.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.two.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.two.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filter.two.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.disjoint.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.disjoint.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.disjoint.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.disjoint.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact.no.subscription.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact.no.subscription.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact.no.subscription.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact.no.subscription.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.both.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.overlapping.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.overlapping.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.overlapping.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.filters.overlapping.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/subscribe.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.no.matching.subscription/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.no.matching.subscription/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.no.matching.subscription/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.no.matching.subscription/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.publish.unfragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.publish.unfragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.publish.unfragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.publish.unfragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.invalid.fixed.header.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.invalid.fixed.header.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.invalid.fixed.header.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.invalid.fixed.header.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.missing.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.missing.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.missing.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.missing.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.no.topic.filter/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.no.topic.filter/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.no.topic.filter/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.reject.no.topic.filter/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filter.single/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filter.single/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filter.single/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filter.single/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/unsubscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.abort/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.abort/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.close/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.close/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.reset/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.reset/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.delegate.connack.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.delegate.connack.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.delegate.connack.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.delegate.connack.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.authentication.method/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.authentication.method/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.authentication.method/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.authentication.method/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.protocol.version/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.protocol.version/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.protocol.version/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.invalid.protocol.version/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.max.packet.size.exceeded/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.max.packet.size.exceeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.max.packet.size.exceeded/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.max.packet.size.exceeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.maximum.qos.0/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.maximum.qos.0/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.maximum.qos.0/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.maximum.qos.0/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.non.successful.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.failed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.failed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.password.authentication.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.exceeding.max.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.exceeding.max.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.exceeding.max.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.exceeding.max.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.missing.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.missing.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.missing.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.missing.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.other.packet.before.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.other.packet.before.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.other.packet.before.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.other.packet.before.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.flag.no.password/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.flag.no.password/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.flag.no.password/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.flag.no.password/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.no.password.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.no.password.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.no.password.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.password.no.password.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.second.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.second.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.second.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.second.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.topic.alias.maximum.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.topic.alias.maximum.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.topic.alias.maximum.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.topic.alias.maximum.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.only/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.only/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.username.flag.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.payload.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.payload.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.payload.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.payload.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.properties.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.properties.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.properties.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.properties.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.topic.missing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.topic.missing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.topic.missing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.reject.will.topic.missing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.assigned.client.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.assigned.client.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.assigned.client.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.assigned.client.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.defined.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.defined.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.defined.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.server.defined.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.subscribe.batched/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.subscribe.batched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.subscribe.batched/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.subscribe.batched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful.fragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful.fragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.timeout.before.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.timeout.before.connect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.timeout.before.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.timeout.before.connect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.unsupported.protocol.version/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.unsupported.protocol.version/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.unsupported.protocol.version/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.unsupported.protocol.version/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.failed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.failed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.authentication.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.invalid.will.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.invalid.will.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.invalid.will.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.invalid.will.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.1.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.1.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.1.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.1.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.2.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.2.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.2.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.qos.2.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.retain.without.will.flag/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.retain.without.will.flag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.retain.without.will.flag/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.will.reject.will.retain.without.will.flag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.keep.alive.timeout/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.keep.alive.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.keep.alive.timeout/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.keep.alive.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.subscribe.and.publish/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.subscribe.and.publish/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.subscribe.and.publish/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.after.subscribe.and.publish/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.invalid.session.expiry/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.invalid.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.invalid.session.expiry/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.invalid.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.no.reasoncode.no.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.no.reasoncode.no.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.no.reasoncode.no.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.no.reasoncode.no.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.reject.invalid.fixed.header.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.reject.invalid.fixed.header.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.reject.invalid.fixed.header.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect.reject.invalid.fixed.header.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.no.pingresp/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.no.pingresp/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.no.pingresp/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.no.pingresp/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.server.override.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.server.override.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.server.override.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping.server.override.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ping/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.10k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.10k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.retained.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.retained.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.retained.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.empty.retained.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.user.property/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.user.property/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.invalid.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.message.with.topic.alias/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.message.with.topic.alias/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.message.with.topic.alias/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.message.with.topic.alias/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.no.carry.over.topic.alias/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.no.carry.over.topic.alias/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.no.carry.over.topic.alias/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.no.carry.over.topic.alias/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.distinct/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.distinct/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.invalid.scope/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.invalid.scope/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.invalid.scope/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.invalid.scope/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.replaced/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.replaced/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.replaced/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.messages.with.topic.alias.replaced/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.clients/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.clients/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.clients/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.clients/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.unfragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.unfragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.unfragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.unfragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.with.delay/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.with.delay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.with.delay/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages.with.delay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.multiple.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.properties/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.one.message.properties/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos1.dup.after.puback/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos1.dup.after.puback/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos1.dup.after.puback/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos1.dup.after.puback/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.ack.with.reasoncode/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.ack.with.reasoncode/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.ack.with.reasoncode/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.ack.with.reasoncode/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.no.dupicate.before.pubrel/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.no.dupicate.before.pubrel/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.no.dupicate.before.pubrel/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.no.dupicate.before.pubrel/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.recovery/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.recovery/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.recovery/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.qos2.recovery/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.client.sent.subscription.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.client.sent.subscription.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.client.sent.subscription.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.client.sent.subscription.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.invalid.payload.format/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.invalid.payload.format/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.invalid.payload.format/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.invalid.payload.format/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.large.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.large.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.large.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.large.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos0.with.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos0.with.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos0.with.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos0.with.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.without.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.without.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.without.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos1.without.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.without.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.without.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.without.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.qos2.without.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.retain.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.retain.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.retain.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.retain.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.exceeds.maximum/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.exceeds.maximum/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.exceeds.maximum/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.exceeds.maximum/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.reject.topic.alias.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained.multiple.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained.multiple.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained.multiple.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained.multiple.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.retained/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.session.takeover/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.session.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.session.takeover/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.session.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.subscribe.batched/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.subscribe.batched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.subscribe.batched/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.subscribe.batched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.not.routed/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.not.routed/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.topic.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.user.property/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.user.property/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.valid.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.distinct/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.distinct/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.distinct/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.distinct/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.properties.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.property/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.property/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.property/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/publish.with.user.property/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.abort.reconnect.non.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.abort.reconnect.non.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.abort.reconnect.non.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.abort.reconnect.non.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.client.takeover/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.client.takeover/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.client.takeover/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.client.takeover/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.override.session.expiry/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.override.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.override.session.expiry/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.override.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.payload.fragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.payload.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.payload.fragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.payload.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.with.session.expiry/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.with.session.expiry/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.with.session.expiry/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.connect.with.session.expiry/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.exists.clean.start/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.exists.clean.start/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.exists.clean.start/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.exists.clean.start/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.after.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.after.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.after.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.after.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.before.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.before.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.before.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.invalid.session.timeout.before.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.reject.non.compacted.sessions.topic/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.reject.non.compacted.sessions.topic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.reject.non.compacted.sessions.topic/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.reject.non.compacted.sessions.topic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.after.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.after.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.after.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.after.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.before.connack/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.before.connack/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.before.connack/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.server.redirect.before.connack/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.multiple.isolated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.multiple.isolated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.multiple.isolated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.multiple.isolated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.publish.routing/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.publish.routing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.publish.routing/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.publish.routing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.via.session.state/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.via.session.state/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.via.session.state/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe.via.session.state/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe.deferred/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe.deferred/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe.deferred/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe.deferred/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.10k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.10k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.disconnect.with.will.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.disconnect.with.will.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.disconnect.with.will.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.disconnect.with.will.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.no.ping.within.keep.alive/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.no.ping.within.keep.alive/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.no.ping.within.keep.alive/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.no.ping.within.keep.alive/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.normal.disconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.normal.disconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.retain/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.retain/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.retain/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.retain/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.get.retained.as.published/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.get.retained.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.get.retained.as.published/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.get.retained.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.fixed.header.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.fixed.header.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.fixed.header.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.fixed.header.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.filter/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.filter/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.filter/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.filter/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.invalid.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.receive.response.topic.and.correlation.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.receive.response.topic.and.correlation.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.user.properties.unaltered/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.user.properties.unaltered/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.user.properties.unaltered/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.user.properties.unaltered/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.with.invalid.subscription.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.with.invalid.subscription.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.with.invalid.subscription.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message.with.invalid.subscription.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.one.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.publish.no.local/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.publish.no.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.publish.no.local/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.publish.no.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.publish.retained.no.replay/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.publish.retained.no.replay/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.publish.retained.no.replay/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.publish.retained.no.replay/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.replay.retained.no.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.replay.retained.no.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.replay.retained.no.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos0.replay.retained.no.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos1.reject.subscription.ids.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos1.reject.subscription.ids.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos1.reject.subscription.ids.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos1.reject.subscription.ids.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos2.reject.subscription.ids.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos2.reject.subscription.ids.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos2.reject.subscription.ids.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.qos2.reject.subscription.ids.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard.mixed.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard.mixed.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.overlapping.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos0.published.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos0.published.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos0.published.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos0.published.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.mixture.qos/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.mixture.qos/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.mixture.qos/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.mixture.qos/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.topic.alias.repeated/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.topic.alias.repeated/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.topic.alias.repeated/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.receive.messages.topic.alias.repeated/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.publish.no.subscription/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.publish.no.subscription/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.publish.no.subscription/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.publish.no.subscription/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos1.unacked.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos1.unacked.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.incomplete.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.incomplete.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.unreceived.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reconnect.replay.qos2.unreceived.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.malformed.subscription.options/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.malformed.subscription.options/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.malformed.subscription.options/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.malformed.subscription.options/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.topic.filters/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.topic.filters/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.topic.filters/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.missing.topic.filters/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.no.local/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.no.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.no.local/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.no.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.shared.subscriptions.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.shared.subscriptions.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.shared.subscriptions.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.shared.subscriptions.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.subscription.ids.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.subscription.ids.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.subscription.ids.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.subscription.ids.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.topic.filter.invalid.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.topic.filter.invalid.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.topic.filter.invalid.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.topic.filter.invalid.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.wildcard.subscriptions.not.supported/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.wildcard.subscriptions.not.supported/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.wildcard.subscriptions.not.supported/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.reject.wildcard.subscriptions.not.supported/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos1/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos1/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos1/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos1/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos2/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos2/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos2/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.replay.retained.message.qos2/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.retain.as.published/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.retain.as.published/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.retain.as.published/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.retain.as.published/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.and.multi.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.and.multi.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.two.single.level.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.two.single.level.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.two.single.level.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filter.two.single.level.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.aggregated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.disjoint.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.disjoint.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.disjoint.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.disjoint.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact.no.subscription.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact.no.subscription.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact.no.subscription.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact.no.subscription.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.both.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.exact.and.wildcard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.isolated.exact.and.wildcard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.overlapping.wildcards/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.overlapping.wildcards/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.overlapping.wildcards/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.filters.overlapping.wildcards/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.guarded.identity.param/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.guarded.identity.param/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.guarded.identity.param/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.topic.guarded.identity.param/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.unroutable/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.unroutable/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.unroutable/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/subscribe.unroutable/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.after.subscribe/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.after.subscribe/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.after.subscribe/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.after.subscribe/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.aggregated.topic.filters.both.exact/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.aggregated.topic.filters.both.exact/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.subscription/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.subscription/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.subscription/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.subscription/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.topic.filter/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.topic.filter/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.topic.filter/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.no.matching.topic.filter/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.publish.unfragmented/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.publish.unfragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.publish.unfragmented/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.publish.unfragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.invalid.fixed.header.flags/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.invalid.fixed.header.flags/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.invalid.fixed.header.flags/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.invalid.fixed.header.flags/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.missing.packet.id/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.missing.packet.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.missing.packet.id/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.missing.packet.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.no.topic.filter/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.no.topic.filter/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.no.topic.filter/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.reject.no.topic.filter/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filter.single/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filter.single/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filter.single/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filter.single/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filters.non.successful/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filters.non.successful/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filters.non.successful/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/unsubscribe.topic.filters.non.successful/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/config/SchemaTest.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctionsTest.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/ConnectionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/PublishIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/UnsubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ConnectionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/PingIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/PingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/PublishIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/SubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/UnsubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v4/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ConnectionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ConnectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/PingIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/PingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/PublishIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/PublishIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/UnsubscribeIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/UnsubscribeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/OpenapiAsyncapiSpecs.java
+++ b/specs/binding-openapi-asyncapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/OpenapiAsyncapiSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/moditect/module-info.java
+++ b/specs/binding-openapi-asyncapi.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy-async.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy-async.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/async.verify.customer/client.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/async.verify.customer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/async.verify.customer/server.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/async.verify.customer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/create.pet/client.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/create.pet/server.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/asyncapi/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/async.verify.customer/client.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/async.verify.customer/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/async.verify.customer/server.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/async.verify.customer/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/create.pet/client.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/create.pet/server.rpt
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/openapi/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/SchemaTest.java
+++ b/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/AsyncapiIT.java
+++ b/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/AsyncapiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/OpenapiIT.java
+++ b/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/streams/OpenapiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-openapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/OpenapiFunctions.java
+++ b/specs/binding-openapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/OpenapiFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/OpenapiSpecs.java
+++ b/specs/binding-openapi.spec/src/main/java/io/aklivity/zilla/specs/binding/openapi/OpenapiSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/moditect/module-info.java
+++ b/specs/binding-openapi.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/resources/META-INF/zilla/openapi.idl
+++ b/specs/binding-openapi.spec/src/main/resources/META-INF/zilla/openapi.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.multiple.specs.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.multiple.specs.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.unresolved.ref.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.unresolved.ref.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.env.prod.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.env.prod.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.multiple.specs.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.multiple.specs.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.secure.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.secure.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.yaml
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.and.item/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.and.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.and.item/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.and.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.invalid/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.invalid/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.prod/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.prod/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.prod/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet.prod/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/composite/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.and.item/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.and.item/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.and.item/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.and.item/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.invalid/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.invalid/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.prod/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.prod/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.prod/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet.prod/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet/client.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet/server.rpt
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/streams/openapi/create.pet/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/config/SchemaTest.java
+++ b/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/internal/OpenapiFunctionsTest.java
+++ b/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/internal/OpenapiFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/streams/CompositeIT.java
+++ b/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/streams/CompositeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/streams/OpenapiIT.java
+++ b/specs/binding-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/streams/OpenapiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/java/io/aklivity/zilla/specs/binding/proxy/internal/ProxyFunctions.java
+++ b/specs/binding-proxy.spec/src/main/java/io/aklivity/zilla/specs/binding/proxy/internal/ProxyFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/moditect/module-info.java
+++ b/specs/binding-proxy.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/resources/META-INF/zilla/proxy.idl
+++ b/specs/binding-proxy.spec/src/main/resources/META-INF/zilla/proxy.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/client.tcp.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/client.tcp.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/client.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.sock.stream.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.sock.stream.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.alpn.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.alpn.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.ssl.version.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.ssl.version.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp4.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp6.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.tcp6.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.yaml
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.abort/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.abort/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.begin.ext/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.begin.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.begin.ext/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.begin.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.challenge/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.challenge/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.close/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.close/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.data/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.data/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.flush/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.flush/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.reset/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.reset/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.discard/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.discard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.discard/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.discard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.abort/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.abort/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.challenge/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.challenge/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.close/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.close/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.data/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.data/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.flush/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.flush/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.reset/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.reset/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.datagram/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.datagram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.datagram/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.datagram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.stream/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.stream/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.sock.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.alpn/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.alpn/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.authority/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.authority/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.authority/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.authority/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.crc32c/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.crc32c/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.crc32c/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.crc32c/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.experimental/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.experimental/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.experimental/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.experimental/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.identity/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.identity/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.identity/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.identity/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.namespace/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.namespace/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.namespace/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.namespace/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.noop/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.noop/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.noop/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.noop/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert.session/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert.session/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert.session/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert.session/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.client.cert/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.experimental/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.experimental/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.experimental/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl.experimental/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.ssl/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.unresolved/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.unresolved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.unresolved/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4.unresolved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6.unresolved/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6.unresolved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6.unresolved/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6.unresolved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.tcp6/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp4/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp4/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp6/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp6/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp6/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/application/connected.udp6/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.abort/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.abort/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.begin.ext/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.begin.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.begin.ext/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.begin.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.challenge/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.challenge/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.close/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.close/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.data/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.data/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.flush/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.flush/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.reset/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.reset/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.discard/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.discard/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.discard/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.discard/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.abort/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.abort/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.challenge/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.challenge/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.close/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.close/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.data/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.data/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.flush/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.flush/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.reset/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.reset/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local.server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.local/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.datagram/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.datagram/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.datagram/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.datagram/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.stream/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.stream/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.sock.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.alpn/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.alpn/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.authority/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.authority/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.authority/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.authority/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.crc32c/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.crc32c/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.crc32c/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.crc32c/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.experimental/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.experimental/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.experimental/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.experimental/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.identity/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.identity/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.identity/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.identity/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.namespace/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.namespace/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.namespace/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.namespace/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.noop/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.noop/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.noop/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.noop/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert.session/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert.session/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert.session/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert.session/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.client.cert/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.experimental/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.experimental/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.experimental/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl.experimental/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4.ssl/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp6/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp6/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp6/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.tcp6/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp4/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp4/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp4/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp4/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp6/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp6/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp6/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/connected.udp6/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.address.family.mismatch/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.address.family.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.address.family.mismatch/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.address.family.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.command.mismatch/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.command.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.command.mismatch/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.command.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.mismatch/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.mismatch/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.version.mismatch/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.version.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.version.mismatch/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.header.version.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.sock.stream.underflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.sock.stream.underflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.sock.stream.underflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.sock.stream.underflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.mismatch/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.mismatch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.mismatch/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.mismatch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.overflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.overflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.overflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.overflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.underflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.underflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.underflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.crc32c.underflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.ssl.underflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.ssl.underflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.ssl.underflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.ssl.underflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.underflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.underflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.underflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp4.underflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp6.underflow/client.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp6.underflow/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp6.underflow/server.rpt
+++ b/specs/binding-proxy.spec/src/main/scripts/io/aklivity/zilla/specs/binding/proxy/streams/network.v2/rejected.tcp6.underflow/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/config/SchemaTest.java
+++ b/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/internal/ProxyFunctionsTest.java
+++ b/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/internal/ProxyFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/streams/ApplicationIT.java
+++ b/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/streams/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/streams/NetworkIT.java
+++ b/specs/binding-proxy.spec/src/test/java/io/aklivity/zilla/specs/binding/proxy/streams/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse-kafka.spec/src/main/moditect/module-info.java
+++ b/specs/binding-sse-kafka.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.event.id.yaml
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.event.id.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.filters.dynamic.yaml
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.filters.dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.filters.yaml
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.and.filters.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.dynamic.yaml
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.yaml
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/config/proxy.with.topic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.abort/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.abort/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.reset/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.reset/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.my.stream/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.my.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.my.stream/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.my.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect.with.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.attributes/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.attributes/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.attributes/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.attributes/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.filters/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.filters/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.filters/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake.with.filters/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.100k.message/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.100k.message/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.abort/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.abort/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.flush/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.flush/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages.with.null.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.null/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.null/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.reset/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.reset/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/kafka/server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.abort/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.abort/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.message/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.message/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.reset/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.reset/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.my.stream/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.my.stream/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.my.stream/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.my.stream/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect.with.key.and.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.reconnect/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.rejected/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.rejected/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.rejected/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.rejected/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.with.filters.dynamic/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.with.filters.dynamic/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.with.filters.dynamic/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake.with.filters.dynamic/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.100k.message/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.100k.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.100k.message/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.100k.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.abort/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.abort/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.flush/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.flush/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.key.and.etag/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages.with.null.key/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.messages/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.null/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.null/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.reset/client.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.reset/server.rpt
+++ b/specs/binding-sse-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/kafka/streams/sse/server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/config/SchemaTest.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/KafkaIT.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/KafkaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/SseIT.java
+++ b/specs/binding-sse-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/kafka/streams/SseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/binding-sse.spec/src/main/java/io/aklivity/zilla/specs/binding/sse/internal/SseFunctions.java
+++ b/specs/binding-sse.spec/src/main/java/io/aklivity/zilla/specs/binding/sse/internal/SseFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/moditect/module-info.java
+++ b/specs/binding-sse.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/resources/META-INF/zilla/sse.idl
+++ b/specs/binding-sse.spec/src/main/resources/META-INF/zilla/sse.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/client.when.yaml
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/client.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/server.validator.yaml
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/server.validator.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/server.when.yaml
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/config/server.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/advise/flush/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/advise/flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/advise/flush/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/advise/flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/non.empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/non.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/non.empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/bom/non.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/challenge/respond.to.challenge/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/challenge/respond.to.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/challenge/respond.to.challenge/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/challenge/respond.to.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.100k/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.100k/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.10k/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.10k/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/fragmented.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/initial.whitespace/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/initial.whitespace/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/initial.whitespace/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/initial.whitespace/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid.utf8/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid.utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid.utf8/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid.utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multi.line/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multi.line/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multi.line/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multi.line/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multiple/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multiple/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multiple/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/multiple/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/name.only/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/name.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/name.only/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/name.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/non.empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/non.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/non.empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/non.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/valid/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/valid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/valid/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/data/valid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed.fragmented/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed.fragmented/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return.line.feed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/carriage.return/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/line.feed/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/line.feed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/line.feed/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/end.of.line/line.feed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.abort/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.abort/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.reset/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.reset/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/client.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.abort/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.abort/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.reset/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.reset/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/error/server.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed.deferred/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed.deferred/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed.deferred/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed.deferred/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.closed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.failed/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.failed/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.succeeded/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.succeeded/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.succeeded/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/connection.succeeded/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id.empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id.empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/handshake/last.event.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/initial.whitespace/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/initial.whitespace/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/initial.whitespace/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/initial.whitespace/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/invalid.utf8/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/invalid.utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/invalid.utf8/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/invalid.utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/non.empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/non.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/non.empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/id/non.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/idle/comment/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/initial.last.event.id/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/initial.last.event.id/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/initial.last.event.id/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/initial.last.event.id/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data.null/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data.null/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data.null/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data.null/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end.fragmented/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end.fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end.fragmented/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end.fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/reconnect/last.event.id.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/fragmented/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/fragmented/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/fragmented/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/fragmented/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/initial.whitespace/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/initial.whitespace/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/initial.whitespace/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/initial.whitespace/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/invalid.utf8/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/invalid.utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/invalid.utf8/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/invalid.utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/name.only/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/name.only/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/name.only/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/name.only/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.interleaved/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.interleaved/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.interleaved/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.interleaved/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.trailing/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.trailing/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.trailing/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty.trailing/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty/client.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty/server.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/application/type/non.empty/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/advise/flush/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/advise/flush/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/advise/flush/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/advise/flush/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/bom/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/challenge/respond.to.challenge/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/challenge/respond.to.challenge/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/challenge/respond.to.challenge/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/challenge/respond.to.challenge/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/multi.line/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/multi.line/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/multi.line/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/multi.line/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/comment/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/initial.whitespace/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/initial.whitespace/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/initial.whitespace/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/initial.whitespace/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/invalid.utf8/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/invalid.utf8/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/invalid.utf8/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/invalid.utf8/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/name.only/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/name.only/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/name.only/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/name.only/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/custom/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.100k/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.100k/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.100k/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.100k/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.10k/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.10k/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.10k/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/fragmented.10k/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/initial.whitespace/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/initial.whitespace/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/initial.whitespace/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/initial.whitespace/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid.utf8/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid.utf8/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid.utf8/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid.utf8/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/invalid/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multi.line/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multi.line/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multi.line/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multi.line/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multiple/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multiple/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multiple/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/multiple/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/name.only/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/name.only/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/name.only/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/name.only/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/valid/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/valid/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/valid/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/data/valid/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed.fragmented/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed.fragmented/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed.fragmented/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed.fragmented/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return.line.feed/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/carriage.return/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/line.feed/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/line.feed/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/line.feed/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/end.of.line/line.feed/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.abort/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.abort/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.abort/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.abort/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.reset/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.reset/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.reset/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/client.reset/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.abort/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.abort/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.abort/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.abort/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.reset/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.reset/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.reset/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/error/server.reset/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed.deferred/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed.deferred/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed.deferred/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed.deferred/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.closed/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded.with.request.parameter/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded.with.request.parameter/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded.with.request.parameter/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded.with.request.parameter/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/connection.succeeded/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/initial.comment/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/initial.comment/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/initial.comment/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/initial.comment/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow.multibyte/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow.multibyte/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow.multibyte/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow.multibyte/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id.overflow/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.header.last.event.id/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.method.unsupported/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.method.unsupported/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.method.unsupported/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.method.unsupported/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.overflow/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.overflow/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.overflow/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.overflow/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.url.encoded/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.url.encoded/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.url.encoded/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id.url.encoded/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/request.parameter.last.event.id/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.missing/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.missing/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.missing/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.missing/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.unsupported/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.unsupported/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.unsupported/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/handshake/response.header.content.type.unsupported/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/initial.whitespace/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/initial.whitespace/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/initial.whitespace/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/initial.whitespace/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/invalid.utf8/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/invalid.utf8/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/invalid.utf8/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/invalid.utf8/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/name.only/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/name.only/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/name.only/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/name.only/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.header.length.exceeding.255/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.header.length.exceeding.255/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.header.length.exceeding.255/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.header.length.exceeding.255/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.query.param.length.exceeding.255/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.query.param.length.exceeding.255/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.query.param.length.exceeding.255/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/id/reject.query.param.length.exceeding.255/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/idle/comment/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.and.parameter.last.event.id/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.and.parameter.last.event.id/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.and.parameter.last.event.id/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.and.parameter.last.event.id/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data.null/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data.null/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data.null/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data.null/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.and.data/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.fragmented/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.fragmented/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.fragmented/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id.fragmented/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/request.header.last.event.id/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.200/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.200/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.200/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.200/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.500/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.500/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.500/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/reconnect/response.status.code.500/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/initial.whitespace/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/initial.whitespace/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/initial.whitespace/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/initial.whitespace/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/invalid.utf8/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/invalid.utf8/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/invalid.utf8/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/invalid.utf8/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/name.only/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/name.only/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/name.only/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/name.only/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/non.numeric/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/non.numeric/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/non.numeric/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/non.numeric/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/numeric/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/numeric/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/numeric/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/retry/numeric/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/fragmented.10k/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/fragmented.10k/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/fragmented.10k/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/fragmented.10k/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty.with.type/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty.with.type/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty.with.type/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty.with.type/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/timestamp/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/fragmented/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/fragmented/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/fragmented/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/fragmented/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/initial.whitespace/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/initial.whitespace/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/initial.whitespace/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/initial.whitespace/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/invalid.utf8/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/invalid.utf8/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/invalid.utf8/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/invalid.utf8/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/name.only/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/name.only/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/name.only/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/name.only/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.interleaved/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.interleaved/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.interleaved/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.interleaved/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.trailing/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.trailing/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.trailing/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty.trailing/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty/request.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty/request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty/response.rpt
+++ b/specs/binding-sse.spec/src/main/scripts/io/aklivity/zilla/specs/binding/sse/streams/network/type/non.empty/response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/config/SchemaTest.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/internal/SseFunctionsTest.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/internal/SseFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/AdvisoryIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ByteOrderMarkIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ByteOrderMarkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/DataIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/DataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/EndOfLineIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/EndOfLineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ErrorIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/HandshakeIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/HandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdleIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/IdleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ReconnectIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/ReconnectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/TypeIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/application/TypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/AdvisoryIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ByteOrderMarkIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ByteOrderMarkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ChallengeIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ChallengeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/CommentIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/CommentIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/CustomIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/CustomIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/DataIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/DataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/EndOfLineIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/EndOfLineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ErrorIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/HandshakeIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/HandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdleIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/IdleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ReconnectIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/ReconnectIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/RetryIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/RetryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/TimestampIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/TimestampIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/TypeIT.java
+++ b/specs/binding-sse.spec/src/test/java/io/aklivity/zilla/specs/binding/sse/streams/network/TypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/moditect/module-info.java
+++ b/specs/binding-tcp.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/resources/META-INF/zilla/tcp.idl
+++ b/specs/binding-tcp.spec/src/main/resources/META-INF/zilla/tcp.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.authority.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.authority.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.event.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.and.subnet.ipv6.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.and.subnet.ipv6.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.and.subnet.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.and.subnet.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.host.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ip.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ip.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ipv6.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ipv6.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ports.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.subnet.ipv6.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.subnet.ipv6.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.subnet.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.subnet.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.ipv6.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.ipv6.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.ports.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.with.padding/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.with.padding/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.and.server.sent.data.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close.immediately/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.abort.sent.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.abort.sent.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.abort.sent.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.abort.sent.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.reset.and.abort/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.reset.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.reset.and.abort/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.received.reset.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort.and.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort.and.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams.second.was.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams.second.was.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams.second.was.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams.second.was.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.multiple.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.abort.and.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.abort.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.abort.and.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.abort.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.received.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.then.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.then.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.then.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data.then.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.end.then.received.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.end.then.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.end.then.received.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.end.then.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset.and.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset.and.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/client.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/concurrent.connections/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/concurrent.connections/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/concurrent.connections/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/concurrent.connections/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established.ipv6/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established.ipv6/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established.ipv6/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established.ipv6/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.failed/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.failed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.failed/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/connection.failed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/max.connections/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.close/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.close/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.abort.sent.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.abort.sent.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.abort.sent.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.abort.sent.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.reset.and.abort/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.reset.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.reset.and.abort/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.received.reset.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort.and.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort.and.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort.and.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort.and.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams.second.was.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams.second.was.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams.second.was.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams.second.was.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.multiple.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset.and.abort/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset.and.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset.and.abort/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset.and.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.received.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.then.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.then.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.then.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data.then.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.end.then.received.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.end.then.received.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.end.then.received.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.end.then.received.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset.and.end/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset.and.end/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset.and.end/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset.and.end/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/rfc793/server.sent.reset/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.host.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.host.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.host.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.host.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv4.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv4.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv4.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv4.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv6.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv6.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv6.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.ipv6.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.port.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.port.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.port.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.connect.with.port.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.rejected.port.not.routed/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.rejected.port.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.rejected.port.not.routed/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.rejected.port.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.reset.with.no.subnet.match/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.reset.with.no.subnet.match/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.reset.with.no.subnet.match/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/application/routing/client.reset.with.no.subnet.match/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.with.padding/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.with.padding/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.and.server.sent.data.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.close/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.close/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.streams/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.streams/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data.multiple.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/concurrent.connections/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/concurrent.connections/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/concurrent.connections/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/concurrent.connections/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/connection.established/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/connection.established/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.close/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.close/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.frames/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.frames/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.frames/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.frames/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.streams/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.streams/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.streams/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data.multiple.streams/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/rfc793/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.host.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.host.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.host.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.host.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv4.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv4.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv4.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv4.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv6.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv6.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv6.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.ipv6.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.port.extension/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.port.extension/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.port.extension/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/client.connect.with.port.extension/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/server.close.port.not.routed/client.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/server.close.port.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/server.close.port.not.routed/server.rpt
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/streams/network/routing/server.close.port.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationRoutingIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationRoutingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkRoutingIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkRoutingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/java/io/aklivity/zilla/specs/binding/tls/internal/TlsFunctions.java
+++ b/specs/binding-tls.spec/src/main/java/io/aklivity/zilla/specs/binding/tls/internal/TlsFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/moditect/module-info.java
+++ b/specs/binding-tls.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/resources/META-INF/zilla/tls.idl
+++ b/specs/binding-tls.spec/src/main/resources/META-INF/zilla/tls.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/bridge.tls1.2.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/bridge.tls1.2.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/bridge.tls1.3.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/bridge.tls1.3.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.alpn.default.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.alpn.default.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.alpn.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.alpn.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.cacerts.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.cacerts.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.event.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.mutual.signer.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.mutual.signer.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.mutual.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.mutual.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.options.default.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.options.default.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.ports.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.sni.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.sni.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.ports.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.sni.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.sni.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.alpn.default.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.alpn.default.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.alpn.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.alpn.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.handshake.timeout.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.handshake.timeout.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.tls.failed.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.event.tls.failed.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.keys.not.found.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.keys.not.found.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.mutual.requested.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.mutual.requested.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.mutual.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.mutual.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.ports.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.ports.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.signer.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.signer.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.sni.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.sni.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.yaml
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth.mismatched/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth.mismatched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth.mismatched/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth.mismatched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.auth/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.handshake.timeout/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.handshake.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.handshake.timeout/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.handshake.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.flush/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.flush/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.read.closed/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.read.closed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.read.closed/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close.read.closed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/client.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.no.hostname.no.alpn/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.no.hostname.no.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.no.hostname.no.alpn/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.no.hostname.no.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.alpn/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.alpn/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.extension.data/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.extension.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.extension.data/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.extension.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.port/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.port/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.port/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established.with.port/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.1000k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.1000k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.1000k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.1000k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.100k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.100k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.10k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.10k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/echo.payload.length.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.mutual.auth/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.mutual.auth/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.mutual.auth/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.mutual.auth/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.flush/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.flush/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/application/server.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/bridge/handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/bridge/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/bridge/handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/bridge/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth.mismatched/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth.mismatched/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth.mismatched/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth.mismatched/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.auth/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.handshake.timeout/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.handshake.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.handshake.timeout/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.handshake.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.hello.malformed/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.hello.malformed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.hello.malformed/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.hello.malformed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.flush/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.flush/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.read.closed/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.read.closed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.read.closed/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close.read.closed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/client.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.no.hostname.no.alpn/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.no.hostname.no.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.no.hostname.no.alpn/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.no.hostname.no.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.alpn/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.alpn/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.extension.data/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.extension.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.extension.data/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established.with.extension.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.established/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.not.established.with.wrong.alpn/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.not.established.with.wrong.alpn/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.not.established.with.wrong.alpn/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/connection.not.established.with.wrong.alpn/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.1000k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.1000k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.1000k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.1000k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.100k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.100k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.100k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.100k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.10k/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.10k/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.10k/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/echo.payload.length.10k/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.handshake.timeout/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.handshake.timeout/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.handshake.timeout/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.handshake.timeout/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.mutual.auth/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.mutual.auth/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.mutual.auth/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.mutual.auth/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.port.not.routed/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.port.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.port.not.routed/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.port.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.flush/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.flush/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close.before.handshake/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close.before.handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close.before.handshake/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close.before.handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/network/server.sent.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.with.sni/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.with.sni/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.with.sni/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.with.sni/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.without.ext/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.without.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.without.ext/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/client.hello.without.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.client.hello.with.sni/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.client.hello.with.sni/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.client.hello.with.sni/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.client.hello.with.sni/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.port.not.routed/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.port.not.routed/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.port.not.routed/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/client/reject.port.not.routed/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.with.sni/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.with.sni/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.with.sni/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.with.sni/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.without.ext/client.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.without.ext/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.without.ext/server.rpt
+++ b/specs/binding-tls.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tls/streams/proxy/server/client.hello.without.ext/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/democa/regen.sh
+++ b/specs/binding-tls.spec/src/test/democa/regen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/config/SchemaTest.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/internal/TlsFunctionsTest.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/internal/TlsFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/ApplicationIT.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/BridgeIT.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/BridgeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/NetworkIT.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/ProxyIT.java
+++ b/specs/binding-tls.spec/src/test/java/io/aklivity/zilla/specs/binding/tls/stream/ProxyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/java/io/aklivity/zilla/specs/binding/ws/internal/WsFunctions.java
+++ b/specs/binding-ws.spec/src/main/java/io/aklivity/zilla/specs/binding/ws/internal/WsFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/moditect/module-info.java
+++ b/specs/binding-ws.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/resources/META-INF/zilla/ws.idl
+++ b/specs/binding-ws.spec/src/main/resources/META-INF/zilla/ws.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/client.when.yaml
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/client.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/client.yaml
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/client.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/server.when.yaml
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/server.when.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/server.yaml
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.challenge/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.challenge/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.flush/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.flush/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.challenge/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.challenge/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.flush/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.flush/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/advise/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.empty.close.frame/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.empty.close.frame/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.empty.close.frame/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/closing/client.send.empty.close.frame/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.0/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.0/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.0/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.0/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.125/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.125/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.125/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.ping.payload.length.125/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.0/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.0/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.0/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.0/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.125/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.125/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.125/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.125/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.126/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.126/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.126/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/client.send.pong.payload.length.126/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/server.send.ping/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/server.send.ping/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/server.send.ping/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/control/server.send.ping/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/flowcontrol/echo.payload.with.padding/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/flowcontrol/echo.payload.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/flowcontrol/echo.payload.with.padding/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/flowcontrol/echo.payload.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/fragmentation/echo.binary.payload.length.125.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/fragmentation/echo.binary.payload.length.125.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/fragmentation/echo.binary.payload.length.125.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/fragmentation/echo.binary.payload.length.125.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.10k/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.10k/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.10k/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.10k/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.65535/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.65535/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.65535/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/framing/echo.binary.payload.length.65535/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established.extension/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established.extension/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established.extension/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established.extension/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/application/opening/connection.established/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.challenge/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.challenge/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.flush/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.flush/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.no.upgrade/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.no.upgrade/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.no.upgrade/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/client.sent.no.upgrade/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.challenge/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.challenge/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.flush/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.flush/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/advise/server.sent.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.reason/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.reason/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.reason/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000.and.reason/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1000/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1001/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1001/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1001/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1001/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1006/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1006/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1006/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1006/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1015/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1015/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1015/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.close.frame.with.code.1015/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.empty.close.frame/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.empty.close.frame/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.empty.close.frame/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/client.send.empty.close.frame/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.invalid.utf8.reason/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.reason/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.reason/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.reason/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000.and.reason/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1000/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1001/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1001/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1001/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1001/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1005/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1005/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1006/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1006/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1006/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1006/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1015/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1015/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1015/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.close.frame.with.code.1015/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.empty.close.frame/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.empty.close.frame/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.empty.close.frame/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/closing/server.send.empty.close.frame/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.close.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0b/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0b/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0b/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0b/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0c/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0c/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0c/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0c/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0d/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0d/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0d/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0d/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0e/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0e/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0e/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0e/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0f/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0f/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0f/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.opcode.0x0f/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.ping.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/client.send.pong.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.close.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0b/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0b/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0b/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0b/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0c/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0c/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0c/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0c/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0d/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0d/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0d/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0d/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0e/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0e/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0e/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0e/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0f/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0f/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0f/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.opcode.0x0f/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.ping.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/control/server.send.pong.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x03/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x03/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x03/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x03/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x04/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x04/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x04/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x04/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x05/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x05/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x05/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x05/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x06/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x06/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x06/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x06/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x07/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x07/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x07/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/client.send.opcode.0x07/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x03/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x03/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x03/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x03/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x04/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x04/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x04/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x04/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x05/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x05/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x05/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x05/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x06/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x06/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x06/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x06/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x07/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x07/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x07/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/data/server.send.opcode.0x07/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.binary.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.close.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.ping.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.pong.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/client.send.text.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.binary.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.close.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.ping.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.pong.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.1/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.1/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.1/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.1/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.2/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.2/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.2/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.2/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.3/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.3/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.3/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.3/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.4/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.4/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.4/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.4/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.5/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.5/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.5/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.5/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.6/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.6/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.6/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.6/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.7/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.7/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.7/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/extensibility/server.send.text.frame.with.rsv.7/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/flowcontrol/echo.payload.with.padding/client.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/flowcontrol/echo.payload.with.padding/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/flowcontrol/echo.payload.with.padding/server.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/flowcontrol/echo.payload.with.padding/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.0.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.binary.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.0.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.echo.text.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.binary.payload.length.125.fragmented.but.not.continued/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.binary.payload.length.125.fragmented.but.not.continued/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.binary.payload.length.125.fragmented.but.not.continued/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.binary.payload.length.125.fragmented.but.not.continued/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.close.payload.length.2.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.close.payload.length.2.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.close.payload.length.2.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.close.payload.length.2.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.continuation.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.ping.payload.length.0.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.ping.payload.length.0.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.ping.payload.length.0.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.ping.payload.length.0.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.pong.payload.length.0.fragmented/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.pong.payload.length.0.fragmented/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.pong.payload.length.0.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.pong.payload.length.0.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.text.payload.length.125.fragmented.but.not.continued/handshake.request.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.text.payload.length.125.fragmented.but.not.continued/handshake.request.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.text.payload.length.125.fragmented.but.not.continued/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/client.send.text.payload.length.125.fragmented.but.not.continued/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.0.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.binary.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.0.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.but.not.utf8.aligned/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.injected.ping.pong/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented.with.some.empty.fragments/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.echo.text.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.binary.payload.length.125.fragmented.but.not.continued/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.binary.payload.length.125.fragmented.but.not.continued/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.binary.payload.length.125.fragmented.but.not.continued/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.binary.payload.length.125.fragmented.but.not.continued/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.close.payload.length.2.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.close.payload.length.2.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.close.payload.length.2.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.close.payload.length.2.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.not.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.continuation.payload.length.125.not.fragmented/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.ping.payload.length.0.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.ping.payload.length.0.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.ping.payload.length.0.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.ping.payload.length.0.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.pong.payload.length.0.fragmented/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.pong.payload.length.0.fragmented/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.pong.payload.length.0.fragmented/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.pong.payload.length.0.fragmented/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.text.payload.length.125.fragmented.but.not.continued/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.text.payload.length.125.fragmented.but.not.continued/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.text.payload.length.125.fragmented.but.not.continued/handshake.response.and.frames.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/fragmentation/server.send.text.payload.length.125.fragmented.but.not.continued/handshake.response.and.frames.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.10k/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.10k/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.10k/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.10k/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.127/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.127/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.127/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.127/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.128/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.128/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.128/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.128/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65535/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65535/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65535/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65535/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65536/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65536/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65536/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.binary.payload.length.65536/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.0/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.0/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.0/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.0/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.125/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.125/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.125/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.125/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.126/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.126/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.126/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.126/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.127/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.127/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.127/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.127/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.128/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.128/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.128/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.128/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65535/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65535/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65535/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65535/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65536/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65536/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65536/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/framing/echo.text.payload.length.65536/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.binary.payload.not.masked/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.binary.payload.not.masked/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.binary.payload.not.masked/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.binary.payload.not.masked/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.text.payload.not.masked/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.text.payload.not.masked/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.text.payload.not.masked/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/send.text.payload.not.masked/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.binary/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.binary/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.binary/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.binary/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.text/handshake.request.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.text/handshake.request.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.text/handshake.response.and.frame.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/masking/server.send.masked.text/handshake.response.and.frame.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/connection.established/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/connection.established/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/connection.established/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/connection.established/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/multiple.connections.established/handshake.requests.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/multiple.connections.established/handshake.requests.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/multiple.connections.established/handshake.responses.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/multiple.connections.established/handshake.responses.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.not.upgrade/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.not.upgrade/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.not.upgrade/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.connection.not.upgrade/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.cookie/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.cookie/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.cookie/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.cookie/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.host.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.host.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.host.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.host.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.origin/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.origin/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.origin/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.origin/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.extensions/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.extensions/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.extensions/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.extensions/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.not.16bytes.base64/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.not.16bytes.base64/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.not.16bytes.base64/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.key.not.16bytes.base64/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol.negotiated/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol.negotiated/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol.negotiated/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol.negotiated/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.protocol/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.version.not.13/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.version.not.13/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.version.not.13/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.sec.websocket.version.not.13/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.not.websocket/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.not.websocket/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.not.websocket/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.header.upgrade.not.websocket/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.headers.random.case/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.headers.random.case/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.headers.random.case/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.headers.random.case/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.method.not.get/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.method.not.get/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.method.not.get/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.method.not.get/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.version.not.http.1.1/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.version.not.http.1.1/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.version.not.http.1.1/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/request.version.not.http.1.1/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.not.upgrade/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.not.upgrade/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.not.upgrade/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.connection.not.upgrade/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.not.hashed/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.not.hashed/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.not.hashed/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.accept.not.hashed/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.not.negotiated/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.not.negotiated/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.not.negotiated/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.not.negotiated/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.partial.agreement/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.partial.agreement/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.partial.agreement/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.partial.agreement/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.reordered/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.reordered/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.reordered/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.extensions.reordered/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.protocol.not.negotiated/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.protocol.not.negotiated/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.protocol.not.negotiated/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.sec.websocket.protocol.not.negotiated/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.missing/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.missing/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.missing/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.missing/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.not.websocket/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.not.websocket/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.not.websocket/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.header.upgrade.not.websocket/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.headers.random.case/handshake.request.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.headers.random.case/handshake.request.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.headers.random.case/handshake.response.rpt
+++ b/specs/binding-ws.spec/src/main/scripts/io/aklivity/zilla/specs/binding/ws/streams/network/opening/response.headers.random.case/handshake.response.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/config/SchemaTest.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/internal/WsFunctionsTest.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/internal/WsFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/AdvisoryIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/BaseFramingIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/BaseFramingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/ClosingHandshakeIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/ClosingHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/ControlIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/ControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/FlowControlIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/FragmentationIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/FragmentationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/OpeningHandshakeIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/application/OpeningHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/AdvisoryIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/AdvisoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/BaseFramingIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/BaseFramingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ClosingHandshakeIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ClosingHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ControlIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/DataFramingIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/DataFramingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ExtensibilityIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/ExtensibilityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/FlowControlIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/FlowControlIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/FragmentationIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/FragmentationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/MaskingIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/MaskingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/OpeningHandshakeIT.java
+++ b/specs/binding-ws.spec/src/test/java/io/aklivity/zilla/specs/binding/ws/streams/network/OpeningHandshakeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/catalog-apicurio.spec/src/main/moditect/module-info.java
+++ b/specs/catalog-apicurio.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/resources/META-INF/zilla/apicurio.idl
+++ b/specs/catalog-apicurio.spec/src/main/resources/META-INF/zilla/apicurio.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/catalog-alias.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/catalog-alias.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/catalog.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/cache/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/retry/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/global/id/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/cache/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/failed/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/failed/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/latest/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/latest/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/retry/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/zilla.yaml
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/config/resolve/artifact/id/subject/version/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.latest.version.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.latest.version.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.failed.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.failed.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.retry.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.retry.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.artifactid.version.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.global.id.retry.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.global.id.retry.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.global.id.rpt
+++ b/specs/catalog-apicurio.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/apicurio/streams/resolve.artifact.via.global.id.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-apicurio.spec/src/test/java/io/aklivity/zilla/specs/catalog/apicurio/config/SchemaTest.java
+++ b/specs/catalog-apicurio.spec/src/test/java/io/aklivity/zilla/specs/catalog/apicurio/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-filesystem.spec/src/main/moditect/module-info.java
+++ b/specs/catalog-filesystem.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-filesystem.spec/src/main/resources/META-INF/zilla/filesystem.idl
+++ b/specs/catalog-filesystem.spec/src/main/resources/META-INF/zilla/filesystem.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/filesystem/config/catalog.yaml
+++ b/specs/catalog-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/filesystem/config/catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/filesystem/config/event.yaml
+++ b/specs/catalog-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/filesystem/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-filesystem.spec/src/test/java/io/aklivity/zilla/specs/catalog/filesystem/config/SchemaTest.java
+++ b/specs/catalog-filesystem.spec/src/test/java/io/aklivity/zilla/specs/catalog/filesystem/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-inline.spec/src/main/moditect/module-info.java
+++ b/specs/catalog-inline.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-inline.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/inline/config/catalog.yaml
+++ b/specs/catalog-inline.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/inline/config/catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-inline.spec/src/test/java/io/aklivity/zilla/specs/catalog/inline/config/SchemaTest.java
+++ b/specs/catalog-inline.spec/src/test/java/io/aklivity/zilla/specs/catalog/inline/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/moditect/module-info.java
+++ b/specs/catalog-karapace.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/catalog-alias.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/catalog-alias.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/catalog.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/cache/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/retry/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/schema/id/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/cache/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/retry/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/resolve/subject/version/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/unretrievable/schema/id/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/unretrievable/schema/id/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/unretrievable/schema/subject/version/zilla.yaml
+++ b/specs/catalog-karapace.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/karapace/config/unretrievable/schema/subject/version/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-karapace.spec/src/test/java/io/aklivity/zilla/specs/catalog/karapace/config/SchemaTest.java
+++ b/specs/catalog-karapace.spec/src/test/java/io/aklivity/zilla/specs/catalog/karapace/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/moditect/module-info.java
+++ b/specs/catalog-schema-registry.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/resources/META-INF/zilla/schema_registry.idl
+++ b/specs/catalog-schema-registry.spec/src/main/resources/META-INF/zilla/schema_registry.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/catalog.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/catalog.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/register/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/register/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/cache/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/retry/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/secure/mtls/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/secure/mtls/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/secure/server/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/secure/server/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/schema/id/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/cache/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/cache/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/retry/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/retry/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/resolve/subject/version/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unregister/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unregister/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unretrievable/schema/id/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unretrievable/schema/id/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unretrievable/schema/subject/version/zilla.yaml
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/config/unretrievable/schema/subject/version/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/register.schema.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/register.schema.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.failed.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.failed.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.on.retry.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.on.retry.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.schema.id.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.failed.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.failed.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.retry.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.retry.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.schema.via.subject.version.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.secure.mtls.schema.via.schema.id.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.secure.mtls.schema.via.schema.id.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.secure.server.schema.via.schema.id.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/resolve.secure.server.schema.via.schema.id.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/unregister.schema.rpt
+++ b/specs/catalog-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/catalog/schema/registry/streams/unregister.schema.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/catalog-schema-registry.spec/src/test/java/io/aklivity/zilla/specs/catalog/schema/registry/config/SchemaTest.java
+++ b/specs/catalog-schema-registry.spec/src/test/java/io/aklivity/zilla/specs/catalog/schema/registry/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/engine.spec/src/main/java/io/aklivity/zilla/specs/engine/config/ConfigSchemaRule.java
+++ b/specs/engine.spec/src/main/java/io/aklivity/zilla/specs/engine/config/ConfigSchemaRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/java/io/aklivity/zilla/specs/engine/internal/CoreFunctions.java
+++ b/specs/engine.spec/src/main/java/io/aklivity/zilla/specs/engine/internal/CoreFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/moditect/module-info.java
+++ b/specs/engine.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
+++ b/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/engine.events.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.entry.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.entry.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.exit.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.exit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.kind.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.kind.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.type.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.no.type.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.routes.and.no.exit.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.binding.with.routes.and.no.exit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.event.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.data/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.data/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.advise.challenge/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.advise.challenge/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.advise.flush/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.advise.flush/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.write.close/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.write.close/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/client.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/event/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/event/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/event/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/event/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/handshake/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/handshake/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http.basic.auth/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http.basic.auth/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http.basic.auth/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http.basic.auth/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.create.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.delete.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.complex.chain.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.complex.chain.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.complex.chain.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.complex.chain.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.no.etag.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.no.etag.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.no.etag.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.no.etag.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.modify.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.not.modify.parse.failed.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.not.modify.parse.failed.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.not.modify.parse.failed.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.not.modify.parse.failed.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.server.error.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.server.error.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.server.error.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/reconfigure.server.error.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.data/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.data/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.advise.challenge/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.advise.challenge/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.advise.flush/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.advise.flush/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.write.close/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.write.close/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/application/server.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.data/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.data/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.advise.challenge/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.advise.challenge/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.advise.flush/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.advise.flush/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.write.close/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.write.close/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/client.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/handshake/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.create.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.delete.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.init.server.error.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.init.server.error.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.init.server.error.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.init.server.error.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.complex.chain.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.complex.chain.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.complex.chain.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.complex.chain.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.no.etag.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.no.etag.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.no.etag.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.no.etag.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.modify.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.not.modify.parse.failed.via.file/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.not.modify.parse.failed.via.file/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.not.modify.parse.failed.via.file/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.not.modify.parse.failed.via.file/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.server.error.via.http/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.server.error.via.http/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.server.error.via.http/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/reconfigure.server.error.via.http/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.data/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.data/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.data/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.data/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.advise.challenge/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.advise.challenge/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.advise.challenge/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.read.advise.challenge/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.abort/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.abort/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.abort/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.abort/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.advise.flush/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.advise.flush/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.advise.flush/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.sent.write.advise.flush/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.write.close/client.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.write.close/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.write.close/server.rpt
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/streams/network/server.write.close/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/config/SchemaTest.java
+++ b/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/internal/CoreFunctionsTest.java
+++ b/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/internal/CoreFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/streams/ApplicationIT.java
+++ b/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/streams/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/streams/NetworkIT.java
+++ b/specs/engine.spec/src/test/java/io/aklivity/zilla/specs/engine/streams/NetworkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/exporter-otlp.spec/src/main/moditect/module-info.java
+++ b/specs/exporter-otlp.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.authorization/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.authorization/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.mtls.authorization/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.mtls.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.mtls.authorization/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.mtls.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.quoted.message/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.quoted.message/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.quoted.message/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event.with.quoted.message/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/event/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics.with.service.name/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics.with.service.name/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics.with.service.name/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics.with.service.name/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics/client.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics/server.rpt
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/application/metrics/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.with.quoted.message.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.with.quoted.message.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.with.service.name.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.with.service.name.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/metrics.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/secure/mtls/zilla.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/secure/mtls/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/secure/zilla.yaml
+++ b/specs/exporter-otlp.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/otlp/config/secure/zilla.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/test/java/io/aklivity/zilla/specs/exporter/otlp/ApplicationIT.java
+++ b/specs/exporter-otlp.spec/src/test/java/io/aklivity/zilla/specs/exporter/otlp/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-otlp.spec/src/test/java/io/aklivity/zilla/specs/exporter/otlp/config/OtlpSchemaTest.java
+++ b/specs/exporter-otlp.spec/src/test/java/io/aklivity/zilla/specs/exporter/otlp/config/OtlpSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-prometheus.spec/src/main/moditect/module-info.java
+++ b/specs/exporter-prometheus.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-stdout.spec/src/main/moditect/module-info.java
+++ b/specs/exporter-stdout.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/exporter-stdout.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/stdout/config/server.event.yaml
+++ b/specs/exporter-stdout.spec/src/main/scripts/io/aklivity/zilla/specs/exporter/stdout/config/server.event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/moditect/module-info.java
+++ b/specs/filesystem-http.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound.success/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound.success/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound.success/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound.success/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.notfound/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.authorization/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.authorization/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.authorization/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.authorization/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.modified/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.modified/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.not.modified/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.not.modified/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.not.modified/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success.etag.not.modified/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/read.success/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch.read/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch.read/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch.read/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch.read/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/server.rpt
+++ b/specs/filesystem-http.spec/src/main/scripts/io/aklivity/zilla/specs/filesystem/http/application/watch/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/filesystem-http.spec/src/test/java/io/aklivity/zilla/specs/filesystem/http/ApplicationIT.java
+++ b/specs/filesystem-http.spec/src/test/java/io/aklivity/zilla/specs/filesystem/http/ApplicationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/java/io/aklivity/zilla/specs/guard/jwt/keys/JwtKeys.java
+++ b/specs/guard-jwt.spec/src/main/java/io/aklivity/zilla/specs/guard/jwt/keys/JwtKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/moditect/module-info.java
+++ b/specs/guard-jwt.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/resources/META-INF/zilla/jwt.idl
+++ b/specs/guard-jwt.spec/src/main/resources/META-INF/zilla/jwt.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/event.yaml
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard-keys-dynamic.yaml
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard-keys-dynamic.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard-keys-implicit.yaml
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard-keys-implicit.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard.yaml
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/guard.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/keys/issuer.rpt
+++ b/specs/guard-jwt.spec/src/main/scripts/io/aklivity/zilla/specs/guard/jwt/config/keys/issuer.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/test/java/io/aklivity/zilla/specs/guard/jwt/config/SchemaTest.java
+++ b/specs/guard-jwt.spec/src/test/java/io/aklivity/zilla/specs/guard/jwt/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/guard-jwt.spec/src/test/java/io/aklivity/zilla/specs/guard/jwt/keys/JwtKeysTest.java
+++ b/specs/guard-jwt.spec/src/test/java/io/aklivity/zilla/specs/guard/jwt/keys/JwtKeysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/metrics-grpc.spec/src/main/moditect/module-info.java
+++ b/specs/metrics-grpc.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/metrics-http.spec/src/main/moditect/module-info.java
+++ b/specs/metrics-http.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/metrics-stream.spec/src/main/moditect/module-info.java
+++ b/specs/metrics-stream.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/moditect/module-info.java
+++ b/specs/model-avro.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/resources/META-INF/zilla/avro_model.idl
+++ b/specs/model-avro.spec/src/main/resources/META-INF/zilla/avro_model.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/event.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.invalid/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.invalid/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.invalid/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.invalid/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/config/SchemaTest.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/moditect/module-info.java
+++ b/specs/model-core.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/resources/META-INF/zilla/core_model.idl
+++ b/specs/model-core.spec/src/main/resources/META-INF/zilla/core_model.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/boolean.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/boolean.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/double.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/double.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/event.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/float.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/float.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/int32.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/int32.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/int64.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/int64.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/string.model.yaml
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/config/string.model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/application/client.sent.string.invalid.utf8/client.rpt
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/application/client.sent.string.invalid.utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/application/client.sent.string.invalid.utf8/server.rpt
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/application/client.sent.string.invalid.utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/network/client.sent.string.invalid.utf8/client.rpt
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/network/client.sent.string.invalid.utf8/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/network/client.sent.string.invalid.utf8/server.rpt
+++ b/specs/model-core.spec/src/main/scripts/io/aklivity/zilla/specs/model/core/streams/network/client.sent.string.invalid.utf8/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/BooleanSchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/BooleanSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/DoubleSchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/DoubleSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/FloatSchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/FloatSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/Int32SchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/Int32SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/Int64SchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/Int64SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/StringSchemaTest.java
+++ b/specs/model-core.spec/src/test/java/io/aklivity/zilla/specs/model/core/config/StringSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/moditect/module-info.java
+++ b/specs/model-json.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/resources/META-INF/zilla/json_model.idl
+++ b/specs/model-json.spec/src/main/resources/META-INF/zilla/json_model.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/event.yaml
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.yaml
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.invalid/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.invalid/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.invalid/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.invalid/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/config/SchemaTest.java
+++ b/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/moditect/module-info.java
+++ b/specs/model-protobuf.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/resources/META-INF/zilla/protobuf_model.idl
+++ b/specs/model-protobuf.spec/src/main/resources/META-INF/zilla/protobuf_model.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/event.yaml
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/event.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.yaml
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/application/client.sent.protobuf.invalid/client.rpt
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/application/client.sent.protobuf.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/application/client.sent.protobuf.invalid/server.rpt
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/application/client.sent.protobuf.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/network/client.sent.protobuf.invalid/client.rpt
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/network/client.sent.protobuf.invalid/client.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/network/client.sent.protobuf.invalid/server.rpt
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/streams/network/client.sent.protobuf.invalid/server.rpt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/model-protobuf.spec/src/test/java/io/aklivity/zilla/specs/model/protobuf/config/SchemaTest.java
+++ b/specs/model-protobuf.spec/src/test/java/io/aklivity/zilla/specs/model/protobuf/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/store-memory.spec/src/main/moditect/module-info.java
+++ b/specs/store-memory.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/store-memory.spec/src/main/scripts/io/aklivity/zilla/specs/store/memory/config/store.yaml
+++ b/specs/store-memory.spec/src/main/scripts/io/aklivity/zilla/specs/store/memory/config/store.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc
+# Copyright 2021-2026 Aklivity Inc
 #
 # Licensed under the Aklivity Community License (the "License"); you may not use
 # this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/store-memory.spec/src/test/java/io/aklivity/zilla/specs/store/memory/config/SchemaTest.java
+++ b/specs/store-memory.spec/src/test/java/io/aklivity/zilla/specs/store/memory/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc
+ * Copyright 2021-2026 Aklivity Inc
  *
  * Licensed under the Aklivity Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/specs/vault-filesystem.spec/src/main/moditect/module-info.java
+++ b/specs/vault-filesystem.spec/src/main/moditect/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/config/vault.crl.yaml
+++ b/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/config/vault.crl.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/config/vault.yaml
+++ b/specs/vault-filesystem.spec/src/main/scripts/io/aklivity/zilla/specs/vault/filesystem/config/vault.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 Aklivity Inc.
+# Copyright 2021-2026 Aklivity Inc.
 #
 # Aklivity licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance

--- a/specs/vault-filesystem.spec/src/test/java/io/aklivity/zilla/specs/vault/filesystem/config/SchemaTest.java
+++ b/specs/vault-filesystem.spec/src/test/java/io/aklivity/zilla/specs/vault/filesystem/config/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
## Description

Bump `copyrightYears` to `${project.inceptionYear}-2026` in the `license-maven-plugin` configuration in the root `pom.xml`, then run `./mvnw license:format` to reformat all license headers across the reactor accordingly.

The standalone `examples/grpc.kafka.fanout/grpc.reliable.streaming` project (outside the main reactor, with its own independent license config pinned to `inceptionYear-2022`) was intentionally left untouched, as it is a separate, independently-versioned project.

Verified via `./mvnw install -DskipITs`: the reactor compiles cleanly with the updated headers; a small number of modules fail their JaCoCo coverage gate purely because integration tests were skipped for a faster check — confirmed pre-existing by reproducing the same failure on the unmodified base commit with the same flags.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeAFdMQRhjjQjW4YRo1g5h)_