### PR TITLE
fix(common-openapi): resolve full servers[] precedence in OpenapiOperationView

### DIFF
--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOperationView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOperationView.java
@@ -20,9 +20,11 @@ import static java.util.stream.Collectors.toMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiOperation;
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiServer;
 import io.aklivity.zilla.runtime.common.openapi.model.resolver.OpenapiResolver;
 
 public final class OpenapiOperationView
@@ -50,6 +52,7 @@ public final class OpenapiOperationView
         OpenapiResolver resolver,
         String method,
         String path,
+        List<OpenapiServer> pathServers,
         OpenapiOperation model)
     {
         this.specification = specification;
@@ -83,9 +86,13 @@ public final class OpenapiOperationView
                     .toList()
                 : specification.security;
 
-        this.servers = model.servers != null
-                ? model.servers.stream()
-                    .flatMap(s -> configs.stream().map(c -> new OpenapiServerView(resolver, s, c)))
+        List<OpenapiServer> effectiveServers = model.servers != null ? model.servers : pathServers;
+
+        this.servers = effectiveServers != null
+                ? effectiveServers.stream()
+                    .flatMap(s -> configs.isEmpty()
+                        ? Stream.of(new OpenapiServerView(resolver, s, null))
+                        : configs.stream().map(c -> new OpenapiServerView(resolver, s, c)))
                     .toList()
                 : specification.servers;
 

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiPathView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiPathView.java
@@ -80,7 +80,7 @@ public final class OpenapiPathView
             .filter(e -> e.getValue().apply(model) != null)
             .collect(Collectors.toMap(Map.Entry::getKey, e ->
                 new OpenapiOperationView(specification, supplyCompositeId.getAsLong(),
-                        configs, resolver, e.getKey(), path, e.getValue().apply(model))));
+                        configs, resolver, e.getKey(), path, model.servers, e.getValue().apply(model))));
         this.extensions = model.extensions;
     }
 

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiServerView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiServerView.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 
 import org.agrona.LangUtil;
 
-import io.aklivity.zilla.runtime.common.openapi.config.OpenapiException;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiServer;
 import io.aklivity.zilla.runtime.common.openapi.model.resolver.OpenapiResolver;
@@ -92,31 +91,13 @@ public final class OpenapiServerView
     {
         private static final Pattern VARIABLE = Pattern.compile("\\{([^}]*.?)\\}");
 
-        private final String template;
-        private final boolean templated;
         private final Matcher matcher;
         private final String defaultValue;
 
         public String resolve(
             String value)
         {
-            String resolved;
-
-            if (!templated || value == null)
-            {
-                resolved = defaultValue;
-            }
-            else if (matcher.reset(value).matches())
-            {
-                resolved = value;
-            }
-            else
-            {
-                throw new OpenapiException(String.format(
-                    "openapi server url \"%s\" does not match variable pattern of template \"%s\"", value, template));
-            }
-
-            return resolved;
+            return value != null && matcher.reset(value).matches() ? value : defaultValue;
         }
 
         private VariableMatcher(
@@ -127,8 +108,6 @@ public final class OpenapiServerView
                 .replaceAll(mr -> resolver.apply(mr.group(1)).values.stream()
                     .collect(joining("|", "(", ")")));
 
-            this.template = value;
-            this.templated = VARIABLE.matcher(value).find();
             this.matcher = Pattern.compile(regex).matcher("");
             this.defaultValue = VARIABLE.matcher(value)
                     .replaceAll(mr -> resolver.apply(mr.group(1)).defaultValue);

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiServerView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiServerView.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 
 import org.agrona.LangUtil;
 
+import io.aklivity.zilla.runtime.common.openapi.config.OpenapiException;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiServer;
 import io.aklivity.zilla.runtime.common.openapi.model.resolver.OpenapiResolver;
@@ -91,13 +92,31 @@ public final class OpenapiServerView
     {
         private static final Pattern VARIABLE = Pattern.compile("\\{([^}]*.?)\\}");
 
+        private final String template;
+        private final boolean templated;
         private final Matcher matcher;
         private final String defaultValue;
 
         public String resolve(
             String value)
         {
-            return value != null && matcher.reset(value).matches() ? value : defaultValue;
+            String resolved;
+
+            if (!templated || value == null)
+            {
+                resolved = defaultValue;
+            }
+            else if (matcher.reset(value).matches())
+            {
+                resolved = value;
+            }
+            else
+            {
+                throw new OpenapiException(String.format(
+                    "openapi server url \"%s\" does not match variable pattern of template \"%s\"", value, template));
+            }
+
+            return resolved;
         }
 
         private VariableMatcher(
@@ -108,6 +127,8 @@ public final class OpenapiServerView
                 .replaceAll(mr -> resolver.apply(mr.group(1)).values.stream()
                     .collect(joining("|", "(", ")")));
 
+            this.template = value;
+            this.templated = VARIABLE.matcher(value).find();
             this.matcher = Pattern.compile(regex).matcher("");
             this.defaultValue = VARIABLE.matcher(value)
                     .replaceAll(mr -> resolver.apply(mr.group(1)).defaultValue);

--- a/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
+++ b/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.common.openapi.config.OpenapiException;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.Openapi;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiComponents;
@@ -39,6 +40,7 @@ import io.aklivity.zilla.runtime.common.openapi.model.OpenapiRequestBody;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiSchema;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiSecurityScheme;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiServer;
+import io.aklivity.zilla.runtime.common.openapi.model.OpenapiServerVariable;
 
 public class OpenapiViewTest
 {
@@ -303,6 +305,153 @@ public class OpenapiViewTest
 
         assertNull(schemeView.flows);
         assertEquals(List.of(), schemeView.scopes);
+    }
+
+    @Test
+    public void shouldResolveOperationLevelServersOverPathAndRoot() throws Exception
+    {
+        OpenapiServer rootServer = new OpenapiServer();
+        rootServer.url = "http://root.example.com";
+
+        OpenapiServer pathServer = new OpenapiServer();
+        pathServer.url = "http://path.example.com";
+
+        OpenapiServer operationServer = new OpenapiServer();
+        operationServer.url = "http://operation.example.com";
+
+        OpenapiOperation operation = new OpenapiOperation();
+        operation.operationId = "ReadItems";
+        operation.servers = List.of(operationServer);
+
+        OpenapiPath path = new OpenapiPath();
+        path.get = operation;
+        path.servers = List.of(pathServer);
+
+        Openapi model = new Openapi();
+        model.servers = List.of(rootServer);
+        model.paths = Map.of("/items", path);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder().build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
+        OpenapiOperationView operationView = view.paths.get("/items").methods.get("GET");
+
+        assertEquals(1, operationView.servers.size());
+        assertEquals(URI.create("http://operation.example.com:80"), operationView.servers.get(0).url);
+    }
+
+    @Test
+    public void shouldResolvePathLevelServersOverRootWhenOperationHasNone() throws Exception
+    {
+        OpenapiServer rootServer = new OpenapiServer();
+        rootServer.url = "http://root.example.com";
+
+        OpenapiServer pathServer = new OpenapiServer();
+        pathServer.url = "http://path.example.com";
+
+        OpenapiOperation operation = new OpenapiOperation();
+        operation.operationId = "ReadItems";
+
+        OpenapiPath path = new OpenapiPath();
+        path.get = operation;
+        path.servers = List.of(pathServer);
+
+        Openapi model = new Openapi();
+        model.servers = List.of(rootServer);
+        model.paths = Map.of("/items", path);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder().build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
+        OpenapiOperationView operationView = view.paths.get("/items").methods.get("GET");
+
+        assertEquals(1, operationView.servers.size());
+        assertEquals(URI.create("http://path.example.com:80"), operationView.servers.get(0).url);
+    }
+
+    @Test
+    public void shouldResolveRootLevelServersWhenNoOperationOrPathServers() throws Exception
+    {
+        OpenapiServer rootServer = new OpenapiServer();
+        rootServer.url = "http://root.example.com";
+
+        OpenapiOperation operation = new OpenapiOperation();
+        operation.operationId = "ReadItems";
+
+        OpenapiPath path = new OpenapiPath();
+        path.get = operation;
+
+        Openapi model = new Openapi();
+        model.servers = List.of(rootServer);
+        model.paths = Map.of("/items", path);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder().build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
+        OpenapiOperationView operationView = view.paths.get("/items").methods.get("GET");
+
+        assertEquals(1, operationView.servers.size());
+        assertEquals(URI.create("http://root.example.com:80"), operationView.servers.get(0).url);
+    }
+
+    @Test
+    public void shouldResolveServerUrlVariableDefaultWhenNoOverride() throws Exception
+    {
+        OpenapiServerVariable variable = new OpenapiServerVariable();
+        variable.values = List.of("prod", "staging");
+        variable.defaultValue = "prod";
+
+        OpenapiServer server = new OpenapiServer();
+        server.url = "http://{env}.example.com";
+        server.variables = Map.of("env", variable);
+
+        Openapi model = new Openapi();
+        model.servers = List.of(server);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder().build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
+
+        assertEquals(URI.create("http://prod.example.com:80"), view.servers.get(0).url);
+    }
+
+    @Test
+    public void shouldResolveServerUrlVariableOverrideMatchingPattern() throws Exception
+    {
+        OpenapiServerVariable variable = new OpenapiServerVariable();
+        variable.values = List.of("prod", "staging");
+        variable.defaultValue = "prod";
+
+        OpenapiServer server = new OpenapiServer();
+        server.url = "http://{env}.example.com";
+        server.variables = Map.of("env", variable);
+
+        Openapi model = new Openapi();
+        model.servers = List.of(server);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder()
+            .url("http://staging.example.com")
+            .build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
+
+        assertEquals(URI.create("http://staging.example.com:80"), view.servers.get(0).url);
+    }
+
+    @Test(expected = OpenapiException.class)
+    public void shouldRejectServerUrlOverrideNotMatchingVariablePattern() throws Exception
+    {
+        OpenapiServerVariable variable = new OpenapiServerVariable();
+        variable.values = List.of("prod", "staging");
+        variable.defaultValue = "prod";
+
+        OpenapiServer server = new OpenapiServer();
+        server.url = "http://{env}.example.com";
+        server.variables = Map.of("env", variable);
+
+        Openapi model = new Openapi();
+        model.servers = List.of(server);
+
+        OpenapiServerConfig config = OpenapiServerConfig.builder()
+            .url("http://dev.example.com")
+            .build();
+
+        OpenapiView.of(model, List.of(config));
     }
 
     public static final class SampleExtension

--- a/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
+++ b/runtime/common-openapi/src/test/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiViewTest.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.common.openapi.config.OpenapiException;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiServerConfig;
 import io.aklivity.zilla.runtime.common.openapi.model.Openapi;
 import io.aklivity.zilla.runtime.common.openapi.model.OpenapiComponents;
@@ -433,8 +432,8 @@ public class OpenapiViewTest
         assertEquals(URI.create("http://staging.example.com:80"), view.servers.get(0).url);
     }
 
-    @Test(expected = OpenapiException.class)
-    public void shouldRejectServerUrlOverrideNotMatchingVariablePattern() throws Exception
+    @Test
+    public void shouldDefaultServerUrlVariableWhenOverrideDoesNotMatchPattern() throws Exception
     {
         OpenapiServerVariable variable = new OpenapiServerVariable();
         variable.values = List.of("prod", "staging");
@@ -450,8 +449,9 @@ public class OpenapiViewTest
         OpenapiServerConfig config = OpenapiServerConfig.builder()
             .url("http://dev.example.com")
             .build();
+        OpenapiView view = OpenapiView.of(model, List.of(config));
 
-        OpenapiView.of(model, List.of(config));
+        assertEquals(URI.create("http://prod.example.com:80"), view.servers.get(0).url);
     }
 
     public static final class SampleExtension


### PR DESCRIPTION
## Description

`OpenapiOperationView.servers` previously only reflected an operation's own `servers[]` array, falling straight back to the root/document-level `servers[]` when absent — it never looked at path-item-level `servers[]`. This change wires the path-item's `servers[]` through `OpenapiPathView` into `OpenapiOperationView`, so `operation.servers` now resolves the full OpenAPI precedence: operation-level > path-item-level > root-level.

While implementing this, `OpenapiOperationView` (and, by extension, the new path-item level) also now mirrors `OpenapiView`'s handling of an empty `configs` list — previously, an operation or path declaring its own `servers[]` combined with an empty server-config list would silently resolve to zero servers instead of falling back to using the model's own server URL directly.

The issue also raised the silent-fallback-on-mismatch behavior in `OpenapiServerView.VariableMatcher` (a caller-supplied server URL override that doesn't match the variable's allowed pattern silently substitutes the declared default). After investigation, this PR intentionally leaves that fallback as-is: `binding-mcp-openapi` already treats a configured server URL as an unconditional override elsewhere (its `resolveServerOverride` bypasses `common-openapi`'s matcher entirely), and `OpenapiOperationView.servers` cross-products every model server against every configured override, so a non-matching pairing is the expected outcome whenever more than one server or config is declared — not a misconfiguration to reject.

This is a building block for downstream work (e.g. `binding-openapi-asyncapi`) that currently duplicates parts of the servers[] precedence logic; simplifying that downstream duplication is left for a follow-up change.

## Testing

Added unit tests in `OpenapiViewTest` covering:
- Operation-level `servers[]` taking precedence over path-item and root
- Path-item-level `servers[]` taking precedence over root when the operation declares none
- Root-level `servers[]` fallback when neither operation nor path-item declare any
- Server URL variable resolution using the declared default when no override is supplied
- Server URL variable resolution using a matching caller-supplied override
- Server URL variable resolution falling back to the default when a caller-supplied override doesn't match the variable's allowed pattern

`./mvnw test -pl runtime/common-openapi` passes, along with the existing test suites for `binding-openapi`, `binding-openapi-asyncapi`, and `binding-mcp-openapi`.

Fixes #2020
