### PR TITLE
fix(binding-kafka): guard fanout initial abort/reset against unopened stream

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -640,7 +640,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private void doServerFanoutInitialEndIfNecessary(
             long traceId)
         {
-            if (!KafkaState.initialClosed(state))
+            if (KafkaState.initialOpening(state) && !KafkaState.initialClosed(state))
             {
                 doServerFanoutInitialEnd(traceId);
             }
@@ -658,7 +658,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private void doServerFanoutInitialAbortIfNecessary(
             long traceId)
         {
-            if (!KafkaState.initialClosed(state))
+            if (KafkaState.initialOpening(state) && !KafkaState.initialClosed(state))
             {
                 doServerFanoutInitialAbort(traceId);
             }
@@ -1240,7 +1240,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private void doServerFanoutReplyResetIfNecessary(
             long traceId)
         {
-            if (!KafkaState.replyClosed(state))
+            if (KafkaState.initialOpening(state) && !KafkaState.replyClosed(state))
             {
                 doServerFanoutReplyReset(traceId);
             }


### PR DESCRIPTION
## Description

Found while diagnosing an intermittent CI failure on #2036 (`CacheMergedIT.shouldFetchMergedFromParameterizedTopicInvalid`), unrelated to that PR's own change (`binding-mcp`) — the failure is a real, pre-existing race in `binding-kafka`, so fixing it here directly against `develop` to unblock that PR separately.

### Root cause

`KafkaCacheServerFetchFanout` (inside `KafkaCacheServerFetchFactory`) lazily opens its single upstream fetch stream (`receiver`) the first time a member successfully attaches (`doServerFanoutInitialBeginIfNecessary` → `doServerFanoutInitialBegin`, which assigns `receiver` and sets the `INITIAL_OPENING` state bit).

`onServerFanoutMemberOpening` can reject a member *before* ever adding it or opening the fanout — e.g. when the member's resolved `leaderId` doesn't match the fanout's (which happens when a partition falls outside the currently-known leader map, as with the "invalid parameterized topic" scenario). That rejection path calls `doServerFanoutInitialAbortIfNecessary` and `doServerFanoutReplyResetIfNecessary` on a fanout that is still in its initial `state == 0` (`receiver == null`). Both guards only checked `!KafkaState.initialClosed(state)` / `!KafkaState.replyClosed(state)` — true for a never-opened fanout — so they proceeded to call `doAbort(receiver, ...)` / `doReset(receiver, ...)` with a null `receiver`, throwing `NullPointerException` (surfaced as `AgentTerminationException` in the CI log, from `KafkaCacheServerFetchFactory.doAbort` via `doServerFanoutInitialAbort` via `doServerFanoutInitialAbortIfNecessary` via `onServerFanoutMemberClosed` via `onServerReplyReset`).

This is timing-sensitive — it only manifests when a member's own reply gets reset before the fanout has finished opening its own upstream stream — which is why it didn't reproduce locally in dozens of isolated and full-class local runs, but did reproduce reliably under CI's load/scheduling.

### Fix

Add the missing `KafkaState.initialOpening(state) &&` guard to `doServerFanoutInitialAbortIfNecessary`, `doServerFanoutInitialEndIfNecessary`, and `doServerFanoutReplyResetIfNecessary` — matching the identical pattern already used by this file's per-stream (non-fanout) equivalents (`doServerInitialResetIfNecessary`, `doServerReplyEndIfNecessary`, `doServerReplyAbortIfNecessary`), which already guard with `xxxOpening(state) && !xxxClosed(state)`. The fanout-level guards were missing the `opening` half of that check.

No behavior change for the normal (already-opened) path — these methods only become no-ops in the specific case where the fanout's own stream was never opened, in which case there is nothing to abort/reset and no resource to release (the fanout entry stays cached for reuse on the next attach, per the existing `doServerFanoutInitialBeginIfNecessary` reset-and-reopen logic).

## Test plan

- [x] `./mvnw verify -pl runtime/binding-kafka` passes: 376 tests, 0 failures, 0 errors, JaCoCo coverage checks met, checkstyle clean
- [x] `CacheMergedIT` (including `shouldFetchMergedFromParameterizedTopicInvalid`) passes, run individually and as part of the full class/module suite
- [x] Traced the fix 1:1 against the CI stack trace (`KafkaCacheServerFetchFactory.doAbort` ← `doServerFanoutInitialAbort` ← `doServerFanoutInitialAbortIfNecessary` ← `onServerFanoutMemberClosed` ← `onServerReplyReset` ← `onServerMessage`)

Note: I was unable to force this race to fail deterministically in a local single-machine run (15 isolated repro attempts + 5 full-class repro attempts on `develop`, all passing) — it appears to require CI-level scheduling contention to trigger reliably. The fix closes the identified state-machine gap regardless, and mirrors an already-established guard convention elsewhere in the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zgiVM2dstgtkjJsJhq757)_