### PR TITLE
fix(common-json): guard JsonGeneratorImpl's unconditional quote/comma writes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
-            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+            <argLine>-ea @{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           </configuration>
           <dependencies>
             <dependency>
@@ -457,7 +457,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.0.0-M4</version>
           <configuration>
-            <argLine>@{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+            <argLine>-ea @{jacoco.java.option} -Xshare:off -Djdk.attach.allowAttachSelf=true -XX:+StartAttachListener --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=deny -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
           </configuration>
           <dependencies>
             <dependency>

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -180,6 +180,14 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         if (pending != Pending.KEY)
         {
+            // see write(CharSequence, Completion)'s equivalent guard: the opening comma/quote sit outside
+            // writeStringBody's own bound check, and an empty, already-complete key never enters that loop
+            // to have its own closing reserve (here: quote + key separator) enforced
+            final boolean closesEmpty = completion == Completion.COMPLETE && name.length() == 0;
+            if (remaining() < (hasMembers[depth - 1] ? 1 : 0) + 1 + (closesEmpty ? 2 : 0))
+            {
+                return this;
+            }
             if (hasMembers[depth - 1])
             {
                 putByte.accept(',');
@@ -195,7 +203,9 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         final int reserve = completion == Completion.COMPLETE ? 2 : 0;
         final int written = writeStringBody(name, reserve);
         consumed += written;
-        if (written == name.length() && completion == Completion.COMPLETE)
+        // guards the resumed-continuation analog of the empty-key case above; see write(CharSequence,
+        // Completion)'s equivalent comment
+        if (written == name.length() && completion == Completion.COMPLETE && remaining() >= 2)
         {
             putByte.accept('"');
             putByte.accept(':');
@@ -233,6 +243,19 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         if (pending != Pending.STRING)
         {
+            // the opening quote (plus a possible preceding comma) is unconditional and outside
+            // writeStringBody's own per-codepoint bound check, so it needs its own room check: without
+            // it, wrapping the generator with little or no room left (as a caller draining a nearly-full
+            // destination legitimately can) writes past limit uncaught. An empty, already-complete value
+            // needs its closing quote reserved here too: writeStringBody's own loop never runs for a zero
+            // length value, so it can't independently enforce that reserve the way it does for non-empty
+            // ones, and deferring the close afterwards would be ambiguous — consumed() would read the same
+            // (zero) whether this value is genuinely done or the close was merely deferred for lack of room
+            final boolean closesEmpty = completion == Completion.COMPLETE && value.length() == 0;
+            if (remaining() < (needsComma() ? 1 : 0) + 1 + (closesEmpty ? 1 : 0))
+            {
+                return this;
+            }
             preValue();
             putByte.accept('"');
             pending = Pending.STRING;
@@ -243,7 +266,10 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         final int reserve = completion == Completion.COMPLETE ? 1 : 0;
         final int written = writeStringBody(value, reserve);
         consumed += written;
-        if (written == value.length() && completion == Completion.COMPLETE)
+        // guards the resumed-continuation analog of the empty-value case above: a prior fragment already
+        // opened the string, this call contributes no new characters, and completion turns COMPLETE — same
+        // trivially-true written == length() with no loop iteration to have checked room for the close
+        if (written == value.length() && completion == Completion.COMPLETE && remaining() >= 1)
         {
             putByte.accept('"');
             pending = Pending.NONE;
@@ -654,6 +680,15 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
             }
             hasMembers[depth - 1] = true;
         }
+    }
+
+    // Peeks whether preValue() would emit a comma, without its hasMembers side effect, so a caller can
+    // check room for both bytes atomically before committing to either (preValue() is not safe to retry:
+    // it marks hasMembers[depth - 1] true unconditionally, so calling it and then bailing out for lack of
+    // room would silently drop the comma on the next attempt).
+    private boolean needsComma()
+    {
+        return pending != Pending.AFTER_KEY && depth > 0 && inArray[depth - 1] && hasMembers[depth - 1];
     }
 
     // Bounded counterpart used by write(CharSequence, Completion): emits whole code points while each one's

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -180,9 +180,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         if (pending != Pending.KEY)
         {
-            // see write(CharSequence, Completion)'s equivalent guard: the opening comma/quote sit outside
-            // writeStringBody's own bound check, and an empty, already-complete key never enters that loop
-            // to have its own closing reserve (here: quote + key separator) enforced
             final boolean closesEmpty = completion == Completion.COMPLETE && name.length() == 0;
             if (remaining() < (hasMembers[depth - 1] ? 1 : 0) + 1 + (closesEmpty ? 2 : 0))
             {
@@ -203,8 +200,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         final int reserve = completion == Completion.COMPLETE ? 2 : 0;
         final int written = writeStringBody(name, reserve);
         consumed += written;
-        // guards the resumed-continuation analog of the empty-key case above; see write(CharSequence,
-        // Completion)'s equivalent comment
         if (written == name.length() && completion == Completion.COMPLETE && remaining() >= 2)
         {
             putByte.accept('"');
@@ -243,14 +238,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
     {
         if (pending != Pending.STRING)
         {
-            // the opening quote (plus a possible preceding comma) is unconditional and outside
-            // writeStringBody's own per-codepoint bound check, so it needs its own room check: without
-            // it, wrapping the generator with little or no room left (as a caller draining a nearly-full
-            // destination legitimately can) writes past limit uncaught. An empty, already-complete value
-            // needs its closing quote reserved here too: writeStringBody's own loop never runs for a zero
-            // length value, so it can't independently enforce that reserve the way it does for non-empty
-            // ones, and deferring the close afterwards would be ambiguous — consumed() would read the same
-            // (zero) whether this value is genuinely done or the close was merely deferred for lack of room
             final boolean closesEmpty = completion == Completion.COMPLETE && value.length() == 0;
             if (remaining() < (needsComma() ? 1 : 0) + 1 + (closesEmpty ? 1 : 0))
             {
@@ -266,9 +253,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         final int reserve = completion == Completion.COMPLETE ? 1 : 0;
         final int written = writeStringBody(value, reserve);
         consumed += written;
-        // guards the resumed-continuation analog of the empty-value case above: a prior fragment already
-        // opened the string, this call contributes no new characters, and completion turns COMPLETE — same
-        // trivially-true written == length() with no loop iteration to have checked room for the close
         if (written == value.length() && completion == Completion.COMPLETE && remaining() >= 1)
         {
             putByte.accept('"');
@@ -682,10 +666,6 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         }
     }
 
-    // Peeks whether preValue() would emit a comma, without its hasMembers side effect, so a caller can
-    // check room for both bytes atomically before committing to either (preValue() is not safe to retry:
-    // it marks hasMembers[depth - 1] true unconditionally, so calling it and then bailing out for lack of
-    // room would silently drop the comma on the next attempt).
     private boolean needsComma()
     {
         return pending != Pending.AFTER_KEY && depth > 0 && inArray[depth - 1] && hasMembers[depth - 1];

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -235,6 +235,71 @@ class JsonGeneratorExTest
             .writeStartArray().writeNumber("1").writeNumber("2").writeNumber("3"));
     }
 
+    // A caller (e.g. a proxy draining its own outbound buffer only as fast as the wire allows) can
+    // legitimately re-wrap a generator with zero room left, once a prior fragment has filled the
+    // destination exactly to capacity. The opening quote sits outside writeStringBody's own per-codepoint
+    // bound check, so without its own guard it would write past a zero-width wrap uncaught.
+    @Test
+    void shouldNotWriteStringOpeningQuoteWithoutRoom()
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 32, 32);
+
+        generator.write("x");
+
+        assertEquals(0, generator.length());
+        assertEquals(0, generator.consumed());
+        byte[] untouched = new byte[1];
+        buffer.getBytes(32, untouched);
+        assertEquals(0, untouched[0]);
+    }
+
+    // An empty, already-complete string never enters writeStringBody's bounded loop (index < length is
+    // immediately false), so it can't rely on that loop to enforce the closing-quote reserve the way a
+    // non-empty string does — both quotes must be confirmed available atomically up front.
+    @Test
+    void shouldDeferEmptyCompleteStringWithoutRoomForBothQuotes()
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 31, 32);
+
+        generator.write("", Completion.COMPLETE);
+
+        assertEquals(0, generator.length());
+        byte[] untouched = new byte[1];
+        buffer.getBytes(31, untouched);
+        assertEquals(0, untouched[0]);
+    }
+
+    @Test
+    void shouldWriteEmptyCompleteStringWhenExactRoomForBothQuotes()
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[64]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(buffer, 30, 32);
+
+        generator.write("", Completion.COMPLETE);
+
+        assertEquals(2, generator.length());
+        byte[] out = new byte[2];
+        buffer.getBytes(30, out);
+        assertEquals("\"\"", new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldResumeStringOpeningQuoteOnceRoomIsAvailable()
+    {
+        MutableDirectBufferEx tight = new UnsafeBufferEx(new byte[64]);
+        JsonGeneratorEx generator = JsonEx.createGenerator().wrap(tight, 32, 32);
+        generator.write("hello");
+        assertEquals(0, generator.consumed());
+
+        MutableDirectBufferEx roomy = new UnsafeBufferEx(new byte[64]);
+        generator.wrap(roomy, 0, roomy.capacity());
+        generator.write("hello");
+
+        assertEquals("\"hello\"", drain(generator, roomy));
+    }
+
     @Test
     void shouldReportPartialConsumptionWhenPlainWriteExceedsLimit()
     {

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorExTest.java
@@ -235,10 +235,6 @@ class JsonGeneratorExTest
             .writeStartArray().writeNumber("1").writeNumber("2").writeNumber("3"));
     }
 
-    // A caller (e.g. a proxy draining its own outbound buffer only as fast as the wire allows) can
-    // legitimately re-wrap a generator with zero room left, once a prior fragment has filled the
-    // destination exactly to capacity. The opening quote sits outside writeStringBody's own per-codepoint
-    // bound check, so without its own guard it would write past a zero-width wrap uncaught.
     @Test
     void shouldNotWriteStringOpeningQuoteWithoutRoom()
     {
@@ -254,9 +250,6 @@ class JsonGeneratorExTest
         assertEquals(0, untouched[0]);
     }
 
-    // An empty, already-complete string never enters writeStringBody's bounded loop (index < length is
-    // immediately false), so it can't rely on that loop to enforce the closing-quote reserve the way a
-    // non-empty string does — both quotes must be confirmed available atomically up front.
     @Test
     void shouldDeferEmptyCompleteStringWithoutRoomForBothQuotes()
     {


### PR DESCRIPTION
## Description

While fixing a window-credit propagation bug in `binding-mcp-http` (`fix/mcp-http-coverage`, #2039), a crash surfaced that traced back to a real, separate defect in `common-json`: `JsonGeneratorImpl.putRaw` has no real bounds check — only `assert progress < limit`, a no-op without `-ea`. `write(CharSequence, Completion)` and `writeKey(CharSequence, Completion)` each write a comma/opening-quote unconditionally, outside `writeStringBody`'s own per-codepoint bound check. A caller that legitimately wraps the generator with little or no destination room left (e.g. a proxy draining its own outbound buffer only as fast as the wire allows) hits an uncaught write past `limit` — silent memory corruption in production, no exception, no crash signal at the point of corruption. It later manifests unpredictably (a `SIGSEGV` somewhere unrelated, once the corrupted memory is touched) rather than failing at the actual fault.

Confirmed via a minimal direct repro: wrapping the generator at a zero-width region (`offset == limit`) and calling `write("x")` silently wrote one byte past the boundary with exit code 0; the identical call under `-ea` threw a clean `AssertionError` at the exact write site instead.

### Changes

1. **Enable `-ea` for surefire/failsafe test runs** (root `pom.xml`) — converts this class of violation from silent corruption into a loud, catchable `AssertionError` during tests. This alone doesn't fix production behavior (assertions are typically off there too) but makes the existing `assert` statements actually useful for catching regressions going forward.

2. **`write(CharSequence, Completion)`** now checks real room before its two unconditional writes:
   - The opening quote (plus a possible preceding comma) checks `remaining()` up front. An already-complete *empty* value also reserves its closing quote atomically here, since `writeStringBody`'s loop never runs for a zero-length value and so can't independently enforce that reserve the way it does for a non-empty one — deferring the close afterwards would be ambiguous (`consumed()` reads the same, zero, whether the value is genuinely done or the close was merely deferred).
   - The closing quote gets its own direct check, covering the resumed-continuation case where the opening already happened in a prior call.

3. **`writeKey(CharSequence, Completion)`** gets the identical treatment (comma + opening quote, then closing quote + key separator), since it has the same shape.

On insufficient room, these methods now write nothing and leave `pending` state unchanged, so a caller (already required to check `consumed()` for the existing chunking contract) correctly resumes on retry — no new caller-visible contract, no behavior change for the already-common case of ordinary write patterns with adequate room.

### Not included (follow-up filed as #2040)

The same "call `preValue()` (or equivalent) then write unconditionally" shape also exists in `write(int)`, `write(long)`, `write(boolean)`, `writeNull()`, `writeStartObject`/`writeStartArray`/`writeEnd`, and in `AvroSinkImpl`/`AvroJsonGeneratorImpl` (`common-avro`) and `ProtobufJsonGeneratorImpl` (`common-protobuf`), which call these same methods unconditionally with no room check of their own. Fixing those properly requires giving them a deferred-write/retry contract and correctly wiring it through each pipeline's resume logic (notably `JsonSinkImpl.resume()`, which currently has no way to re-attempt a structural/boolean/null write that never happened — naively extending today's contract would silently drop data rather than corrupt memory, which is worse). Scoped out here given the cross-module surface and correctness risk of getting resume semantics wrong under time pressure; tracked in #2040.

### Testing

- New regression tests in `JsonGeneratorExTest`: `shouldNotWriteStringOpeningQuoteWithoutRoom`, `shouldDeferEmptyCompleteStringWithoutRoomForBothQuotes`, `shouldWriteEmptyCompleteStringWhenExactRoomForBothQuotes`, `shouldResumeStringOpeningQuoteOnceRoomIsAvailable`.
- Verified test-first: these tests fail with `AssertionError` (3 of 4) against the pre-fix code, and pass against the fix.
- Full `common-json` module suite (4836 tests) passes with `-ea` enabled, no regressions — including the pre-existing `shouldNotWriteBeyondLimit` test, which already expected `AssertionError` and is now genuinely exercised with `-ea` on.
- Checkstyle and license checks pass.

Fixes the root cause behind the crash seen in #2039; that branch will rebase onto this once merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_016EtF5FFTbYY4jTAYLd1DoH)_