### PR TITLE
feat(binding-mcp-openapi): options.resources overrides, resource/template classification, optional query param omission

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpResourceConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpResourceConfig.java
@@ -14,6 +14,8 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.http.config;
 
+import java.util.function.Function;
+
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 
 public final class McpHttpResourceConfig
@@ -25,17 +27,18 @@ public final class McpHttpResourceConfig
     public final String mimeType;
     public final ModelConfig output;
 
-    public McpHttpResourceConfig(
-        String name,
-        String uri,
-        String description,
-        String mimeType,
-        ModelConfig output)
+    public static McpHttpResourceConfigBuilder<McpHttpResourceConfig> builder()
     {
-        this(name, uri, uri != null && uri.indexOf('{') >= 0, description, mimeType, output);
+        return new McpHttpResourceConfigBuilder<>(McpHttpResourceConfig.class::cast);
     }
 
-    public McpHttpResourceConfig(
+    public static <T> McpHttpResourceConfigBuilder<T> builder(
+        Function<McpHttpResourceConfig, T> mapper)
+    {
+        return new McpHttpResourceConfigBuilder<>(mapper);
+    }
+
+    McpHttpResourceConfig(
         String name,
         String uri,
         boolean template,

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpResourceConfigBuilder.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpResourceConfigBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.config;
+
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
+
+public final class McpHttpResourceConfigBuilder<T> extends ConfigBuilder<T, McpHttpResourceConfigBuilder<T>>
+{
+    private final Function<McpHttpResourceConfig, T> mapper;
+
+    private String name;
+    private String uri;
+    private boolean template;
+    private String description;
+    private String mimeType;
+    private ModelConfig output;
+
+    McpHttpResourceConfigBuilder(
+        Function<McpHttpResourceConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpHttpResourceConfigBuilder<T>> thisType()
+    {
+        return (Class<McpHttpResourceConfigBuilder<T>>) getClass();
+    }
+
+    public McpHttpResourceConfigBuilder<T> name(
+        String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    public McpHttpResourceConfigBuilder<T> uri(
+        String uri)
+    {
+        this.uri = uri;
+        return this;
+    }
+
+    public McpHttpResourceConfigBuilder<T> template(
+        boolean template)
+    {
+        this.template = template;
+        return this;
+    }
+
+    public McpHttpResourceConfigBuilder<T> description(
+        String description)
+    {
+        this.description = description;
+        return this;
+    }
+
+    public McpHttpResourceConfigBuilder<T> mimeType(
+        String mimeType)
+    {
+        this.mimeType = mimeType;
+        return this;
+    }
+
+    public McpHttpResourceConfigBuilder<T> output(
+        ModelConfig output)
+    {
+        this.output = output;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpHttpResourceConfig(name, uri, template, description, mimeType, output));
+    }
+}

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapter.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpOptionsConfigAdapter.java
@@ -244,7 +244,15 @@ public final class McpHttpOptionsConfigAdapter implements OptionsConfigAdapterSp
                     }
                 }
 
-                resources.add(new McpHttpResourceConfig(name, uri, description, mimeType, output));
+                final boolean template = uri != null && uri.indexOf('{') >= 0;
+                resources.add(McpHttpResourceConfig.builder()
+                    .name(name)
+                    .uri(uri)
+                    .template(template)
+                    .description(description)
+                    .mimeType(mimeType)
+                    .output(output)
+                    .build());
             }
         }
 

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpQueryFragment.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpQueryFragment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
+
+public final class McpHttpQueryFragment
+{
+    public final String template;
+    public final String expression;
+    public final String name;
+
+    public static McpHttpQueryFragment required(
+        String template)
+    {
+        return new McpHttpQueryFragment(template, null, null);
+    }
+
+    public static McpHttpQueryFragment optional(
+        String expression,
+        String name)
+    {
+        return new McpHttpQueryFragment(null, expression, name);
+    }
+
+    public boolean optional()
+    {
+        return template == null;
+    }
+
+    private McpHttpQueryFragment(
+        String template,
+        String expression,
+        String name)
+    {
+        this.template = template;
+        this.expression = expression;
+        this.name = name;
+    }
+}

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.UnaryOperator.identity;
 
 import java.util.ArrayList;
@@ -134,6 +135,159 @@ public final class McpHttpRouteConfig
         String name)
     {
         return resource != null && resource.equals(name);
+    }
+
+    public String resolvePath(
+        Map<String, String> args,
+        Map<String, String> params)
+    {
+        String result = interpolatePath(pathBase, args, params);
+
+        if (!pathQueryFragments.isEmpty())
+        {
+            final StringBuilder queryString = new StringBuilder();
+            for (McpHttpQueryFragment fragment : pathQueryFragments)
+            {
+                final String resolved = fragment.optional()
+                    ? resolveOptionalFragment(fragment, args, params)
+                    : interpolatePath(fragment.template, args, params);
+                if (resolved != null)
+                {
+                    if (queryString.length() > 0)
+                    {
+                        queryString.append('&');
+                    }
+                    queryString.append(resolved);
+                }
+            }
+            result = queryString.length() > 0 ? result + "?" + queryString : result;
+        }
+
+        return result;
+    }
+
+    private static String resolveOptionalFragment(
+        McpHttpQueryFragment fragment,
+        Map<String, String> args,
+        Map<String, String> params)
+    {
+        final String raw = rawValue(fragment.expression, args, params);
+        return raw != null ? fragment.name + "=" + encode(raw) : null;
+    }
+
+    private static String interpolatePath(
+        String template,
+        Map<String, String> args,
+        Map<String, String> params)
+    {
+        String result = template;
+
+        if (template != null && template.contains("${"))
+        {
+            final StringBuilder builder = new StringBuilder();
+            int index = 0;
+            while (index < template.length())
+            {
+                final int start = template.indexOf("${", index);
+                if (start < 0)
+                {
+                    builder.append(template, index, template.length());
+                    index = template.length();
+                }
+                else
+                {
+                    builder.append(template, index, start);
+                    final int end = template.indexOf('}', start + 2);
+                    if (end < 0)
+                    {
+                        builder.append(template, start, template.length());
+                        index = template.length();
+                    }
+                    else
+                    {
+                        final String expression = template.substring(start + 2, end);
+                        final String raw = rawValue(expression, args, params);
+                        builder.append(raw != null ? encode(raw) : "");
+                        index = end + 1;
+                    }
+                }
+            }
+            result = builder.toString();
+        }
+
+        return result;
+    }
+
+    private static String rawValue(
+        String expression,
+        Map<String, String> args,
+        Map<String, String> params)
+    {
+        String value = null;
+        if (expression.startsWith(ARGS_PREFIX) && args != null)
+        {
+            value = args.get(expression.substring(ARGS_PREFIX.length()));
+        }
+        else if (expression.startsWith(PARAMS_PREFIX) && params != null)
+        {
+            value = params.get(expression.substring(PARAMS_PREFIX.length()));
+        }
+        return value;
+    }
+
+    // ASCII input (the common case for tool args, ids, route params) is percent-encoded by iterating
+    // chars directly, skipping the UTF-8 byte conversion the general case requires below: a single-byte
+    // ASCII char and its UTF-8 byte are bit-identical, so this produces the same output either way.
+    public static String encode(
+        String value)
+    {
+        final StringBuilder builder = new StringBuilder();
+        if (isAscii(value))
+        {
+            for (int i = 0; i < value.length(); i++)
+            {
+                encodeByte(builder, value.charAt(i));
+            }
+        }
+        else
+        {
+            final byte[] bytes = value.getBytes(UTF_8);
+            for (byte b : bytes)
+            {
+                encodeByte(builder, b & 0xff);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static boolean isAscii(
+        String value)
+    {
+        boolean ascii = true;
+        for (int i = 0; ascii && i < value.length(); i++)
+        {
+            ascii = value.charAt(i) < 0x80;
+        }
+        return ascii;
+    }
+
+    private static void encodeByte(
+        StringBuilder builder,
+        int c)
+    {
+        if (c >= 'A' && c <= 'Z' ||
+            c >= 'a' && c <= 'z' ||
+            c >= '0' && c <= '9' ||
+            c == '-' || c == '.' || c == '_' || c == '~')
+        {
+            builder.append((char) c);
+        }
+        else
+        {
+            builder.append('%');
+            builder.append(Character.toUpperCase(Character.forDigit(c >> 4 & 0xf, 16)));
+            builder.append(Character.toUpperCase(Character.forDigit(c & 0xf, 16)));
+        }
     }
 
     private static void collectAccessors(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
@@ -37,6 +37,7 @@ public final class McpHttpRouteConfig
     private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{\\s*([^}]+?)\\s*\\}");
     private static final String ARGS_PREFIX = "args.";
     private static final String PARAMS_PREFIX = "params.";
+    private static final String HEADER_PATH = ":path";
 
     public final long id;
     public final String tool;
@@ -47,6 +48,8 @@ public final class McpHttpRouteConfig
     public final Map<String, String> bodyTemplateRenames;
     public final List<String> argAccessors;
     public final List<String> paramAccessors;
+    public final String pathBase;
+    public final List<McpHttpQueryFragment> pathQueryFragments;
 
     private final LongObjectPredicate<UnaryOperator<String>> authorized;
 
@@ -108,6 +111,11 @@ public final class McpHttpRouteConfig
         }
         this.argAccessors = args;
         this.paramAccessors = params;
+
+        final String path = with != null && with.headers != null ? with.headers.get(HEADER_PATH) : null;
+        final int query = path != null ? path.indexOf('?') : -1;
+        this.pathBase = query >= 0 ? path.substring(0, query) : path;
+        this.pathQueryFragments = query >= 0 ? pathQueryFragments(path.substring(query + 1)) : List.of();
     }
 
     boolean authorized(
@@ -157,6 +165,26 @@ public final class McpHttpRouteConfig
                 }
             }
         }
+    }
+
+    private static List<McpHttpQueryFragment> pathQueryFragments(
+        String query)
+    {
+        final List<McpHttpQueryFragment> fragments = new ArrayList<>();
+        for (String fragment : query.split("&"))
+        {
+            if (fragment.startsWith("${?") && fragment.endsWith("}"))
+            {
+                final String inner = fragment.substring(3, fragment.length() - 1);
+                final int equals = inner.indexOf('=');
+                fragments.add(McpHttpQueryFragment.optional(inner.substring(0, equals), inner.substring(equals + 1)));
+            }
+            else
+            {
+                fragments.add(McpHttpQueryFragment.required(fragment));
+            }
+        }
+        return fragments;
     }
 
     private static String pointer(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -794,7 +794,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             doMcpWindow(traceId);
 
             final McpHttpWithConfig with = route.with;
-            final String path = interpolate(with.headers.get(HEADER_PATH), this::resolveParam);
+            final String path = buildPath(with.headers.get(HEADER_PATH), this::resolveParam, this::resolveRawParam);
             credentials.clear();
             binding.resolveCredentials(authorization, credentials);
             delegate.doHttpBegin(traceId, with.headers, credentials, path, null);
@@ -810,6 +810,21 @@ public final class McpHttpProxyFactory implements BindingHandler
             {
                 final String captured = params.get(expression.substring(7));
                 value = encode(captured != null ? captured : "");
+            }
+            return value;
+        }
+
+        // Unlike resolveParam (used for path segments, which are always present), this reports true
+        // absence: null when the referenced capture was never supplied, distinct from an explicitly
+        // captured empty string. Used only to decide whether an optional query fragment (see buildPath)
+        // is included in the outbound request at all.
+        private String resolveRawParam(
+            String expression)
+        {
+            String value = null;
+            if (expression.startsWith("params."))
+            {
+                value = params.get(expression.substring(7));
             }
             return value;
         }
@@ -1251,7 +1266,8 @@ public final class McpHttpProxyFactory implements BindingHandler
             long traceId)
         {
             final McpHttpWithConfig with = route.with;
-            String path = interpolate(with.headers.get(HEADER_PATH), this::resolveStreamingRequest);
+            String path = buildPath(with.headers.get(HEADER_PATH),
+                this::resolveStreamingRequest, this::resolveRawStreamingRequest);
             if (queryCaptured != null)
             {
                 final String query = buildQueryString(queryCaptured);
@@ -1293,6 +1309,24 @@ public final class McpHttpProxyFactory implements BindingHandler
             {
                 final String captured = params.get(expression.substring(7));
                 value = encode(captured != null ? captured : "");
+            }
+            return value;
+        }
+
+        // See McpProxy.resolveRawParam: reports true absence (null) rather than falling back to an
+        // empty string, so buildPath can tell an omitted optional argument apart from one the caller
+        // explicitly set to "".
+        private String resolveRawStreamingRequest(
+            String expression)
+        {
+            String value = null;
+            if (expression.startsWith("args."))
+            {
+                value = requestArgs.get(expression.substring(5));
+            }
+            else if (expression.startsWith("params."))
+            {
+                value = params.get(expression.substring(7));
             }
             return value;
         }
@@ -2421,7 +2455,7 @@ public final class McpHttpProxyFactory implements BindingHandler
                 .add("name", resource.name);
             if (resource.uri != null)
             {
-                final String key = resource.uri.indexOf('{') >= 0 ? "uriTemplate" : "uri";
+                final String key = resource.template ? "uriTemplate" : "uri";
                 item.add(key, resource.uri);
             }
             if (resource.description != null)
@@ -2472,6 +2506,69 @@ public final class McpHttpProxyFactory implements BindingHandler
             json.write(value);
         }
         return writer.toString();
+    }
+
+    // Builds a request :path from a generated template whose query section (if any) may contain
+    // optional-parameter markers of the form ${?expression=name}, injected by mcp_openapi's queryString()
+    // for OpenAPI query parameters that are not required. Required query fragments (plain name=${expr})
+    // and the path portion are resolved via the ordinary interpolate/resolver; each optional fragment is
+    // resolved via rawResolver (which reports true absence as null, unlike resolver's empty-string
+    // fallback) and is dropped entirely — along with its separator — when the referenced value is absent,
+    // so multiple optional parameters compose without dangling '&' or '?' regardless of which are present.
+    private static String buildPath(
+        String template,
+        Function<String, String> resolver,
+        Function<String, String> rawResolver)
+    {
+        String result = template;
+
+        final int query = template != null ? template.indexOf('?') : -1;
+        if (query >= 0)
+        {
+            final String base = interpolate(template.substring(0, query), resolver);
+            final StringBuilder queryString = new StringBuilder();
+            for (String fragment : template.substring(query + 1).split("&"))
+            {
+                final String resolved = resolveQueryFragment(fragment, resolver, rawResolver);
+                if (resolved != null)
+                {
+                    if (queryString.length() > 0)
+                    {
+                        queryString.append('&');
+                    }
+                    queryString.append(resolved);
+                }
+            }
+            result = queryString.length() > 0 ? base + "?" + queryString : base;
+        }
+        else
+        {
+            result = interpolate(template, resolver);
+        }
+
+        return result;
+    }
+
+    private static String resolveQueryFragment(
+        String fragment,
+        Function<String, String> resolver,
+        Function<String, String> rawResolver)
+    {
+        String result;
+        if (fragment.startsWith("${?") && fragment.endsWith("}"))
+        {
+            final String inner = fragment.substring(3, fragment.length() - 1);
+            final int equals = inner.indexOf('=');
+            final String expression = inner.substring(0, equals);
+            final String name = inner.substring(equals + 1);
+            final String raw = rawResolver.apply(expression);
+            result = raw != null ? name + "=" + encode(raw) : null;
+        }
+        else
+        {
+            result = interpolate(fragment, resolver);
+        }
+        return result;
     }
 
     private static String interpolate(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -51,6 +51,7 @@ import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpBindingConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpQueryFragment;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.events.McpHttpEventContext;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.transform.McpHttpArguments;
@@ -794,7 +795,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             doMcpWindow(traceId);
 
             final McpHttpWithConfig with = route.with;
-            final String path = buildPath(with.headers.get(HEADER_PATH), this::resolveParam, this::resolveRawParam);
+            final String path = buildPath(route, this::resolveParam, this::resolveRawParam);
             credentials.clear();
             binding.resolveCredentials(authorization, credentials);
             delegate.doHttpBegin(traceId, with.headers, credentials, path, null);
@@ -814,10 +815,6 @@ public final class McpHttpProxyFactory implements BindingHandler
             return value;
         }
 
-        // Unlike resolveParam (used for path segments, which are always present), this reports true
-        // absence: null when the referenced capture was never supplied, distinct from an explicitly
-        // captured empty string. Used only to decide whether an optional query fragment (see buildPath)
-        // is included in the outbound request at all.
         private String resolveRawParam(
             String expression)
         {
@@ -1266,8 +1263,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             long traceId)
         {
             final McpHttpWithConfig with = route.with;
-            String path = buildPath(with.headers.get(HEADER_PATH),
-                this::resolveStreamingRequest, this::resolveRawStreamingRequest);
+            String path = buildPath(route, this::resolveStreamingRequest, this::resolveRawStreamingRequest);
             if (queryCaptured != null)
             {
                 final String query = buildQueryString(queryCaptured);
@@ -1313,9 +1309,6 @@ public final class McpHttpProxyFactory implements BindingHandler
             return value;
         }
 
-        // See McpProxy.resolveRawParam: reports true absence (null) rather than falling back to an
-        // empty string, so buildPath can tell an omitted optional argument apart from one the caller
-        // explicitly set to "".
         private String resolveRawStreamingRequest(
             String expression)
         {
@@ -2508,28 +2501,23 @@ public final class McpHttpProxyFactory implements BindingHandler
         return writer.toString();
     }
 
-    // Builds a request :path from a generated template whose query section (if any) may contain
-    // optional-parameter markers of the form ${?expression=name}, injected by mcp_openapi's queryString()
-    // for OpenAPI query parameters that are not required. Required query fragments (plain name=${expr})
-    // and the path portion are resolved via the ordinary interpolate/resolver; each optional fragment is
-    // resolved via rawResolver (which reports true absence as null, unlike resolver's empty-string
-    // fallback) and is dropped entirely — along with its separator — when the referenced value is absent,
-    // so multiple optional parameters compose without dangling '&' or '?' regardless of which are present.
+    // route.pathBase/pathQueryFragments are parsed once by McpHttpRouteConfig from the generated :path
+    // template; this only resolves and concatenates them per request.
     private static String buildPath(
-        String template,
+        McpHttpRouteConfig route,
         Function<String, String> resolver,
         Function<String, String> rawResolver)
     {
-        String result = template;
+        String result = interpolate(route.pathBase, resolver);
 
-        final int query = template != null ? template.indexOf('?') : -1;
-        if (query >= 0)
+        if (!route.pathQueryFragments.isEmpty())
         {
-            final String base = interpolate(template.substring(0, query), resolver);
             final StringBuilder queryString = new StringBuilder();
-            for (String fragment : template.substring(query + 1).split("&"))
+            for (McpHttpQueryFragment fragment : route.pathQueryFragments)
             {
-                final String resolved = resolveQueryFragment(fragment, resolver, rawResolver);
+                final String resolved = fragment.optional()
+                    ? resolveOptionalFragment(fragment, rawResolver)
+                    : interpolate(fragment.template, resolver);
                 if (resolved != null)
                 {
                     if (queryString.length() > 0)
@@ -2539,36 +2527,18 @@ public final class McpHttpProxyFactory implements BindingHandler
                     queryString.append(resolved);
                 }
             }
-            result = queryString.length() > 0 ? base + "?" + queryString : base;
-        }
-        else
-        {
-            result = interpolate(template, resolver);
+            result = queryString.length() > 0 ? result + "?" + queryString : result;
         }
 
         return result;
     }
 
-    private static String resolveQueryFragment(
-        String fragment,
-        Function<String, String> resolver,
+    private static String resolveOptionalFragment(
+        McpHttpQueryFragment fragment,
         Function<String, String> rawResolver)
     {
-        String result;
-        if (fragment.startsWith("${?") && fragment.endsWith("}"))
-        {
-            final String inner = fragment.substring(3, fragment.length() - 1);
-            final int equals = inner.indexOf('=');
-            final String expression = inner.substring(0, equals);
-            final String name = inner.substring(equals + 1);
-            final String raw = rawResolver.apply(expression);
-            result = raw != null ? name + "=" + encode(raw) : null;
-        }
-        else
-        {
-            result = interpolate(fragment, resolver);
-        }
-        return result;
+        final String raw = rawResolver.apply(fragment.expression);
+        return raw != null ? fragment.name + "=" + encode(raw) : null;
     }
 
     private static String interpolate(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -51,7 +51,6 @@ import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpBindingConfig;
-import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpQueryFragment;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.events.McpHttpEventContext;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.transform.McpHttpArguments;
@@ -795,35 +794,12 @@ public final class McpHttpProxyFactory implements BindingHandler
             doMcpWindow(traceId);
 
             final McpHttpWithConfig with = route.with;
-            final String path = buildPath(route, this::resolveParam, this::resolveRawParam);
+            final String path = route.resolvePath(null, params);
             credentials.clear();
             binding.resolveCredentials(authorization, credentials);
             delegate.doHttpBegin(traceId, with.headers, credentials, path, null);
             delegate.requestComplete();
             delegate.flushRequest(traceId);
-        }
-
-        private String resolveParam(
-            String expression)
-        {
-            String value = "";
-            if (expression.startsWith("params."))
-            {
-                final String captured = params.get(expression.substring(7));
-                value = encode(captured != null ? captured : "");
-            }
-            return value;
-        }
-
-        private String resolveRawParam(
-            String expression)
-        {
-            String value = null;
-            if (expression.startsWith("params."))
-            {
-                value = params.get(expression.substring(7));
-            }
-            return value;
         }
 
         // Unreachable for both concrete kinds: McpToolsCallProxy and McpResourcesReadProxy each fully
@@ -1263,7 +1239,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             long traceId)
         {
             final McpHttpWithConfig with = route.with;
-            String path = buildPath(route, this::resolveStreamingRequest, this::resolveRawStreamingRequest);
+            String path = route.resolvePath(requestArgs, params);
             if (queryCaptured != null)
             {
                 final String query = buildQueryString(queryCaptured);
@@ -1290,38 +1266,6 @@ public final class McpHttpProxyFactory implements BindingHandler
                 }
             }
             return builder.toString();
-        }
-
-        private String resolveStreamingRequest(
-            String expression)
-        {
-            String value = "";
-            if (expression.startsWith("args."))
-            {
-                final String captured = requestArgs.get(expression.substring(5));
-                value = encode(captured != null ? captured : "");
-            }
-            else if (expression.startsWith("params."))
-            {
-                final String captured = params.get(expression.substring(7));
-                value = encode(captured != null ? captured : "");
-            }
-            return value;
-        }
-
-        private String resolveRawStreamingRequest(
-            String expression)
-        {
-            String value = null;
-            if (expression.startsWith("args."))
-            {
-                value = requestArgs.get(expression.substring(5));
-            }
-            else if (expression.startsWith("params."))
-            {
-                value = params.get(expression.substring(7));
-            }
-            return value;
         }
 
         void grantMcpWindow(
@@ -2364,7 +2308,7 @@ public final class McpHttpProxyFactory implements BindingHandler
         {
             builder.append('&');
         }
-        builder.append(encode(key)).append('=').append(encode(value));
+        builder.append(McpHttpRouteConfig.encode(key)).append('=').append(McpHttpRouteConfig.encode(value));
     }
 
     private byte[] toolsList(
@@ -2501,46 +2445,6 @@ public final class McpHttpProxyFactory implements BindingHandler
         return writer.toString();
     }
 
-    // route.pathBase/pathQueryFragments are parsed once by McpHttpRouteConfig from the generated :path
-    // template; this only resolves and concatenates them per request.
-    private static String buildPath(
-        McpHttpRouteConfig route,
-        Function<String, String> resolver,
-        Function<String, String> rawResolver)
-    {
-        String result = interpolate(route.pathBase, resolver);
-
-        if (!route.pathQueryFragments.isEmpty())
-        {
-            final StringBuilder queryString = new StringBuilder();
-            for (McpHttpQueryFragment fragment : route.pathQueryFragments)
-            {
-                final String resolved = fragment.optional()
-                    ? resolveOptionalFragment(fragment, rawResolver)
-                    : interpolate(fragment.template, resolver);
-                if (resolved != null)
-                {
-                    if (queryString.length() > 0)
-                    {
-                        queryString.append('&');
-                    }
-                    queryString.append(resolved);
-                }
-            }
-            result = queryString.length() > 0 ? result + "?" + queryString : result;
-        }
-
-        return result;
-    }
-
-    private static String resolveOptionalFragment(
-        McpHttpQueryFragment fragment,
-        Function<String, String> rawResolver)
-    {
-        final String raw = rawResolver.apply(fragment.expression);
-        return raw != null ? fragment.name + "=" + encode(raw) : null;
-    }
-
     private static String interpolate(
         String template,
         Function<String, String> resolver)
@@ -2585,59 +2489,6 @@ public final class McpHttpProxyFactory implements BindingHandler
 
     // ASCII input (the common case for tool args, ids, route params) is percent-encoded by iterating
     // chars directly, skipping the UTF-8 byte conversion the general case requires below: a single-byte
-    // ASCII char and its UTF-8 byte are bit-identical, so this produces the same output either way.
-    private static String encode(
-        String value)
-    {
-        final StringBuilder builder = new StringBuilder();
-        if (isAscii(value))
-        {
-            for (int i = 0; i < value.length(); i++)
-            {
-                encodeByte(builder, value.charAt(i));
-            }
-        }
-        else
-        {
-            final byte[] bytes = value.getBytes(UTF_8);
-            for (byte b : bytes)
-            {
-                encodeByte(builder, b & 0xff);
-            }
-        }
-        return builder.toString();
-    }
-
-    private static boolean isAscii(
-        String value)
-    {
-        boolean ascii = true;
-        for (int i = 0; ascii && i < value.length(); i++)
-        {
-            ascii = value.charAt(i) < 0x80;
-        }
-        return ascii;
-    }
-
-    private static void encodeByte(
-        StringBuilder builder,
-        int c)
-    {
-        if (c >= 'A' && c <= 'Z' ||
-            c >= 'a' && c <= 'z' ||
-            c >= '0' && c <= '9' ||
-            c == '-' || c == '.' || c == '_' || c == '~')
-        {
-            builder.append((char) c);
-        }
-        else
-        {
-            builder.append('%');
-            builder.append(Character.toUpperCase(Character.forDigit(c >> 4 & 0xf, 16)));
-            builder.append(Character.toUpperCase(Character.forDigit(c & 0xf, 16)));
-        }
-    }
-
     private static int put(
         MutableDirectBufferEx buffer,
         int offset,

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
@@ -256,6 +256,26 @@ public class McpHttpProxyIT
         k3po.finish();
     }
 
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${mcp}/search.items/client",
+        "${http}/search.items/server"})
+    public void shouldCallToolSearchItemsWithoutOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${mcp}/search.items.with.limit/client",
+        "${http}/search.items.with.limit/server"})
+    public void shouldCallToolSearchItemsWithOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
     // a ~100KB tools/call response, streamed across many suspend/resume cycles; the leading total_count
     // field is captured well before the large trailing items[].path value finishes streaming, proving
     // tool.summary interpolation survives more than one window (see McpHttpResults)

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiOptionsConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiOptionsConfig.java
@@ -23,6 +23,7 @@ public final class McpOpenapiOptionsConfig extends OptionsConfig
 {
     public final List<McpOpenapiSpecificationConfig> specs;
     public final List<McpOpenapiToolConfig> tools;
+    public final List<McpOpenapiResourceConfig> resources;
 
     public static McpOpenapiOptionsConfigBuilder<McpOpenapiOptionsConfig> builder()
     {
@@ -37,9 +38,11 @@ public final class McpOpenapiOptionsConfig extends OptionsConfig
 
     McpOpenapiOptionsConfig(
         List<McpOpenapiSpecificationConfig> specs,
-        List<McpOpenapiToolConfig> tools)
+        List<McpOpenapiToolConfig> tools,
+        List<McpOpenapiResourceConfig> resources)
     {
         this.specs = specs;
         this.tools = tools;
+        this.resources = resources;
     }
 }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiOptionsConfigBuilder.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiOptionsConfigBuilder.java
@@ -27,6 +27,7 @@ public final class McpOpenapiOptionsConfigBuilder<T> extends ConfigBuilder<T, Mc
 
     private List<McpOpenapiSpecificationConfig> specs;
     private List<McpOpenapiToolConfig> tools;
+    private List<McpOpenapiResourceConfig> resources;
 
     McpOpenapiOptionsConfigBuilder(
         Function<OptionsConfig, T> mapper)
@@ -73,9 +74,25 @@ public final class McpOpenapiOptionsConfigBuilder<T> extends ConfigBuilder<T, Mc
         return this;
     }
 
+    public McpOpenapiResourceConfigBuilder<McpOpenapiOptionsConfigBuilder<T>> resource()
+    {
+        return new McpOpenapiResourceConfigBuilder<>(this::resource);
+    }
+
+    public McpOpenapiOptionsConfigBuilder<T> resource(
+        McpOpenapiResourceConfig resource)
+    {
+        if (resources == null)
+        {
+            resources = new ArrayList<>();
+        }
+        resources.add(resource);
+        return this;
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new McpOpenapiOptionsConfig(specs, tools));
+        return mapper.apply(new McpOpenapiOptionsConfig(specs, tools, resources));
     }
 }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiResourceConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiResourceConfig.java
@@ -12,42 +12,36 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.binding.mcp.http.config;
+package io.aklivity.zilla.runtime.binding.mcp.openapi.config;
+
+import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 
-public final class McpHttpResourceConfig
+public final class McpOpenapiResourceConfig
 {
-    public final String name;
     public final String uri;
-    public final boolean template;
     public final String description;
-    public final String mimeType;
     public final ModelConfig output;
 
-    public McpHttpResourceConfig(
-        String name,
-        String uri,
-        String description,
-        String mimeType,
-        ModelConfig output)
+    public static McpOpenapiResourceConfigBuilder<McpOpenapiResourceConfig> builder()
     {
-        this(name, uri, uri != null && uri.indexOf('{') >= 0, description, mimeType, output);
+        return new McpOpenapiResourceConfigBuilder<>(McpOpenapiResourceConfig.class::cast);
     }
 
-    public McpHttpResourceConfig(
-        String name,
+    public static <T> McpOpenapiResourceConfigBuilder<T> builder(
+        Function<McpOpenapiResourceConfig, T> mapper)
+    {
+        return new McpOpenapiResourceConfigBuilder<>(mapper);
+    }
+
+    McpOpenapiResourceConfig(
         String uri,
-        boolean template,
         String description,
-        String mimeType,
         ModelConfig output)
     {
-        this.name = name;
         this.uri = uri;
-        this.template = template;
         this.description = description;
-        this.mimeType = mimeType;
         this.output = output;
     }
 }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiResourceConfigBuilder.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/config/McpOpenapiResourceConfigBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.openapi.config;
+
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
+
+public final class McpOpenapiResourceConfigBuilder<T> extends ConfigBuilder<T, McpOpenapiResourceConfigBuilder<T>>
+{
+    private final Function<McpOpenapiResourceConfig, T> mapper;
+
+    private String uri;
+    private String description;
+    private ModelConfig output;
+
+    McpOpenapiResourceConfigBuilder(
+        Function<McpOpenapiResourceConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpOpenapiResourceConfigBuilder<T>> thisType()
+    {
+        return (Class<McpOpenapiResourceConfigBuilder<T>>) getClass();
+    }
+
+    public McpOpenapiResourceConfigBuilder<T> uri(
+        String uri)
+    {
+        this.uri = uri;
+        return this;
+    }
+
+    public McpOpenapiResourceConfigBuilder<T> description(
+        String description)
+    {
+        this.description = description;
+        return this;
+    }
+
+    public McpOpenapiResourceConfigBuilder<T> output(
+        ModelConfig output)
+    {
+        this.output = output;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpOpenapiResourceConfig(uri, description, output));
+    }
+}

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiOptionsConfigAdapter.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiOptionsConfigAdapter.java
@@ -26,6 +26,7 @@ import jakarta.json.bind.adapter.JsonbAdapter;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiOptionsConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiOptionsConfigBuilder;
+import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiResourceConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiSpecificationConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiToolConfig;
@@ -44,6 +45,7 @@ public final class McpOpenapiOptionsConfigAdapter implements OptionsConfigAdapte
     private static final String SUBJECT_NAME = "subject";
     private static final String VERSION_NAME = "version";
     private static final String TOOLS_NAME = "tools";
+    private static final String RESOURCES_NAME = "resources";
     private static final String DESCRIPTION_NAME = "description";
     private static final String SCHEMAS_NAME = "schemas";
     private static final String OUTPUT_NAME = "output";
@@ -125,6 +127,27 @@ public final class McpOpenapiOptionsConfigAdapter implements OptionsConfigAdapte
                 toolsObject.add(tool.name, toolObject);
             }
             object.add(TOOLS_NAME, toolsObject);
+        }
+
+        if (mcpOpenapiOptions.resources != null)
+        {
+            JsonObjectBuilder resourcesObject = Json.createObjectBuilder();
+            for (McpOpenapiResourceConfig resource : mcpOpenapiOptions.resources)
+            {
+                JsonObjectBuilder resourceObject = Json.createObjectBuilder();
+                if (resource.description != null)
+                {
+                    resourceObject.add(DESCRIPTION_NAME, resource.description);
+                }
+                if (resource.output != null)
+                {
+                    JsonObjectBuilder schemas = Json.createObjectBuilder();
+                    schemas.add(OUTPUT_NAME, model.adaptToJson(resource.output));
+                    resourceObject.add(SCHEMAS_NAME, schemas);
+                }
+                resourcesObject.add(resource.uri, resourceObject);
+            }
+            object.add(RESOURCES_NAME, resourcesObject);
         }
 
         return object.build();
@@ -210,6 +233,34 @@ public final class McpOpenapiOptionsConfigAdapter implements OptionsConfigAdapte
 
                 mcpOpenapiOptions.tool()
                     .name(name)
+                    .description(description)
+                    .output(output)
+                    .build();
+            }
+        }
+
+        if (object.containsKey(RESOURCES_NAME))
+        {
+            JsonObject resourcesObject = object.getJsonObject(RESOURCES_NAME);
+            for (String uri : resourcesObject.keySet())
+            {
+                JsonObject resourceObject = resourcesObject.getJsonObject(uri);
+                String description = resourceObject.containsKey(DESCRIPTION_NAME)
+                    ? resourceObject.getString(DESCRIPTION_NAME)
+                    : null;
+
+                ModelConfig output = null;
+                if (resourceObject.containsKey(SCHEMAS_NAME))
+                {
+                    JsonObject schemas = resourceObject.getJsonObject(SCHEMAS_NAME);
+                    if (schemas.containsKey(OUTPUT_NAME))
+                    {
+                        output = model.adaptFromJson(schemas.get(OUTPUT_NAME));
+                    }
+                }
+
+                mcpOpenapiOptions.resource()
+                    .uri(uri)
                     .description(description)
                     .output(output)
                     .build();

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -51,8 +51,10 @@ import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiResourceConfig;
+import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiResourceConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiToolConfig;
+import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiToolConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.McpOpenapiBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.McpOpenapiCompositeConfig;
@@ -185,8 +187,8 @@ public final class McpOpenapiCompositeGenerator
                     continue;
                 }
 
-                routed.add(new RoutedOperation(routeTool, resource, operation, toolConfig(binding, routeTool),
-                    resourceConfig(binding, resource), resolution.guarded, serverByLabel.get(with.spec)));
+                routed.add(new RoutedOperation(toolConfig(binding, routeTool), resourceConfig(binding, resource),
+                    operation, resolution.guarded, serverByLabel.get(with.spec)));
             }
         }
 
@@ -217,30 +219,56 @@ public final class McpOpenapiCompositeGenerator
         McpOpenapiBindingConfig binding,
         String tool)
     {
-        McpOpenapiToolConfig result = null;
-        if (tool != null && binding.options != null && binding.options.tools != null)
+        return tool != null
+            ? McpOpenapiToolConfig.builder()
+                .name(tool)
+                .inject(t -> injectToolOverrides(t, binding, tool))
+                .build()
+            : null;
+    }
+
+    private <C> McpOpenapiToolConfigBuilder<C> injectToolOverrides(
+        McpOpenapiToolConfigBuilder<C> tool,
+        McpOpenapiBindingConfig binding,
+        String name)
+    {
+        if (binding.options != null && binding.options.tools != null)
         {
-            result = binding.options.tools.stream()
-                .filter(t -> tool.equals(t.name))
+            binding.options.tools.stream()
+                .filter(t -> name.equals(t.name))
                 .findFirst()
-                .orElse(null);
+                .ifPresent(override -> tool.description(override.description).output(override.output));
         }
-        return result;
+
+        return tool;
     }
 
     private McpOpenapiResourceConfig resourceConfig(
         McpOpenapiBindingConfig binding,
         String resource)
     {
-        McpOpenapiResourceConfig result = null;
-        if (resource != null && binding.options != null && binding.options.resources != null)
+        return resource != null
+            ? McpOpenapiResourceConfig.builder()
+                .uri(resource)
+                .inject(r -> injectResourceOverrides(r, binding, resource))
+                .build()
+            : null;
+    }
+
+    private <C> McpOpenapiResourceConfigBuilder<C> injectResourceOverrides(
+        McpOpenapiResourceConfigBuilder<C> resource,
+        McpOpenapiBindingConfig binding,
+        String uri)
+    {
+        if (binding.options != null && binding.options.resources != null)
         {
-            result = binding.options.resources.stream()
-                .filter(r -> resource.equals(r.uri))
+            binding.options.resources.stream()
+                .filter(r -> uri.equals(r.uri))
                 .findFirst()
-                .orElse(null);
+                .ifPresent(override -> resource.description(override.description).output(override.output));
         }
-        return result;
+
+        return resource;
     }
 
     private <C> NamespaceConfigBuilder<C> injectCatalog(
@@ -337,11 +365,11 @@ public final class McpOpenapiCompositeGenerator
 
             if (entry.tool != null)
             {
-                final ModelConfig output = entry.toolConfig != null && entry.toolConfig.output != null
-                    ? entry.toolConfig.output
+                final ModelConfig output = entry.tool.output != null
+                    ? entry.tool.output
                     : jsonModel("%s-output".formatted(name));
-                final String description = entry.toolConfig != null && entry.toolConfig.description != null
-                    ? entry.toolConfig.description
+                final String description = entry.tool.description != null
+                    ? entry.tool.description
                     : entry.operation.description != null
                         ? entry.operation.description
                         : entry.operation.id;
@@ -351,20 +379,19 @@ public final class McpOpenapiCompositeGenerator
                 final String summary = entry.operation.summary != null
                     ? entry.operation.summary
                     : "Call %s".formatted(entry.operation.id);
-                tools.add(new McpHttpToolConfig(entry.tool, summary, description, input, output));
+                tools.add(new McpHttpToolConfig(entry.tool.name, summary, description, input, output));
             }
             else
             {
-                final ModelConfig output = entry.resourceConfig != null && entry.resourceConfig.output != null
-                    ? entry.resourceConfig.output
+                final ModelConfig output = entry.resource.output != null
+                    ? entry.resource.output
                     : jsonModel("%s-output".formatted(name));
-                final String description = entry.resourceConfig != null ? entry.resourceConfig.description : null;
                 final boolean template = entry.operation.path != null && entry.operation.path.indexOf('{') >= 0;
                 resources.add(McpHttpResourceConfig.builder()
-                    .name(entry.resource)
+                    .name(entry.resource.uri)
                     .uri(resourceUri(entry.operation))
                     .template(template)
-                    .description(description)
+                    .description(entry.resource.description)
                     .output(output)
                     .inject(r -> injectMimeType(r, entry.operation))
                     .build());
@@ -382,7 +409,9 @@ public final class McpOpenapiCompositeGenerator
     {
         for (RoutedOperation entry : routed)
         {
-            final McpHttpConditionConfig when = new McpHttpConditionConfig(entry.tool, entry.resource);
+            final McpHttpConditionConfig when = new McpHttpConditionConfig(
+                entry.tool != null ? entry.tool.name : null,
+                entry.resource != null ? entry.resource.uri : null);
             final McpHttpWithConfig with = withConfig(entry);
 
             binding.route()
@@ -900,35 +929,29 @@ public final class McpOpenapiCompositeGenerator
 
     private static final class RoutedOperation
     {
-        private final String tool;
-        private final String resource;
+        private final McpOpenapiToolConfig tool;
+        private final McpOpenapiResourceConfig resource;
         private final OpenapiOperationView operation;
-        private final McpOpenapiToolConfig toolConfig;
-        private final McpOpenapiResourceConfig resourceConfig;
         private final List<GuardedRef> guarded;
         private final String server;
 
         private RoutedOperation(
-            String tool,
-            String resource,
+            McpOpenapiToolConfig tool,
+            McpOpenapiResourceConfig resource,
             OpenapiOperationView operation,
-            McpOpenapiToolConfig toolConfig,
-            McpOpenapiResourceConfig resourceConfig,
             List<GuardedRef> guarded,
             String server)
         {
             this.tool = tool;
             this.resource = resource;
             this.operation = operation;
-            this.toolConfig = toolConfig;
-            this.resourceConfig = resourceConfig;
             this.guarded = guarded;
             this.server = server;
         }
 
         private String subjectName()
         {
-            return tool != null ? tool : resource;
+            return tool != null ? tool.name : resource.uri;
         }
     }
 

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -49,6 +49,7 @@ import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiConditionConfig;
+import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiResourceConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiWithConfig;
@@ -184,7 +185,7 @@ public final class McpOpenapiCompositeGenerator
                 }
 
                 routed.add(new RoutedOperation(routeTool, resource, operation, toolConfig(binding, routeTool),
-                    resolution.guarded, serverByLabel.get(with.spec)));
+                    resourceConfig(binding, resource), resolution.guarded, serverByLabel.get(with.spec)));
             }
         }
 
@@ -220,6 +221,21 @@ public final class McpOpenapiCompositeGenerator
         {
             result = binding.options.tools.stream()
                 .filter(t -> tool.equals(t.name))
+                .findFirst()
+                .orElse(null);
+        }
+        return result;
+    }
+
+    private McpOpenapiResourceConfig resourceConfig(
+        McpOpenapiBindingConfig binding,
+        String resource)
+    {
+        McpOpenapiResourceConfig result = null;
+        if (resource != null && binding.options != null && binding.options.resources != null)
+        {
+            result = binding.options.resources.stream()
+                .filter(r -> resource.equals(r.uri))
                 .findFirst()
                 .orElse(null);
         }
@@ -317,12 +333,12 @@ public final class McpOpenapiCompositeGenerator
         {
             final String name = entry.subjectName();
             final ModelConfig input = jsonModel("%s-input".formatted(name));
-            final ModelConfig output = entry.tool != null && entry.toolConfig != null && entry.toolConfig.output != null
-                ? entry.toolConfig.output
-                : jsonModel("%s-output".formatted(name));
 
             if (entry.tool != null)
             {
+                final ModelConfig output = entry.toolConfig != null && entry.toolConfig.output != null
+                    ? entry.toolConfig.output
+                    : jsonModel("%s-output".formatted(name));
                 final String description = entry.toolConfig != null && entry.toolConfig.description != null
                     ? entry.toolConfig.description
                     : entry.operation.description != null
@@ -338,14 +354,22 @@ public final class McpOpenapiCompositeGenerator
             }
             else
             {
-                final String uri = entry.operation.path;
+                final ModelConfig output = entry.resourceConfig != null && entry.resourceConfig.output != null
+                    ? entry.resourceConfig.output
+                    : jsonModel("%s-output".formatted(name));
+                final String description = entry.resourceConfig != null ? entry.resourceConfig.description : null;
+                // a {param} path-parameter expression in the OpenAPI path is what makes this a resource
+                // template rather than a concrete, enumerable resource; a query-only parameterization
+                // (appended below as a separate {?...} suffix) does not disqualify it from being concrete
+                final boolean template = entry.operation.path != null && entry.operation.path.indexOf('{') >= 0;
+                final String uri = resourceUri(entry.operation);
                 String mimeType = null;
                 final OpenapiResponseView success = successResponse(entry.operation);
                 if (success != null && success.content != null && !success.content.isEmpty())
                 {
                     mimeType = success.content.values().iterator().next().name;
                 }
-                resources.add(new McpHttpResourceConfig(entry.resource, uri, null, mimeType, output));
+                resources.add(new McpHttpResourceConfig(entry.resource, uri, template, description, mimeType, output));
             }
         }
 
@@ -650,6 +674,32 @@ public final class McpOpenapiCompositeGenerator
         return result;
     }
 
+    // Builds the URI advertised for a resource in resources/list or resources/templates/list: the OpenAPI
+    // path verbatim (still carrying any {param} path captures), plus an RFC 6570 form-style query
+    // expansion ({?name1,name2}) listing every query parameter the operation declares, so a resource's
+    // entire input surface (path and query captures) is visible in the one URI a client sees.
+    private static String resourceUri(
+        OpenapiOperationView operation)
+    {
+        final StringBuilder uri = new StringBuilder(operation.path);
+        if (operation.parameters != null)
+        {
+            final List<String> names = new ArrayList<>();
+            for (OpenapiParameterView parameter : operation.parameters)
+            {
+                if ("query".equals(parameter.in))
+                {
+                    names.add(parameter.name);
+                }
+            }
+            if (!names.isEmpty())
+            {
+                uri.append("{?").append(String.join(",", names)).append('}');
+            }
+        }
+        return uri.toString();
+    }
+
     private static String queryString(
         OpenapiOperationView operation,
         String accessor)
@@ -665,12 +715,30 @@ public final class McpOpenapiCompositeGenerator
                     {
                         query.append('&');
                     }
-                    query.append(parameter.name)
-                        .append("=${")
-                        .append(accessor)
-                        .append('.')
-                        .append(parameter.name)
-                        .append('}');
+                    if (parameter.required)
+                    {
+                        query.append(parameter.name)
+                            .append("=${")
+                            .append(accessor)
+                            .append('.')
+                            .append(parameter.name)
+                            .append('}');
+                    }
+                    else
+                    {
+                        // an optional query parameter is only ever included in the outbound request when
+                        // the caller actually supplies a value; McpHttpProxyFactory recognizes this ${?...}
+                        // marker at request time and drops the whole name=value fragment (and its separator)
+                        // when the referenced accessor has no captured value, rather than emitting name=
+                        // with an empty value or an unresolved expression
+                        query.append("${?")
+                            .append(accessor)
+                            .append('.')
+                            .append(parameter.name)
+                            .append('=')
+                            .append(parameter.name)
+                            .append('}');
+                    }
                 }
             }
         }
@@ -834,6 +902,7 @@ public final class McpOpenapiCompositeGenerator
         private final String resource;
         private final OpenapiOperationView operation;
         private final McpOpenapiToolConfig toolConfig;
+        private final McpOpenapiResourceConfig resourceConfig;
         private final List<GuardedRef> guarded;
         private final String server;
 
@@ -842,6 +911,7 @@ public final class McpOpenapiCompositeGenerator
             String resource,
             OpenapiOperationView operation,
             McpOpenapiToolConfig toolConfig,
+            McpOpenapiResourceConfig resourceConfig,
             List<GuardedRef> guarded,
             String server)
         {
@@ -849,6 +919,7 @@ public final class McpOpenapiCompositeGenerator
             this.resource = resource;
             this.operation = operation;
             this.toolConfig = toolConfig;
+            this.resourceConfig = resourceConfig;
             this.guarded = guarded;
             this.server = server;
         }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -358,9 +358,6 @@ public final class McpOpenapiCompositeGenerator
                     ? entry.resourceConfig.output
                     : jsonModel("%s-output".formatted(name));
                 final String description = entry.resourceConfig != null ? entry.resourceConfig.description : null;
-                // a {param} path-parameter expression in the OpenAPI path is what makes this a resource
-                // template rather than a concrete, enumerable resource; a query-only parameterization
-                // (appended below as a separate {?...} suffix) does not disqualify it from being concrete
                 final boolean template = entry.operation.path != null && entry.operation.path.indexOf('{') >= 0;
                 final String uri = resourceUri(entry.operation);
                 String mimeType = null;
@@ -369,7 +366,14 @@ public final class McpOpenapiCompositeGenerator
                 {
                     mimeType = success.content.values().iterator().next().name;
                 }
-                resources.add(new McpHttpResourceConfig(entry.resource, uri, template, description, mimeType, output));
+                resources.add(McpHttpResourceConfig.builder()
+                    .name(entry.resource)
+                    .uri(uri)
+                    .template(template)
+                    .description(description)
+                    .mimeType(mimeType)
+                    .output(output)
+                    .build());
             }
         }
 
@@ -674,10 +678,6 @@ public final class McpOpenapiCompositeGenerator
         return result;
     }
 
-    // Builds the URI advertised for a resource in resources/list or resources/templates/list: the OpenAPI
-    // path verbatim (still carrying any {param} path captures), plus an RFC 6570 form-style query
-    // expansion ({?name1,name2}) listing every query parameter the operation declares, so a resource's
-    // entire input surface (path and query captures) is visible in the one URI a client sees.
     private static String resourceUri(
         OpenapiOperationView operation)
     {
@@ -726,11 +726,6 @@ public final class McpOpenapiCompositeGenerator
                     }
                     else
                     {
-                        // an optional query parameter is only ever included in the outbound request when
-                        // the caller actually supplies a value; McpHttpProxyFactory recognizes this ${?...}
-                        // marker at request time and drops the whole name=value fragment (and its separator)
-                        // when the referenced accessor has no captured value, rather than emitting name=
-                        // with an empty value or an unresolved expression
                         query.append("${?")
                             .append(accessor)
                             .append('.')

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -45,6 +45,7 @@ import jakarta.json.bind.JsonbBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpOptionsConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpResourceConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpResourceConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiCatalogConfig;
@@ -359,20 +360,13 @@ public final class McpOpenapiCompositeGenerator
                     : jsonModel("%s-output".formatted(name));
                 final String description = entry.resourceConfig != null ? entry.resourceConfig.description : null;
                 final boolean template = entry.operation.path != null && entry.operation.path.indexOf('{') >= 0;
-                final String uri = resourceUri(entry.operation);
-                String mimeType = null;
-                final OpenapiResponseView success = successResponse(entry.operation);
-                if (success != null && success.content != null && !success.content.isEmpty())
-                {
-                    mimeType = success.content.values().iterator().next().name;
-                }
                 resources.add(McpHttpResourceConfig.builder()
                     .name(entry.resource)
-                    .uri(uri)
+                    .uri(resourceUri(entry.operation))
                     .template(template)
                     .description(description)
-                    .mimeType(mimeType)
                     .output(output)
+                    .inject(r -> injectMimeType(r, entry.operation))
                     .build());
             }
         }
@@ -415,6 +409,19 @@ public final class McpOpenapiCompositeGenerator
         }
 
         return route;
+    }
+
+    private <C> McpHttpResourceConfigBuilder<C> injectMimeType(
+        McpHttpResourceConfigBuilder<C> resource,
+        OpenapiOperationView operation)
+    {
+        final OpenapiResponseView success = successResponse(operation);
+        if (success != null && success.content != null && !success.content.isEmpty())
+        {
+            resource.mimeType(success.content.values().iterator().next().name);
+        }
+
+        return resource;
     }
 
     private <C> GuardedConfigBuilder<C> injectRoles(

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiOptionsConfigAdapterTest.java
@@ -78,6 +78,11 @@ public class McpOpenapiOptionsConfigAdapterTest
                 "create_pr": {
                   "description": "Create a pull request."
                 }
+              },
+              "resources": {
+                "repo://{owner}/{repo}": {
+                  "description": "A GitHub repository."
+                }
               }
             }
             """;
@@ -94,6 +99,9 @@ public class McpOpenapiOptionsConfigAdapterTest
         assertThat(options.tools, not(nullValue()));
         assertThat(options.tools.get(0).name, equalTo("create_pr"));
         assertThat(options.tools.get(0).description, equalTo("Create a pull request."));
+        assertThat(options.resources, not(nullValue()));
+        assertThat(options.resources.get(0).uri, equalTo("repo://{owner}/{repo}"));
+        assertThat(options.resources.get(0).description, equalTo("A GitHub repository."));
     }
 
     @Test
@@ -102,7 +110,8 @@ public class McpOpenapiOptionsConfigAdapterTest
         String expected =
             "{\"specs\":{\"openapi_github0\":{\"catalog\":{\"catalog0\":" +
             "{\"subject\":\"rest-api\",\"version\":\"latest\"}},\"server\":\"https://api.github.com\"}}," +
-            "\"tools\":{\"create_pr\":{\"description\":\"Create a pull request.\"}}}";
+            "\"tools\":{\"create_pr\":{\"description\":\"Create a pull request.\"}}," +
+            "\"resources\":{\"repo://{owner}/{repo}\":{\"description\":\"A GitHub repository.\"}}}";
 
         McpOpenapiOptionsConfig options = McpOpenapiOptionsConfig.builder()
             .spec()
@@ -117,6 +126,10 @@ public class McpOpenapiOptionsConfigAdapterTest
             .tool()
                 .name("create_pr")
                 .description("Create a pull request.")
+                .build()
+            .resource()
+                .uri("repo://{owner}/{repo}")
+                .description("A GitHub repository.")
                 .build()
             .build();
 

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -50,6 +50,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpOptionsConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpResourceConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpToolConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiConditionConfig;
@@ -195,6 +196,39 @@ public class McpOpenapiCompositeGeneratorTest
             "/ping": {
               "get": {
                 "operationId": "ping",
+                "responses": { "200": { "description": "ok",
+                  "content": { "application/json": { "schema": { "type": "object" } } } } }
+              }
+            }
+          }
+        }
+        """;
+
+    private static final String NOTIFICATIONS_SPEC =
+        """
+        {
+          "openapi": "3.1.0",
+          "info": { "title": "notifications", "version": "1.0.0" },
+          "servers": [ { "url": "https://api.example.com" } ],
+          "paths": {
+            "/notifications": {
+              "get": {
+                "operationId": "notifications/list",
+                "parameters": [
+                  { "name": "unread", "in": "query", "schema": { "type": "boolean" } }
+                ],
+                "responses": { "200": { "description": "ok",
+                  "content": { "application/json": { "schema": { "type": "object" } } } } }
+              }
+            },
+            "/repos/{owner}/{repo}/notifications": {
+              "get": {
+                "operationId": "repo_notifications/list",
+                "parameters": [
+                  { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+                  { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } },
+                  { "name": "unread", "in": "query", "schema": { "type": "boolean" } }
+                ],
                 "responses": { "200": { "description": "ok",
                   "content": { "application/json": { "schema": { "type": "object" } } } } }
               }
@@ -469,6 +503,197 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
+    public void shouldOverrideResourceDescriptionAndOutputSchema()
+    {
+        ModelConfig override = StringModelConfig.builder().build();
+
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .security(Map.of("bearerAuth", "guard0", "oauthScheme", "guard0"))
+                    .build()
+                .resource()
+                    .uri("repo://{owner}/{repo}")
+                    .description("A GitHub repository.")
+                    .output(override)
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .resource("repo://{owner}/{repo}")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("repos/get")
+                    .build())
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
+        McpHttpResourceConfig resource = mcpHttpOptions.resources.stream()
+            .filter(r -> "repo://{owner}/{repo}".equals(r.name))
+            .findFirst()
+            .orElse(null);
+        assertThat(resource, notNullValue());
+        assertThat(resource.description, equalTo("A GitHub repository."));
+        assertThat(resource.output, sameInstance(override));
+    }
+
+    @Test
+    public void shouldDefaultResourceDescriptionToNullWhenNoOverrideConfigured()
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .security(Map.of("bearerAuth", "guard0", "oauthScheme", "guard0"))
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .resource("repo://{owner}/{repo}")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("repos/get")
+                    .build())
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
+        McpHttpResourceConfig resource = mcpHttpOptions.resources.get(0);
+        assertThat(resource.description, nullValue());
+        assertThat(resource.output, notNullValue());
+    }
+
+    @Test
+    public void shouldClassifyConcreteResourceWithQueryCaptureSuffix()
+    {
+        lenient().when(catalog.resolve(eq("notifications-api"), eq("latest"))).thenReturn(88);
+        lenient().when(catalog.resolve(eq(88))).thenReturn(NOTIFICATIONS_SPEC);
+
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("notifications")
+                    .server("https://api.example.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("notifications-api")
+                        .version("latest")
+                        .build()
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .resource("notifications")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("notifications")
+                    .operation("notifications/list")
+                    .build())
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
+        McpHttpResourceConfig resource = mcpHttpOptions.resources.get(0);
+        assertThat(resource.template, equalTo(false));
+        assertThat(resource.uri, equalTo("/notifications{?unread}"));
+    }
+
+    @Test
+    public void shouldClassifyPathParameterizedResourceAsTemplate()
+    {
+        lenient().when(catalog.resolve(eq("notifications-api"), eq("latest"))).thenReturn(88);
+        lenient().when(catalog.resolve(eq(88))).thenReturn(NOTIFICATIONS_SPEC);
+
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("notifications")
+                    .server("https://api.example.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("notifications-api")
+                        .version("latest")
+                        .build()
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .resource("repo://{owner}/{repo}/notifications")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("notifications")
+                    .operation("repo_notifications/list")
+                    .build())
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
+        McpHttpResourceConfig resource = mcpHttpOptions.resources.get(0);
+        assertThat(resource.template, equalTo(true));
+        assertThat(resource.uri, equalTo("/repos/{owner}/{repo}/notifications{?unread}"));
+    }
+
+    @Test
     public void shouldUseOpenapiSummaryAsToolSummary()
     {
         BindingConfig binding = BindingConfig.builder()
@@ -655,7 +880,7 @@ public class McpOpenapiCompositeGeneratorTest
             .findFirst()
             .orElse(null);
         assertThat(with, notNullValue());
-        assertThat(with.headers.get(":path"), equalTo("/search/code?q=${args.q}&page=${args.page}"));
+        assertThat(with.headers.get(":path"), equalTo("/search/code?q=${args.q}&${?args.page=page}"));
     }
 
     @Test

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
@@ -97,6 +97,15 @@ public class McpOpenapiClientIT
     }
 
     @Test
+    @Configuration("proxy.resource.override.yaml")
+    @Specification({
+        "${mcp}/resources.list.with.override/client"})
+    public void shouldListResourcesWithOverriddenDescription() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.yaml")
     @Specification({
         "${mcp}/create.pr.10k/client",
@@ -161,6 +170,26 @@ public class McpOpenapiClientIT
         "${mcp}/read.order/client",
         "${http}/read.order/server"})
     public void shouldReadResourceWithoutGuard() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.query.yaml")
+    @Specification({
+        "${mcp}/search.items/client",
+        "${http}/search.items/server"})
+    public void shouldCallToolSearchItemsWithoutOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.query.yaml")
+    @Specification({
+        "${mcp}/search.items.with.limit/client",
+        "${http}/search.items.with.limit/server"})
+    public void shouldCallToolSearchItemsWithOptionalQueryParameter() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.yaml
@@ -126,6 +126,26 @@ catalogs:
                 "total":  { "type": "number" }
               }
             }
+        search_items_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":     { "type": "string" },
+                "limit": { "type": "integer" }
+              }
+            }
+        search_items_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "items": { "type": "array", "items": { "type": "string" } }
+              }
+            }
         report_params:
           version: latest
           schema: |
@@ -392,6 +412,23 @@ bindings:
                 http_github0:
                   - subject: profile_result
                     version: latest
+        search_items:
+          description: >
+            Search items, optionally limiting the number of results.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_items_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_items_result
+                    version: latest
       resources:
         order:
           uri: "order://{orderId}"
@@ -516,3 +553,12 @@ bindings:
             ":scheme": https
             ":authority": api.github.com
             ":path": /profile
+      - when:
+          - tool: search_items
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com
+            ":path": /items?q=${args.q}&${?args.limit=limit}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items.with.limit/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items.with.limit/client.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/http0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "GET")
+                            .header(":scheme", "https")
+                            .header(":authority", "api.github.com")
+                            .header(":path", "/items?q=widgets&limit=5")
+                            .build()}
+
+connected
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read  '{"items":["a","b"]}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items.with.limit/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items.with.limit/server.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/http0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":scheme", "https")
+                           .header(":authority", "api.github.com")
+                           .header(":path", "/items?q=widgets&limit=5")
+                           .build()}
+
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"items":["a","b"]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/http0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+# limit is absent, so the ${?args.limit=limit} fragment (and its separator) is dropped entirely
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "GET")
+                            .header(":scheme", "https")
+                            .header(":authority", "api.github.com")
+                            .header(":path", "/items?q=widgets")
+                            .build()}
+
+connected
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read  '{"items":["a","b"]}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/http/search.items/server.rpt
@@ -1,0 +1,48 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/http0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+# limit is absent from arguments, so the ${?args.limit=limit} fragment (and its separator)
+# must be dropped entirely rather than emitted as limit= or left unresolved
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":scheme", "https")
+                           .header(":authority", "api.github.com")
+                           .header(":path", "/items?q=widgets")
+                           .build()}
+
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"items":["a","b"]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items.with.limit/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items.with.limit/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("search_items")
+                               .contentLength(25)
+                               .build()
+                           .build()}
+
+connected
+
+# limit is supplied this time; the outbound request must include it
+write '{"name":"search_items","arguments":{"q":"widgets","limit":5}}'
+
+read  '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"done"}],'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items.with.limit/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items.with.limit/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("search_items")
+                              .contentLength(25)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"name":"search_items","arguments":{"q":"widgets","limit":5}}'
+
+write flush
+
+write '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"done"}],'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("search_items")
+                               .contentLength(15)
+                               .build()
+                           .build()}
+
+connected
+
+# limit is optional and not supplied here; the outbound request must omit it entirely
+write '{"name":"search_items","arguments":{"q":"widgets"}}'
+
+read  '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"done"}],'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/search.items/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("search_items")
+                              .contentLength(15)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"name":"search_items","arguments":{"q":"widgets"}}'
+
+write flush
+
+write '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"done"}],'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/HttpClientIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/HttpClientIT.java
@@ -128,6 +128,24 @@ public class HttpClientIT
 
     @Test
     @Specification({
+        "${http}/search.items/client",
+        "${http}/search.items/server"})
+    public void shouldProxySearchItemsWithoutOptionalQueryParameterToHttp() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${http}/search.items.with.limit/client",
+        "${http}/search.items.with.limit/server"})
+    public void shouldProxySearchItemsWithOptionalQueryParameterToHttp() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${http}/create.pr.error/client",
         "${http}/create.pr.error/server"})
     public void shouldProxyCreatePrErrorToHttp() throws Exception

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
@@ -191,6 +191,24 @@ public class McpServerIT
 
     @Test
     @Specification({
+        "${mcp}/search.items/client",
+        "${mcp}/search.items/server"})
+    public void shouldCallToolSearchItemsWithoutOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${mcp}/search.items.with.limit/client",
+        "${mcp}/search.items.with.limit/server"})
+    public void shouldCallToolSearchItemsWithOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/create.pr.error/client",
         "${mcp}/create.pr.error/server"})
     public void shouldRejectToolCreatePr() throws Exception

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.query.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.query.yaml
@@ -1,0 +1,74 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  catalog0:
+    type: inline
+    options:
+      subjects:
+        github:
+          version: latest
+          schema: |
+            {
+              "openapi": "3.1.0",
+              "info": { "title": "GitHub", "version": "1.0.0" },
+              "servers": [ { "url": "https://api.github.com" } ],
+              "paths": {
+                "/items": {
+                  "get": {
+                    "operationId": "search_items",
+                    "summary": "Search items",
+                    "parameters": [
+                      { "name": "q", "in": "query", "required": true, "schema": { "type": "string" } },
+                      { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "ok",
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "type": "object",
+                              "properties": {
+                                "items": { "type": "array", "items": { "type": "string" } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: client
+    options:
+      specs:
+        github:
+          catalog:
+            catalog0:
+              subject: github
+              version: latest
+    routes:
+      - when:
+          - tool: search_items
+        with:
+          spec: github
+          operation: search_items

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.override.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.override.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  catalog0:
+    type: inline
+    options:
+      subjects:
+        github:
+          version: latest
+          schema: |
+            {
+              "openapi": "3.1.0",
+              "info": { "title": "GitHub", "version": "1.0.0" },
+              "servers": [ { "url": "https://api.github.com" } ],
+              "paths": {
+                "/orders/{orderId}": {
+                  "get": {
+                    "operationId": "read_order",
+                    "summary": "Read an order",
+                    "parameters": [
+                      { "name": "orderId", "in": "path", "required": true, "schema": { "type": "string" } }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "ok",
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "string" },
+                                "status": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: client
+    options:
+      specs:
+        github:
+          catalog:
+            catalog0:
+              subject: github
+              version: latest
+      resources:
+        read_order:
+          description: Read a customer order by id.
+    routes:
+      - when:
+          - resource: read_order
+        with:
+          spec: github
+          operation: read_order

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -136,6 +136,42 @@
                                     }
                                 },
                                 "additionalProperties": false
+                            },
+                            "resources":
+                            {
+                                "title": "Resources",
+                                "type": "object",
+                                "patternProperties":
+                                {
+                                    "^.+$":
+                                    {
+                                        "type": "object",
+                                        "properties":
+                                        {
+                                            "description":
+                                            {
+                                                "title": "Resource Description",
+                                                "type": "string"
+                                            },
+                                            "schemas":
+                                            {
+                                                "title": "Schemas",
+                                                "type": "object",
+                                                "properties":
+                                                {
+                                                    "output":
+                                                    {
+                                                        "title": "Output Schema",
+                                                        "$ref": "#/$defs/converter"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/http/search.items.with.limit/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/http/search.items.with.limit/server.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/http0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":scheme", "https")
+                           .header(":authority", "api.github.com")
+                           .header(":path", "/items?q=widgets&limit=5")
+                           .build()}
+
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"items":["a","b"]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/http/search.items/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/http/search.items/server.rpt
@@ -1,0 +1,48 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/http0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+# limit is absent from arguments, so the generated ${?args.limit=limit} fragment (and its
+# separator) must be dropped entirely rather than emitted as limit= or left unresolved
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "GET")
+                           .header(":scheme", "https")
+                           .header(":authority", "api.github.com")
+                           .header(":path", "/items?q=widgets")
+                           .build()}
+
+connected
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"items":["a","b"]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list.with.override/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list.with.override/client.rpt
@@ -1,0 +1,55 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+# options.resources overrides the spec-derived description for read_order
+read  '{"resources":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
+read closed
+
+write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list.with.override/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list.with.override/server.rpt
@@ -1,0 +1,56 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write '{"resources":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items.with.limit/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items.with.limit/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("search_items")
+                               .contentLength(25)
+                               .build()
+                           .build()}
+
+connected
+
+# limit is supplied this time; the outbound request must include it
+write '{"name":"search_items","arguments":{"q":"widgets","limit":5}}'
+
+read  '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"Search items"}],'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items.with.limit/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items.with.limit/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("search_items")
+                              .contentLength(25)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"name":"search_items","arguments":{"q":"widgets","limit":5}}'
+
+write flush
+
+write '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"Search items"}],'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("search_items")
+                               .contentLength(15)
+                               .build()
+                           .build()}
+
+connected
+
+# limit is optional and not supplied here; the outbound request must omit it entirely
+write '{"name":"search_items","arguments":{"q":"widgets"}}'
+
+read  '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"Search items"}],'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/search.items/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                            .typeId(zilla:id("mcp"))
+                            .lifecycle()
+                                .sessionId("session-1")
+                                .build()
+                            .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("search_items")
+                              .contentLength(15)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{"name":"search_items","arguments":{"q":"widgets"}}'
+
+write flush
+
+write '{'
+        '"structuredContent":{"items":["a","b"]},'
+        '"content":[{"type":"text","text":"Search items"}],'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
@@ -74,6 +74,15 @@ public class McpServerIT
 
     @Test
     @Specification({
+        "${mcp}/resources.list.with.override/client",
+        "${mcp}/resources.list.with.override/server"})
+    public void shouldListResourcesWithOverriddenDescription() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/create.pr.10k/client",
         "${mcp}/create.pr.10k/server"})
     public void shouldCallToolCreatePr10k() throws Exception
@@ -104,6 +113,24 @@ public class McpServerIT
         "${mcp}/search.code.forbidden/client",
         "${mcp}/search.code.forbidden/server"})
     public void shouldRejectToolWhenUnauthorized() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${mcp}/search.items/client",
+        "${mcp}/search.items/server"})
+    public void shouldCallToolSearchItemsWithoutOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${mcp}/search.items.with.limit/client",
+        "${mcp}/search.items.with.limit/server"})
+    public void shouldCallToolSearchItemsWithOptionalQueryParameter() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
## Description

Implements two of the three gaps described in #2023, plus the classification groundwork for the third:

- **`options.resources` override map** — a new map keyed by resource URI, analogous to the existing `options.tools` map. Each entry may override `description` and `schemas.output`, applied the same way tool overrides already are.
- **Resource vs. resource-template classification** — a resource is classified as a template based on whether its OpenAPI path contains a `{param}` path capture; a query-only parameterization no longer disqualifies it from being concrete. Concrete resources with query parameters now advertise an RFC 6570 `{?name1,name2}` suffix on their URI. `McpHttpResourceConfig` carries this as an explicit `template` boolean rather than inferring it from brace-presence in the URI (which the new query-capture suffix would otherwise make ambiguous).
- **Query-param omit-when-absent** — optional query parameters are now embedded as a `${?expression=name}` marker at generation time; `McpHttpProxyFactory` resolves each query fragment independently at request time and drops absent optional parameters (and their separator) entirely, instead of emitting `name=` with an empty value or an unresolved expression. An explicitly empty-string value is still emitted.

All three changes are covered by new unit tests and k3po spec/IT scenarios across `binding-mcp-openapi`, `binding-mcp-http`, and their spec modules. `./mvnw verify` (including JaCoCo coverage gates) passes on all four touched modules.

**Not included here:** a distinct `resources/templates/list` JSON-RPC method at the `binding-mcp` protocol layer — resource templates still surface via `resources/list` with a `uriTemplate` key, same as before. That requires new IDL types, server/proxy/client dispatch, and a new fan-in list-cache factory in `binding-mcp`, which is tracked separately in #2033 so `mcp_openapi`/`mcp_http` can be wired to it once it lands.

Fixes #2023 (partially — see #2033 for the remaining protocol-layer follow-up)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WXGys1DUG73JHVG9Nhjcw1)_