### PR TITLE
feat(binding-mcp-http): align route when/guarded semantics with mcp binding

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -135,16 +135,20 @@ public final class McpHttpBindingConfig
         String name,
         long authorization)
     {
-        McpHttpRouteConfig matched = null;
+        McpHttpRouteConfig mapping = null;
+        boolean authorized = true;
         for (McpHttpRouteConfig route : routes)
         {
-            if (route.authorized(authorization) && route.matchesTool(name))
+            if (route.appliesToTool(name))
             {
-                matched = route;
-                break;
+                authorized &= route.authorized(authorization);
+                if (route.with != null && mapping == null)
+                {
+                    mapping = route;
+                }
             }
         }
-        return matched;
+        return authorized && mapping != null ? mapping : null;
     }
 
     public McpHttpResourceConfig resolveResource(
@@ -167,28 +171,45 @@ public final class McpHttpBindingConfig
         String name,
         long authorization)
     {
-        McpHttpRouteConfig matched = null;
+        McpHttpRouteConfig mapping = null;
+        boolean authorized = true;
         for (McpHttpRouteConfig route : routes)
         {
-            if (route.authorized(authorization) && route.matchesResource(name))
+            if (route.appliesToResource(name))
             {
-                matched = route;
-                break;
+                authorized &= route.authorized(authorization);
+                if (route.with != null && mapping == null)
+                {
+                    mapping = route;
+                }
             }
         }
-        return matched;
+        return authorized && mapping != null ? mapping : null;
     }
 
     public List<GuardedConfig> toolGuarded(
         String name)
     {
-        List<GuardedConfig> result = List.of();
+        final List<GuardedConfig> result = new ArrayList<>();
         for (McpHttpRouteConfig route : routes)
         {
-            if (route.matchesTool(name))
+            if (route.appliesToTool(name))
             {
-                result = route.guarded;
-                break;
+                result.addAll(route.guarded);
+            }
+        }
+        return result;
+    }
+
+    public List<GuardedConfig> resourceGuarded(
+        String name)
+    {
+        final List<GuardedConfig> result = new ArrayList<>();
+        for (McpHttpRouteConfig route : routes)
+        {
+            if (route.appliesToResource(name))
+            {
+                result.addAll(route.guarded);
             }
         }
         return result;

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfig.java
@@ -136,6 +136,23 @@ public final class McpHttpRouteConfig
         return resource != null && resource.equals(name);
     }
 
+    boolean appliesToTool(
+        String name)
+    {
+        return matchesTool(name) || isUnscoped();
+    }
+
+    boolean appliesToResource(
+        String name)
+    {
+        return matchesResource(name) || isUnscoped();
+    }
+
+    private boolean isUnscoped()
+    {
+        return tool == null && resource == null;
+    }
+
     // Resolves every header other than :path (handled separately via resolvePath, since it also
     // carries the query string). A header whose value references an args./params. accessor that is
     // absent is omitted entirely, not sent with an empty value -- unlike interpolatePath (used for

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -2449,29 +2449,39 @@ public final class McpHttpProxyFactory implements BindingHandler
             {
                 item.add("outputSchema", outputSchema);
             }
-            final List<GuardedConfig> guarded = binding.toolGuarded(tool.name);
-            if (!guarded.isEmpty())
+            final JsonArrayBuilder toolSchemes = securitySchemes(binding.toolGuarded(tool.name));
+            if (toolSchemes != null)
             {
-                final JsonArrayBuilder schemes = Json.createArrayBuilder();
-                for (GuardedConfig g : guarded)
-                {
-                    if (!g.roles.isEmpty())
-                    {
-                        final JsonArrayBuilder scopes = Json.createArrayBuilder();
-                        for (String role : g.roles)
-                        {
-                            scopes.add(role);
-                        }
-                        schemes.add(Json.createObjectBuilder()
-                            .add("type", "oauth2")
-                            .add("scopes", scopes));
-                    }
-                }
-                item.add("securitySchemes", schemes);
+                item.add("securitySchemes", toolSchemes);
             }
             tools.add(item);
         }
         return compact(Json.createObjectBuilder().add("tools", tools).build());
+    }
+
+    private static JsonArrayBuilder securitySchemes(
+        List<GuardedConfig> guarded)
+    {
+        JsonArrayBuilder schemes = null;
+        for (GuardedConfig g : guarded)
+        {
+            if (!g.roles.isEmpty())
+            {
+                if (schemes == null)
+                {
+                    schemes = Json.createArrayBuilder();
+                }
+                final JsonArrayBuilder scopes = Json.createArrayBuilder();
+                for (String role : g.roles)
+                {
+                    scopes.add(role);
+                }
+                schemes.add(Json.createObjectBuilder()
+                    .add("type", "oauth2")
+                    .add("scopes", scopes));
+            }
+        }
+        return schemes;
     }
 
     private String buildResourcesList(
@@ -2498,6 +2508,11 @@ public final class McpHttpProxyFactory implements BindingHandler
             {
                 item.add("mimeType", resource.mimeType);
             }
+            final JsonArrayBuilder resourceSchemes = securitySchemes(binding.resourceGuarded(resource.name));
+            if (resourceSchemes != null)
+            {
+                item.add("securitySchemes", resourceSchemes);
+            }
             resources.add(item);
         }
         return compact(Json.createObjectBuilder().add("resources", resources).build());
@@ -2523,6 +2538,11 @@ public final class McpHttpProxyFactory implements BindingHandler
             if (resource.mimeType != null)
             {
                 item.add("mimeType", resource.mimeType);
+            }
+            final JsonArrayBuilder templateSchemes = securitySchemes(binding.resourceGuarded(resource.name));
+            if (templateSchemes != null)
+            {
+                item.add("securitySchemes", templateSchemes);
             }
             resourceTemplates.add(item);
         }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -15,13 +15,150 @@
 package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpBindingConfig.argPathValid;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpConditionConfig;
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.KindConfig;
+import io.aklivity.zilla.runtime.engine.config.RouteConfig;
+import io.aklivity.zilla.runtime.engine.config.RouteConfigBuilder;
+
 public class McpHttpBindingConfigTest
 {
+    private static RouteConfig route(
+        int order,
+        String tool,
+        String resource,
+        boolean withMapping,
+        boolean authorized)
+    {
+        RouteConfigBuilder<RouteConfig> builder = RouteConfig.builder().order(order);
+        if (tool != null || resource != null)
+        {
+            builder = builder.when(new McpHttpConditionConfig(tool, resource));
+        }
+        if (withMapping)
+        {
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put(":path", "/items");
+            builder = builder.with(new McpHttpWithConfig(headers, null, null, null, null))
+                .exit("http0");
+        }
+        RouteConfig config = builder.build();
+        config.authorized = (auth, identity) -> authorized;
+        return config;
+    }
+
+    private static McpHttpBindingConfig binding(
+        List<RouteConfig> routes)
+    {
+        BindingConfig config = BindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp_http")
+            .kind(KindConfig.PROXY)
+            .routes(routes)
+            .build();
+        return new McpHttpBindingConfig(config, null);
+    }
+
+    @Test
+    public void shouldRejectToolWhenGlobalGuardOnlyLayerFails()
+    {
+        McpHttpBindingConfig binding = binding(List.of(
+            route(0, null, null, false, false),
+            route(1, "create_pr", null, true, true)));
+
+        assertNull(binding.resolveTool("create_pr", 1L));
+    }
+
+    @Test
+    public void shouldResolveToolWhenAllApplicableLayersAuthorize()
+    {
+        McpHttpBindingConfig binding = binding(List.of(
+            route(0, null, null, false, true),
+            route(1, "create_pr", null, true, true)));
+
+        assertNotNull(binding.resolveTool("create_pr", 1L));
+    }
+
+    @Test
+    public void shouldRejectResourceWhenScopedGuardOnlyLayerFails()
+    {
+        McpHttpBindingConfig binding = binding(List.of(
+            route(0, null, "order", false, false),
+            route(1, null, "order", true, true)));
+
+        assertNull(binding.resolveResourceRoute("order", 1L));
+    }
+
+    @Test
+    public void shouldAggregateToolGuardedAcrossMappingAndGlobalLayer()
+    {
+        RouteConfig global = RouteConfig.builder()
+            .order(0)
+            .guarded().name("test0").roles(List.of("read")).build()
+            .build();
+        global.authorized = (auth, identity) -> true;
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put(":path", "/items");
+        RouteConfig mapping = RouteConfig.builder()
+            .order(1)
+            .when(new McpHttpConditionConfig("create_pr", null))
+            .guarded().name("test1").roles(List.of("write")).build()
+            .with(new McpHttpWithConfig(headers, null, null, null, null))
+            .exit("http0")
+            .build();
+        mapping.authorized = (auth, identity) -> true;
+
+        McpHttpBindingConfig binding = binding(List.of(global, mapping));
+
+        assertThat(binding.toolGuarded("create_pr"), hasSize(2));
+        assertThat(binding.toolGuarded("search_code"), hasSize(1));
+    }
+
+    @Test
+    public void shouldAggregateResourceGuardedAcrossMappingAndScopedLayer()
+    {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put(":path", "/items");
+
+        RouteConfig scoped = RouteConfig.builder()
+            .order(0)
+            .when(new McpHttpConditionConfig(null, "order"))
+            .guarded().name("test0").roles(List.of("read")).build()
+            .build();
+        scoped.authorized = (auth, identity) -> true;
+
+        RouteConfig mapping = RouteConfig.builder()
+            .order(1)
+            .when(new McpHttpConditionConfig(null, "order"))
+            .guarded().name("test1").roles(List.of("write")).build()
+            .with(new McpHttpWithConfig(headers, null, null, null, null))
+            .exit("http0")
+            .build();
+        mapping.authorized = (auth, identity) -> true;
+
+        McpHttpBindingConfig binding = binding(List.of(scoped, mapping));
+
+        assertThat(binding.resourceGuarded("order"), hasSize(2));
+        assertThat(binding.resourceGuarded("other"), empty());
+    }
+
     private static final String FLAT = "{\"type\":\"object\",\"properties\":{\"owner\":{\"type\":\"string\"}}}";
     private static final String NESTED = "{\"type\":\"object\",\"properties\":" +
         "{\"user\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}}}}}";

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -23,9 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -52,9 +50,9 @@ public class McpHttpBindingConfigTest
         }
         if (withMapping)
         {
-            Map<String, String> headers = new LinkedHashMap<>();
-            headers.put(":path", "/items");
-            builder = builder.with(new McpHttpWithConfig(headers, null, null, null, null))
+            builder = builder.with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
                 .exit("http0");
         }
         RouteConfig config = builder.build();
@@ -114,13 +112,13 @@ public class McpHttpBindingConfigTest
             .build();
         global.authorized = (auth, identity) -> true;
 
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/items");
         RouteConfig mapping = RouteConfig.builder()
             .order(1)
             .when(new McpHttpConditionConfig("create_pr", null))
             .guarded().name("test1").roles(List.of("write")).build()
-            .with(new McpHttpWithConfig(headers, null, null, null, null))
+            .with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
             .exit("http0")
             .build();
         mapping.authorized = (auth, identity) -> true;
@@ -134,9 +132,6 @@ public class McpHttpBindingConfigTest
     @Test
     public void shouldAggregateResourceGuardedAcrossMappingAndScopedLayer()
     {
-        Map<String, String> headers = new LinkedHashMap<>();
-        headers.put(":path", "/items");
-
         RouteConfig scoped = RouteConfig.builder()
             .order(0)
             .when(new McpHttpConditionConfig(null, "order"))
@@ -148,7 +143,9 @@ public class McpHttpBindingConfigTest
             .order(1)
             .when(new McpHttpConditionConfig(null, "order"))
             .guarded().name("test1").roles(List.of("write")).build()
-            .with(new McpHttpWithConfig(headers, null, null, null, null))
+            .with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
             .exit("http0")
             .build();
         mapping.authorized = (auth, identity) -> true;

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,11 +26,68 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.http.config.McpHttpWithConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
+import io.aklivity.zilla.runtime.engine.config.RouteConfigBuilder;
 
 public class McpHttpRouteConfigTest
 {
+    private static McpHttpRouteConfig route(
+        String tool,
+        String resource,
+        boolean withMapping)
+    {
+        RouteConfigBuilder<RouteConfig> builder = RouteConfig.builder();
+        if (tool != null || resource != null)
+        {
+            builder = builder.when(new McpHttpConditionConfig(tool, resource));
+        }
+        if (withMapping)
+        {
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put(":path", "/items");
+            builder = builder.with(new McpHttpWithConfig(headers, null, null, null, null));
+        }
+        return new McpHttpRouteConfig(builder.exit("http0").build());
+    }
+
+    @Test
+    public void shouldApplyUnscopedGuardOnlyRouteToAnyTool()
+    {
+        McpHttpRouteConfig route = route(null, null, false);
+
+        assertTrue(route.appliesToTool("create_pr"));
+        assertTrue(route.appliesToTool("search_code"));
+    }
+
+    @Test
+    public void shouldApplyUnscopedGuardOnlyRouteToAnyResource()
+    {
+        McpHttpRouteConfig route = route(null, null, false);
+
+        assertTrue(route.appliesToResource("order"));
+    }
+
+    @Test
+    public void shouldApplyScopedGuardOnlyRouteToItsOwnToolOnly()
+    {
+        McpHttpRouteConfig route = route("create_pr", null, false);
+
+        assertTrue(route.appliesToTool("create_pr"));
+        assertFalse(route.appliesToTool("search_code"));
+        assertFalse(route.appliesToResource("create_pr"));
+    }
+
+    @Test
+    public void shouldNotApplyMappingRouteToOtherToolNames()
+    {
+        McpHttpRouteConfig route = route("create_pr", null, true);
+
+        assertTrue(route.appliesToTool("create_pr"));
+        assertFalse(route.appliesToTool("search_code"));
+    }
+
     @Test
     public void shouldResolveHeaderWhenArgumentPresent()
     {

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpRouteConfigTest.java
@@ -44,9 +44,9 @@ public class McpHttpRouteConfigTest
         }
         if (withMapping)
         {
-            Map<String, String> headers = new LinkedHashMap<>();
-            headers.put(":path", "/items");
-            builder = builder.with(new McpHttpWithConfig(headers, null, null, null, null));
+            builder = builder.with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build();
         }
         return new McpHttpRouteConfig(builder.exit("http0").build());
     }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyIT.java
@@ -463,6 +463,33 @@ public class McpHttpProxyIT
     }
 
     @Test
+    @Configuration("proxy.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/create.pr.forbidden.by.global.guard/client"})
+    public void shouldRejectToolWhenGlobalGuardOnlyLayerFails() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/tools.list.security.schemes.layered/client"})
+    public void shouldListToolsSecuritySchemesLayered() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/resources.list.security.schemes/client"})
+    public void shouldListResourcesSecuritySchemes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.credentials.yaml")
     @Specification({
         "${mcp}/create.pr/client",

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.global.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.global.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - guarded:
+          test0:
+            - read
+      - when:
+          - tool: create_pr
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": example.com
+            ":path": /items

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.layered.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.layered.yaml
@@ -1,0 +1,70 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+guards:
+  test0:
+    type: test
+    options:
+      roles:
+        - pr:write
+  test1:
+    type: test
+    options:
+      roles:
+        - guest
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    options:
+      tools:
+        create_pr:
+          description: Create a pull request
+          summary: "Created pull request"
+          schemas:
+            input:
+              model: test
+      resources:
+        settings:
+          uri: "config://settings"
+          description: Application settings
+          mimeType: application/json
+    routes:
+      - guarded:
+          test1:
+            - admin
+      - when:
+          - tool: create_pr
+        exit: http0
+        guarded:
+          test0:
+            - pr:write
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com
+            ":path": /repos/acme/widget/pulls
+      - when:
+          - resource: settings
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.example.internal
+            ":path": /settings

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.scoped.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.scoped.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+        guarded:
+          test0:
+            - write
+      - when:
+          - tool: create_pr
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": example.com
+            ":path": /items

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.both.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.both.invalid.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+            resource: order
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": example.com
+            ":path": /items

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.multiple.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.multiple.invalid.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+          - tool: search_code
+        exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": example.com
+            ":path": /items

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.required.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.required.invalid.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - exit: http0
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": example.com
+            ":path": /items

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
@@ -188,6 +188,7 @@
                                 {
                                     "title": "When",
                                     "type": "array",
+                                    "maxItems": 1,
                                     "items":
                                     {
                                         "type": "object",
@@ -204,6 +205,12 @@
                                                 "type": "string"
                                             }
                                         },
+                                        "anyOf":
+                                        [
+                                            { "required": [ "tool" ] },
+                                            { "required": [ "resource" ] }
+                                        ],
+                                        "not": { "required": [ "tool", "resource" ] },
                                         "additionalProperties": false
                                     }
                                 },
@@ -278,6 +285,21 @@
                                     },
                                     "required": [ "headers" ],
                                     "additionalProperties": false
+                                }
+                            },
+                            "if":
+                            {
+                                "required": [ "with" ]
+                            },
+                            "then":
+                            {
+                                "required": [ "when" ],
+                                "properties":
+                                {
+                                    "when":
+                                    {
+                                        "minItems": 1
+                                    }
                                 }
                             }
                         }

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.forbidden.by.global.guard/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/create.pr.forbidden.by.global.guard/client.rpt
@@ -1,0 +1,53 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+# create_pr's own route is authorized (test0 grants pr:write), but the global guard-only
+# route requires "admin" from test1, which grants no roles -- the layered check rejects the call
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("create_pr")
+                               .contentLength(64)
+                               .build()
+                           .build()}
+
+connect aborted

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list.security.schemes/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/resources.list.security.schemes/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+# "settings" is a plain (non-templated) resource, so it appears in resources/list; its
+# securitySchemes reflect the global guard-only route (test1, admin) -- resources/list
+# previously never emitted securitySchemes at all
+read  '{"resources":[{"name":"settings","uri":"config://settings","description":"Application settings",'
+      '"mimeType":"application/json","securitySchemes":[{"type":"oauth2","scopes":["admin"]}]}]}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/tools.list.security.schemes.layered/client.rpt
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/streams/mcp/tools.list.security.schemes.layered/client.rpt
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+# create_pr's securitySchemes aggregate both layers: the global guard-only route (test1, admin)
+# and create_pr's own mapping route guard (test0, pr:write) -- in route declaration order
+read  '{"tools":[{"name":"create_pr","description":"Create a pull request",'
+      '"securitySchemes":[{"type":"oauth2","scopes":["admin"]},{"type":"oauth2","scopes":["pr:write"]}]}]}'
+read closed
+
+write close

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/config/SchemaTest.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/config/SchemaTest.java
@@ -71,4 +71,38 @@ public class SchemaTest
     {
         schema.validate("proxy.route.invalid.yaml");
     }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectRouteWithWithButNoWhen()
+    {
+        schema.validate("proxy.route.when.required.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectRouteWhenWithBothToolAndResource()
+    {
+        schema.validate("proxy.route.when.both.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectRouteWithMultipleWhenEntries()
+    {
+        schema.validate("proxy.route.when.multiple.invalid.yaml");
+    }
+
+    @Test
+    public void shouldValidateGuardedRouteWithoutWhen()
+    {
+        JsonObject config = schema.validate("proxy.guarded.global.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateGuardedRouteScopedByWhenWithoutWith()
+    {
+        JsonObject config = schema.validate("proxy.guarded.scoped.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
 }


### PR DESCRIPTION
## Description

Aligns `mcp_http` proxy route condition/guard semantics with the precedent already established by the `mcp` binding, per discussion on the `mcp` client vs. `mcp_http` proxy `when` condition syntax.

- **`when`/`with` schema**: `routes[].when` is capped to a single entry, and that entry must specify exactly one of `tool`/`resource` (never both, never neither). `when` is now required only when `with` is present — a route with `with` is an unambiguous 1:1 tool/resource → HTTP request mapping, so it must declare which capability it maps. A route without `with` is a guard-only layer, so `when` becomes optional: omitting it scopes the guard to every tool and resource, mirroring how an unconditioned route in the `mcp` binding already applies to everything (`client.guarded.roles.yaml`).
- **Layered guard enforcement**: `McpHttpRouteConfig` gained `appliesToTool`/`appliesToResource`, treating an unconditioned route as applying to any name. `McpHttpBindingConfig.resolveTool`/`resolveResourceRoute` now require *every* applicable route — the specific mapping route plus any guard-only layers — to authorize a `tools/call`/`resources/read`, not just the mapping route's own guard. This matches standard Zilla route-authorization behavior: `guarded` always gates access to whatever a route governs, including a route governing "everything."
- **`securitySchemes` metadata**: `toolGuarded`/new `resourceGuarded` now aggregate roles across all applicable routes instead of first-match-wins, so the metadata reflects the full set of cumulative guard layers. The scheme-building logic was extracted into a shared helper and wired into `resources/list` and `resources/templates/list`, which previously emitted no security metadata at all (only `tools/list` did).

Fixes # (n/a — design discussion, no tracked issue)

## Test plan

- [x] New schema fixtures + `SchemaTest` methods covering the `when`/`with` cross-field constraints (required-when-`with`, mutual exclusion of `tool`/`resource`, single-entry cap)
- [x] New unit tests in `McpHttpRouteConfigTest`/`McpHttpBindingConfigTest` for `appliesToTool`/`appliesToResource`, layered authorization rejection, and guard aggregation
- [x] New k3po IT scenarios in `McpHttpProxyIT` proving a `tools/call` can be rejected by a global guard-only layer despite its own mapping route's guard passing, plus `tools/list` and `resources/list` `securitySchemes` output
- [x] `./mvnw test -pl specs/binding-mcp-http.spec` — 11/11 pass
- [x] `./mvnw test -pl runtime/binding-mcp-http` — 45/45 pass
- [x] `./mvnw verify -pl runtime/binding-mcp-http -Dit.test=McpHttpProxyIT` — 58/58 pass
- [x] `./mvnw checkstyle:check` on both modules — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01QowzQ6AAJTxYxGCXK4Ujjt)_