### PR TITLE
refactor(binding-mcp-http): nest body/bodyTemplate into McpHttpBodyConfig

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfig.java
@@ -17,24 +17,17 @@ package io.aklivity.zilla.runtime.binding.mcp.http.config;
 import java.util.Map;
 
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
-import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
-public final class McpHttpWithConfig extends WithConfig
+public final class McpHttpBodyConfig
 {
-    public final Map<String, String> headers;
-    public final Map<String, String> cookies;
-    public final ModelConfig query;
-    public final McpHttpBodyConfig body;
+    public final ModelConfig model;
+    public final Map<String, String> template;
 
-    public McpHttpWithConfig(
-        Map<String, String> headers,
-        Map<String, String> cookies,
-        ModelConfig query,
-        McpHttpBodyConfig body)
+    public McpHttpBodyConfig(
+        ModelConfig model,
+        Map<String, String> template)
     {
-        this.headers = headers;
-        this.cookies = cookies;
-        this.query = query;
-        this.body = body;
+        this.model = model;
+        this.template = template;
     }
 }

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfig.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.binding.mcp.http.config;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 
@@ -23,7 +24,18 @@ public final class McpHttpBodyConfig
     public final ModelConfig model;
     public final Map<String, String> template;
 
-    public McpHttpBodyConfig(
+    public static McpHttpBodyConfigBuilder<McpHttpBodyConfig> builder()
+    {
+        return new McpHttpBodyConfigBuilder<>(McpHttpBodyConfig.class::cast);
+    }
+
+    public static <T> McpHttpBodyConfigBuilder<T> builder(
+        Function<McpHttpBodyConfig, T> mapper)
+    {
+        return new McpHttpBodyConfigBuilder<>(mapper);
+    }
+
+    McpHttpBodyConfig(
         ModelConfig model,
         Map<String, String> template)
     {

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfigBuilder.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpBodyConfigBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.config;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
+
+public final class McpHttpBodyConfigBuilder<T> extends ConfigBuilder<T, McpHttpBodyConfigBuilder<T>>
+{
+    private final Function<McpHttpBodyConfig, T> mapper;
+
+    private ModelConfig model;
+    private Map<String, String> template;
+
+    McpHttpBodyConfigBuilder(
+        Function<McpHttpBodyConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpHttpBodyConfigBuilder<T>> thisType()
+    {
+        return (Class<McpHttpBodyConfigBuilder<T>>) getClass();
+    }
+
+    public McpHttpBodyConfigBuilder<T> model(
+        ModelConfig model)
+    {
+        this.model = model;
+        return this;
+    }
+
+    public McpHttpBodyConfigBuilder<T> template(
+        Map<String, String> template)
+    {
+        this.template = template;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpHttpBodyConfig(model, template));
+    }
+}

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfig.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.binding.mcp.http.config;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 import io.aklivity.zilla.runtime.engine.config.WithConfig;
@@ -26,7 +27,18 @@ public final class McpHttpWithConfig extends WithConfig
     public final ModelConfig query;
     public final McpHttpBodyConfig body;
 
-    public McpHttpWithConfig(
+    public static McpHttpWithConfigBuilder<McpHttpWithConfig> builder()
+    {
+        return new McpHttpWithConfigBuilder<>(McpHttpWithConfig.class::cast);
+    }
+
+    public static <T> McpHttpWithConfigBuilder<T> builder(
+        Function<WithConfig, T> mapper)
+    {
+        return new McpHttpWithConfigBuilder<>(mapper);
+    }
+
+    McpHttpWithConfig(
         Map<String, String> headers,
         Map<String, String> cookies,
         ModelConfig query,

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfigBuilder.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfigBuilder.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.http.config;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -50,10 +51,34 @@ public final class McpHttpWithConfigBuilder<T> extends ConfigBuilder<T, McpHttpW
         return this;
     }
 
+    public McpHttpWithConfigBuilder<T> header(
+        String name,
+        String value)
+    {
+        if (headers == null)
+        {
+            headers = new LinkedHashMap<>();
+        }
+        headers.put(name, value);
+        return this;
+    }
+
     public McpHttpWithConfigBuilder<T> cookies(
         Map<String, String> cookies)
     {
         this.cookies = cookies;
+        return this;
+    }
+
+    public McpHttpWithConfigBuilder<T> cookie(
+        String name,
+        String value)
+    {
+        if (cookies == null)
+        {
+            cookies = new LinkedHashMap<>();
+        }
+        cookies.put(name, value);
         return this;
     }
 

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfigBuilder.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/config/McpHttpWithConfigBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.config;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+import io.aklivity.zilla.runtime.engine.config.ModelConfig;
+import io.aklivity.zilla.runtime.engine.config.WithConfig;
+
+public final class McpHttpWithConfigBuilder<T> extends ConfigBuilder<T, McpHttpWithConfigBuilder<T>>
+{
+    private final Function<WithConfig, T> mapper;
+
+    private Map<String, String> headers;
+    private Map<String, String> cookies;
+    private ModelConfig query;
+    private McpHttpBodyConfig body;
+
+    McpHttpWithConfigBuilder(
+        Function<WithConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpHttpWithConfigBuilder<T>> thisType()
+    {
+        return (Class<McpHttpWithConfigBuilder<T>>) getClass();
+    }
+
+    public McpHttpWithConfigBuilder<T> headers(
+        Map<String, String> headers)
+    {
+        this.headers = headers;
+        return this;
+    }
+
+    public McpHttpWithConfigBuilder<T> cookies(
+        Map<String, String> cookies)
+    {
+        this.cookies = cookies;
+        return this;
+    }
+
+    public McpHttpWithConfigBuilder<T> query(
+        ModelConfig query)
+    {
+        this.query = query;
+        return this;
+    }
+
+    public McpHttpWithConfigBuilder<T> body(
+        McpHttpBodyConfig body)
+    {
+        this.body = body;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpHttpWithConfig(headers, cookies, query, body));
+    }
+}

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
@@ -67,7 +67,7 @@ public final class McpHttpRouteConfig
         this.tool = condition != null ? condition.tool : null;
         this.resource = condition != null ? condition.resource : null;
 
-        final Map<String, String> bodyTemplate = with != null ? with.bodyTemplate : null;
+        final Map<String, String> bodyTemplate = with != null && with.body != null ? with.body.template : null;
         if (bodyTemplate != null)
         {
             final List<String> pointers = new ArrayList<>();

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapter.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapter.java
@@ -22,6 +22,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpBodyConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpBinding;
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
@@ -72,15 +73,16 @@ public final class McpHttpWithConfigAdapter implements WithConfigAdapterSpi, Jso
             object.add(QUERY_NAME, model.adaptToJson(mcpHttpWith.query));
         }
 
-        if (mcpHttpWith.bodyTemplate != null)
+        McpHttpBodyConfig body = mcpHttpWith.body;
+        if (body != null && body.template != null)
         {
             JsonObjectBuilder template = Json.createObjectBuilder();
-            mcpHttpWith.bodyTemplate.forEach(template::add);
+            body.template.forEach(template::add);
             object.add(BODY_NAME, Json.createObjectBuilder().add(TEMPLATE_NAME, template));
         }
-        else if (mcpHttpWith.body != null)
+        else if (body != null && body.model != null)
         {
-            object.add(BODY_NAME, model.adaptToJson(mcpHttpWith.body));
+            object.add(BODY_NAME, model.adaptToJson(body.model));
         }
 
         return object.build();
@@ -116,26 +118,26 @@ public final class McpHttpWithConfigAdapter implements WithConfigAdapterSpi, Jso
             ? model.adaptFromJson(object.get(QUERY_NAME))
             : null;
 
-        ModelConfig body = null;
-        Map<String, String> bodyTemplate = null;
+        McpHttpBodyConfig body = null;
         if (object.containsKey(BODY_NAME))
         {
             JsonObject bodyObject = object.getJsonObject(BODY_NAME);
             if (bodyObject.containsKey(TEMPLATE_NAME))
             {
                 JsonObject templateObject = bodyObject.getJsonObject(TEMPLATE_NAME);
-                bodyTemplate = new LinkedHashMap<>();
+                Map<String, String> template = new LinkedHashMap<>();
                 for (String name : templateObject.keySet())
                 {
-                    bodyTemplate.put(name, templateObject.getString(name));
+                    template.put(name, templateObject.getString(name));
                 }
+                body = new McpHttpBodyConfig(null, template);
             }
             else
             {
-                body = model.adaptFromJson(object.get(BODY_NAME));
+                body = new McpHttpBodyConfig(model.adaptFromJson(object.get(BODY_NAME)), null);
             }
         }
 
-        return new McpHttpWithConfig(headers, cookies, query, body, bodyTemplate);
+        return new McpHttpWithConfig(headers, cookies, query, body);
     }
 }

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapter.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapter.java
@@ -130,14 +130,19 @@ public final class McpHttpWithConfigAdapter implements WithConfigAdapterSpi, Jso
                 {
                     template.put(name, templateObject.getString(name));
                 }
-                body = new McpHttpBodyConfig(null, template);
+                body = McpHttpBodyConfig.builder().template(template).build();
             }
             else
             {
-                body = new McpHttpBodyConfig(model.adaptFromJson(object.get(BODY_NAME)), null);
+                body = McpHttpBodyConfig.builder().model(model.adaptFromJson(object.get(BODY_NAME))).build();
             }
         }
 
-        return new McpHttpWithConfig(headers, cookies, query, body);
+        return McpHttpWithConfig.builder()
+            .headers(headers)
+            .cookies(cookies)
+            .query(query)
+            .body(body)
+            .build();
     }
 }

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -641,7 +641,7 @@ public final class McpHttpProxyFactory implements BindingHandler
         // pumpRequest drain more of this side's own decodeSlot; the window granted back to the mcp client
         // reflects only this side's own backlog — decodeSlotOffset is in mcp-client request bytes, the same
         // units as initialSeq/initialAck, unlike HttpProxy's own initial-direction counters, which are a
-        // distinct byte stream once request shaping (body/bodyTemplate/query) has transformed the content.
+        // distinct byte stream once request shaping (body/query) has transformed the content.
         // max stays pinned to the slot's full physical capacity; ack alone carries the backlog discount, so
         // ack + max lands exactly on the true remaining room without double-counting the backlog.
         void flushMcpWindow(
@@ -813,7 +813,7 @@ public final class McpHttpProxyFactory implements BindingHandler
             return false;
         }
 
-        // Default no-op: only McpToolsCallProxy streams a request body/bodyTemplate/query pipeline that needs
+        // Default no-op: only McpToolsCallProxy streams a request body/query pipeline that needs
         // pumping across multiple onMcpData calls; overridden there. Called polymorphically from
         // HttpProxy.resumeRequest via the same McpHttpProxy-typed reference requestPumpable() serves.
         void pumpRequest(
@@ -823,8 +823,8 @@ public final class McpHttpProxyFactory implements BindingHandler
 
         // Dispatches a bodyless upstream request immediately, resolving only ${params.*} references in
         // with.headers (there is no arguments/body concept at all for this shape). Used by both concrete
-        // kinds for a route with nothing to stream: McpToolsCallProxy's fallback when with.body/bodyTemplate/
-        // query are all absent (and tool.input is either absent or skipped — see its onMcpBegin), and
+        // kinds for a route with nothing to stream: McpToolsCallProxy's fallback when with.body/
+        // with.query are all absent (and tool.input is either absent or skipped — see its onMcpBegin), and
         // McpResourcesReadProxy's only supported shape today (see its onMcpBegin). This is genuinely
         // shared, kind-independent plumbing — not the per-kind streaming/dispatch logic those two classes
         // otherwise keep separate.
@@ -998,11 +998,11 @@ public final class McpHttpProxyFactory implements BindingHandler
         private int errorRelayConsumed;
         private int errorRelayRemaining;
 
-        // the single streaming pipeline for this route's request shape: with.body/with.bodyTemplate project
+        // the single streaming pipeline for this route's request shape: with.body (model or template) projects
         // into requestGenerator (which writes into HttpProxy's own encode slot via requestStep); with.query
         // alone projects into a McpHttpQuery sink (requestGenerator stays null — nothing to write into
         // encodeSlot); neither, but tool.input still needs validating, projects into a McpHttpDiscard sink.
-        // A route combining with.body/bodyTemplate and with.query is not yet supported here — see onMcpBegin.
+        // A route combining with.body and with.query is not yet supported here — see onMcpBegin.
         private JsonPipeline requestPipeline;
         private JsonGeneratorEx requestGenerator;
         private Map<String, String> requestArgs;
@@ -1046,7 +1046,7 @@ public final class McpHttpProxyFactory implements BindingHandler
 
             final McpHttpWithConfig with = route.with;
             final McpHttpToolConfig tool = tool();
-            final boolean needsBody = with.body != null || with.bodyTemplate != null;
+            final boolean needsBody = with.body != null;
             final boolean needsQuery = with.query != null;
             final boolean needsValidation = tool != null && tool.input != null &&
                 contentLength >= 0 && contentLength <= decodePool.slotCapacity();
@@ -1074,17 +1074,17 @@ public final class McpHttpProxyFactory implements BindingHandler
 
                 if (needsBody)
                 {
-                    // a route combining with.body/bodyTemplate and with.query is not yet supported: producing
+                    // a route combining with.body and with.query is not yet supported: producing
                     // both an outbound body and a query string from one incremental pass would need a second,
                     // independently-driven pipeline sharing the same decode-slot window (JsonPipeline has no
                     // fan-out — see JsonStream), which raises real compaction-ordering questions across two
                     // pipelines completing at different times; no current route configures both, so this is
                     // deferred rather than solved speculatively — with.query is silently ignored in this case
                     requestGenerator = JsonEx.createGenerator();
-                    stream = with.bodyTemplate != null
+                    stream = with.body.template != null
                         ? stream.transform(JsonTransforms.projector(route.bodyTemplatePointers))
                             .transform(JsonTransforms.flatten(route.bodyTemplateTargets))
-                        : stream.transform(JsonTransforms.projector(binding.jsonSchema(with.body)));
+                        : stream.transform(JsonTransforms.projector(binding.jsonSchema(with.body.model)));
                     requestPipeline = stream.into(JsonEx.createSink(requestGenerator, SINK_SEGMENTABLE));
                 }
                 else if (needsQuery)

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpDiscard.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/transform/McpHttpDiscard.java
@@ -24,7 +24,7 @@ import io.aklivity.zilla.runtime.common.json.JsonSource;
  * Terminal {@link JsonSink} that discards every event, reaching {@link Status#COMPLETED} when the top-level
  * value closes at depth zero. Used when a tool's {@code tool.input} schema must be validated (a validator
  * stage sits upstream of this sink) but the route has nothing to shape a request from that value — no
- * {@code with.body}, {@code with.bodyTemplate}, or {@code with.query} — so there is no destination for the
+ * {@code with.body}, {@code with.body.template}, or {@code with.query} — so there is no destination for the
  * validated bytes to project into.
  */
 public final class McpHttpDiscard implements JsonSink

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -31,7 +31,7 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldResolveHeaderWhenArgumentPresent()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
@@ -39,7 +39,7 @@ public class McpHttpRouteConfigTest
             .build());
 
         Map<String, String> args = Map.of("trace.id", "trace-abc");
-        Map<String, String> resolved = config.resolveHeaders(args, Map.of());
+        Map<String, String> resolved = route.resolveHeaders(args, Map.of());
 
         assertThat(resolved.get("x-trace-id"), equalTo("trace-abc"));
     }
@@ -47,14 +47,14 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitHeaderWhenArgumentAbsent()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
                 .build()
             .build());
 
-        Map<String, String> resolved = config.resolveHeaders(Map.of(), Map.of());
+        Map<String, String> resolved = route.resolveHeaders(Map.of(), Map.of());
 
         assertThat(resolved.get("x-trace-id"), nullValue());
     }
@@ -62,20 +62,20 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectNestedArgAccessorFromHeader()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
                 .build()
             .build());
 
-        assertThat(config.argAccessors, equalTo(List.of("trace.id")));
+        assertThat(route.argAccessors, equalTo(List.of("trace.id")));
     }
 
     @Test
     public void shouldAggregateCookiesWhenAllPresent()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
@@ -84,7 +84,7 @@ public class McpHttpRouteConfigTest
             .build());
 
         Map<String, String> args = Map.of("a", "1", "b", "2");
-        String resolved = config.resolveCookies(args, Map.of());
+        String resolved = route.resolveCookies(args, Map.of());
 
         assertThat(resolved, equalTo("a=1; b=2"));
     }
@@ -92,7 +92,7 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitOneCookieWhenPartiallyAbsent()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
@@ -101,7 +101,7 @@ public class McpHttpRouteConfigTest
             .build());
 
         Map<String, String> args = Map.of("a", "1");
-        String resolved = config.resolveCookies(args, Map.of());
+        String resolved = route.resolveCookies(args, Map.of());
 
         assertThat(resolved, equalTo("a=1"));
     }
@@ -109,7 +109,7 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitCookieHeaderWhenAllAbsent()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
@@ -117,7 +117,7 @@ public class McpHttpRouteConfigTest
                 .build()
             .build());
 
-        String resolved = config.resolveCookies(Map.of(), Map.of());
+        String resolved = route.resolveCookies(Map.of(), Map.of());
 
         assertThat(resolved, nullValue());
     }
@@ -125,13 +125,13 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectArgAccessorFromCookie()
     {
-        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
+        McpHttpRouteConfig route = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("session", "${args.session.id}")
                 .build()
             .build());
 
-        assertThat(config.argAccessors, equalTo(List.of("session.id")));
+        assertThat(route.argAccessors, equalTo(List.of("session.id")));
     }
 }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,12 +31,10 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldResolveHeaderWhenArgumentPresent()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        headers.put("x-trace-id", "${args.trace.id}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
+                .header(":path", "/notifications")
+                .header("x-trace-id", "${args.trace.id}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -51,12 +48,10 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitHeaderWhenArgumentAbsent()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        headers.put("x-trace-id", "${args.trace.id}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
+                .header(":path", "/notifications")
+                .header("x-trace-id", "${args.trace.id}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -69,12 +64,10 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectNestedArgAccessorFromHeader()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        headers.put("x-trace-id", "${args.trace.id}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
+                .header(":path", "/notifications")
+                .header("x-trace-id", "${args.trace.id}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -85,15 +78,11 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldAggregateCookiesWhenAllPresent()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        Map<String, String> cookies = new LinkedHashMap<>();
-        cookies.put("a", "${args.a}");
-        cookies.put("b", "${args.b}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
-                .cookies(cookies)
+                .header(":path", "/notifications")
+                .cookie("a", "${args.a}")
+                .cookie("b", "${args.b}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -107,15 +96,11 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitOneCookieWhenPartiallyAbsent()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        Map<String, String> cookies = new LinkedHashMap<>();
-        cookies.put("a", "${args.a}");
-        cookies.put("b", "${args.b}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
-                .cookies(cookies)
+                .header(":path", "/notifications")
+                .cookie("a", "${args.a}")
+                .cookie("b", "${args.b}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -129,15 +114,11 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitCookieHeaderWhenAllAbsent()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        Map<String, String> cookies = new LinkedHashMap<>();
-        cookies.put("a", "${args.a}");
-        cookies.put("b", "${args.b}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
-                .cookies(cookies)
+                .header(":path", "/notifications")
+                .cookie("a", "${args.a}")
+                .cookie("b", "${args.b}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
@@ -150,14 +131,10 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectArgAccessorFromCookie()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/notifications");
-        Map<String, String> cookies = new LinkedHashMap<>();
-        cookies.put("session", "${args.session.id}");
         RouteConfig route = RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
-                .headers(headers)
-                .cookies(cookies)
+                .header(":path", "/notifications")
+                .cookie("session", "${args.session.id}")
                 .build()
             .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -31,13 +31,12 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldResolveHeaderWhenArgumentPresent()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         Map<String, String> args = Map.of("trace.id", "trace-abc");
         Map<String, String> resolved = config.resolveHeaders(args, Map.of());
@@ -48,13 +47,12 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitHeaderWhenArgumentAbsent()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         Map<String, String> resolved = config.resolveHeaders(Map.of(), Map.of());
 
@@ -64,13 +62,12 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectNestedArgAccessorFromHeader()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .header("x-trace-id", "${args.trace.id}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         assertThat(config.argAccessors, equalTo(List.of("trace.id")));
     }
@@ -78,14 +75,13 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldAggregateCookiesWhenAllPresent()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
                 .cookie("b", "${args.b}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         Map<String, String> args = Map.of("a", "1", "b", "2");
         String resolved = config.resolveCookies(args, Map.of());
@@ -96,14 +92,13 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitOneCookieWhenPartiallyAbsent()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
                 .cookie("b", "${args.b}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         Map<String, String> args = Map.of("a", "1");
         String resolved = config.resolveCookies(args, Map.of());
@@ -114,14 +109,13 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldOmitCookieHeaderWhenAllAbsent()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("a", "${args.a}")
                 .cookie("b", "${args.b}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         String resolved = config.resolveCookies(Map.of(), Map.of());
 
@@ -131,13 +125,12 @@ public class McpHttpRouteConfigTest
     @Test
     public void shouldCollectArgAccessorFromCookie()
     {
-        RouteConfig route = RouteConfig.builder()
+        McpHttpRouteConfig config = new McpHttpRouteConfig(RouteConfig.builder()
             .with(McpHttpWithConfig::builder)
                 .header(":path", "/notifications")
                 .cookie("session", "${args.session.id}")
                 .build()
-            .build();
-        McpHttpRouteConfig config = new McpHttpRouteConfig(route);
+            .build());
 
         assertThat(config.argAccessors, equalTo(List.of("session.id")));
     }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -35,7 +35,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -51,7 +51,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -66,7 +66,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -81,7 +81,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -99,7 +99,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -117,7 +117,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -133,7 +133,7 @@ public class McpHttpRouteConfigTest
         headers.put(":path", "/notifications");
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("session", "${args.session.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
+        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -35,8 +35,11 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         Map<String, String> args = Map.of("trace.id", "trace-abc");
@@ -51,8 +54,11 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         Map<String, String> resolved = config.resolveHeaders(Map.of(), Map.of());
@@ -66,8 +72,11 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         assertThat(config.argAccessors, equalTo(List.of("trace.id")));
@@ -81,8 +90,12 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .cookies(cookies)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         Map<String, String> args = Map.of("a", "1", "b", "2");
@@ -99,8 +112,12 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .cookies(cookies)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         Map<String, String> args = Map.of("a", "1");
@@ -117,8 +134,12 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .cookies(cookies)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         String resolved = config.resolveCookies(Map.of(), Map.of());
@@ -133,8 +154,12 @@ public class McpHttpRouteConfigTest
         headers.put(":path", "/notifications");
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("session", "${args.session.id}");
-        McpHttpWithConfig with = McpHttpWithConfig.builder().headers(headers).cookies(cookies).build();
-        RouteConfig route = RouteConfig.builder().with(with).build();
+        RouteConfig route = RouteConfig.builder()
+            .with(McpHttpWithConfig::builder)
+                .headers(headers)
+                .cookies(cookies)
+                .build()
+            .build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
         assertThat(config.argAccessors, equalTo(List.of("session.id")));

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -35,7 +35,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -51,7 +51,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -66,7 +66,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> headers = new LinkedHashMap<>();
         headers.put(":path", "/notifications");
         headers.put("x-trace-id", "${args.trace.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, null, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -81,7 +81,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -99,7 +99,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -117,7 +117,7 @@ public class McpHttpRouteConfigTest
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("a", "${args.a}");
         cookies.put("b", "${args.b}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 
@@ -133,7 +133,7 @@ public class McpHttpRouteConfigTest
         headers.put(":path", "/notifications");
         Map<String, String> cookies = new LinkedHashMap<>();
         cookies.put("session", "${args.session.id}");
-        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null, null);
+        McpHttpWithConfig with = new McpHttpWithConfig(headers, cookies, null, null);
         RouteConfig route = RouteConfig.builder().with(with).build();
         McpHttpRouteConfig config = new McpHttpRouteConfig(route);
 

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapterTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpWithConfigAdapterTest.java
@@ -64,9 +64,10 @@ public class McpHttpWithConfigAdapterTest
         assertThat(with.headers, not(nullValue()));
         assertThat(with.headers.get(":method"), equalTo("POST"));
         assertThat(with.headers.get(":path"), equalTo("/repos/owner/repo/pulls"));
-        assertThat(with.bodyTemplate, not(nullValue()));
-        assertThat(with.bodyTemplate.get("title"), equalTo("${args.title}"));
-        assertThat(with.body, nullValue());
+        assertThat(with.body, not(nullValue()));
+        assertThat(with.body.template, not(nullValue()));
+        assertThat(with.body.template.get("title"), equalTo("${args.title}"));
+        assertThat(with.body.model, nullValue());
         assertThat(with.query, nullValue());
     }
 
@@ -86,7 +87,8 @@ public class McpHttpWithConfigAdapterTest
         assertThat(with, not(nullValue()));
         assertThat(with.query, not(nullValue()));
         assertThat(with.body, not(nullValue()));
-        assertThat(with.bodyTemplate, nullValue());
+        assertThat(with.body.model, not(nullValue()));
+        assertThat(with.body.template, nullValue());
         assertThat(with.headers, nullValue());
     }
 

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -43,6 +43,7 @@ import jakarta.json.JsonWriter;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpBodyConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpOptionsConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpResourceConfig;
@@ -686,12 +687,19 @@ public final class McpOpenapiCompositeGenerator
         injectCookieParams(cookies, operation, accessor, entry.params);
 
         final boolean bodyTemplated = !entry.body.isEmpty();
-        final ModelConfig body = !bodyTemplated && operation.hasRequestBody()
+        final ModelConfig bodyModel = !bodyTemplated && operation.hasRequestBody()
             ? jsonModel("%s-body".formatted(entry.subjectName()))
             : null;
 
-        return new McpHttpWithConfig(headers, cookies.isEmpty() ? null : cookies, null, body,
-            bodyTemplated ? entry.body : null);
+        final McpHttpBodyConfig body = bodyTemplated
+            ? McpHttpBodyConfig.builder().template(entry.body).build()
+            : bodyModel != null ? McpHttpBodyConfig.builder().model(bodyModel).build() : null;
+
+        return McpHttpWithConfig.builder()
+            .headers(headers)
+            .cookies(cookies.isEmpty() ? null : cookies)
+            .body(body)
+            .build();
     }
 
     private static ResolvedServer resolveServerFromSpec(

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -1106,8 +1106,9 @@ public class McpOpenapiCompositeGeneratorTest
             .findFirst()
             .orElse(null);
         assertThat(with, notNullValue());
-        assertThat(with.body, nullValue());
-        assertThat(with.bodyTemplate, equalTo(Map.of(
+        assertThat(with.body, notNullValue());
+        assertThat(with.body.model, nullValue());
+        assertThat(with.body.template, equalTo(Map.of(
             "title", "${args.title}",
             "owner", "${args.pr.owner}")));
     }


### PR DESCRIPTION
## Description

`McpHttpWithConfig` (the `routes[].with` config for `binding-mcp-http`) previously flattened the `with.body` YAML shape — which is a `oneOf(model, {template: {...}})` — into two separate top-level Java fields: `body: ModelConfig` and `bodyTemplate: Map<String,String>`. This required null-arbitration logic in `McpHttpWithConfigAdapter` and every downstream consumer to figure out which variant was configured.

This PR introduces `McpHttpBodyConfig` (with `model` and `template` fields) and replaces the two flat fields on `McpHttpWithConfig` with a single `body: McpHttpBodyConfig` field, so the Java object graph mirrors the nested YAML shape directly. No YAML/JSON-schema changes were needed since the wire format was already nested — this is purely a Java-side API cleanup.

Updated:
- `McpHttpWithConfig` — new `body: McpHttpBodyConfig` field replaces `body`/`bodyTemplate`
- `McpHttpWithConfigAdapter` — adapts to/from the nested `McpHttpBodyConfig`
- `McpHttpRouteConfig` — reads `with.body.template` instead of `with.bodyTemplate`
- `McpHttpProxyFactory` — reads `with.body.model` / `with.body.template`, updated stale comments
- `McpHttpDiscard` — updated a doc comment referencing the old field name
- Existing unit tests updated to construct/assert against the new nested shape

Fixes # (N/A — internal API cleanup, no tracked issue)

## Test plan

- [x] `./mvnw clean verify -pl runtime/binding-mcp-http` — unit tests, K3PO integration tests, checkstyle, license headers, and JaCoCo coverage all pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBnVdB5HngbmWkohRqjRys)_