### PR TITLE
feat(binding-mcp): support resources/templates/list as a distinct JSON-RPC method

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -73,6 +73,7 @@ public final class McpHttpBindingConfig
     // memoized list replies; derived solely from static binding config, built once on first request
     private byte[] toolsListJson;
     private byte[] resourcesListJson;
+    private byte[] resourceTemplatesListJson;
 
     public McpHttpBindingConfig(
         BindingConfig binding,
@@ -223,6 +224,17 @@ public final class McpHttpBindingConfig
         byte[] json)
     {
         this.resourcesListJson = json;
+    }
+
+    public byte[] resourceTemplatesListJson()
+    {
+        return resourceTemplatesListJson;
+    }
+
+    public void resourceTemplatesListJson(
+        byte[] json)
+    {
+        this.resourceTemplatesListJson = json;
     }
 
     public McpHttpResourceConfig resource(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -73,7 +73,7 @@ public final class McpHttpBindingConfig
     // memoized list replies; derived solely from static binding config, built once on first request
     private byte[] toolsListJson;
     private byte[] resourcesListJson;
-    private byte[] resourceTemplatesListJson;
+    private byte[] resourcesTemplatesListJson;
 
     public McpHttpBindingConfig(
         BindingConfig binding,
@@ -226,15 +226,15 @@ public final class McpHttpBindingConfig
         this.resourcesListJson = json;
     }
 
-    public byte[] resourceTemplatesListJson()
+    public byte[] resourcesTemplatesListJson()
     {
-        return resourceTemplatesListJson;
+        return resourcesTemplatesListJson;
     }
 
-    public void resourceTemplatesListJson(
+    public void resourcesTemplatesListJson(
         byte[] json)
     {
-        this.resourceTemplatesListJson = json;
+        this.resourcesTemplatesListJson = json;
     }
 
     public McpHttpResourceConfig resource(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.http.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
@@ -258,6 +259,10 @@ public final class McpHttpProxyFactory implements BindingHandler
                         break;
                     case KIND_RESOURCES_LIST:
                         newStream = new McpResourcesListProxy(binding,
+                            sender, originId, routedId, initialId, authorization, affinity)::onMcpMessage;
+                        break;
+                    case KIND_RESOURCE_TEMPLATES_LIST:
+                        newStream = new McpResourceTemplatesListProxy(binding,
                             sender, originId, routedId, initialId, authorization, affinity)::onMcpMessage;
                         break;
                     case KIND_TOOLS_CALL:
@@ -1591,6 +1596,31 @@ public final class McpHttpProxyFactory implements BindingHandler
         }
     }
 
+    private final class McpResourceTemplatesListProxy extends McpProxy
+    {
+        private McpResourceTemplatesListProxy(
+            McpHttpBindingConfig binding,
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long authorization,
+            long affinity)
+        {
+            super(binding, null, null, null, EMPTY_PARAMS, -1, sender, originId, routedId, initialId,
+                authorization, affinity);
+        }
+
+        @Override
+        void onMcpRequest(
+            long traceId)
+        {
+            requestHandled = true;
+            doMcpReply(traceId, resourceTemplatesList(binding));
+            cleanupDecodeSlot();
+        }
+    }
+
     private final class HttpProxy
     {
         private final McpHttpProxy mcp;
@@ -2246,6 +2276,9 @@ public final class McpHttpProxyFactory implements BindingHandler
         case KIND_RESOURCES_LIST:
             sessionId = beginEx.resourcesList().sessionId().asString();
             break;
+        case KIND_RESOURCE_TEMPLATES_LIST:
+            sessionId = beginEx.resourceTemplatesList().sessionId().asString();
+            break;
         case KIND_RESOURCES_READ:
             sessionId = beginEx.resourcesRead().sessionId().asString();
             break;
@@ -2335,6 +2368,18 @@ public final class McpHttpProxyFactory implements BindingHandler
         return json;
     }
 
+    private byte[] resourceTemplatesList(
+        McpHttpBindingConfig binding)
+    {
+        byte[] json = binding.resourceTemplatesListJson();
+        if (json == null)
+        {
+            json = buildResourceTemplatesList(binding).getBytes(UTF_8);
+            binding.resourceTemplatesListJson(json);
+        }
+        return json;
+    }
+
     private String buildToolsList(
         McpHttpBindingConfig binding)
     {
@@ -2388,12 +2433,15 @@ public final class McpHttpProxyFactory implements BindingHandler
         final JsonArrayBuilder resources = Json.createArrayBuilder();
         for (McpHttpResourceConfig resource : binding.resources())
         {
+            if (resource.template)
+            {
+                continue;
+            }
             final JsonObjectBuilder item = Json.createObjectBuilder()
                 .add("name", resource.name);
             if (resource.uri != null)
             {
-                final String key = resource.template ? "uriTemplate" : "uri";
-                item.add(key, resource.uri);
+                item.add("uri", resource.uri);
             }
             if (resource.description != null)
             {
@@ -2406,6 +2454,32 @@ public final class McpHttpProxyFactory implements BindingHandler
             resources.add(item);
         }
         return compact(Json.createObjectBuilder().add("resources", resources).build());
+    }
+
+    private String buildResourceTemplatesList(
+        McpHttpBindingConfig binding)
+    {
+        final JsonArrayBuilder resourceTemplates = Json.createArrayBuilder();
+        for (McpHttpResourceConfig resource : binding.resources())
+        {
+            if (!resource.template)
+            {
+                continue;
+            }
+            final JsonObjectBuilder item = Json.createObjectBuilder()
+                .add("name", resource.name)
+                .add("uriTemplate", resource.uri);
+            if (resource.description != null)
+            {
+                item.add("description", resource.description);
+            }
+            if (resource.mimeType != null)
+            {
+                item.add("mimeType", resource.mimeType);
+            }
+            resourceTemplates.add(item);
+        }
+        return compact(Json.createObjectBuilder().add("resourceTemplates", resourceTemplates).build());
     }
 
     private JsonObject schemaObject(

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.http.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
-import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
@@ -261,8 +261,8 @@ public final class McpHttpProxyFactory implements BindingHandler
                         newStream = new McpResourcesListProxy(binding,
                             sender, originId, routedId, initialId, authorization, affinity)::onMcpMessage;
                         break;
-                    case KIND_RESOURCE_TEMPLATES_LIST:
-                        newStream = new McpResourceTemplatesListProxy(binding,
+                    case KIND_RESOURCES_TEMPLATES_LIST:
+                        newStream = new McpResourcesTemplatesListProxy(binding,
                             sender, originId, routedId, initialId, authorization, affinity)::onMcpMessage;
                         break;
                     case KIND_TOOLS_CALL:
@@ -1596,9 +1596,9 @@ public final class McpHttpProxyFactory implements BindingHandler
         }
     }
 
-    private final class McpResourceTemplatesListProxy extends McpProxy
+    private final class McpResourcesTemplatesListProxy extends McpProxy
     {
-        private McpResourceTemplatesListProxy(
+        private McpResourcesTemplatesListProxy(
             McpHttpBindingConfig binding,
             MessageConsumer sender,
             long originId,
@@ -1616,7 +1616,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             long traceId)
         {
             requestHandled = true;
-            doMcpReply(traceId, resourceTemplatesList(binding));
+            doMcpReply(traceId, resourcesTemplatesList(binding));
             cleanupDecodeSlot();
         }
     }
@@ -2276,8 +2276,8 @@ public final class McpHttpProxyFactory implements BindingHandler
         case KIND_RESOURCES_LIST:
             sessionId = beginEx.resourcesList().sessionId().asString();
             break;
-        case KIND_RESOURCE_TEMPLATES_LIST:
-            sessionId = beginEx.resourceTemplatesList().sessionId().asString();
+        case KIND_RESOURCES_TEMPLATES_LIST:
+            sessionId = beginEx.resourcesTemplatesList().sessionId().asString();
             break;
         case KIND_RESOURCES_READ:
             sessionId = beginEx.resourcesRead().sessionId().asString();
@@ -2368,14 +2368,14 @@ public final class McpHttpProxyFactory implements BindingHandler
         return json;
     }
 
-    private byte[] resourceTemplatesList(
+    private byte[] resourcesTemplatesList(
         McpHttpBindingConfig binding)
     {
-        byte[] json = binding.resourceTemplatesListJson();
+        byte[] json = binding.resourcesTemplatesListJson();
         if (json == null)
         {
-            json = buildResourceTemplatesList(binding).getBytes(UTF_8);
-            binding.resourceTemplatesListJson(json);
+            json = buildResourcesTemplatesList(binding).getBytes(UTF_8);
+            binding.resourcesTemplatesListJson(json);
         }
         return json;
     }
@@ -2456,7 +2456,7 @@ public final class McpHttpProxyFactory implements BindingHandler
         return compact(Json.createObjectBuilder().add("resources", resources).build());
     }
 
-    private String buildResourceTemplatesList(
+    private String buildResourcesTemplatesList(
         McpHttpBindingConfig binding)
     {
         final JsonArrayBuilder resourceTemplates = Json.createArrayBuilder();

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
@@ -211,6 +211,15 @@ public class McpHttpProxyIT
     @Test
     @Configuration("proxy.discovery.yaml")
     @Specification({
+        "${mcp}/resources.templates.list/client"})
+    public void shouldListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.discovery.yaml")
+    @Specification({
         "${mcp}/read.resource.unknown/client"})
     public void shouldRejectResourceReadWhenUriUnmatched() throws Exception
     {

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
@@ -212,7 +212,7 @@ public class McpHttpProxyIT
     @Configuration("proxy.discovery.yaml")
     @Specification({
         "${mcp}/resources.templates.list/client"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
@@ -108,6 +108,15 @@ public class McpOpenapiClientIT
     @Test
     @Configuration("proxy.yaml")
     @Specification({
+        "${mcp}/resources.templates.list/client"})
+    public void shouldListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
         "${mcp}/create.pr.10k/client",
         "${http}/create.pr.10k/server"})
     public void shouldCallToolCreatePr10k() throws Exception

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
@@ -100,7 +100,7 @@ public class McpOpenapiClientIT
     @Configuration("proxy.resource.override.yaml")
     @Specification({
         "${mcp}/resources.templates.list.with.override/client"})
-    public void shouldListResourceTemplatesWithOverriddenDescription() throws Exception
+    public void shouldListResourcesTemplatesWithOverriddenDescription() throws Exception
     {
         k3po.finish();
     }
@@ -109,7 +109,7 @@ public class McpOpenapiClientIT
     @Configuration("proxy.yaml")
     @Specification({
         "${mcp}/resources.templates.list/client"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
@@ -99,8 +99,8 @@ public class McpOpenapiClientIT
     @Test
     @Configuration("proxy.resource.override.yaml")
     @Specification({
-        "${mcp}/resources.list.with.override/client"})
-    public void shouldListResourcesWithOverriddenDescription() throws Exception
+        "${mcp}/resources.templates.list.with.override/client"})
+    public void shouldListResourceTemplatesWithOverriddenDescription() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -16,7 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKERS;
 
@@ -318,7 +318,7 @@ public class McpConfiguration extends Configuration
                 break;
             case "resources":
                 kinds.add(KIND_RESOURCES_LIST);
-                kinds.add(KIND_RESOURCE_TEMPLATES_LIST);
+                kinds.add(KIND_RESOURCES_TEMPLATES_LIST);
                 break;
             case "prompts":
                 kinds.add(KIND_PROMPTS_LIST);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpConfiguration.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKERS;
 
@@ -317,6 +318,7 @@ public class McpConfiguration extends Configuration
                 break;
             case "resources":
                 kinds.add(KIND_RESOURCES_LIST);
+                kinds.add(KIND_RESOURCE_TEMPLATES_LIST);
                 break;
             case "prompts":
                 kinds.add(KIND_PROMPTS_LIST);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static java.util.function.UnaryOperator.identity;
@@ -264,7 +265,7 @@ public final class McpRouteConfig
         {
         case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
         case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;
-        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ -> CAPABILITY_RESOURCES;
+        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ, KIND_RESOURCE_TEMPLATES_LIST -> CAPABILITY_RESOURCES;
         default -> null;
         };
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpRouteConfig.java
@@ -21,7 +21,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static java.util.function.UnaryOperator.identity;
@@ -265,7 +265,7 @@ public final class McpRouteConfig
         {
         case KIND_TOOLS_LIST, KIND_TOOLS_CALL -> CAPABILITY_TOOLS;
         case KIND_PROMPTS_LIST, KIND_PROMPTS_GET -> CAPABILITY_PROMPTS;
-        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ, KIND_RESOURCE_TEMPLATES_LIST -> CAPABILITY_RESOURCES;
+        case KIND_RESOURCES_LIST, KIND_RESOURCES_READ, KIND_RESOURCES_TEMPLATES_LIST -> CAPABILITY_RESOURCES;
         default -> null;
         };
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -27,6 +27,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
@@ -150,6 +151,7 @@ public final class McpClientFactory implements McpStreamFactory
     private static final String JSON_RPC_PROMPTS_GET_METHOD = ",\"method\":\"prompts/get\",\"params\":";
     private static final String JSON_RPC_RESOURCES_LIST_METHOD = ",\"method\":\"resources/list\"}";
     private static final String JSON_RPC_RESOURCES_READ_METHOD = ",\"method\":\"resources/read\",\"params\":";
+    private static final String JSON_RPC_RESOURCE_TEMPLATES_LIST_METHOD = ",\"method\":\"resources/templates/list\"}";
     private static final String JSON_RPC_PING_METHOD = ",\"method\":\"ping\"}";
     private static final String JSON_RPC_NOTIFY_CANCELLED_PREFIX =
         "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":";
@@ -275,6 +277,7 @@ public final class McpClientFactory implements McpStreamFactory
         resolvers.put(KIND_PROMPTS_GET, ex -> ex.promptsGet().sessionId().asString());
         resolvers.put(KIND_RESOURCES_LIST, ex -> ex.resourcesList().sessionId().asString());
         resolvers.put(KIND_RESOURCES_READ, ex -> ex.resourcesRead().sessionId().asString());
+        resolvers.put(KIND_RESOURCE_TEMPLATES_LIST, ex -> ex.resourceTemplatesList().sessionId().asString());
         this.resolvers = resolvers;
 
         final Int2ObjectHashMap<McpRequestStreamFactory> requestFactories = new Int2ObjectHashMap<>();
@@ -284,6 +287,7 @@ public final class McpClientFactory implements McpStreamFactory
         requestFactories.put(KIND_PROMPTS_GET, McpPromptsGetStream::new);
         requestFactories.put(KIND_RESOURCES_LIST, McpResourcesListStream::new);
         requestFactories.put(KIND_RESOURCES_READ, McpResourcesReadStream::new);
+        requestFactories.put(KIND_RESOURCE_TEMPLATES_LIST, McpResourceTemplatesListStream::new);
         this.requestFactories = requestFactories;
     }
 
@@ -1467,6 +1471,7 @@ public final class McpClientFactory implements McpStreamFactory
                             case KIND_PROMPTS_GET -> mcpBeginEx.promptsGet().timeout();
                             case KIND_RESOURCES_LIST -> mcpBeginEx.resourcesList().timeout();
                             case KIND_RESOURCES_READ -> mcpBeginEx.resourcesRead().timeout();
+                            case KIND_RESOURCE_TEMPLATES_LIST -> mcpBeginEx.resourceTemplatesList().timeout();
                             default -> 0L;
                             };
                             newStream = request::onAppMessage;
@@ -3462,6 +3467,34 @@ public final class McpClientFactory implements McpStreamFactory
         }
     }
 
+    private final class McpResourceTemplatesListStream extends McpRequestStream
+    {
+        McpResourceTemplatesListStream(
+            McpLifecycleStream session,
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long resolvedId,
+            long affinity,
+            long authorization)
+        {
+            super(session, sender, originId, routedId, initialId, resolvedId, affinity,
+                HttpResourceTemplatesListStream::new);
+        }
+
+        @Override
+        void onAppBeginImpl(
+            long traceId,
+            long authorization,
+            McpBeginExFW mcpBeginEx)
+        {
+            state = McpState.openedInitial(state);
+            http.doEncodeRequestEnd(traceId, authorization);
+            decoder = decodeRequestEnd;
+        }
+    }
+
     private final class McpResourcesReadStream extends McpRequestStream
     {
         McpResourcesReadStream(
@@ -5111,6 +5144,49 @@ public final class McpClientFactory implements McpStreamFactory
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_LIST_METHOD);
+
+            injectAuthorization(extBuilder);
+
+            final int contentLength = codecLength;
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_CONTENT_LENGTH).value(Integer.toString(contentLength)));
+            final HttpBeginExFW httpBeginEx = extBuilder.build();
+
+            doNetBegin(traceId, authorization, httpBeginEx);
+            doNetData(traceId, authorization, codecBuffer, 0, codecLength);
+        }
+
+    }
+
+    private final class HttpResourceTemplatesListStream extends HttpRequestStream
+    {
+        HttpResourceTemplatesListStream(
+            McpStream mcp)
+        {
+            super(mcp);
+        }
+
+        @Override
+        void doEncodeRequestBegin(
+            long traceId,
+            long authorization)
+        {
+            final HttpBeginExFW.Builder extBuilder = httpBeginExRW
+                .wrap(extBuffer, 0, extBuffer.capacity())
+                .typeId(httpTypeId);
+            mcp.binding().injectHeaders(extBuilder);
+            extBuilder
+                .headersItem(h -> h.name(HTTP_HEADER_METHOD).value(HTTP_METHOD_POST))
+                .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
+                .headersItem(h -> h.name(HTTP_HEADER_ACCEPT).value(CONTENT_TYPE_JSON_AND_EVENT_STREAM))
+                .headersItem(h -> h.name(HTTP_HEADER_MCP_VERSION).value(mcp.protocolVersion()));
+
+            final String sid = mcp.transportSessionId();
+            extBuilder.headersItem(h -> h.name(HTTP_HEADER_SESSION).value(sid));
+
+            int codecLength = 0;
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
+            codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCE_TEMPLATES_LIST_METHOD);
 
             injectAuthorization(extBuilder);
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -27,7 +27,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
@@ -151,7 +151,7 @@ public final class McpClientFactory implements McpStreamFactory
     private static final String JSON_RPC_PROMPTS_GET_METHOD = ",\"method\":\"prompts/get\",\"params\":";
     private static final String JSON_RPC_RESOURCES_LIST_METHOD = ",\"method\":\"resources/list\"}";
     private static final String JSON_RPC_RESOURCES_READ_METHOD = ",\"method\":\"resources/read\",\"params\":";
-    private static final String JSON_RPC_RESOURCE_TEMPLATES_LIST_METHOD = ",\"method\":\"resources/templates/list\"}";
+    private static final String JSON_RPC_RESOURCES_TEMPLATES_LIST_METHOD = ",\"method\":\"resources/templates/list\"}";
     private static final String JSON_RPC_PING_METHOD = ",\"method\":\"ping\"}";
     private static final String JSON_RPC_NOTIFY_CANCELLED_PREFIX =
         "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":";
@@ -277,7 +277,7 @@ public final class McpClientFactory implements McpStreamFactory
         resolvers.put(KIND_PROMPTS_GET, ex -> ex.promptsGet().sessionId().asString());
         resolvers.put(KIND_RESOURCES_LIST, ex -> ex.resourcesList().sessionId().asString());
         resolvers.put(KIND_RESOURCES_READ, ex -> ex.resourcesRead().sessionId().asString());
-        resolvers.put(KIND_RESOURCE_TEMPLATES_LIST, ex -> ex.resourceTemplatesList().sessionId().asString());
+        resolvers.put(KIND_RESOURCES_TEMPLATES_LIST, ex -> ex.resourcesTemplatesList().sessionId().asString());
         this.resolvers = resolvers;
 
         final Int2ObjectHashMap<McpRequestStreamFactory> requestFactories = new Int2ObjectHashMap<>();
@@ -287,7 +287,7 @@ public final class McpClientFactory implements McpStreamFactory
         requestFactories.put(KIND_PROMPTS_GET, McpPromptsGetStream::new);
         requestFactories.put(KIND_RESOURCES_LIST, McpResourcesListStream::new);
         requestFactories.put(KIND_RESOURCES_READ, McpResourcesReadStream::new);
-        requestFactories.put(KIND_RESOURCE_TEMPLATES_LIST, McpResourceTemplatesListStream::new);
+        requestFactories.put(KIND_RESOURCES_TEMPLATES_LIST, McpResourcesTemplatesListStream::new);
         this.requestFactories = requestFactories;
     }
 
@@ -1471,7 +1471,7 @@ public final class McpClientFactory implements McpStreamFactory
                             case KIND_PROMPTS_GET -> mcpBeginEx.promptsGet().timeout();
                             case KIND_RESOURCES_LIST -> mcpBeginEx.resourcesList().timeout();
                             case KIND_RESOURCES_READ -> mcpBeginEx.resourcesRead().timeout();
-                            case KIND_RESOURCE_TEMPLATES_LIST -> mcpBeginEx.resourceTemplatesList().timeout();
+                            case KIND_RESOURCES_TEMPLATES_LIST -> mcpBeginEx.resourcesTemplatesList().timeout();
                             default -> 0L;
                             };
                             newStream = request::onAppMessage;
@@ -3467,9 +3467,9 @@ public final class McpClientFactory implements McpStreamFactory
         }
     }
 
-    private final class McpResourceTemplatesListStream extends McpRequestStream
+    private final class McpResourcesTemplatesListStream extends McpRequestStream
     {
-        McpResourceTemplatesListStream(
+        McpResourcesTemplatesListStream(
             McpLifecycleStream session,
             MessageConsumer sender,
             long originId,
@@ -3480,7 +3480,7 @@ public final class McpClientFactory implements McpStreamFactory
             long authorization)
         {
             super(session, sender, originId, routedId, initialId, resolvedId, affinity,
-                HttpResourceTemplatesListStream::new);
+                HttpResourcesTemplatesListStream::new);
         }
 
         @Override
@@ -5157,9 +5157,9 @@ public final class McpClientFactory implements McpStreamFactory
 
     }
 
-    private final class HttpResourceTemplatesListStream extends HttpRequestStream
+    private final class HttpResourcesTemplatesListStream extends HttpRequestStream
     {
-        HttpResourceTemplatesListStream(
+        HttpResourcesTemplatesListStream(
             McpStream mcp)
         {
             super(mcp);
@@ -5186,7 +5186,7 @@ public final class McpClientFactory implements McpStreamFactory
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_REQUEST_ID_PREFIX);
             codecLength += codecBuffer.putIntAscii(codecLength, request.requestId);
-            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCE_TEMPLATES_LIST_METHOD);
+            codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_RESOURCES_TEMPLATES_LIST_METHOD);
 
             injectAuthorization(extBuilder);
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -229,17 +229,30 @@ public final class McpProxyCacheHydrater
             switch (flushEx.kind())
             {
             case KIND_TOOLS_LIST_CHANGED:
-                onChanged(KIND_TOOLS_LIST);
+                onChangedIfCached(KIND_TOOLS_LIST);
                 break;
             case KIND_PROMPTS_LIST_CHANGED:
-                onChanged(KIND_PROMPTS_LIST);
+                onChangedIfCached(KIND_PROMPTS_LIST);
                 break;
             case KIND_RESOURCES_LIST_CHANGED:
-                onChanged(KIND_RESOURCES_LIST);
-                onChanged(KIND_RESOURCE_TEMPLATES_LIST);
+                onChangedIfCached(KIND_RESOURCES_LIST);
+                onChangedIfCached(KIND_RESOURCE_TEMPLATES_LIST);
                 break;
             default:
                 break;
+            }
+        }
+
+        // the upstream server's own capabilities are independent of this proxy's local
+        // hydrate.filter, so it may emit a list_changed notification for a kind this
+        // binding was configured not to cache; ignore it rather than hydrate a kind with
+        // no cache entry
+        private void onChangedIfCached(
+            int kind)
+        {
+            if (cache.cacheOf(kind) != null)
+            {
+                onChanged(kind);
             }
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -16,7 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlushExFW.KIND_PROMPTS_LIST_CHANGED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlushExFW.KIND_RESOURCES_LIST_CHANGED;
@@ -236,17 +236,13 @@ public final class McpProxyCacheHydrater
                 break;
             case KIND_RESOURCES_LIST_CHANGED:
                 onChangedIfCached(KIND_RESOURCES_LIST);
-                onChangedIfCached(KIND_RESOURCE_TEMPLATES_LIST);
+                onChangedIfCached(KIND_RESOURCES_TEMPLATES_LIST);
                 break;
             default:
                 break;
             }
         }
 
-        // the upstream server's own capabilities are independent of this proxy's local
-        // hydrate.filter, so it may emit a list_changed notification for a kind this
-        // binding was configured not to cache; ignore it rather than hydrate a kind with
-        // no cache entry
         private void onChangedIfCached(
             int kind)
         {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlushExFW.KIND_PROMPTS_LIST_CHANGED;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlushExFW.KIND_RESOURCES_LIST_CHANGED;
@@ -235,6 +236,7 @@ public final class McpProxyCacheHydrater
                 break;
             case KIND_RESOURCES_LIST_CHANGED:
                 onChanged(KIND_RESOURCES_LIST);
+                onChanged(KIND_RESOURCE_TEMPLATES_LIST);
                 break;
             default:
                 break;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -19,6 +19,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
@@ -74,11 +75,14 @@ public final class McpProxyFactory implements McpStreamFactory
             new McpProxyPromptsListFactory(config, context, bindings::get);
         final McpProxyResourcesListFactory resourcesListFactory =
             new McpProxyResourcesListFactory(config, context, bindings::get);
+        final McpProxyResourceTemplatesListFactory resourceTemplatesListFactory =
+            new McpProxyResourceTemplatesListFactory(config, context, bindings::get);
 
         final Int2ObjectHashMap<McpProxyListFactory> listFactories = new Int2ObjectHashMap<>();
         listFactories.put(KIND_TOOLS_LIST, toolsListFactory);
         listFactories.put(KIND_PROMPTS_LIST, promptsListFactory);
         listFactories.put(KIND_RESOURCES_LIST, resourcesListFactory);
+        listFactories.put(KIND_RESOURCE_TEMPLATES_LIST, resourceTemplatesListFactory);
 
         final McpProxyCacheHydrater hydrater = new McpProxyCacheHydrater(
             context.bufferPool(), context::supplyTraceId, bindings::get, lifecycleFactory, listFactories);
@@ -94,6 +98,7 @@ public final class McpProxyFactory implements McpStreamFactory
         this.factories.put(KIND_TOOLS_LIST, toolsListFactory);
         this.factories.put(KIND_PROMPTS_LIST, promptsListFactory);
         this.factories.put(KIND_RESOURCES_LIST, resourcesListFactory);
+        this.factories.put(KIND_RESOURCE_TEMPLATES_LIST, resourceTemplatesListFactory);
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyFactory.java
@@ -19,7 +19,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeg
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_READ;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_CALL;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
@@ -75,14 +75,14 @@ public final class McpProxyFactory implements McpStreamFactory
             new McpProxyPromptsListFactory(config, context, bindings::get);
         final McpProxyResourcesListFactory resourcesListFactory =
             new McpProxyResourcesListFactory(config, context, bindings::get);
-        final McpProxyResourceTemplatesListFactory resourceTemplatesListFactory =
-            new McpProxyResourceTemplatesListFactory(config, context, bindings::get);
+        final McpProxyResourcesTemplatesListFactory resourcesTemplatesListFactory =
+            new McpProxyResourcesTemplatesListFactory(config, context, bindings::get);
 
         final Int2ObjectHashMap<McpProxyListFactory> listFactories = new Int2ObjectHashMap<>();
         listFactories.put(KIND_TOOLS_LIST, toolsListFactory);
         listFactories.put(KIND_PROMPTS_LIST, promptsListFactory);
         listFactories.put(KIND_RESOURCES_LIST, resourcesListFactory);
-        listFactories.put(KIND_RESOURCE_TEMPLATES_LIST, resourceTemplatesListFactory);
+        listFactories.put(KIND_RESOURCES_TEMPLATES_LIST, resourcesTemplatesListFactory);
 
         final McpProxyCacheHydrater hydrater = new McpProxyCacheHydrater(
             context.bufferPool(), context::supplyTraceId, bindings::get, lifecycleFactory, listFactories);
@@ -98,7 +98,7 @@ public final class McpProxyFactory implements McpStreamFactory
         this.factories.put(KIND_TOOLS_LIST, toolsListFactory);
         this.factories.put(KIND_PROMPTS_LIST, promptsListFactory);
         this.factories.put(KIND_RESOURCES_LIST, resourcesListFactory);
-        this.factories.put(KIND_RESOURCE_TEMPLATES_LIST, resourceTemplatesListFactory);
+        this.factories.put(KIND_RESOURCES_TEMPLATES_LIST, resourcesTemplatesListFactory);
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -17,7 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
 import java.util.ArrayList;
@@ -814,7 +814,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 .typeId(mcpTypeId)
                 .promptsListChanged(b -> {})
                 .build();
-            case KIND_RESOURCES_LIST, KIND_RESOURCE_TEMPLATES_LIST -> mcpFlushExRW
+            case KIND_RESOURCES_LIST, KIND_RESOURCES_TEMPLATES_LIST -> mcpFlushExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesListChanged(b -> {})

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
 import java.util.ArrayList;
@@ -813,7 +814,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 .typeId(mcpTypeId)
                 .promptsListChanged(b -> {})
                 .build();
-            case KIND_RESOURCES_LIST -> mcpFlushExRW
+            case KIND_RESOURCES_LIST, KIND_RESOURCE_TEMPLATES_LIST -> mcpFlushExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesListChanged(b -> {})

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourceTemplatesListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourceTemplatesListFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
+
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.LongFunction;
+
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+
+final class McpProxyResourceTemplatesListFactory extends McpProxyListFactory
+{
+    private final DirectBufferEx prelude =
+        new UnsafeBufferEx("{\"resourceTemplates\":[".getBytes(StandardCharsets.UTF_8));
+
+    McpProxyResourceTemplatesListFactory(
+        McpConfiguration config,
+        EngineContext context,
+        LongFunction<McpBindingConfig> supplyBinding)
+    {
+        super(config, context, supplyBinding, McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST);
+    }
+
+    @Override
+    protected McpProxyCache.McpListCache cacheOf(
+        McpBindingConfig binding)
+    {
+        return binding.cache != null ? binding.cache.cacheOf(KIND_RESOURCE_TEMPLATES_LIST) : null;
+    }
+
+    @Override
+    protected void injectInitialBeginEx(
+        McpBeginExFW.Builder builder,
+        String sessionId)
+    {
+        builder.resourceTemplatesList(r -> r.sessionId(sessionId));
+    }
+
+    @Override
+    protected void injectReplyBeginEx(
+        McpBeginExFW.Builder builder,
+        String sessionId)
+    {
+        builder.resourceTemplatesList(r -> r.sessionId(sessionId));
+    }
+
+    @Override
+    protected DirectBufferEx listReplyOpenPrelude()
+    {
+        return prelude;
+    }
+
+    @Override
+    protected String arrayKey()
+    {
+        return "resourceTemplates";
+    }
+
+    @Override
+    protected String idKey()
+    {
+        return "uriTemplate";
+    }
+
+    @Override
+    protected String sessionId(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.resourceTemplatesList().sessionId().asString();
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesTemplatesListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesTemplatesListFactory.java
@@ -14,7 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 
 import java.nio.charset.StandardCharsets;
 import java.util.function.LongFunction;
@@ -27,24 +27,24 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 
-final class McpProxyResourceTemplatesListFactory extends McpProxyListFactory
+final class McpProxyResourcesTemplatesListFactory extends McpProxyListFactory
 {
     private final DirectBufferEx prelude =
         new UnsafeBufferEx("{\"resourceTemplates\":[".getBytes(StandardCharsets.UTF_8));
 
-    McpProxyResourceTemplatesListFactory(
+    McpProxyResourcesTemplatesListFactory(
         McpConfiguration config,
         EngineContext context,
         LongFunction<McpBindingConfig> supplyBinding)
     {
-        super(config, context, supplyBinding, McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST);
+        super(config, context, supplyBinding, McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST);
     }
 
     @Override
     protected McpProxyCache.McpListCache cacheOf(
         McpBindingConfig binding)
     {
-        return binding.cache != null ? binding.cache.cacheOf(KIND_RESOURCE_TEMPLATES_LIST) : null;
+        return binding.cache != null ? binding.cache.cacheOf(KIND_RESOURCES_TEMPLATES_LIST) : null;
     }
 
     @Override
@@ -52,7 +52,7 @@ final class McpProxyResourceTemplatesListFactory extends McpProxyListFactory
         McpBeginExFW.Builder builder,
         String sessionId)
     {
-        builder.resourceTemplatesList(r -> r.sessionId(sessionId));
+        builder.resourcesTemplatesList(r -> r.sessionId(sessionId));
     }
 
     @Override
@@ -60,7 +60,7 @@ final class McpProxyResourceTemplatesListFactory extends McpProxyListFactory
         McpBeginExFW.Builder builder,
         String sessionId)
     {
-        builder.resourceTemplatesList(r -> r.sessionId(sessionId));
+        builder.resourcesTemplatesList(r -> r.sessionId(sessionId));
     }
 
     @Override
@@ -85,6 +85,6 @@ final class McpProxyResourceTemplatesListFactory extends McpProxyListFactory
     protected String sessionId(
         McpBeginExFW beginEx)
     {
-        return beginEx.resourceTemplatesList().sessionId().asString();
+        return beginEx.resourcesTemplatesList().sessionId().asString();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -963,6 +963,10 @@ public final class McpServerFactory implements McpStreamFactory
                     server.onDecodeResourcesList(traceId, authorization);
                     server.decodedRequest = server::onDecodeRequestParams;
                     break;
+                case "resources/templates/list":
+                    server.onDecodeResourceTemplatesList(traceId, authorization);
+                    server.decodedRequest = server::onDecodeRequestParams;
+                    break;
                 case "resources/read":
                     server.decodedMethodParam = "uri";
                     server.decodedRequest = server::onDecodeRequestParams;
@@ -2217,6 +2221,23 @@ public final class McpServerFactory implements McpStreamFactory
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
                 .resourcesList(r -> r
+                    .sessionId(session.unifiedId)
+                    .timeout(session.requestTimeout))
+                .build();
+
+            assert stream == null;
+            stream = new McpRequestStream(session, this);
+            stream.doAppBegin(traceId, authorization, beginEx);
+        }
+
+        private void onDecodeResourceTemplatesList(
+            long traceId,
+            long authorization)
+        {
+            McpBeginExFW beginEx = mcpBeginExRW
+                .wrap(codecBuffer, 0, codecBuffer.capacity())
+                .typeId(mcpTypeId)
+                .resourceTemplatesList(r -> r
                     .sessionId(session.unifiedId)
                     .timeout(session.requestTimeout))
                 .build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -964,7 +964,7 @@ public final class McpServerFactory implements McpStreamFactory
                     server.decodedRequest = server::onDecodeRequestParams;
                     break;
                 case "resources/templates/list":
-                    server.onDecodeResourceTemplatesList(traceId, authorization);
+                    server.onDecodeResourcesTemplatesList(traceId, authorization);
                     server.decodedRequest = server::onDecodeRequestParams;
                     break;
                 case "resources/read":
@@ -2230,14 +2230,14 @@ public final class McpServerFactory implements McpStreamFactory
             stream.doAppBegin(traceId, authorization, beginEx);
         }
 
-        private void onDecodeResourceTemplatesList(
+        private void onDecodeResourcesTemplatesList(
             long traceId,
             long authorization)
         {
             McpBeginExFW beginEx = mcpBeginExRW
                 .wrap(codecBuffer, 0, codecBuffer.capacity())
                 .typeId(mcpTypeId)
-                .resourceTemplatesList(r -> r
+                .resourcesTemplatesList(r -> r
                     .sessionId(session.unifiedId)
                     .timeout(session.requestTimeout))
                 .build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
 import java.io.Closeable;
@@ -50,10 +51,12 @@ public final class McpProxyCache
 {
     private static final String STORE_KEY_TOOLS = "tools";
     private static final String STORE_KEY_RESOURCES = "resources";
+    private static final String STORE_KEY_RESOURCE_TEMPLATES = "resourceTemplates";
     private static final String STORE_KEY_PROMPTS = "prompts";
     private static final String STORE_LOCK_SUFFIX = ".lock";
     private static final String STORE_LOCK_KEY_TOOLS = STORE_KEY_TOOLS + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_RESOURCES = STORE_KEY_RESOURCES + STORE_LOCK_SUFFIX;
+    private static final String STORE_LOCK_KEY_RESOURCE_TEMPLATES = STORE_KEY_RESOURCE_TEMPLATES + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_PROMPTS = STORE_KEY_PROMPTS + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_LIFECYCLE = "lifecycle.lock";
     private static final Duration STORE_TTL_FOREVER = null;
@@ -124,6 +127,11 @@ public final class McpProxyCache
         {
             caches.put(KIND_RESOURCES_LIST,
                 new McpListCache(KIND_RESOURCES_LIST, STORE_KEY_RESOURCES, STORE_LOCK_KEY_RESOURCES));
+        }
+        if (filter.test(KIND_RESOURCE_TEMPLATES_LIST))
+        {
+            caches.put(KIND_RESOURCE_TEMPLATES_LIST,
+                new McpListCache(KIND_RESOURCE_TEMPLATES_LIST, STORE_KEY_RESOURCE_TEMPLATES, STORE_LOCK_KEY_RESOURCE_TEMPLATES));
         }
         if (filter.test(KIND_PROMPTS_LIST))
         {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -16,7 +16,7 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_PROMPTS_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_TOOLS_LIST;
 
 import java.io.Closeable;
@@ -51,12 +51,12 @@ public final class McpProxyCache
 {
     private static final String STORE_KEY_TOOLS = "tools";
     private static final String STORE_KEY_RESOURCES = "resources";
-    private static final String STORE_KEY_RESOURCE_TEMPLATES = "resourceTemplates";
+    private static final String STORE_KEY_RESOURCES_TEMPLATES = "resources/templates";
     private static final String STORE_KEY_PROMPTS = "prompts";
     private static final String STORE_LOCK_SUFFIX = ".lock";
     private static final String STORE_LOCK_KEY_TOOLS = STORE_KEY_TOOLS + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_RESOURCES = STORE_KEY_RESOURCES + STORE_LOCK_SUFFIX;
-    private static final String STORE_LOCK_KEY_RESOURCE_TEMPLATES = STORE_KEY_RESOURCE_TEMPLATES + STORE_LOCK_SUFFIX;
+    private static final String STORE_LOCK_KEY_RESOURCES_TEMPLATES = STORE_KEY_RESOURCES_TEMPLATES + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_PROMPTS = STORE_KEY_PROMPTS + STORE_LOCK_SUFFIX;
     private static final String STORE_LOCK_KEY_LIFECYCLE = "lifecycle.lock";
     private static final Duration STORE_TTL_FOREVER = null;
@@ -128,10 +128,11 @@ public final class McpProxyCache
             caches.put(KIND_RESOURCES_LIST,
                 new McpListCache(KIND_RESOURCES_LIST, STORE_KEY_RESOURCES, STORE_LOCK_KEY_RESOURCES));
         }
-        if (filter.test(KIND_RESOURCE_TEMPLATES_LIST))
+        if (filter.test(KIND_RESOURCES_TEMPLATES_LIST))
         {
-            caches.put(KIND_RESOURCE_TEMPLATES_LIST,
-                new McpListCache(KIND_RESOURCE_TEMPLATES_LIST, STORE_KEY_RESOURCE_TEMPLATES, STORE_LOCK_KEY_RESOURCE_TEMPLATES));
+            caches.put(KIND_RESOURCES_TEMPLATES_LIST,
+                new McpListCache(KIND_RESOURCES_TEMPLATES_LIST, STORE_KEY_RESOURCES_TEMPLATES,
+                    STORE_LOCK_KEY_RESOURCES_TEMPLATES));
         }
         if (filter.test(KIND_PROMPTS_LIST))
         {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -14,7 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 
 import java.io.Closeable;
@@ -29,7 +29,7 @@ import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 
 public final class McpProxyCacheManager implements McpProxyCacheListener
 {
-    private static final int KIND_SLOTS = KIND_RESOURCE_TEMPLATES_LIST + 1;
+    private static final int KIND_SLOTS = KIND_RESOURCES_TEMPLATES_LIST + 1;
     private static final BiConsumer<String, String> NO_OP = (k, v) -> {};
 
     private final McpProxyCacheHydrater hydrater;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheManager.java
@@ -14,7 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
 
-import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCES_LIST;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 
 import java.io.Closeable;
@@ -29,7 +29,7 @@ import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 
 public final class McpProxyCacheManager implements McpProxyCacheListener
 {
-    private static final int KIND_SLOTS = KIND_RESOURCES_LIST + 1;
+    private static final int KIND_SLOTS = KIND_RESOURCE_TEMPLATES_LIST + 1;
     private static final BiConsumer<String, String> NO_OP = (k, v) -> {};
 
     private final McpProxyCacheHydrater hydrater;

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -400,6 +400,16 @@ public class McpClientIT
     @Test
     @Configuration("client.yaml")
     @Specification({
+        "${app}/resources.templates.list.aborted/client",
+        "${net}/resources.templates.list.aborted/server"})
+    public void shouldAbortListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
         "${app}/resources.read.aborted/client",
         "${net}/resources.read.aborted/server"})
     public void shouldAbortReadResource() throws Exception
@@ -445,6 +455,16 @@ public class McpClientIT
         "${app}/resources.list/client",
         "${net}/resources.list/server"})
     public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${app}/resources.templates.list/client",
+        "${net}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -402,7 +402,7 @@ public class McpClientIT
     @Specification({
         "${app}/resources.templates.list.aborted/client",
         "${net}/resources.templates.list.aborted/server"})
-    public void shouldAbortListResourceTemplates() throws Exception
+    public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }
@@ -464,7 +464,7 @@ public class McpClientIT
     @Specification({
         "${app}/resources.templates.list/client",
         "${net}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -348,6 +348,17 @@ public class McpProxyIT
     }
 
     @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.templates.list/client",
+        "${app}/resources.templates.list/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.toolkit.yaml")
     @Specification({
         "${app}/resources.list.toolkit.prefixed/client",
@@ -419,6 +430,17 @@ public class McpProxyIT
         "${app}/resources.list.aborted/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
     public void shouldAbortListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
+    @Specification({
+        "${app}/resources.templates.list.aborted/client",
+        "${app}/resources.templates.list.aborted/server" })
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    public void shouldAbortListResourceTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -353,7 +353,7 @@ public class McpProxyIT
         "${app}/resources.templates.list/client",
         "${app}/resources.templates.list/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }
@@ -440,7 +440,7 @@ public class McpProxyIT
         "${app}/resources.templates.list.aborted/client",
         "${app}/resources.templates.list.aborted/server" })
     @ScriptProperty("serverAddress \"zilla://streams/app1\"")
-    public void shouldAbortListResourceTemplates() throws Exception
+    public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -511,7 +511,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.templates.list.aborted/client",
         "${app}/resources.templates.list.aborted/server"})
-    public void shouldAbortListResourceTemplates() throws Exception
+    public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }
@@ -571,7 +571,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.templates.list/client",
         "${app}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -509,6 +509,16 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/resources.templates.list.aborted/client",
+        "${app}/resources.templates.list.aborted/server"})
+    public void shouldAbortListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/resources.read.aborted/client",
         "${app}/resources.read.aborted/server"})
     public void shouldAbortReadResource() throws Exception
@@ -552,6 +562,16 @@ public class McpServerIT
         "${net}/resources.list/client",
         "${app}/resources.list/server"})
     public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/resources.templates.list/client",
+        "${app}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list/client.rpt
@@ -49,8 +49,9 @@ write zilla:begin.ext ${mcp:beginEx()
 connected
 
 # resources/list is answered entirely from config; no upstream HTTP call
-read  '{"resources":[{"name":"item","uriTemplate":"item://{itemId}",'
-      '"description":"An item resource","mimeType":"application/json"}]}'
+# the "item" resource is a template (uri contains a path capture), so it is
+# excluded here and only appears in resources/templates/list
+read '{"resources":[]}'
 read closed
 
 write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list/client.rpt
@@ -48,9 +48,6 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-# resources/list is answered entirely from config; no upstream HTTP call
-# the "item" resource is a template (uri contains a path capture), so it is
-# excluded here and only appears in resources/templates/list
 read '{"resources":[]}'
 read closed
 

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/client.rpt
@@ -41,14 +41,13 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/templates/list is answered entirely from config; no upstream HTTP call
 read  '{"resourceTemplates":[{"name":"item","uriTemplate":"item://{itemId}",'
       '"description":"An item resource","mimeType":"application/json"}]}'
 read closed

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/client.rpt
@@ -41,17 +41,16 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesList()
+                           .resourceTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
+# resources/templates/list is answered entirely from config; no upstream HTTP call
+read  '{"resourceTemplates":[{"name":"item","uriTemplate":"item://{itemId}",'
+      '"description":"An item resource","mimeType":"application/json"}]}'
 read closed
 
 write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/server.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.templates.list/server.rpt
@@ -41,14 +41,15 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourcesList()
+                          .resourceTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}
 
 connected
 
-write '{"resources":[]}'
+write '{"resourceTemplates":[{"name":"item","uriTemplate":"item://{itemId}",'
+      '"description":"An item resource","mimeType":"application/json"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
@@ -164,6 +164,15 @@ public class McpServerIT
 
     @Test
     @Specification({
+        "${mcp}/resources.templates.list/client",
+        "${mcp}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/read.order/client",
         "${mcp}/read.order/server"})
     public void shouldReadResourceOrder() throws Exception

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/streams/McpServerIT.java
@@ -166,7 +166,7 @@ public class McpServerIT
     @Specification({
         "${mcp}/resources.templates.list/client",
         "${mcp}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list/client.rpt
@@ -48,9 +48,6 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
 read '{"resources":[]}'
 read closed
 

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.list/server.rpt
@@ -48,7 +48,7 @@ read zilla:begin.ext ${mcp:matchBeginEx()
 
 connected
 
-write '{"resources":[{"name":"read_order","uriTemplate":"/orders/{orderId}","mimeType":"application/json"}]}'
+write '{"resources":[]}'
 write flush
 
 write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/client.rpt
@@ -41,14 +41,13 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# options.resources overrides the spec-derived description for read_order
 read  '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
 read closed
 

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/client.rpt
@@ -41,7 +41,7 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesList()
+                           .resourceTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
@@ -49,7 +49,7 @@ write zilla:begin.ext ${mcp:beginEx()
 connected
 
 # options.resources overrides the spec-derived description for read_order
-read  '{"resources":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
+read  '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
 read closed
 
 write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/server.rpt
@@ -41,14 +41,14 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourcesList()
+                          .resourceTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}
 
 connected
 
-write '{"resources":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
+write '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","description":"Read a customer order by id.","mimeType":"application/json"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list.with.override/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/client.rpt
@@ -41,17 +41,15 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesList()
+                           .resourceTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
+# resources/templates/list answered from the generated mcp_http config
+read  '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","mimeType":"application/json"}]}'
 read closed
 
 write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/client.rpt
@@ -41,14 +41,13 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/templates/list answered from the generated mcp_http config
 read  '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","mimeType":"application/json"}]}'
 read closed
 

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/server.rpt
@@ -41,14 +41,14 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourcesList()
+                          .resourceTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}
 
 connected
 
-write '{"resources":[]}'
+write '{"resourceTemplates":[{"name":"read_order","uriTemplate":"/orders/{orderId}","mimeType":"application/json"}]}'
 write flush
 
 write close

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/server.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/resources.templates.list/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
@@ -83,6 +83,15 @@ public class McpServerIT
 
     @Test
     @Specification({
+        "${mcp}/resources.templates.list/client",
+        "${mcp}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/create.pr.10k/client",
         "${mcp}/create.pr.10k/server"})
     public void shouldCallToolCreatePr10k() throws Exception

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
@@ -74,9 +74,9 @@ public class McpServerIT
 
     @Test
     @Specification({
-        "${mcp}/resources.list.with.override/client",
-        "${mcp}/resources.list.with.override/server"})
-    public void shouldListResourcesWithOverriddenDescription() throws Exception
+        "${mcp}/resources.templates.list.with.override/client",
+        "${mcp}/resources.templates.list.with.override/server"})
+    public void shouldListResourceTemplatesWithOverriddenDescription() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/streams/McpServerIT.java
@@ -76,7 +76,7 @@ public class McpServerIT
     @Specification({
         "${mcp}/resources.templates.list.with.override/client",
         "${mcp}/resources.templates.list.with.override/server"})
-    public void shouldListResourceTemplatesWithOverriddenDescription() throws Exception
+    public void shouldListResourcesTemplatesWithOverriddenDescription() throws Exception
     {
         k3po.finish();
     }
@@ -85,7 +85,7 @@ public class McpServerIT
     @Specification({
         "${mcp}/resources.templates.list/client",
         "${mcp}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
+++ b/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
@@ -47,10 +47,10 @@ import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsGetBe
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsListChangedFlushExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResetExFW;
-import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourceTemplatesListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesListChangedFlushExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesReadBeginExFW;
+import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesTemplatesListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResumableFlushExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResumeChallengeExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpSuspendFlushExFW;
@@ -135,9 +135,9 @@ public final class McpFunctions
             return new McpResourcesReadBeginExBuilder();
         }
 
-        public McpResourceTemplatesListBeginExBuilder resourceTemplatesList()
+        public McpResourcesTemplatesListBeginExBuilder resourcesTemplatesList()
         {
-            return new McpResourceTemplatesListBeginExBuilder();
+            return new McpResourcesTemplatesListBeginExBuilder();
         }
 
         public byte[] build()
@@ -385,19 +385,19 @@ public final class McpFunctions
             }
         }
 
-        public final class McpResourceTemplatesListBeginExBuilder
+        public final class McpResourcesTemplatesListBeginExBuilder
         {
             private String sessionId;
             private long timeout;
 
-            public McpResourceTemplatesListBeginExBuilder sessionId(
+            public McpResourcesTemplatesListBeginExBuilder sessionId(
                 String sessionId)
             {
                 this.sessionId = sessionId;
                 return this;
             }
 
-            public McpResourceTemplatesListBeginExBuilder timeout(
+            public McpResourcesTemplatesListBeginExBuilder timeout(
                 long timeout)
             {
                 this.timeout = timeout;
@@ -406,7 +406,7 @@ public final class McpFunctions
 
             public McpBeginExBuilder build()
             {
-                beginExRW.resourceTemplatesList(b -> b.sessionId(sessionId).timeout(timeout));
+                beginExRW.resourcesTemplatesList(b -> b.sessionId(sessionId).timeout(timeout));
                 return McpBeginExBuilder.this;
             }
         }
@@ -484,10 +484,10 @@ public final class McpFunctions
             return matcher;
         }
 
-        public McpResourceTemplatesListBeginExMatcherBuilder resourceTemplatesList()
+        public McpResourcesTemplatesListBeginExMatcherBuilder resourcesTemplatesList()
         {
-            this.kind = McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
-            final McpResourceTemplatesListBeginExMatcherBuilder matcher = new McpResourceTemplatesListBeginExMatcherBuilder();
+            this.kind = McpBeginExFW.KIND_RESOURCES_TEMPLATES_LIST;
+            final McpResourcesTemplatesListBeginExMatcherBuilder matcher = new McpResourcesTemplatesListBeginExMatcherBuilder();
             this.caseMatcher = matcher::match;
             return matcher;
         }
@@ -947,19 +947,19 @@ public final class McpFunctions
             }
         }
 
-        public final class McpResourceTemplatesListBeginExMatcherBuilder
+        public final class McpResourcesTemplatesListBeginExMatcherBuilder
         {
             private String16FW sessionId;
             private Long timeout;
 
-            public McpResourceTemplatesListBeginExMatcherBuilder sessionId(
+            public McpResourcesTemplatesListBeginExMatcherBuilder sessionId(
                 String sessionId)
             {
                 this.sessionId = new String16FW(sessionId);
                 return this;
             }
 
-            public McpResourceTemplatesListBeginExMatcherBuilder timeout(
+            public McpResourcesTemplatesListBeginExMatcherBuilder timeout(
                 long timeout)
             {
                 this.timeout = timeout;
@@ -974,20 +974,20 @@ public final class McpFunctions
             private boolean match(
                 McpBeginExFW beginEx)
             {
-                final McpResourceTemplatesListBeginExFW resourceTemplatesList = beginEx.resourceTemplatesList();
-                return matchSessionId(resourceTemplatesList) && matchTimeout(resourceTemplatesList);
+                final McpResourcesTemplatesListBeginExFW resourcesTemplatesList = beginEx.resourcesTemplatesList();
+                return matchSessionId(resourcesTemplatesList) && matchTimeout(resourcesTemplatesList);
             }
 
             private boolean matchSessionId(
-                McpResourceTemplatesListBeginExFW resourceTemplatesList)
+                McpResourcesTemplatesListBeginExFW resourcesTemplatesList)
             {
-                return sessionId == null || sessionId.equals(resourceTemplatesList.sessionId());
+                return sessionId == null || sessionId.equals(resourcesTemplatesList.sessionId());
             }
 
             private boolean matchTimeout(
-                McpResourceTemplatesListBeginExFW resourceTemplatesList)
+                McpResourcesTemplatesListBeginExFW resourcesTemplatesList)
             {
-                return timeout == null || timeout == resourceTemplatesList.timeout();
+                return timeout == null || timeout == resourcesTemplatesList.timeout();
             }
         }
     }

--- a/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
+++ b/specs/binding-mcp.spec/src/main/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctions.java
@@ -47,6 +47,7 @@ import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsGetBe
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpPromptsListChangedFlushExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResetExFW;
+import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourceTemplatesListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesListBeginExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesListChangedFlushExFW;
 import io.aklivity.zilla.specs.binding.mcp.internal.types.stream.McpResourcesReadBeginExFW;
@@ -132,6 +133,11 @@ public final class McpFunctions
         public McpResourcesReadBeginExBuilder resourcesRead()
         {
             return new McpResourcesReadBeginExBuilder();
+        }
+
+        public McpResourceTemplatesListBeginExBuilder resourceTemplatesList()
+        {
+            return new McpResourceTemplatesListBeginExBuilder();
         }
 
         public byte[] build()
@@ -378,6 +384,32 @@ public final class McpFunctions
                 return McpBeginExBuilder.this;
             }
         }
+
+        public final class McpResourceTemplatesListBeginExBuilder
+        {
+            private String sessionId;
+            private long timeout;
+
+            public McpResourceTemplatesListBeginExBuilder sessionId(
+                String sessionId)
+            {
+                this.sessionId = sessionId;
+                return this;
+            }
+
+            public McpResourceTemplatesListBeginExBuilder timeout(
+                long timeout)
+            {
+                this.timeout = timeout;
+                return this;
+            }
+
+            public McpBeginExBuilder build()
+            {
+                beginExRW.resourceTemplatesList(b -> b.sessionId(sessionId).timeout(timeout));
+                return McpBeginExBuilder.this;
+            }
+        }
     }
 
     public static final class McpBeginExMatcherBuilder
@@ -448,6 +480,14 @@ public final class McpFunctions
         {
             this.kind = McpBeginExFW.KIND_RESOURCES_READ;
             final McpResourcesReadBeginExMatcherBuilder matcher = new McpResourcesReadBeginExMatcherBuilder();
+            this.caseMatcher = matcher::match;
+            return matcher;
+        }
+
+        public McpResourceTemplatesListBeginExMatcherBuilder resourceTemplatesList()
+        {
+            this.kind = McpBeginExFW.KIND_RESOURCE_TEMPLATES_LIST;
+            final McpResourceTemplatesListBeginExMatcherBuilder matcher = new McpResourceTemplatesListBeginExMatcherBuilder();
             this.caseMatcher = matcher::match;
             return matcher;
         }
@@ -904,6 +944,50 @@ public final class McpFunctions
                 McpResourcesReadBeginExFW resourcesRead)
             {
                 return timeout == null || timeout == resourcesRead.timeout();
+            }
+        }
+
+        public final class McpResourceTemplatesListBeginExMatcherBuilder
+        {
+            private String16FW sessionId;
+            private Long timeout;
+
+            public McpResourceTemplatesListBeginExMatcherBuilder sessionId(
+                String sessionId)
+            {
+                this.sessionId = new String16FW(sessionId);
+                return this;
+            }
+
+            public McpResourceTemplatesListBeginExMatcherBuilder timeout(
+                long timeout)
+            {
+                this.timeout = timeout;
+                return this;
+            }
+
+            public McpBeginExMatcherBuilder build()
+            {
+                return McpBeginExMatcherBuilder.this;
+            }
+
+            private boolean match(
+                McpBeginExFW beginEx)
+            {
+                final McpResourceTemplatesListBeginExFW resourceTemplatesList = beginEx.resourceTemplatesList();
+                return matchSessionId(resourceTemplatesList) && matchTimeout(resourceTemplatesList);
+            }
+
+            private boolean matchSessionId(
+                McpResourceTemplatesListBeginExFW resourceTemplatesList)
+            {
+                return sessionId == null || sessionId.equals(resourceTemplatesList.sessionId());
+            }
+
+            private boolean matchTimeout(
+                McpResourceTemplatesListBeginExFW resourceTemplatesList)
+            {
+                return timeout == null || timeout == resourceTemplatesList.timeout();
             }
         }
     }

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -40,7 +40,7 @@ scope mcp
             case 4: mcp::stream::McpPromptsGetBeginEx promptsGet;
             case 5: mcp::stream::McpResourcesListBeginEx resourcesList;
             case 6: mcp::stream::McpResourcesReadBeginEx resourcesRead;
-            case 7: mcp::stream::McpResourceTemplatesListBeginEx resourceTemplatesList;
+            case 7: mcp::stream::McpResourcesTemplatesListBeginEx resourcesTemplatesList;
         }
 
         union McpFlushEx switch (uint8) extends core::stream::Extension
@@ -182,7 +182,7 @@ scope mcp
             int64 timeout = 0;
         }
 
-        struct McpResourceTemplatesListBeginEx
+        struct McpResourcesTemplatesListBeginEx
         {
             string16 sessionId;
             int64 timeout = 0;

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -40,6 +40,7 @@ scope mcp
             case 4: mcp::stream::McpPromptsGetBeginEx promptsGet;
             case 5: mcp::stream::McpResourcesListBeginEx resourcesList;
             case 6: mcp::stream::McpResourcesReadBeginEx resourcesRead;
+            case 7: mcp::stream::McpResourceTemplatesListBeginEx resourceTemplatesList;
         }
 
         union McpFlushEx switch (uint8) extends core::stream::Extension
@@ -178,6 +179,12 @@ scope mcp
             string16 sessionId;
             string16 uri;
             int32 contentLength = -1;
+            int64 timeout = 0;
+        }
+
+        struct McpResourceTemplatesListBeginEx
+        {
+            string16 sessionId;
             int64 timeout = 0;
         }
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.yaml
@@ -24,7 +24,7 @@ stores:
           {"tools":[{"name": "get_weather","title": "Weather Information Provider","description": "Get current weather information for a location","inputSchema": {"type": "object","properties": {"location": {"type": "string","description": "City name or zip code"}},"required": ["location"]},"icons": [{"src": "https://example.com/weather-icon.png","mimeType": "image/png","sizes": ["48x48"]}],"execution": {"taskSupport": "optional"}}]}
         resources: |-
           {"resources":[{"uri": "file:///docs/welcome.md","name": "welcome","description": "Welcome document","mimeType": "text/markdown"}]}
-        resourceTemplates: |-
+        resources/templates: |-
           {"resourceTemplates":[]}
         prompts: |-
           {"prompts":[{"name": "summarize","description": "Summarize a document"}]}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.yaml
@@ -24,6 +24,8 @@ stores:
           {"tools":[{"name": "get_weather","title": "Weather Information Provider","description": "Get current weather information for a location","inputSchema": {"type": "object","properties": {"location": {"type": "string","description": "City name or zip code"}},"required": ["location"]},"icons": [{"src": "https://example.com/weather-icon.png","mimeType": "image/png","sizes": ["48x48"]}],"execution": {"taskSupport": "optional"}}]}
         resources: |-
           {"resources":[{"uri": "file:///docs/welcome.md","name": "welcome","description": "Welcome document","mimeType": "text/markdown"}]}
+        resourceTemplates: |-
+          {"resourceTemplates":[]}
         prompts: |-
           {"prompts":[{"name": "summarize","description": "Summarize a document"}]}
 bindings:

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.validation.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.validation.yaml
@@ -64,7 +64,7 @@ stores:
               }
             ]
           }
-        resourceTemplates: |-
+        resources/templates: |-
           {"resourceTemplates":[]}
         prompts: |-
           {

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.validation.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.validation.yaml
@@ -64,6 +64,8 @@ stores:
               }
             ]
           }
+        resourceTemplates: |-
+          {"resourceTemplates":[]}
         prompts: |-
           {
             "prompts": [

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
@@ -85,6 +85,27 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
@@ -85,7 +85,7 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -97,9 +97,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
@@ -83,7 +83,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
@@ -83,6 +83,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
@@ -85,6 +85,27 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
@@ -85,7 +85,7 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -97,9 +97,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
@@ -83,7 +83,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
@@ -83,6 +83,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
@@ -89,6 +89,28 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
@@ -89,7 +89,7 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -101,9 +101,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
@@ -83,7 +83,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
@@ -83,6 +83,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
@@ -83,6 +83,27 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
@@ -83,7 +83,7 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -95,9 +95,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
@@ -74,7 +74,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
@@ -74,6 +74,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
@@ -90,7 +90,7 @@ connect await TOOLS_HYDRATED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -102,9 +102,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_HYDRATED
+read notify RESOURCES_TEMPLATES_HYDRATED
 
-connect await RESOURCE_TEMPLATES_HYDRATED
+connect await RESOURCES_TEMPLATES_HYDRATED
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -196,7 +196,7 @@ connect await TOOLS2_HYDRATED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -208,9 +208,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES2_HYDRATED
+read notify RESOURCES_TEMPLATES2_HYDRATED
 
-connect await RESOURCE_TEMPLATES2_HYDRATED
+connect await RESOURCES_TEMPLATES2_HYDRATED
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
@@ -90,6 +90,27 @@ connect await TOOLS_HYDRATED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_HYDRATED
+
+connect await RESOURCE_TEMPLATES_HYDRATED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()
@@ -169,6 +190,27 @@ write close
 read notify TOOLS2_HYDRATED
 
 connect await TOOLS2_HYDRATED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES2_HYDRATED
+
+connect await RESOURCE_TEMPLATES2_HYDRATED
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
@@ -85,7 +85,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}
@@ -185,7 +185,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
@@ -85,6 +85,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()
@@ -155,6 +175,26 @@ connected
 write flush
 
 write '{"tools":[{"name":"get_weather"},{"name":"get_time"}]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
@@ -84,7 +84,7 @@ connect await APP1_TOOLS
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -96,9 +96,9 @@ read closed
 
 write close
 
-read notify APP1_RESOURCE_TEMPLATES
+read notify APP1_RESOURCES_TEMPLATES
 
-connect await APP1_RESOURCE_TEMPLATES
+connect await APP1_RESOURCES_TEMPLATES
         "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -190,7 +190,7 @@ connect await APP2_TOOLS
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -202,9 +202,9 @@ read closed
 
 write close
 
-read notify APP2_RESOURCE_TEMPLATES
+read notify APP2_RESOURCES_TEMPLATES
 
-connect await APP2_RESOURCE_TEMPLATES
+connect await APP2_RESOURCES_TEMPLATES
         "zilla://streams/app2"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/client.rpt
@@ -84,6 +84,27 @@ connect await APP1_TOOLS
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify APP1_RESOURCE_TEMPLATES
+
+connect await APP1_RESOURCE_TEMPLATES
+        "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()
@@ -163,6 +184,27 @@ write close
 read notify APP2_TOOLS
 
 connect await APP2_TOOLS
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify APP2_RESOURCE_TEMPLATES
+
+connect await APP2_RESOURCE_TEMPLATES
         "zilla://streams/app2"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
@@ -79,7 +79,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}
@@ -181,7 +181,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
@@ -79,6 +79,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()
@@ -151,6 +171,26 @@ connected
 write flush
 
 write '{"tools":[{"name":"get_current_time"}]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
@@ -83,6 +83,27 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
@@ -83,7 +83,7 @@ connect await TOOLS_LIST_COMPLETE
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -95,9 +95,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
@@ -81,6 +81,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
@@ -81,7 +81,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
@@ -41,6 +41,27 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
                            .resourcesList()
                                .sessionId("hydrate-1")
                                .build()
@@ -56,6 +77,27 @@ write close
 read notify HYDRATED
 
 connect await HYDRATED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourceTemplatesList()
+                               .sessionId("hydrate-1")
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCE_TEMPLATES_LIST_COMPLETE2
+
+connect await RESOURCE_TEMPLATES_LIST_COMPLETE2
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
@@ -41,7 +41,7 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -53,9 +53,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -83,7 +83,7 @@ connect await HYDRATED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("hydrate-1")
                                .build()
                            .build()}
@@ -95,9 +95,9 @@ read closed
 
 write close
 
-read notify RESOURCE_TEMPLATES_LIST_COMPLETE2
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE2
 
-connect await RESOURCE_TEMPLATES_LIST_COMPLETE2
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE2
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}
@@ -81,7 +81,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("hydrate-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
@@ -41,6 +41,26 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
                           .resourcesList()
                               .sessionId("hydrate-1")
                               .build()
@@ -51,6 +71,26 @@ connected
 write flush
 
 write '{"resources":[{"uri":"file:///docs/welcome.md","name":"welcome"}]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
+                              .sessionId("hydrate-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
@@ -41,17 +41,13 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesList()
+                           .resourceTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
-read closed
+read aborted
 
-write close
+write abort

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
@@ -41,7 +41,7 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
@@ -13,45 +13,43 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .resourcesList()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
-read closed
+write flush
 
-write close
+write abort
+
+read aborted

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
@@ -41,7 +41,7 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourceTemplatesList()
+                           .resourcesTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
@@ -41,17 +41,14 @@ connect await LIFECYCLE_INITIALIZED
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
-                           .resourcesList()
+                           .resourceTemplatesList()
                                .sessionId("session-1")
                                .build()
                            .build()}
 
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
+read '{"resourceTemplates":[]}'
 read closed
 
 write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
@@ -13,45 +13,46 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
+property serverAddress "zilla://streams/app0"
 
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .lifecycle()
-                               .build()
-                           .build()}
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
 
-connected
+accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourceTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}
 
-read notify LIFECYCLE_INITIALIZED
-
-connect await LIFECYCLE_INITIALIZED
-        "zilla://streams/app0"
-        option zilla:window 8192
-        option zilla:transmission "half-duplex"
-
-write zilla:begin.ext ${mcp:beginEx()
-                           .typeId(zilla:id("mcp"))
-                           .resourcesList()
-                               .sessionId("session-1")
-                               .build()
-                           .build()}
-
 connected
 
-# resources/list answered from the generated mcp_http config
-# read_order is a resource template (path capture), so it is excluded here
-# and only appears in resources/templates/list
-read '{"resources":[]}'
-read closed
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
 
 write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
@@ -41,7 +41,7 @@ accepted
 
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
-                          .resourceTemplatesList()
+                          .resourcesTemplatesList()
                               .sessionId("session-1")
                               .build()
                           .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list.aborted/client.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+read notify LIFECYCLE_INITIALIZING
+
+connect await LIFECYCLE_INITIALIZING
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+write close
+
+read closed
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":2,"method":"resources/templates/list"}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read aborted

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list.aborted/server.rpt
@@ -1,0 +1,98 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":2,"method":"resources/templates/list"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write abort

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list/client.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+read notify LIFECYCLE_INITIALIZING
+
+connect await LIFECYCLE_INITIALIZING
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+write close
+
+read closed
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":2,"method":"resources/templates/list"}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":2,"result":{"resourceTemplates":[]}}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/resources.templates.list/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":2,"method":"resources/templates/list"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":2,"result":{"resourceTemplates":[]}}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
@@ -342,11 +342,11 @@ public class McpFunctionsTest
     }
 
     @Test
-    public void shouldGenerateResourceTemplatesListBeginEx()
+    public void shouldGenerateResourcesTemplatesListBeginEx()
     {
         byte[] bytes = McpFunctions.beginEx()
             .typeId(0)
-            .resourceTemplatesList()
+            .resourcesTemplatesList()
                 .sessionId("session-1")
                 .timeout(10000L)
                 .build()
@@ -355,15 +355,15 @@ public class McpFunctionsTest
         assertNotNull(bytes);
 
         McpBeginExFW beginEx = new McpBeginExFW().wrap(new UnsafeBufferEx(bytes), 0, bytes.length);
-        assertEquals(10000L, beginEx.resourceTemplatesList().timeout());
+        assertEquals(10000L, beginEx.resourcesTemplatesList().timeout());
     }
 
     @Test
-    public void shouldMatchResourceTemplatesListBeginEx() throws Exception
+    public void shouldMatchResourcesTemplatesListBeginEx() throws Exception
     {
         BytesMatcher matcher = McpFunctions.matchBeginEx()
             .typeId(0)
-            .resourceTemplatesList()
+            .resourcesTemplatesList()
                 .sessionId("session-1")
                 .timeout(10000L)
                 .build()
@@ -374,7 +374,7 @@ public class McpFunctionsTest
         new McpBeginExFW.Builder()
             .wrap(new UnsafeBufferEx(byteBuf), 0, byteBuf.capacity())
             .typeId(0)
-            .resourceTemplatesList(b -> b
+            .resourcesTemplatesList(b -> b
                 .sessionId("session-1")
                 .timeout(10000L))
             .build();

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/internal/McpFunctionsTest.java
@@ -341,6 +341,47 @@ public class McpFunctionsTest
         assertNotNull(matcher.match(byteBuf));
     }
 
+    @Test
+    public void shouldGenerateResourceTemplatesListBeginEx()
+    {
+        byte[] bytes = McpFunctions.beginEx()
+            .typeId(0)
+            .resourceTemplatesList()
+                .sessionId("session-1")
+                .timeout(10000L)
+                .build()
+            .build();
+
+        assertNotNull(bytes);
+
+        McpBeginExFW beginEx = new McpBeginExFW().wrap(new UnsafeBufferEx(bytes), 0, bytes.length);
+        assertEquals(10000L, beginEx.resourceTemplatesList().timeout());
+    }
+
+    @Test
+    public void shouldMatchResourceTemplatesListBeginEx() throws Exception
+    {
+        BytesMatcher matcher = McpFunctions.matchBeginEx()
+            .typeId(0)
+            .resourceTemplatesList()
+                .sessionId("session-1")
+                .timeout(10000L)
+                .build()
+            .build();
+
+        ByteBuffer byteBuf = ByteBuffer.allocate(256);
+
+        new McpBeginExFW.Builder()
+            .wrap(new UnsafeBufferEx(byteBuf), 0, byteBuf.capacity())
+            .typeId(0)
+            .resourceTemplatesList(b -> b
+                .sessionId("session-1")
+                .timeout(10000L))
+            .build();
+
+        assertNotNull(matcher.match(byteBuf));
+    }
+
     @Test(expected = Exception.class)
     public void shouldFailWhenCaseMismatch() throws Exception
     {

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -319,7 +319,7 @@ public class ApplicationIT
     @Specification({
         "${app}/resources.templates.list.aborted/client",
         "${app}/resources.templates.list.aborted/server"})
-    public void shouldAbortListResourceTemplates() throws Exception
+    public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }
@@ -373,7 +373,7 @@ public class ApplicationIT
     @Specification({
         "${app}/resources.templates.list/client",
         "${app}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -317,6 +317,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/resources.templates.list.aborted/client",
+        "${app}/resources.templates.list.aborted/server"})
+    public void shouldAbortListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/resources.read.aborted/client",
         "${app}/resources.read.aborted/server"})
     public void shouldAbortReadResource() throws Exception
@@ -356,6 +365,15 @@ public class ApplicationIT
         "${app}/resources.list/client",
         "${app}/resources.list/server"})
     public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/resources.templates.list/client",
+        "${app}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -355,7 +355,7 @@ public class NetworkIT
     @Specification({
         "${net}/resources.templates.list.aborted/client",
         "${net}/resources.templates.list.aborted/server"})
-    public void shouldAbortListResourceTemplates() throws Exception
+    public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }
@@ -418,7 +418,7 @@ public class NetworkIT
     @Specification({
         "${net}/resources.templates.list/client",
         "${net}/resources.templates.list/server"})
-    public void shouldListResourceTemplates() throws Exception
+    public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -353,6 +353,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/resources.templates.list.aborted/client",
+        "${net}/resources.templates.list.aborted/server"})
+    public void shouldAbortListResourceTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/resources.read.aborted/client",
         "${net}/resources.read.aborted/server"})
     public void shouldAbortReadResource() throws Exception
@@ -401,6 +410,15 @@ public class NetworkIT
         "${net}/resources.list/client",
         "${net}/resources.list/server"})
     public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/resources.templates.list/client",
+        "${net}/resources.templates.list/server"})
+    public void shouldListResourceTemplates() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
## Description

Adds real protocol-level support for the MCP `resources/templates/list` JSON-RPC method across all three `binding-mcp` kinds (`server`, `proxy`, `client`), plus `binding-mcp-http`. Previously, resource templates were folded into `resources/list`, discriminated only by a `uriTemplate` vs. `uri` key. Per the MCP spec, `resources/templates/list` is a separate method with its own response shape (`{"resourceTemplates":[...]}`), gated by the same `resources` capability rather than a new one.

Rebased onto #2035 (merged), which added the `McpHttpResourceConfig.template` field this work relies on for the `binding-mcp-http` split.

### `mcp.idl`
- New `McpBeginEx` union case 7, `resourceTemplatesList`, with a new `McpResourceTemplatesListBeginEx` struct (`sessionId`, `timeout`), mirroring `McpResourcesListBeginEx`.

### `runtime/binding-mcp`
- `McpServerFactory`: new `"resources/templates/list"` JSON-RPC dispatch case + `onDecodeResourceTemplatesList` handler.
- New `McpProxyResourceTemplatesListFactory` (fan-in list aggregation, mirrors `McpProxyResourcesListFactory`): `arrayKey() = "resourceTemplates"`, `idKey() = "uriTemplate"`, own `KIND_RESOURCE_TEMPLATES_LIST` constant and cache slot.
- `McpProxyCache` / `McpProxyCacheManager` / `McpProxyCacheHydrater`: new cache kind, `KIND_SLOTS` extended, hydrate-filter word `"resources"` now covers both listings (matches the MCP spec, where templates are part of the single `resources` capability — a server advertising `resources` is expected to support both).
- `McpProxyCacheHydrater.onLifecycleFlush`: added a defensive `cacheOf(kind) != null` guard before hydrating on any list-changed notification — applied uniformly to the pre-existing tools/prompts/resources cases too, since an upstream server can legitimately emit a list-changed notification for a capability this proxy was configured not to cache, which previously NPE'd.
- `McpClientFactory`: new `JSON_RPC_RESOURCE_TEMPLATES_LIST_METHOD`, `McpResourceTemplatesListStream`, `HttpResourceTemplatesListStream` mirroring the `resources/list` forwarding path.

### `runtime/binding-mcp-http`
- New `McpResourceTemplatesListProxy`, dispatched on `KIND_RESOURCE_TEMPLATES_LIST`.
- `buildResourcesList()` now excludes resources where `resource.template` is true; new `buildResourceTemplatesList()` includes only those, under the `resourceTemplates` key with `uriTemplate`.
- New `resourceTemplatesListJson` cache field on `McpHttpBindingConfig`.

### Spec/test coverage (test-first)
- `specs/binding-mcp.spec`: new `resources.templates.list` / `resources.templates.list.aborted` scenarios at both `network/` and `application/` layers, plus direct unit coverage in `McpFunctionsTest`. Existing fan-in cache fixtures (`cache.hydrate*`, `cache.refresh.resources`, seeded configs) updated to include the new hydration leg, since the cache now hydrates and caches `resources/templates/list` alongside `resources/list` by default.
- `specs/binding-mcp-http.spec`: new scenario exercising a hand-authored resource template vs. a concrete resource, asserting they land in the correct listing; existing `resources.list` fixture updated since the previously-templated item now moves to the new listing.
- `specs/binding-mcp-openapi.spec` / `runtime/binding-mcp-openapi`: mirrored the same split for `mcp_openapi`-generated resources; renamed the `options.resources` override test scenario (added in #2035, predates this split) to route through `resources/templates/list` since its resource is templated.

Fixes #2033

## Test plan

- [x] `./mvnw verify` passes (tests + JaCoCo coverage) on `runtime/binding-mcp`, `runtime/binding-mcp-http`, `runtime/binding-mcp-openapi`, `specs/binding-mcp.spec`, `specs/binding-mcp-http.spec`, `specs/binding-mcp-openapi.spec`
- [x] New `resources/templates/list` protocol scenarios pass at network, application, and mcp-http layers
- [x] Existing fan-in cache hydration scenarios updated and pass with the new hydration leg
- [x] No new capability bit added — gated on existing `SERVER_RESOURCES`, matching the MCP spec


---
_Generated by [Claude Code](https://claude.ai/code/session_013zgiVM2dstgtkjJsJhq757)_