### PR TITLE
fix(common-json): account for double-escaping cost in GENERATE_ESCAPED width budgets

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonGeneratorImpl.java
@@ -210,10 +210,11 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         CharSequence name,
         Completion completion)
     {
+        final int quoteWidth = escaped ? 2 : 1;
         if (pending != Pending.KEY)
         {
             final boolean closesEmpty = completion == Completion.COMPLETE && name.length() == 0;
-            if (remaining() < (hasMembers[depth - 1] ? 1 : 0) + 1 + (closesEmpty ? 2 : 0))
+            if (remaining() < (hasMembers[depth - 1] ? 1 : 0) + quoteWidth + (closesEmpty ? quoteWidth + 1 : 0))
             {
                 return this;
             }
@@ -229,10 +230,10 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         // fragment for the closing quote and key separator; report the source chars taken via consumed() so a
         // chunking driver advances its cursor and resumes from the remainder, the key-domain analog of
         // write(CharSequence, Completion)
-        final int reserve = completion == Completion.COMPLETE ? 2 : 0;
+        final int reserve = completion == Completion.COMPLETE ? quoteWidth + 1 : 0;
         final int written = writeStringBody(name, reserve);
         consumed += written;
-        if (written == name.length() && completion == Completion.COMPLETE && remaining() >= 2)
+        if (written == name.length() && completion == Completion.COMPLETE && remaining() >= quoteWidth + 1)
         {
             putByte.accept('"');
             putByte.accept(':');
@@ -283,10 +284,11 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         CharSequence value,
         Completion completion)
     {
+        final int quoteWidth = escaped ? 2 : 1;
         if (pending != Pending.STRING)
         {
             final boolean closesEmpty = completion == Completion.COMPLETE && value.length() == 0;
-            if (remaining() < (needsComma() ? 1 : 0) + 1 + (closesEmpty ? 1 : 0))
+            if (remaining() < (needsComma() ? 1 : 0) + quoteWidth + (closesEmpty ? quoteWidth : 0))
             {
                 return this;
             }
@@ -297,10 +299,10 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         // emit only the code points whose escaped form fits the output bound (reserving room for the
         // closing quote on the final fragment); report the source chars taken via consumed() so a chunking
         // driver advances its cursor and resumes from the remainder, the char-domain analog of writeSegment
-        final int reserve = completion == Completion.COMPLETE ? 1 : 0;
+        final int reserve = completion == Completion.COMPLETE ? quoteWidth : 0;
         final int written = writeStringBody(value, reserve);
         consumed += written;
-        if (written == value.length() && completion == Completion.COMPLETE && remaining() >= 1)
+        if (written == value.length() && completion == Completion.COMPLETE && remaining() >= quoteWidth)
         {
             putByte.accept('"');
             pending = Pending.NONE;
@@ -856,10 +858,18 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
         }
     }
 
-    // Output byte width of a code point once written as canonical JSON string content: a short escape
-    // (2 bytes), a control-char \\uXXXX escape (6), or its UTF-8 encoding (1-4). Mirrors emitStringCodePoint
-    // for the verbatim (non GENERATE_ESCAPED) generator, which is the only mode the decoded value path uses.
-    private static int codePointWidth(
+    // Output byte width of a code point once written as canonical JSON string content, dispatching on
+    // escaped so the budget matches what emitStringCodePoint (via putByte) actually produces in each mode.
+    private int codePointWidth(
+        int codePoint)
+    {
+        return escaped ? escapedCodePointWidth(codePoint) : verbatimCodePointWidth(codePoint);
+    }
+
+    // Verbatim-mode width: a short escape (2 bytes), a control-char \\uXXXX escape (6), or the UTF-8
+    // encoding (1-4). Also the width of any code point's UTF-8 bytes once escaped, since none of those
+    // bytes ever match a special escape byte value (see escapedCodePointWidth).
+    private static int verbatimCodePointWidth(
         int codePoint)
     {
         int width;
@@ -895,6 +905,34 @@ public final class JsonGeneratorImpl implements JsonGeneratorEx
             {
                 width = 4;
             }
+            break;
+        }
+        return width;
+    }
+
+    // Escaped-mode width: emitStringCodePoint's own escape bytes (e.g. '\\' then '"' for a quote) are
+    // themselves routed through the escaping putByte, so each doubles up per escapedWidth; a code point
+    // with no special handling falls through to writeUtf8, whose raw bytes are never special escape
+    // values and so cost the same as verbatim.
+    private static int escapedCodePointWidth(
+        int codePoint)
+    {
+        int width;
+        switch (codePoint)
+        {
+        case '"':
+        case '\\':
+            width = 4;
+            break;
+        case '\n':
+        case '\r':
+        case '\t':
+        case '\b':
+        case '\f':
+            width = 3;
+            break;
+        default:
+            width = codePoint < 0x20 ? 7 : verbatimCodePointWidth(codePoint);
             break;
         }
         return width;

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEscapeTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonGeneratorEscapeTest.java
@@ -122,6 +122,57 @@ class JsonGeneratorEscapeTest
     }
 
     @Test
+    void shouldWriteDoublyEscapedQuoteWhenExactRoom()
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[10]);
+        JsonGeneratorEx generator = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true))
+            .wrap(buffer, 0, 10);
+        generator.write("a\"b");
+        assertEquals(3, generator.consumed());
+        assertEquals(10, generator.length());
+    }
+
+    @Test
+    void shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedQuote()
+    {
+        for (int limit = 1; limit <= 10; limit++)
+        {
+            MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[limit]);
+            JsonGeneratorEx generator = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true))
+                .wrap(buffer, 0, limit);
+            generator.write("a\"b");
+            assertTrue(generator.length() <= limit, "overran limit=" + limit);
+        }
+    }
+
+    @Test
+    void shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedKeyQuote()
+    {
+        for (int limit = 1; limit <= 12; limit++)
+        {
+            MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[limit]);
+            JsonGeneratorEx generator = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true))
+                .wrap(buffer, 0, limit);
+            generator.writeStartObject();
+            generator.writeKey("a\"b");
+            assertTrue(generator.length() <= limit, "overran limit=" + limit);
+        }
+    }
+
+    @Test
+    void shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedBackslashOrControl()
+    {
+        for (int limit = 1; limit <= 12; limit++)
+        {
+            MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[limit]);
+            JsonGeneratorEx generator = JsonEx.createGenerator(Map.of(JsonGeneratorEx.GENERATE_ESCAPED, true))
+                .wrap(buffer, 0, limit);
+            generator.write("a\\\nb");
+            assertTrue(generator.length() <= limit, "overran limit=" + limit);
+        }
+    }
+
+    @Test
     void shouldRoundTripNestedDocument()
     {
         assertRoundTrips(g -> g


### PR DESCRIPTION
## Summary

Fixes #2043.

`JsonGeneratorImpl`'s `GENERATE_ESCAPED` mode routes every output byte, including its own string-delimiter quotes, through the escaping `putByte` — correct by design, since the whole generated document becomes the *content* of an outer JSON string, so the document's own `"` / `\` characters must themselves be escaped a second time.

However, every width/room-reservation calculation in the file assumed single-layer escaping (correct only for the non-escaped "verbatim" generator):

- `codePointWidth()` (budgeting body content in `writeStringBody`) assumed a `"`/`\` character costs 2 bytes; under escaped mode it actually costs 4 (e.g. a literal `"` becomes `\"` at the first escaping layer, then each of those two characters is escaped again into `\\` and `\"`). Control characters were similarly under-counted (7 actual bytes vs. 6 assumed).
- `write(CharSequence, Completion)` and `writeKey(CharSequence, Completion)` assumed their opening/closing string-delimiter quote costs 1 byte; under escaped mode it costs 2 (`\"`).

This silently under-reserved room and let the generator write past the buffer region passed to `wrap(buffer, offset, limit)`. It's the root cause of the SIGSEGV crash discovered while verifying PR #2039 (`fix/mcp-http-coverage`): `binding-mcp-http`'s `McpHttpProxyFactory` constructs both its `responseGenerator` and `errorGenerator` with `GENERATE_ESCAPED=true` (used for the JSON envelope around every MCP tool-call response), and hits this bug whenever a tool result string contains a `"` or `\`.

## Fix

- Split `codePointWidth` into an `escaped`-dispatching instance method, with `verbatimCodePointWidth` (unchanged, original logic) and a new `escapedCodePointWidth` that accounts for the second escaping layer.
- Corrected the fixed opening/closing-quote byte-cost assumptions in `write(CharSequence, Completion)` and `writeKey(CharSequence, Completion)` to be conditional on `escaped` (2 bytes instead of 1).

## Test plan

- [x] Added `shouldWriteDoublyEscapedQuoteWhenExactRoom`, `shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedQuote`, `shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedKeyQuote`, `shouldNotOverrunWrappedLimitWhenRoomInsufficientForDoublyEscapedBackslashOrControl` to `JsonGeneratorEscapeTest` — confirmed all three overrun-detection tests fail against the pre-fix code (`AssertionError` from `putRaw`'s `progress < limit` guard, with `-ea` enabled per #2041) and pass after the fix.
- [x] `./mvnw clean verify jacoco:report -pl runtime/common-json` — full unit suite (4855 tests) passes, checkstyle/license clean, 90% coverage gate passes.
- [x] `./mvnw clean verify jacoco:report -pl runtime/binding-mcp-http` — the `McpHttpProxyIT` SIGSEGV crash is gone; full IT suite and coverage gate now pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_016EtF5FFTbYY4jTAYLd1DoH)_