### PR TITLE
fix(common-json): resolve terminal-window STARVED to REJECTED

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -151,16 +151,22 @@ public final class JsonPipelineImpl implements JsonPipeline
                 // stage starved mid-value (e.g. a validator declining a fragment to accumulate it). Always
                 // give the sink a final drain before the window is replaced: a verbatim run pulls the bytes it
                 // has consumed so far via getVerbatim, so its cursor tracks the parse frontier across windows
-                // and never lags into a replaced window. STARVED stays STARVED; an exhausted-but-advancing
-                // pump needs more input (or is truncated on the final window).
+                // and never lags into a replaced window. On the final window neither case can ever resolve —
+                // no further input is coming to satisfy an exhausted pump or a stage still starved mid-value —
+                // so both convert to REJECTED; otherwise an exhausted-but-advancing pump needs more input and
+                // a stage-starved status is left as is (the stage owns that decision until then).
                 final Status drained = root.flush(control, source);
                 if (drained == Status.SUSPENDED)
                 {
                     status = Status.SUSPENDED;
                 }
+                else if (last)
+                {
+                    status = Status.REJECTED;
+                }
                 else if (status == Status.ADVANCED)
                 {
-                    status = last ? Status.REJECTED : Status.STARVED;
+                    status = Status.STARVED;
                 }
             }
         }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPipelineDeferralTest.java
@@ -95,4 +95,54 @@ class JsonPipelineDeferralTest
 
         assertEquals(Status.REJECTED, status);
     }
+
+    // Unconditionally declines every scalar it sees, regardless of source.deferredBytes() — simulating a
+    // value that can never be reassembled (e.g. one that permanently exceeds some external bound the stage
+    // enforces on its own terms). Used to prove the pump's own last-driven contract independent of any
+    // particular decliner's reassembly logic.
+    private static final class AlwaysDeclineTransform implements JsonTransform
+    {
+        @Override
+        public Status transform(
+            JsonController control,
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            Status status;
+            boolean scalar = event == JsonEvent.VALUE_STRING || event == JsonEvent.VALUE_NUMBER;
+            if (scalar)
+            {
+                control.consumed(0);
+                status = Status.STARVED;
+            }
+            else
+            {
+                status = sink.transform(control, source, event);
+            }
+            return status;
+        }
+    }
+
+    // Issue #2016: a stage that declines a scalar (consumed(0), STARVED) to force reassembly must still
+    // resolve to REJECTED once last == true, rather than stall in STARVED forever. JsonPipeline documents
+    // that STARVED is only returned when last == false (see JsonPipeline#transform javadoc), but the pump's
+    // last-driven STARVED-to-REJECTED conversion only fired when its own driving loop ran out of events
+    // (status == ADVANCED); a stage returning STARVED directly bypassed it entirely.
+    @Test
+    void shouldRejectPermanentlyDeclinedScalarOnTerminalWindow()
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(new AlwaysDeclineTransform())
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        // the scalar arrives whole and well-formed, but the stage declines it unconditionally; since this
+        // is the final window, no further input is ever coming to satisfy the decliner
+        byte[] bytes = "42".getBytes(UTF_8);
+        Status status = pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length, true);
+
+        assertEquals(Status.REJECTED, status);
+    }
 }


### PR DESCRIPTION
## Description

`JsonPipelineImpl.transform()`'s last-driven `STARVED`→`REJECTED` conversion only fired when its own driving loop exhausted events (`status == ADVANCED`). It never overrode a `STARVED` status that a stage (e.g. `JsonSchemaImpl.Validator`) returned directly after declining an unreassembled scalar fragment via `consumed(0)`. On the final window (`last == true`) this left the pipeline stuck in `STARVED` forever instead of resolving to `REJECTED`, contrary to the documented `JsonPipeline` contract (`JsonPipeline#transform` javadoc: "STARVED is returned only when last == false; an incomplete value under last == true yields REJECTED").

The fix converts *any* unresolved `ADVANCED` or `STARVED` status to `REJECTED` on the final window, not just `ADVANCED` — the minimal, general fix suggested as "direction 2" in the issue. `SUSPENDED` (output back-pressure) is unaffected — it's checked first and always wins, since it represents a legitimate "call `transform()` again with the same window" case, unlike a stage-level `STARVED` on the terminal window which can never resolve on its own.

Added a regression test (`JsonPipelineDeferralTest.shouldRejectPermanentlyDeclinedScalarOnTerminalWindow`) with a stage that unconditionally declines scalars, confirming it now resolves to `REJECTED` instead of stalling. Full `common-json` test suite (4832 tests) passes, checkstyle/license checks pass, and the `JsonPipelineBM` JMH benchmark shows no throughput regression.

Fixes #2016


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXRVA6wobMSpBiw1vcNGDf)_