### PR TITLE
feat(binding-mcp-openapi): pick up OpenAPI operation summary and description for generated tools

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpToolConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpToolConfig.java
@@ -19,21 +19,21 @@ import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 public final class McpHttpToolConfig
 {
     public final String name;
-    public final String description;
     public final String summary;
+    public final String description;
     public final ModelConfig input;
     public final ModelConfig output;
 
     public McpHttpToolConfig(
         String name,
-        String description,
         String summary,
+        String description,
         ModelConfig input,
         ModelConfig output)
     {
         this.name = name;
-        this.description = description;
         this.summary = summary;
+        this.description = description;
         this.input = input;
         this.output = output;
     }

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapter.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapter.java
@@ -107,13 +107,13 @@ public final class McpHttpOptionsConfigAdapter implements OptionsConfigAdapterSp
             for (McpHttpToolConfig tool : tools)
             {
                 JsonObjectBuilder toolObject = Json.createObjectBuilder();
-                if (tool.description != null)
-                {
-                    toolObject.add(DESCRIPTION_NAME, tool.description);
-                }
                 if (tool.summary != null)
                 {
                     toolObject.add(SUMMARY_NAME, tool.summary);
+                }
+                if (tool.description != null)
+                {
+                    toolObject.add(DESCRIPTION_NAME, tool.description);
                 }
                 JsonObjectBuilder schemas = Json.createObjectBuilder();
                 if (tool.input != null)
@@ -240,12 +240,12 @@ public final class McpHttpOptionsConfigAdapter implements OptionsConfigAdapterSp
             for (String name : toolsObject.keySet())
             {
                 JsonObject toolObject = toolsObject.getJsonObject(name);
-                String description = toolObject.containsKey(DESCRIPTION_NAME)
-                    ? toolObject.getString(DESCRIPTION_NAME)
-                    : null;
-
                 String summary = toolObject.containsKey(SUMMARY_NAME)
                     ? toolObject.getString(SUMMARY_NAME)
+                    : null;
+
+                String description = toolObject.containsKey(DESCRIPTION_NAME)
+                    ? toolObject.getString(DESCRIPTION_NAME)
                     : null;
 
                 ModelConfig input = null;
@@ -263,7 +263,7 @@ public final class McpHttpOptionsConfigAdapter implements OptionsConfigAdapterSp
                     }
                 }
 
-                tools.add(new McpHttpToolConfig(name, description, summary, input, output));
+                tools.add(new McpHttpToolConfig(name, summary, description, input, output));
             }
         }
 

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -298,8 +298,10 @@ public final class McpOpenapiCompositeGenerator
             {
                 final String description = entry.toolConfig != null && entry.toolConfig.description != null
                     ? entry.toolConfig.description
-                    : entry.operation.id;
-                tools.add(new McpHttpToolConfig(entry.tool, description, null, input, output));
+                    : entry.operation.description != null
+                        ? entry.operation.description
+                        : entry.operation.id;
+                tools.add(new McpHttpToolConfig(entry.tool, entry.operation.summary, description, input, output));
             }
             else
             {

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -138,6 +138,8 @@ public class McpOpenapiCompositeGeneratorTest
         "      }," +
         "      \"get\": {" +
         "        \"operationId\": \"issues/list\"," +
+        "        \"summary\": \"List repository issues\"," +
+        "        \"description\": \"Retrieve a paginated list of open and closed issues for the specified repository.\"," +
         "        \"security\": []," +
         "        \"parameters\": [" +
         "          { \"name\": \"owner\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }," +
@@ -316,6 +318,56 @@ public class McpOpenapiCompositeGeneratorTest
         assertThat(tool, notNullValue());
         assertThat(tool.description, equalTo("Create a pull request."));
         assertThat(tool.output, sameInstance(override));
+    }
+
+    @Test
+    public void shouldUseOpenapiSummaryAsToolSummary()
+    {
+        BindingConfig binding = bindingWithRoutes(route(0, "list_issues", null, "issues/list"));
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp(composite).options;
+        McpHttpToolConfig tool = mcpHttpOptions.tools.stream()
+            .filter(t -> "list_issues".equals(t.name))
+            .findFirst()
+            .orElse(null);
+        assertThat(tool, notNullValue());
+        assertThat(tool.summary, equalTo("List repository issues"));
+    }
+
+    @Test
+    public void shouldDefaultToolDescriptionToOperationDescriptionWhenPresent()
+    {
+        BindingConfig binding = bindingWithRoutes(route(0, "list_issues", null, "issues/list"));
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp(composite).options;
+        McpHttpToolConfig tool = mcpHttpOptions.tools.stream()
+            .filter(t -> "list_issues".equals(t.name))
+            .findFirst()
+            .orElse(null);
+        assertThat(tool, notNullValue());
+        assertThat(tool.description,
+            equalTo("Retrieve a paginated list of open and closed issues for the specified repository."));
+    }
+
+    @Test
+    public void shouldDefaultToolDescriptionToOperationIdWhenDescriptionAbsent()
+    {
+        BindingConfig binding = bindingWithRoutes(route(0, "get_repo", null, "repos/get"));
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp(composite).options;
+        McpHttpToolConfig tool = mcpHttpOptions.tools.stream()
+            .filter(t -> "get_repo".equals(t.name))
+            .findFirst()
+            .orElse(null);
+        assertThat(tool, notNullValue());
+        assertThat(tool.description, equalTo("repos/get"));
+        assertThat(tool.summary, nullValue());
     }
 
     @Test

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOperation.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/model/OpenapiOperation.java
@@ -20,6 +20,8 @@ import java.util.Map;
 public class OpenapiOperation
 {
     public String operationId;
+    public String summary;
+    public String description;
     public List<OpenapiParameter> parameters;
     public OpenapiRequestBody requestBody;
     public Map<String, OpenapiResponse> responses;

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOperationView.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/view/OpenapiOperationView.java
@@ -36,6 +36,8 @@ public final class OpenapiOperationView
     public final String method;
     public final String path;
     public final String id;
+    public final String summary;
+    public final String description;
 
     public final List<OpenapiParameterView> parameters;
     public final OpenapiRequestBodyView requestBody;
@@ -61,6 +63,8 @@ public final class OpenapiOperationView
         this.path = path;
 
         this.id = model.operationId;
+        this.summary = model.summary;
+        this.description = model.description;
 
         this.parameters = model.parameters != null
                 ? model.parameters.stream()

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/client.rpt
@@ -54,7 +54,6 @@ write '{"name":"create_pr","arguments":{"owner":"acme","repo":"widget","title":"
 write ${core:randomBase64(10000)}
 write '"}}'
 
-# openapi operation summary "Create a pull request" is used as the content text
 read  '{"content":[{"type":"text","text":"Create a pull request"}],'
       '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
       '"isError":false'

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/client.rpt
@@ -54,8 +54,8 @@ write '{"name":"create_pr","arguments":{"owner":"acme","repo":"widget","title":"
 write ${core:randomBase64(10000)}
 write '"}}'
 
-read  '{"content":[{"type":"text","text":'
-      '"{\\"number\\":42,\\"html_url\\":\\"https://github.com/acme/widget/pull/42\\",\\"state\\":\\"open\\",\\"title\\":\\"Add feature\\"}"}],'
+# openapi operation summary "Create a pull request" is used as the content text
+read  '{"content":[{"type":"text","text":"Create a pull request"}],'
       '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
       '"isError":false'
       '}'

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr.10k/server.rpt
@@ -56,8 +56,7 @@ read '"}}'
 
 write flush
 
-write '{"content":[{"type":"text","text":'
-      '"{\\"number\\":42,\\"html_url\\":\\"https://github.com/acme/widget/pull/42\\",\\"state\\":\\"open\\",\\"title\\":\\"Add feature\\"}"}],'
+write '{"content":[{"type":"text","text":"Create a pull request"}],'
       '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
       '"isError":false'
       '}'

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/client.rpt
@@ -52,10 +52,9 @@ connected
 
 write '{"name":"create_pr","arguments":{"owner":"acme","repo":"widget","title":"Add feature","head":"feature","base":"main"}}'
 
-# no summary configured -> mcp_http sets content text to the compact projected JSON
+# openapi operation summary "Create a pull request" is used as the content text
 read  '{'
-        '"content":[{"type":"text","text":'
-        '"{\\"number\\":42,\\"html_url\\":\\"https://github.com/acme/widget/pull/42\\",\\"state\\":\\"open\\",\\"title\\":\\"Add feature\\"}"}],'
+        '"content":[{"type":"text","text":"Create a pull request"}],'
         '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
         '"isError":false'
       '}'

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/client.rpt
@@ -52,7 +52,6 @@ connected
 
 write '{"name":"create_pr","arguments":{"owner":"acme","repo":"widget","title":"Add feature","head":"feature","base":"main"}}'
 
-# openapi operation summary "Create a pull request" is used as the content text
 read  '{'
         '"content":[{"type":"text","text":"Create a pull request"}],'
         '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/create.pr/server.rpt
@@ -55,8 +55,7 @@ read  '{"name":"create_pr","arguments":{"owner":"acme","repo":"widget","title":"
 write flush
 
 write '{'
-        '"content":[{"type":"text","text":'
-        '"{\\"number\\":42,\\"html_url\\":\\"https://github.com/acme/widget/pull/42\\",\\"state\\":\\"open\\",\\"title\\":\\"Add feature\\"}"}],'
+        '"content":[{"type":"text","text":"Create a pull request"}],'
         '"structuredContent":{"number":42,"html_url":"https://github.com/acme/widget/pull/42","state":"open","title":"Add feature"},'
         '"isError":false'
       '}'


### PR DESCRIPTION
## Description

`mcp_openapi` previously ignored the OpenAPI operation's `summary` field entirely, and defaulted a tool's `description` to the raw `operationId` when no explicit `options.tools[].description` override was configured.

This change:

- Parses `summary` and `description` from OpenAPI operations (`OpenapiOperation` / `OpenapiOperationView` in `common-openapi`).
- Wires `operation.summary` into the generated `mcp_http` tool's `summary` field (the static text is used verbatim by `mcp_http` as the tool-call response content, ahead of a fuller dynamic/templated summary story for later).
- Changes the tool `description` fallback chain to: explicit `options.tools[].description` override → OpenAPI `operation.description` → `operationId` (previously just `operationId`). `operationId` is natural-language-poor (e.g. `pulls/create`), while `description` is written prose that's far more useful for an LLM deciding whether to invoke a tool.
- Reorders `McpHttpToolConfig` fields/constructor to `(name, summary, description, input, output)` for readability, and updates the two call sites plus the JSON adapter's read/write order to match.
- Updates `binding-mcp-openapi.spec` k3po fixtures (`create.pr`, `create.pr.10k`): these already embedded an OpenAPI `summary` field that was previously inert; it now becomes the literal tool-call response text, so the expected scripts are updated accordingly.

Added unit tests in `McpOpenapiCompositeGeneratorTest` covering: summary pass-through, description defaulting to `operation.description` when present, and falling back to `operationId` when absent.

Verified `mvn clean verify` (checkstyle + license + unit + IT) is green across `common-openapi`, `binding-mcp-http`, and `binding-mcp-openapi`, including the k3po integration tests and the spec module's peer-to-peer scripts.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFooPFoGdGCsjVrpDhZSHR)_