### PR TITLE
feat(engine): add Binding.validate(BindingConfig) SPI hook for config load-time validation

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/Binding.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/binding/Binding.java
@@ -19,6 +19,8 @@ import java.net.URL;
 
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.EngineController;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.ConfigException;
 import io.aklivity.zilla.runtime.engine.config.KindConfig;
 
 /**
@@ -143,5 +145,30 @@ public interface Binding
         KindConfig kind)
     {
         return Integer.MAX_VALUE;
+    }
+
+    /**
+     * Validates a binding's fully-resolved configuration at load time.
+     * <p>
+     * Called once per binding, after its options and routes have been resolved into
+     * {@link BindingConfig} and {@code RouteConfig} objects, but before the binding is
+     * registered and begins routing traffic. This is the place for cross-field or
+     * multi-object checks that span the binding's own already-parsed config tree — the
+     * kind of validation a {@code ConfigAdapter} should not carry because it spans more
+     * than the single JSON shape being adapted.
+     * </p>
+     * <p>
+     * Does nothing by default. Implementations that need this hook should throw
+     * {@link ConfigException} to fail the configuration load; validation that depends on
+     * data resolved asynchronously from outside the config document itself does not belong
+     * here.
+     * </p>
+     *
+     * @param binding  the fully-resolved binding configuration
+     * @throws ConfigException  if the binding configuration is invalid
+     */
+    default void validate(
+        BindingConfig binding) throws ConfigException
+    {
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -502,6 +502,8 @@ public class EngineManager
                 }
             }
 
+            typed.validate(binding);
+
             Set<Long> metricIds = new HashSet<>();
             TelemetryRefConfig telemetryRef = binding.telemetryRef;
             if (telemetryRef != null)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -278,6 +278,32 @@ public class EngineTest
     }
 
     @Test
+    public void shouldNotConfigureBindingValidationFailure()
+    {
+        String resource = String.format("%s-%s.yaml", getClass().getSimpleName(), "configure-validation-invalid");
+        URL configURL = getClass().getResource(resource);
+        assert configURL != null;
+        properties.put(ENGINE_CONFIG_URL.name(), configURL.toString());
+        EngineConfiguration config = new EngineConfiguration(properties);
+        List<Throwable> errors = new LinkedList<>();
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+        finally
+        {
+            assertThat(errors, not(empty()));
+        }
+    }
+
+    @Test
     public void shouldNotConfigureUnknownScheme() throws Exception
     {
         List<Throwable> errors = new LinkedList<>();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBinding.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBinding.java
@@ -20,10 +20,13 @@ import java.net.URL;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.Binding;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.ConfigException;
 
 public final class TestBinding implements Binding
 {
     public static final String NAME = "test";
+    public static final String NAME_INVALID = "invalid";
 
     private final Configuration config;
 
@@ -50,5 +53,15 @@ public final class TestBinding implements Binding
         EngineContext context)
     {
         return new TestBindingContext(config, context);
+    }
+
+    @Override
+    public void validate(
+        BindingConfig binding) throws ConfigException
+    {
+        if (NAME_INVALID.equals(binding.name))
+        {
+            throw new ConfigException(String.format("%s: binding validation failed", binding.qname));
+        }
     }
 }

--- a/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-validation-invalid.yaml
+++ b/runtime/engine/src/test/resources/io/aklivity/zilla/runtime/engine/internal/EngineTest-configure-validation-invalid.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2024 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: default
+bindings:
+    invalid:
+        type: test
+        kind: server
+        exit: test1


### PR DESCRIPTION
## Description

Adds a `default void validate(BindingConfig binding) throws ConfigException` no-op hook to the `Binding` SPI (`runtime/engine/.../binding/Binding.java`), giving bindings a principled place to run cross-field / multi-object validation over their own already-parsed config tree before the engine starts routing traffic.

- `EngineManager.process(...)` now calls `typed.validate(binding)` once per binding, immediately after that binding's routes/options are fully resolved into `BindingConfig`/`RouteConfig` objects, and before the binding is registered/attached.
- A thrown `ConfigException` propagates through the same path JSON-schema violations already use, failing the whole config load deterministically and synchronously.
- The hook defaults to a no-op, so it's backward compatible with every existing `Binding` implementation.
- `TestBinding` (engine test scaffolding) now overrides `validate()` to throw for a sentinel binding name, and `EngineTest` has a new `shouldNotConfigureBindingValidationFailure` regression test exercising the hook end-to-end. Verified the test fails without the `EngineManager` wiring and passes with it.

This lands only the generic hook, per the issue's stated scope. Wiring it up for the `mcp_openapi` `params:` checks from #2022 is left as follow-up work.

### Testing

- `./mvnw test -pl runtime/engine` — full unit test suite passes (245 tests), aside from one pre-existing, environment-related failure (`TrustedTest.shouldConfigureTrustViaCacerts`) confirmed to fail identically on the unmodified base branch (no CA certs in this sandbox).
- `./mvnw checkstyle:check -pl runtime/engine` — clean.

Fixes #2031


---
_Generated by [Claude Code](https://claude.ai/code/session_01DzmC3AxYNy2HVtagPZjun5)_