### PR TITLE
feat(binding-mcp): agent-callable tool search in mcp proxy with BM25 ranking

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheConfigBuilder.java
@@ -26,6 +26,7 @@ public final class McpCacheConfigBuilder<T> extends ConfigBuilder<T, McpCacheCon
     private String store;
     private Duration ttl;
     private McpAuthorizationConfig authorization;
+    private McpCacheToolsConfig tools;
 
     McpCacheConfigBuilder(
         Function<McpCacheConfig, T> mapper)
@@ -66,9 +67,21 @@ public final class McpCacheConfigBuilder<T> extends ConfigBuilder<T, McpCacheCon
         return McpAuthorizationConfig.builder(this::authorization);
     }
 
+    public McpCacheConfigBuilder<T> tools(
+        McpCacheToolsConfig tools)
+    {
+        this.tools = tools;
+        return this;
+    }
+
+    public McpCacheToolsConfigBuilder<McpCacheConfigBuilder<T>> tools()
+    {
+        return McpCacheToolsConfig.builder(this::tools);
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new McpCacheConfig(store, ttl, authorization));
+        return mapper.apply(new McpCacheConfig(store, ttl, authorization, tools));
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfig.java
@@ -16,36 +16,26 @@ package io.aklivity.zilla.runtime.binding.mcp.config;
 
 import static java.util.function.Function.identity;
 
-import java.time.Duration;
 import java.util.function.Function;
 
-public final class McpCacheConfig
+public final class McpCacheToolsConfig
 {
-    public final String store;
-    public final Duration ttl;
-    public final McpAuthorizationConfig authorization;
-    public final McpCacheToolsConfig tools;
+    public final McpCacheToolsSearchConfig search;
 
-    McpCacheConfig(
-        String store,
-        Duration ttl,
-        McpAuthorizationConfig authorization,
-        McpCacheToolsConfig tools)
+    McpCacheToolsConfig(
+        McpCacheToolsSearchConfig search)
     {
-        this.store = store;
-        this.ttl = ttl;
-        this.authorization = authorization;
-        this.tools = tools;
+        this.search = search;
     }
 
-    public static McpCacheConfigBuilder<McpCacheConfig> builder()
+    public static McpCacheToolsConfigBuilder<McpCacheToolsConfig> builder()
     {
-        return new McpCacheConfigBuilder<>(identity());
+        return new McpCacheToolsConfigBuilder<>(identity());
     }
 
-    public static <T> McpCacheConfigBuilder<T> builder(
-        Function<McpCacheConfig, T> mapper)
+    public static <T> McpCacheToolsConfigBuilder<T> builder(
+        Function<McpCacheToolsConfig, T> mapper)
     {
-        return new McpCacheConfigBuilder<>(mapper);
+        return new McpCacheToolsConfigBuilder<>(mapper);
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfigBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+
+public final class McpCacheToolsConfigBuilder<T> extends ConfigBuilder<T, McpCacheToolsConfigBuilder<T>>
+{
+    private final Function<McpCacheToolsConfig, T> mapper;
+
+    private McpCacheToolsSearchConfig search;
+
+    McpCacheToolsConfigBuilder(
+        Function<McpCacheToolsConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpCacheToolsConfigBuilder<T>> thisType()
+    {
+        return (Class<McpCacheToolsConfigBuilder<T>>) getClass();
+    }
+
+    public McpCacheToolsConfigBuilder<T> search(
+        McpCacheToolsSearchConfig search)
+    {
+        this.search = search;
+        return this;
+    }
+
+    public McpCacheToolsSearchConfigBuilder<McpCacheToolsConfigBuilder<T>> search()
+    {
+        return McpCacheToolsSearchConfig.builder(this::search);
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpCacheToolsConfig(search));
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsSearchConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsSearchConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import static java.util.function.Function.identity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class McpCacheToolsSearchConfig
+{
+    public final String tool;
+    public final int limit;
+    public final List<String> fields;
+    public final Map<String, Double> weights;
+    public final List<McpToolSearchIndexConfig> indexes;
+
+    McpCacheToolsSearchConfig(
+        String tool,
+        int limit,
+        List<String> fields,
+        Map<String, Double> weights,
+        List<McpToolSearchIndexConfig> indexes)
+    {
+        this.tool = tool;
+        this.limit = limit;
+        this.fields = fields;
+        this.weights = weights;
+        this.indexes = indexes;
+    }
+
+    public static McpCacheToolsSearchConfigBuilder<McpCacheToolsSearchConfig> builder()
+    {
+        return new McpCacheToolsSearchConfigBuilder<>(identity());
+    }
+
+    public static <T> McpCacheToolsSearchConfigBuilder<T> builder(
+        Function<McpCacheToolsSearchConfig, T> mapper)
+    {
+        return new McpCacheToolsSearchConfigBuilder<>(mapper);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsSearchConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsSearchConfigBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+
+public final class McpCacheToolsSearchConfigBuilder<T> extends ConfigBuilder<T, McpCacheToolsSearchConfigBuilder<T>>
+{
+    private final Function<McpCacheToolsSearchConfig, T> mapper;
+
+    private String tool;
+    private int limit = -1;
+    private List<String> fields;
+    private Map<String, Double> weights;
+    private List<McpToolSearchIndexConfig> indexes;
+
+    McpCacheToolsSearchConfigBuilder(
+        Function<McpCacheToolsSearchConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpCacheToolsSearchConfigBuilder<T>> thisType()
+    {
+        return (Class<McpCacheToolsSearchConfigBuilder<T>>) getClass();
+    }
+
+    public McpCacheToolsSearchConfigBuilder<T> tool(
+        String tool)
+    {
+        this.tool = tool;
+        return this;
+    }
+
+    public McpCacheToolsSearchConfigBuilder<T> limit(
+        int limit)
+    {
+        this.limit = limit;
+        return this;
+    }
+
+    public McpCacheToolsSearchConfigBuilder<T> fields(
+        List<String> fields)
+    {
+        this.fields = fields;
+        return this;
+    }
+
+    public McpCacheToolsSearchConfigBuilder<T> weight(
+        String field,
+        double weight)
+    {
+        if (weights == null)
+        {
+            weights = new LinkedHashMap<>();
+        }
+        weights.put(field, weight);
+        return this;
+    }
+
+    public McpCacheToolsSearchConfigBuilder<T> index(
+        McpToolSearchIndexConfig index)
+    {
+        if (indexes == null)
+        {
+            indexes = new ArrayList<>();
+        }
+        indexes.add(index);
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpCacheToolsSearchConfig(tool, limit, fields, weights, indexes));
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpKeywordToolSearchIndexConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpKeywordToolSearchIndexConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+public final class McpKeywordToolSearchIndexConfig extends McpToolSearchIndexConfig
+{
+    public static final String NAME = "keyword";
+
+    public McpKeywordToolSearchIndexConfig()
+    {
+        super(NAME);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpToolSearchIndexConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpToolSearchIndexConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+public abstract class McpToolSearchIndexConfig
+{
+    public final String type;
+
+    protected McpToolSearchIndexConfig(
+        String type)
+    {
+        this.type = type;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpToolSearchIndexConfigAdapterSpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpToolSearchIndexConfigAdapterSpi.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import jakarta.json.JsonObject;
+import jakarta.json.bind.adapter.JsonbAdapter;
+
+/**
+ * Service provider interface for a pluggable ranking backend behind
+ * {@code options.cache.tools.search}'s {@code type}/{@code index} discriminator.
+ * <p>
+ * Each backend provides an implementation, registered via {@link java.util.ServiceLoader} in
+ * {@code META-INF/services/io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi}.
+ * The binding selects the correct adapter by matching {@link #type()} against an indexer
+ * entry's {@code type} field value.
+ * </p>
+ */
+public interface McpToolSearchIndexConfigAdapterSpi extends JsonbAdapter<McpToolSearchIndexConfig, JsonObject>
+{
+    /**
+     * Returns the index type name this adapter handles, e.g. {@code "keyword"}.
+     * <p>
+     * Must match the {@code type} field value of the indexer entry.
+     * </p>
+     *
+     * @return the index type name
+     */
+    String type();
+
+    /**
+     * Serializes a type-specific {@link McpToolSearchIndexConfig} instance to a
+     * {@link jakarta.json.JsonObject} for writing back to YAML/JSON.
+     *
+     * @param options  the indexer configuration to serialize
+     * @return a {@link jakarta.json.JsonObject} representation of the indexer configuration
+     */
+    @Override
+    JsonObject adaptToJson(
+        McpToolSearchIndexConfig options);
+
+    /**
+     * Deserializes a {@link jakarta.json.JsonObject} indexer entry into a type-specific
+     * {@link McpToolSearchIndexConfig} instance.
+     *
+     * @param object  the raw JSON object from the indexer entry
+     * @return the deserialized {@link McpToolSearchIndexConfig}
+     */
+    @Override
+    McpToolSearchIndexConfig adaptFromJson(
+        JsonObject object);
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpCacheToolsConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpCacheToolsConfigAdapter.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsConfigBuilder;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfigBuilder;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+
+public final class McpCacheToolsConfigAdapter
+{
+    private static final String SEARCH_NAME = "search";
+    private static final String SEARCH_TOOL_NAME = "tool";
+    private static final String SEARCH_LIMIT_NAME = "limit";
+    private static final int SEARCH_LIMIT_DEFAULT = 5;
+    private static final String SEARCH_FIELDS_NAME = "fields";
+    private static final List<String> SEARCH_FIELDS_DEFAULT = List.of("name", "description");
+    private static final String SEARCH_WEIGHTS_NAME = "weights";
+    private static final String SEARCH_TYPE_NAME = "type";
+    private static final String SEARCH_INDEX_NAME = "index";
+    private static final String SEARCH_TYPE_DEFAULT = McpKeywordToolSearchIndexConfig.NAME;
+
+    private final McpToolSearchIndexConfigAdapter index = new McpToolSearchIndexConfigAdapter();
+
+    public JsonObject adaptToJson(
+        McpCacheToolsConfig tools)
+    {
+        JsonObjectBuilder object = Json.createObjectBuilder();
+
+        if (tools.search != null)
+        {
+            McpCacheToolsSearchConfig search = tools.search;
+            JsonObjectBuilder searchObject = Json.createObjectBuilder()
+                .add(SEARCH_TOOL_NAME, search.tool)
+                .add(SEARCH_LIMIT_NAME, search.limit);
+
+            if (search.fields != null)
+            {
+                JsonArrayBuilder fields = Json.createArrayBuilder();
+                search.fields.forEach(fields::add);
+                searchObject.add(SEARCH_FIELDS_NAME, fields);
+            }
+
+            if (search.weights != null && !search.weights.isEmpty())
+            {
+                JsonObjectBuilder weights = Json.createObjectBuilder();
+                search.weights.forEach(weights::add);
+                searchObject.add(SEARCH_WEIGHTS_NAME, weights);
+            }
+
+            if (search.indexes != null)
+            {
+                JsonArrayBuilder indexes = Json.createArrayBuilder();
+                search.indexes.forEach(each -> indexes.add(index.adaptToJson(each)));
+                searchObject.add(SEARCH_INDEX_NAME, indexes);
+            }
+
+            object.add(SEARCH_NAME, searchObject);
+        }
+
+        return object.build();
+    }
+
+    public McpCacheToolsConfig adaptFromJson(
+        JsonObject object)
+    {
+        McpCacheToolsConfigBuilder<McpCacheToolsConfig> builder = McpCacheToolsConfig.builder();
+
+        if (object.containsKey(SEARCH_NAME))
+        {
+            JsonObject search = object.getJsonObject(SEARCH_NAME);
+
+            McpCacheToolsSearchConfigBuilder<McpCacheToolsConfigBuilder<McpCacheToolsConfig>> searchBuilder = builder.search()
+                .tool(search.getString(SEARCH_TOOL_NAME))
+                .limit(search.containsKey(SEARCH_LIMIT_NAME) ? search.getInt(SEARCH_LIMIT_NAME) : SEARCH_LIMIT_DEFAULT);
+
+            List<String> fields = search.containsKey(SEARCH_FIELDS_NAME)
+                ? search.getJsonArray(SEARCH_FIELDS_NAME).getValuesAs(JsonString.class).stream()
+                    .map(JsonString::getString)
+                    .collect(Collectors.toList())
+                : SEARCH_FIELDS_DEFAULT;
+            searchBuilder.fields(fields);
+
+            if (search.containsKey(SEARCH_WEIGHTS_NAME))
+            {
+                JsonObject weights = search.getJsonObject(SEARCH_WEIGHTS_NAME);
+                weights.forEach((field, value) -> searchBuilder.weight(field, ((JsonNumber) value).doubleValue()));
+            }
+
+            if (search.containsKey(SEARCH_INDEX_NAME))
+            {
+                search.getJsonArray(SEARCH_INDEX_NAME).stream()
+                    .map(JsonValue::asJsonObject)
+                    .map(index::adaptFromJson)
+                    .forEach(searchBuilder::index);
+            }
+            else
+            {
+                String type = search.containsKey(SEARCH_TYPE_NAME)
+                    ? search.getString(SEARCH_TYPE_NAME)
+                    : SEARCH_TYPE_DEFAULT;
+                JsonObject indexObject = Json.createObjectBuilder()
+                    .add(SEARCH_TYPE_NAME, type)
+                    .build();
+                McpToolSearchIndexConfig indexConfig = index.adaptFromJson(indexObject);
+                searchBuilder.index(indexConfig);
+            }
+
+            searchBuilder.build();
+        }
+
+        return builder.build();
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpKeywordToolSearchIndexConfigAdapterSpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpKeywordToolSearchIndexConfigAdapterSpi.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.config;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi;
+
+public final class McpKeywordToolSearchIndexConfigAdapterSpi implements McpToolSearchIndexConfigAdapterSpi
+{
+    private static final String TYPE_NAME = "type";
+
+    @Override
+    public String type()
+    {
+        return McpKeywordToolSearchIndexConfig.NAME;
+    }
+
+    @Override
+    public JsonObject adaptToJson(
+        McpToolSearchIndexConfig options)
+    {
+        return Json.createObjectBuilder()
+            .add(TYPE_NAME, McpKeywordToolSearchIndexConfig.NAME)
+            .build();
+    }
+
+    @Override
+    public McpToolSearchIndexConfig adaptFromJson(
+        JsonObject object)
+    {
+        return new McpKeywordToolSearchIndexConfig();
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapter.java
@@ -51,12 +51,14 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
     private static final String CACHE_TTL_DEFAULT = "PT5M";
     private static final String CACHE_AUTHORIZATION_NAME = "authorization";
     private static final String CACHE_AUTHORIZATION_CREDENTIALS_NAME = "credentials";
+    private static final String CACHE_TOOLS_NAME = "tools";
 
     private static final String SERVER_NAME = "server";
 
     private static final String TOOLS_NAME = "tools";
 
     private final ModelConfigAdapter model = new ModelConfigAdapter();
+    private final McpCacheToolsConfigAdapter cacheTools = new McpCacheToolsConfigAdapter();
 
     @Override
     public Kind kind()
@@ -122,6 +124,11 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
                 }
                 authorization.add(cacheConfig.authorization.name, guardObject);
                 cache.add(CACHE_AUTHORIZATION_NAME, authorization);
+            }
+
+            if (cacheConfig.tools != null)
+            {
+                cache.add(CACHE_TOOLS_NAME, cacheTools.adaptToJson(cacheConfig.tools));
             }
 
             object.add(CACHE_NAME, cache);
@@ -202,6 +209,11 @@ public final class McpOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
                         .credentials(credentials)
                         .build();
                 });
+            }
+
+            if (cache.containsKey(CACHE_TOOLS_NAME))
+            {
+                cacheBuilder.tools(cacheTools.adaptFromJson(cache.getJsonObject(CACHE_TOOLS_NAME)));
             }
 
             cacheBuilder.build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpToolSearchIndexConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpToolSearchIndexConfigAdapter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.config;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.bind.adapter.JsonbAdapter;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi;
+
+public final class McpToolSearchIndexConfigAdapter implements JsonbAdapter<McpToolSearchIndexConfig, JsonObject>
+{
+    private static final String TYPE_NAME = "type";
+
+    private final Map<String, McpToolSearchIndexConfigAdapterSpi> delegatesByType;
+
+    public McpToolSearchIndexConfigAdapter()
+    {
+        delegatesByType = ServiceLoader
+            .load(McpToolSearchIndexConfigAdapterSpi.class)
+            .stream()
+            .map(Supplier::get)
+            .collect(toMap(McpToolSearchIndexConfigAdapterSpi::type, identity()));
+    }
+
+    @Override
+    public JsonObject adaptToJson(
+        McpToolSearchIndexConfig options)
+    {
+        McpToolSearchIndexConfigAdapterSpi delegate = delegatesByType.get(options.type);
+        return delegate != null ? delegate.adaptToJson(options) : null;
+    }
+
+    @Override
+    public McpToolSearchIndexConfig adaptFromJson(
+        JsonObject object)
+    {
+        String type = object.getString(TYPE_NAME, null);
+        McpToolSearchIndexConfigAdapterSpi delegate = delegatesByType.get(type);
+        if (delegate == null)
+        {
+            throw new JsonException(String.format("Unrecognized tool search index type: %s", type));
+        }
+        return delegate.adaptFromJson(object);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+/**
+ * BM25 ranking over the configured fields, with each field's weighted term frequency summed
+ * into a single per-document score before applying the standard BM25 formula. Field weights
+ * are a simple multiplier, not full BM25F term-independent length normalization.
+ */
+final class McpKeywordToolSearchIndex implements McpToolSearchIndex
+{
+    private static final double K1 = 1.2;
+    private static final double B = 0.75;
+
+    private final List<String> fields;
+    private final Map<String, Double> weights;
+
+    private final Map<String, Map<String, Double>> termFrequenciesByDocument = new LinkedHashMap<>();
+    private final Map<String, Double> documentLengths = new LinkedHashMap<>();
+    private final Map<String, Integer> documentFrequencies = new HashMap<>();
+    private double averageDocumentLength;
+
+    McpKeywordToolSearchIndex(
+        List<String> fields,
+        Map<String, Double> weights)
+    {
+        this.fields = fields;
+        this.weights = weights;
+    }
+
+    @Override
+    public void index(
+        Collection<McpToolSearchDocument> documents)
+    {
+        termFrequenciesByDocument.clear();
+        documentLengths.clear();
+        documentFrequencies.clear();
+
+        double totalLength = 0.0;
+
+        for (McpToolSearchDocument document : documents)
+        {
+            Map<String, Double> termFrequencies = new HashMap<>();
+            double length = 0.0;
+
+            for (String field : fields)
+            {
+                String text = document.field(field);
+                if (text == null)
+                {
+                    continue;
+                }
+
+                double weight = weights.getOrDefault(field, 1.0);
+                List<String> tokens = McpTextTokenizer.tokenize(text);
+                length += tokens.size() * weight;
+
+                for (String token : tokens)
+                {
+                    termFrequencies.merge(token, weight, Double::sum);
+                }
+            }
+
+            termFrequenciesByDocument.put(document.name, termFrequencies);
+            documentLengths.put(document.name, length);
+            totalLength += length;
+
+            for (String term : termFrequencies.keySet())
+            {
+                documentFrequencies.merge(term, 1, Integer::sum);
+            }
+        }
+
+        int documentCount = documentLengths.size();
+        averageDocumentLength = documentCount == 0 ? 0.0 : totalLength / documentCount;
+    }
+
+    @Override
+    public List<McpToolSearchMatch> query(
+        String text)
+    {
+        List<String> queryTerms = McpTextTokenizer.tokenize(text);
+        List<McpToolSearchMatch> matches = new ArrayList<>();
+
+        if (!queryTerms.isEmpty() && !documentLengths.isEmpty())
+        {
+            int documentCount = documentLengths.size();
+
+            for (Map.Entry<String, Map<String, Double>> entry : termFrequenciesByDocument.entrySet())
+            {
+                String name = entry.getKey();
+                Map<String, Double> termFrequencies = entry.getValue();
+                double length = documentLengths.get(name);
+                double score = 0.0;
+
+                for (String term : queryTerms)
+                {
+                    Double frequency = termFrequencies.get(term);
+                    if (frequency == null)
+                    {
+                        continue;
+                    }
+
+                    int documentFrequency = documentFrequencies.getOrDefault(term, 0);
+                    double idf = Math.log(1.0 + (documentCount - documentFrequency + 0.5) / (documentFrequency + 0.5));
+                    double normalization = 1.0 - B + B * (length / averageDocumentLength);
+                    score += idf * (frequency * (K1 + 1.0)) / (frequency + K1 * normalization);
+                }
+
+                if (score > 0.0)
+                {
+                    matches.add(new McpToolSearchMatch(name, score));
+                }
+            }
+
+            matches.sort((a, b) -> Double.compare(b.score, a.score));
+        }
+
+        return matches;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndex.java
@@ -47,8 +47,8 @@ final class McpKeywordToolSearchIndex implements McpToolSearchIndex
         List<String> fields,
         Map<String, Double> weights)
     {
-        this.fields = fields;
-        this.weights = weights;
+        this.fields = fields != null ? fields : List.of();
+        this.weights = weights != null ? weights : Map.of();
     }
 
     @Override

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexFactorySpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexFactorySpi.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.util.List;
+import java.util.Map;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi;
+
+public final class McpKeywordToolSearchIndexFactorySpi implements McpToolSearchIndexFactorySpi
+{
+    @Override
+    public String type()
+    {
+        return McpKeywordToolSearchIndexConfig.NAME;
+    }
+
+    @Override
+    public McpToolSearchIndex create(
+        McpToolSearchIndexConfig config,
+        List<String> fields,
+        Map<String, Double> weights)
+    {
+        return new McpKeywordToolSearchIndex(fields, weights);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallArgs.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallArgs.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+public final class McpSearchToolCallArgs
+{
+    public final String query;
+    public final int maxResults;
+
+    public McpSearchToolCallArgs(
+        String query,
+        int maxResults)
+    {
+        this.query = query;
+        this.maxResults = maxResults;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallScanner.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallScanner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import jakarta.json.stream.JsonParser;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
+
+/**
+ * Scans a buffered {@code tools/call} request payload for the agent-callable search tool,
+ * extracting {@code arguments.query} and {@code arguments.max_results} without materializing a DOM.
+ */
+public final class McpSearchToolCallScanner
+{
+    private static final String ARGUMENTS_NAME = "arguments";
+    private static final String QUERY_NAME = "query";
+    private static final String MAX_RESULTS_NAME = "max_results";
+
+    private McpSearchToolCallScanner()
+    {
+    }
+
+    public static McpSearchToolCallArgs scan(
+        DirectBufferEx buffer,
+        int index,
+        int limit)
+    {
+        McpSearchToolCallArgs args;
+
+        final JsonParserEx parser = JsonEx.createParser();
+        parser.wrap(buffer, index, limit);
+        try
+        {
+            args = scanRequest(parser);
+        }
+        catch (Exception ex)
+        {
+            args = null;
+        }
+
+        return args;
+    }
+
+    private static McpSearchToolCallArgs scanRequest(
+        JsonParserEx parser)
+    {
+        String query = null;
+        int maxResults = 0;
+
+        if (parser.hasNext() && parser.next() == JsonParser.Event.START_OBJECT)
+        {
+            int depth = 1;
+            while (depth > 0 && parser.hasNext())
+            {
+                final JsonParser.Event event = parser.next();
+                switch (event)
+                {
+                case START_OBJECT:
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    if (depth == 1 && ARGUMENTS_NAME.contentEquals(parser.getStringView()))
+                    {
+                        final McpSearchToolCallArgs arguments = scanArguments(parser);
+                        query = arguments.query;
+                        maxResults = arguments.maxResults;
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        return new McpSearchToolCallArgs(query, maxResults);
+    }
+
+    private static McpSearchToolCallArgs scanArguments(
+        JsonParserEx parser)
+    {
+        String query = null;
+        int maxResults = 0;
+
+        if (parser.hasNext() && parser.next() == JsonParser.Event.START_OBJECT)
+        {
+            int depth = 1;
+            while (depth > 0 && parser.hasNext())
+            {
+                final JsonParser.Event event = parser.next();
+                switch (event)
+                {
+                case START_OBJECT:
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    if (depth == 1 && QUERY_NAME.contentEquals(parser.getStringView()))
+                    {
+                        parser.next();
+                        query = parser.getString();
+                    }
+                    else if (depth == 1 && MAX_RESULTS_NAME.contentEquals(parser.getStringView()))
+                    {
+                        parser.next();
+                        maxResults = (int) parser.getLong();
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        return new McpSearchToolCallArgs(query, maxResults);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolDescriptor.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.nio.charset.StandardCharsets;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+/**
+ * Builds the synthetic {@code Tool} JSON descriptor advertised in {@code tools/list} for the
+ * agent-callable search tool, once per binding lifecycle (never re-serialized per request).
+ */
+public final class McpSearchToolDescriptor
+{
+    private static final String DESCRIPTION =
+        "Search the tool catalog by relevance and return references to matching tools.";
+    private static final String QUERY_DESCRIPTION = "Natural-language search query";
+    private static final String LIMIT_DESCRIPTION = "Maximum number of results to return";
+
+    private McpSearchToolDescriptor()
+    {
+    }
+
+    public static byte[] build(
+        String tool)
+    {
+        JsonObject inputSchema = Json.createObjectBuilder()
+            .add("type", "object")
+            .add("properties", Json.createObjectBuilder()
+                .add("query", Json.createObjectBuilder()
+                    .add("type", "string")
+                    .add("description", QUERY_DESCRIPTION))
+                .add("max_results", Json.createObjectBuilder()
+                    .add("type", "integer")
+                    .add("description", LIMIT_DESCRIPTION)))
+            .add("required", Json.createArrayBuilder().add("query"))
+            .build();
+
+        JsonObject descriptor = Json.createObjectBuilder()
+            .add("name", tool)
+            .add("description", DESCRIPTION)
+            .add("inputSchema", inputSchema)
+            .build();
+
+        return descriptor.toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolInjector.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolInjector.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Splices the synthetic search-tool descriptor into a served {@code tools/list} JSON response.
+ * <p>
+ * Every {@code tools/list} response produced by this codebase (warm-cache or degraded-empty
+ * fallback) has the exact, fixed shape {@code {"tools":[...]}} — the prelude and close are
+ * literal constants in {@code McpProxyListFactory}/{@code McpProxyToolsListFactory}, never
+ * upstream-controlled content. That makes this a safe, cheap byte-array splice rather than
+ * requiring a full streaming JSON transform: the array always closes with the literal two bytes
+ * {@code ]}}, so inserting before that suffix (with a leading comma when the array is
+ * non-empty) is correct by construction, not by guessing the shape.
+ * </p>
+ * <p>
+ * Applied unconditionally, after any scope filtering — the search tool is never subject to
+ * per-tool authorization, so it must never be dropped by that filter.
+ * </p>
+ */
+public final class McpSearchToolInjector
+{
+    private static final byte[] ARRAY_CLOSE = "]}".getBytes(StandardCharsets.UTF_8);
+    private static final byte COMMA = ',';
+    private static final byte ARRAY_OPEN = '[';
+
+    private McpSearchToolInjector()
+    {
+    }
+
+    public static byte[] inject(
+        byte[] json,
+        byte[] toolBytes)
+    {
+        byte[] result = json;
+
+        if (toolBytes != null && json.length >= ARRAY_CLOSE.length)
+        {
+            final int splitAt = json.length - ARRAY_CLOSE.length;
+            final boolean empty = splitAt > 0 && json[splitAt - 1] == ARRAY_OPEN;
+            final int insertLength = toolBytes.length + (empty ? 0 : 1);
+
+            final byte[] injected = new byte[json.length + insertLength];
+            System.arraycopy(json, 0, injected, 0, splitAt);
+
+            int offset = splitAt;
+            if (!empty)
+            {
+                injected[offset++] = COMMA;
+            }
+            System.arraycopy(toolBytes, 0, injected, offset, toolBytes.length);
+            offset += toolBytes.length;
+            System.arraycopy(ARRAY_CLOSE, 0, injected, offset, ARRAY_CLOSE.length);
+
+            result = injected;
+        }
+
+        return result;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpTextTokenizer.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpTextTokenizer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Lowercases, splits on non-alphanumeric characters and camelCase word boundaries
+ * (including acronym-to-word boundaries, e.g. {@code parseXMLDocument} to
+ * {@code parse}/{@code xml}/{@code document}), and strips a small built-in English
+ * stopword list. No stemming.
+ */
+public final class McpTextTokenizer
+{
+    private static final Set<String> STOPWORDS = Set.of(
+        "a", "an", "the", "and", "or", "but", "if", "then", "else", "for", "to", "of", "in", "on",
+        "at", "by", "with", "from", "as", "is", "are", "was", "were", "be", "been", "being",
+        "this", "that", "these", "those", "it", "its", "into", "than", "so", "such", "not", "no",
+        "do", "does", "did", "can", "will", "would", "should", "could", "may", "might", "must",
+        "about", "up", "down", "out", "off", "over", "under", "again", "further", "once", "here",
+        "there", "when", "where", "why", "how", "all", "each", "other", "some", "own", "same");
+
+    private McpTextTokenizer()
+    {
+    }
+
+    public static List<String> tokenize(
+        String text)
+    {
+        List<String> tokens = new ArrayList<>();
+        if (text == null || text.isEmpty())
+        {
+            return tokens;
+        }
+
+        StringBuilder token = new StringBuilder();
+        int length = text.length();
+
+        for (int i = 0; i < length; i++)
+        {
+            char current = text.charAt(i);
+            if (Character.isLetterOrDigit(current))
+            {
+                if (token.length() > 0 && isWordBoundary(text, i))
+                {
+                    addToken(tokens, token);
+                    token.setLength(0);
+                }
+                token.append(Character.toLowerCase(current));
+            }
+            else if (token.length() > 0)
+            {
+                addToken(tokens, token);
+                token.setLength(0);
+            }
+        }
+
+        if (token.length() > 0)
+        {
+            addToken(tokens, token);
+        }
+
+        return tokens;
+    }
+
+    private static boolean isWordBoundary(
+        String text,
+        int index)
+    {
+        char current = text.charAt(index);
+        char previous = text.charAt(index - 1);
+
+        boolean lowerToUpper = Character.isUpperCase(current) && Character.isLowerCase(previous);
+        boolean acronymToWord = Character.isUpperCase(current) &&
+            Character.isUpperCase(previous) &&
+            index + 1 < text.length() &&
+            Character.isLowerCase(text.charAt(index + 1));
+
+        return lowerToUpper || acronymToWord;
+    }
+
+    private static void addToken(
+        List<String> tokens,
+        StringBuilder token)
+    {
+        String word = token.toString();
+        if (!STOPWORDS.contains(word))
+        {
+            tokens.add(word);
+        }
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchComposite.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+/**
+ * Composes any number of configured {@link McpToolSearchIndex} backends behind a single
+ * {@link McpToolSearchIndex}, fusing their rankings with Reciprocal Rank Fusion. A single
+ * backend is queried directly, with no fusion overhead.
+ */
+public final class McpToolSearchComposite implements McpToolSearchIndex
+{
+    private final List<McpToolSearchIndex> indexes;
+
+    public McpToolSearchComposite(
+        List<McpToolSearchIndex> indexes)
+    {
+        this.indexes = indexes;
+    }
+
+    @Override
+    public void index(
+        Collection<McpToolSearchDocument> documents)
+    {
+        indexes.forEach(index -> index.index(documents));
+    }
+
+    @Override
+    public List<McpToolSearchMatch> query(
+        String text)
+    {
+        List<McpToolSearchMatch> result;
+
+        if (indexes.size() == 1)
+        {
+            result = indexes.get(0).query(text);
+        }
+        else
+        {
+            List<List<McpToolSearchMatch>> rankings = new ArrayList<>(indexes.size());
+            indexes.forEach(index -> rankings.add(index.query(text)));
+            result = McpToolSearchRankFusion.fuse(rankings);
+        }
+
+        return result;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchDocumentScanner.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchDocumentScanner.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.json.stream.JsonParser;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
+
+/**
+ * Scans a cached {@code tools/list} JSON response into {@link McpToolSearchDocument}s, one per
+ * tool, extracting only the configured {@code fields}. A field whose JSON value is an object
+ * (e.g. {@code outputSchema}) is flattened to space-joined text (every key name and string value
+ * in its subtree) rather than indexed as structured JSON.
+ */
+public final class McpToolSearchDocumentScanner
+{
+    private static final String TOOLS_NAME = "tools";
+    private static final String NAME_NAME = "name";
+    private static final String DESCRIPTION_NAME = "description";
+    private static final String DESCRIPTION_FIELD = "description";
+    private static final String OUTPUT_SCHEMA_NAME = "outputSchema";
+    private static final String OUTPUT_SCHEMA_FIELD = "output-schema";
+
+    private McpToolSearchDocumentScanner()
+    {
+    }
+
+    public static List<McpToolSearchDocument> scan(
+        String toolsListJson,
+        List<String> fields)
+    {
+        List<McpToolSearchDocument> documents = new ArrayList<>();
+
+        if (toolsListJson != null && fields != null && !fields.isEmpty())
+        {
+            final byte[] bytes = toolsListJson.getBytes(StandardCharsets.UTF_8);
+            final JsonParserEx parser = JsonEx.createParser();
+            parser.wrap(new UnsafeBufferEx(bytes), 0, bytes.length);
+            try
+            {
+                scanToolsList(parser, fields, documents);
+            }
+            catch (Exception ex)
+            {
+                documents.clear();
+            }
+        }
+
+        return documents;
+    }
+
+    private static void scanToolsList(
+        JsonParserEx parser,
+        List<String> fields,
+        List<McpToolSearchDocument> documents)
+    {
+        if (parser.hasNext() && parser.next() == JsonParser.Event.START_OBJECT)
+        {
+            int depth = 1;
+            while (depth > 0 && parser.hasNext())
+            {
+                final JsonParser.Event event = parser.next();
+                switch (event)
+                {
+                case START_OBJECT:
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    if (depth == 1 && TOOLS_NAME.contentEquals(parser.getStringView()))
+                    {
+                        scanTools(parser, fields, documents);
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void scanTools(
+        JsonParserEx parser,
+        List<String> fields,
+        List<McpToolSearchDocument> documents)
+    {
+        if (parser.hasNext() && parser.next() == JsonParser.Event.START_ARRAY)
+        {
+            boolean items = true;
+            while (items && parser.hasNext())
+            {
+                final JsonParser.Event event = parser.next();
+                switch (event)
+                {
+                case START_OBJECT:
+                    final McpToolSearchDocument document = scanTool(parser, fields);
+                    if (document != null)
+                    {
+                        documents.add(document);
+                    }
+                    break;
+                case END_ARRAY:
+                    items = false;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+    }
+
+    private static McpToolSearchDocument scanTool(
+        JsonParserEx parser,
+        List<String> fields)
+    {
+        String name = null;
+        final Map<String, String> values = new HashMap<>();
+        int depth = 1;
+        while (depth > 0 && parser.hasNext())
+        {
+            final JsonParser.Event event = parser.next();
+            switch (event)
+            {
+            case START_OBJECT:
+            case START_ARRAY:
+                depth++;
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                depth--;
+                break;
+            case KEY_NAME:
+                if (depth == 1)
+                {
+                    final CharSequence key = parser.getStringView();
+                    if (NAME_NAME.contentEquals(key))
+                    {
+                        parser.next();
+                        name = parser.getString();
+                        if (fields.contains(NAME_NAME))
+                        {
+                            values.put(NAME_NAME, name);
+                        }
+                    }
+                    else
+                    {
+                        final String field = fieldFor(key, fields);
+                        if (field != null)
+                        {
+                            values.put(field, flattenText(parser));
+                        }
+                    }
+                }
+                break;
+            default:
+                break;
+            }
+        }
+
+        return name != null ? new McpToolSearchDocument(name, values) : null;
+    }
+
+    private static String fieldFor(
+        CharSequence key,
+        List<String> fields)
+    {
+        String field = null;
+        if (DESCRIPTION_NAME.contentEquals(key) && fields.contains(DESCRIPTION_FIELD))
+        {
+            field = DESCRIPTION_FIELD;
+        }
+        else if (OUTPUT_SCHEMA_NAME.contentEquals(key) && fields.contains(OUTPUT_SCHEMA_FIELD))
+        {
+            field = OUTPUT_SCHEMA_FIELD;
+        }
+        return field;
+    }
+
+    // flattens a scalar string value, or every key name and string value within an object/array
+    // subtree, into one space-joined string; the parser is left positioned after the value either way
+    private static String flattenText(
+        JsonParserEx parser)
+    {
+        final StringBuilder text = new StringBuilder();
+        final JsonParser.Event first = parser.hasNext() ? parser.next() : null;
+
+        if (first == JsonParser.Event.VALUE_STRING)
+        {
+            text.append(parser.getString());
+        }
+        else if (first == JsonParser.Event.START_OBJECT || first == JsonParser.Event.START_ARRAY)
+        {
+            int depth = 1;
+            while (depth > 0 && parser.hasNext())
+            {
+                final JsonParser.Event event = parser.next();
+                switch (event)
+                {
+                case START_OBJECT:
+                case START_ARRAY:
+                    depth++;
+                    break;
+                case END_OBJECT:
+                case END_ARRAY:
+                    depth--;
+                    break;
+                case KEY_NAME:
+                    appendText(text, parser.getStringView());
+                    break;
+                case VALUE_STRING:
+                    appendText(text, parser.getStringView());
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        return text.toString();
+    }
+
+    private static void appendText(
+        StringBuilder text,
+        CharSequence value)
+    {
+        if (text.length() > 0)
+        {
+            text.append(' ');
+        }
+        text.append(value);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi;
+
+/**
+ * Builds the runtime {@link McpToolSearchIndex} for a configured
+ * {@code options.cache.tools.search}, dispatching each configured indexer to the
+ * {@link McpToolSearchIndexFactorySpi} registered for its {@code type}, and composing more than
+ * one behind {@link McpToolSearchComposite}.
+ */
+public final class McpToolSearchIndexFactory
+{
+    private final Map<String, McpToolSearchIndexFactorySpi> factoriesByType;
+
+    public McpToolSearchIndexFactory()
+    {
+        this.factoriesByType = ServiceLoader
+            .load(McpToolSearchIndexFactorySpi.class)
+            .stream()
+            .map(Supplier::get)
+            .collect(toMap(McpToolSearchIndexFactorySpi::type, identity()));
+    }
+
+    public McpToolSearchIndex create(
+        McpCacheToolsSearchConfig search)
+    {
+        McpToolSearchIndex result = null;
+
+        if (search != null && search.indexes != null && !search.indexes.isEmpty())
+        {
+            List<McpToolSearchIndex> indexes = new ArrayList<>();
+            for (McpToolSearchIndexConfig config : search.indexes)
+            {
+                McpToolSearchIndexFactorySpi factory = factoriesByType.get(config.type);
+                if (factory != null)
+                {
+                    indexes.add(factory.create(config, search.fields, search.weights));
+                }
+            }
+
+            if (!indexes.isEmpty())
+            {
+                result = indexes.size() == 1 ? indexes.get(0) : new McpToolSearchComposite(indexes);
+            }
+        }
+
+        return result;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchRankFusion.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchRankFusion.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+/**
+ * Reciprocal Rank Fusion: combines any number of independently-ranked match lists by rank
+ * position rather than raw score, so heterogeneous ranking algorithms (e.g. BM25 alongside a
+ * future embedding-based backend) compose without needing comparable score scales. A single
+ * input list degenerates to its own order, since the fused score is a strictly monotonic
+ * function of rank.
+ */
+final class McpToolSearchRankFusion
+{
+    private static final double K = 60.0;
+
+    private McpToolSearchRankFusion()
+    {
+    }
+
+    static List<McpToolSearchMatch> fuse(
+        List<List<McpToolSearchMatch>> rankings)
+    {
+        Map<String, Double> fusedScores = new LinkedHashMap<>();
+
+        for (List<McpToolSearchMatch> ranking : rankings)
+        {
+            for (int rank = 0; rank < ranking.size(); rank++)
+            {
+                String name = ranking.get(rank).name;
+                double contribution = 1.0 / (K + rank + 1);
+                fusedScores.merge(name, contribution, Double::sum);
+            }
+        }
+
+        List<McpToolSearchMatch> fused = new ArrayList<>(fusedScores.size());
+        fusedScores.forEach((name, score) -> fused.add(new McpToolSearchMatch(name, score)));
+        fused.sort((a, b) -> Double.compare(b.score, a.score));
+
+        return fused;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -16,15 +16,26 @@ package io.aklivity.zilla.runtime.binding.mcp.internal.stream;
 
 import static io.aklivity.zilla.runtime.engine.catalog.CatalogHandler.NO_SCHEMA_ID;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpSearchToolCallArgs;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpSearchToolCallScanner;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleClient;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleServer;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpRouteRequest;
+import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
@@ -37,6 +48,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpResetExFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ResetFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.WindowFW;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableDirectByteBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
@@ -44,6 +56,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.util.function.LongIntToLongFunction;
 
 abstract class McpProxyItemFactory implements BindingHandler
@@ -129,31 +142,73 @@ abstract class McpProxyItemFactory implements BindingHandler
             final String sessionId = sessionId(beginEx);
             if (binding.sessions.get(sessionId) instanceof McpLifecycleServer lifecycle)
             {
-                final McpRouteConfig route = binding.resolve(beginEx, authorization);
-                if (route != null)
+                final McpProxyCache.McpListCache searchCache = searchCacheFor(binding, beginEx);
+                if (searchCache != null)
                 {
-                    final String identifier = route.strip(beginEx);
-                    final int contentLength = contentLength(beginEx);
-                    final String prefix = route.prefix(beginEx);
-
-                    newStream = new McpServer(
-                        binding,
-                        lifecycle,
+                    newStream = new McpToolSearchServer(
                         sender,
                         originId,
                         routedId,
                         initialId,
-                        route.id,
                         affinity,
                         authorization,
-                        identifier,
-                        contentLength,
-                        prefix)::onServerMessage;
+                        binding.filterGuard,
+                        searchCache,
+                        contentLength(beginEx),
+                        binding.options.cache.tools.search.limit)::onToolSearchMessage;
+                }
+                else
+                {
+                    final McpRouteConfig route = binding.resolve(beginEx, authorization);
+                    if (route != null)
+                    {
+                        final String identifier = route.strip(beginEx);
+                        final int contentLength = contentLength(beginEx);
+                        final String prefix = route.prefix(beginEx);
+
+                        newStream = new McpServer(
+                            binding,
+                            lifecycle,
+                            sender,
+                            originId,
+                            routedId,
+                            initialId,
+                            route.id,
+                            affinity,
+                            authorization,
+                            identifier,
+                            contentLength,
+                            prefix)::onServerMessage;
+                    }
                 }
             }
         }
 
         return newStream;
+    }
+
+    private McpProxyCache.McpListCache searchCacheFor(
+        McpBindingConfig binding,
+        McpBeginExFW beginEx)
+    {
+        McpProxyCache.McpListCache searchCache = null;
+
+        final McpCacheToolsSearchConfig search = binding.cache != null && binding.options.cache.tools != null
+            ? binding.options.cache.tools.search
+            : null;
+
+        if (kind == McpBeginExFW.KIND_TOOLS_CALL &&
+            search != null &&
+            search.tool.equals(beginEx.toolsCall().name().asString()))
+        {
+            final McpProxyCache.McpListCache listCache = binding.cache.cacheOf(McpBeginExFW.KIND_TOOLS_LIST);
+            if (listCache != null && listCache.searchIndex() != null)
+            {
+                searchCache = listCache;
+            }
+        }
+
+        return searchCache;
     }
 
     protected abstract void injectInitialBeginEx(
@@ -629,6 +684,340 @@ abstract class McpProxyItemFactory implements BindingHandler
             long traceId)
         {
             doServerReset(traceId, emptyRO);
+        }
+
+        private void doServerReset(
+            long traceId,
+            Flyweight extension)
+        {
+            if (!McpState.initialClosed(state))
+            {
+                doReset(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization,
+                    extension);
+                state = McpState.closedInitial(state);
+            }
+        }
+    }
+
+    private final class McpToolSearchServer
+    {
+        private final MessageConsumer sender;
+        private final long originId;
+        private final long routedId;
+        private final long initialId;
+        private final long replyId;
+        private final long affinity;
+        private final long authorization;
+        private final GuardHandler filterGuard;
+        private final McpProxyCache.McpListCache cache;
+        private final int contentLength;
+        private final int limitDefault;
+
+        private ExpandableDirectByteBufferEx argsBuffer;
+        private int argsProgress;
+
+        private int state;
+        private boolean ready;
+        private DirectBufferEx cachedBuf;
+        private int cachedLen;
+        private int emitOffset;
+
+        private long initialSeq;
+        private long initialAck;
+        private int initialMax;
+
+        private long replySeq;
+        private long replyAck;
+        private int replyMax;
+        private int replyPad;
+
+        private McpToolSearchServer(
+            MessageConsumer sender,
+            long originId,
+            long routedId,
+            long initialId,
+            long affinity,
+            long authorization,
+            GuardHandler filterGuard,
+            McpProxyCache.McpListCache cache,
+            int contentLength,
+            int limitDefault)
+        {
+            this.sender = sender;
+            this.originId = originId;
+            this.routedId = routedId;
+            this.initialId = initialId;
+            this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.affinity = affinity;
+            this.authorization = authorization;
+            this.filterGuard = filterGuard;
+            this.cache = cache;
+            this.contentLength = contentLength;
+            this.limitDefault = limitDefault;
+        }
+
+        private void onToolSearchMessage(
+            int msgTypeId,
+            DirectBufferEx buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+            case BeginFW.TYPE_ID:
+                onServerBegin(beginRO.wrap(buffer, index, index + length));
+                break;
+            case DataFW.TYPE_ID:
+                onServerData(dataRO.wrap(buffer, index, index + length));
+                break;
+            case EndFW.TYPE_ID:
+                onServerEnd(endRO.wrap(buffer, index, index + length));
+                break;
+            case AbortFW.TYPE_ID:
+                onServerAbort(abortRO.wrap(buffer, index, index + length));
+                break;
+            case WindowFW.TYPE_ID:
+                onServerWindow(windowRO.wrap(buffer, index, index + length));
+                break;
+            case ResetFW.TYPE_ID:
+                onServerReset(resetRO.wrap(buffer, index, index + length));
+                break;
+            default:
+                break;
+            }
+        }
+
+        private void onServerBegin(
+            BeginFW begin)
+        {
+            final long traceId = begin.traceId();
+
+            initialSeq = begin.sequence();
+            initialAck = begin.acknowledge();
+            state = McpState.openingInitial(state);
+
+            doServerBegin(traceId);
+            flushServerWindow(traceId, 0L, 0, 0L, codecBuffer.capacity());
+        }
+
+        private void onServerData(
+            DataFW data)
+        {
+            final long sequence = data.sequence();
+            final long acknowledge = data.acknowledge();
+            final long traceId = data.traceId();
+            final int reserved = data.reserved();
+            final OctetsFW payload = data.payload();
+
+            assert acknowledge <= sequence;
+            assert sequence >= initialSeq;
+            assert acknowledge <= initialAck;
+
+            initialSeq = sequence + reserved;
+
+            assert initialAck <= initialSeq;
+
+            bufferQuery(traceId, payload.buffer(), payload.offset(), payload.sizeof());
+        }
+
+        private void bufferQuery(
+            long traceId,
+            DirectBufferEx buffer,
+            int offset,
+            int length)
+        {
+            if (argsBuffer == null)
+            {
+                argsBuffer = new ExpandableDirectByteBufferEx();
+            }
+            argsBuffer.putBytes(argsProgress, buffer, offset, length);
+            argsProgress += length;
+
+            if (argsProgress >= contentLength)
+            {
+                onQueryReady(traceId);
+            }
+        }
+
+        private void onQueryReady(
+            long traceId)
+        {
+            final McpSearchToolCallArgs args = McpSearchToolCallScanner.scan(argsBuffer, 0, argsProgress);
+            if (args == null || args.query == null || args.query.isEmpty())
+            {
+                final McpResetExFW resetEx = mcpResetExRW
+                    .wrap(extBuffer, 0, extBuffer.capacity())
+                    .typeId(mcpTypeId)
+                    .error(e -> e.code(ERROR_CODE_INVALID_PARAMS).message(ERROR_MESSAGE_INVALID_PARAMS))
+                    .build();
+                doServerReset(traceId, resetEx);
+            }
+            else
+            {
+                final int limit = args.maxResults > 0 ? Math.min(args.maxResults, limitDefault) : limitDefault;
+                final byte[] bytes = buildResponse(args.query, limit);
+                cachedBuf = new UnsafeBufferEx(bytes);
+                cachedLen = bytes.length;
+                ready = true;
+                emitIfReady(traceId);
+            }
+        }
+
+        private byte[] buildResponse(
+            String query,
+            int limit)
+        {
+            final Map<CharSequence, List<String>> scopesByName = cache.scopesByName();
+            final List<McpToolSearchMatch> matches = cache.searchIndex().query(query);
+
+            final JsonArrayBuilder content = Json.createArrayBuilder();
+            int admitted = 0;
+            for (int i = 0; i < matches.size() && admitted < limit; i++)
+            {
+                final McpToolSearchMatch match = matches.get(i);
+                final List<String> roles = scopesByName.get(match.name);
+                if (filterGuard == null || filterGuard.verify(authorization, roles != null ? roles : List.of()))
+                {
+                    content.add(Json.createObjectBuilder()
+                        .add("type", "tool_reference")
+                        .add("tool_name", match.name));
+                    admitted++;
+                }
+            }
+
+            final JsonObject response = Json.createObjectBuilder()
+                .add("content", content)
+                .add("isError", false)
+                .build();
+
+            return response.toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        private void onServerEnd(
+            EndFW end)
+        {
+            initialSeq = end.sequence();
+            state = McpState.closedInitial(state);
+        }
+
+        private void onServerAbort(
+            AbortFW abort)
+        {
+            initialSeq = abort.sequence();
+            state = McpState.closedInitial(state);
+            doServerAbort(abort.traceId());
+        }
+
+        private void onServerWindow(
+            WindowFW window)
+        {
+            replyAck = window.acknowledge();
+            replyMax = window.maximum();
+            replyPad = window.padding();
+            state = McpState.openedReply(state);
+            emitIfReady(window.traceId());
+        }
+
+        private void onServerReset(
+            ResetFW reset)
+        {
+            replyAck = reset.acknowledge();
+            state = McpState.closedReply(state);
+        }
+
+        private void emitIfReady(
+            long traceId)
+        {
+            if (!ready || McpState.replyClosed(state))
+            {
+                return;
+            }
+
+            while (emitOffset < cachedLen)
+            {
+                final int replyWin = replyMax - (int) (replySeq - replyAck) - replyPad;
+                if (replyWin <= 0)
+                {
+                    return;
+                }
+                final int chunkLen = Math.min(replyWin, cachedLen - emitOffset);
+                doServerData(traceId, 0L, DATA_FLAG_COMPLETE, chunkLen, cachedBuf, emitOffset, chunkLen);
+                emitOffset += chunkLen;
+            }
+
+            doServerEnd(traceId);
+        }
+
+        private void doServerBegin(
+            long traceId)
+        {
+            doBegin(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                traceId, authorization, affinity, emptyRO);
+            state = McpState.openingReply(state);
+        }
+
+        private void doServerData(
+            long traceId,
+            long budgetId,
+            int flags,
+            int reserved,
+            DirectBufferEx payload,
+            int offset,
+            int length)
+        {
+            doData(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                traceId, authorization, flags, budgetId, reserved, payload, offset, length);
+            replySeq += reserved;
+        }
+
+        private void doServerEnd(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doEnd(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                    traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerAbort(
+            long traceId)
+        {
+            if (!McpState.replyClosed(state))
+            {
+                doAbort(sender, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                    traceId, authorization);
+                state = McpState.closedReply(state);
+            }
+        }
+
+        private void doServerWindow(
+            long traceId,
+            long budgetId,
+            int padding)
+        {
+            state = McpState.openedInitial(state);
+            doWindow(sender, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                traceId, authorization, budgetId, padding);
+        }
+
+        private void flushServerWindow(
+            long traceId,
+            long budgetId,
+            int padding,
+            long minInitialNoAck,
+            int minInitialMax)
+        {
+            final long newInitialAck = Math.max(initialAck, initialSeq - minInitialNoAck);
+            final int newInitialMax = Math.max(initialMax, minInitialMax);
+
+            if (newInitialAck > initialAck || newInitialMax > initialMax || !McpState.initialOpened(state))
+            {
+                initialAck = newInitialAck;
+                initialMax = newInitialMax;
+                doServerWindow(traceId, budgetId, padding);
+            }
         }
 
         private void doServerReset(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -35,6 +35,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRoutePrefix;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpSearchToolInjector;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleClient;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleServer;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpRouteRequest;
@@ -2148,7 +2149,8 @@ abstract class McpProxyListFactory implements BindingHandler
             fetched = true;
             if (value != null)
             {
-                final byte[] bytes = filterByScopes(value);
+                final byte[] filtered = filterByScopes(value);
+                final byte[] bytes = McpSearchToolInjector.inject(filtered, cache.searchToolBytes());
                 cachedBuf = new UnsafeBufferEx(bytes);
                 cachedLen = bytes.length;
             }
@@ -2249,8 +2251,9 @@ abstract class McpProxyListFactory implements BindingHandler
                 final byte[] empty = new byte[prelude.capacity() + listReplyCloseRO.capacity()];
                 prelude.getBytes(0, empty, 0, prelude.capacity());
                 listReplyCloseRO.getBytes(0, empty, prelude.capacity(), listReplyCloseRO.capacity());
-                cachedBuf = new UnsafeBufferEx(empty);
-                cachedLen = empty.length;
+                final byte[] withSearchTool = McpSearchToolInjector.inject(empty, cache.searchToolBytes());
+                cachedBuf = new UnsafeBufferEx(withSearchTool);
+                cachedLen = withSearchTool.length;
             }
 
             while (emitOffset < cachedLen)

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -39,6 +39,7 @@ import org.agrona.collections.Int2ObjectHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpSearchToolDescriptor;
 import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpToolSearchDocumentScanner;
 import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpToolSearchIndexFactory;
 import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
@@ -130,8 +131,12 @@ public final class McpProxyCache
             final List<String> searchFields = cache.tools != null && cache.tools.search != null
                 ? cache.tools.search.fields
                 : null;
+            final byte[] searchToolBytes = cache.tools != null && cache.tools.search != null
+                ? McpSearchToolDescriptor.build(cache.tools.search.tool)
+                : null;
             caches.put(KIND_TOOLS_LIST,
-                new McpListCache(KIND_TOOLS_LIST, STORE_KEY_TOOLS, STORE_LOCK_KEY_TOOLS, searchIndex, searchFields));
+                new McpListCache(KIND_TOOLS_LIST, STORE_KEY_TOOLS, STORE_LOCK_KEY_TOOLS,
+                    searchIndex, searchFields, searchToolBytes));
         }
         if (filter.test(KIND_RESOURCES_LIST))
         {
@@ -272,6 +277,7 @@ public final class McpProxyCache
         private final Map<String, String> fragments;
         private final McpToolSearchIndex searchIndex;
         private final List<String> searchFields;
+        private final byte[] searchToolBytes;
         private Map<CharSequence, List<String>> scopesByName = Collections.emptyMap();
         private long lastChecksum = -1L;
         private String lockToken;
@@ -299,12 +305,17 @@ public final class McpProxyCache
             return searchIndex;
         }
 
+        public byte[] searchToolBytes()
+        {
+            return searchToolBytes;
+        }
+
         private McpListCache(
             int kind,
             String storeKey,
             String storeLockKey)
         {
-            this(kind, storeKey, storeLockKey, null, null);
+            this(kind, storeKey, storeLockKey, null, null, null);
         }
 
         private McpListCache(
@@ -312,7 +323,8 @@ public final class McpProxyCache
             String storeKey,
             String storeLockKey,
             McpToolSearchIndex searchIndex,
-            List<String> searchFields)
+            List<String> searchFields,
+            byte[] searchToolBytes)
         {
             this.kind = kind;
             this.storeKey = storeKey;
@@ -320,6 +332,7 @@ public final class McpProxyCache
             this.fragments = new TreeMap<>();
             this.searchIndex = searchIndex;
             this.searchFields = searchFields;
+            this.searchToolBytes = searchToolBytes;
         }
 
         public void putFragment(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -39,6 +39,9 @@ import org.agrona.collections.Int2ObjectHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpToolSearchDocumentScanner;
+import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpToolSearchIndexFactory;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
@@ -121,7 +124,14 @@ public final class McpProxyCache
         final IntPredicate filter = config.hydrateFilter();
         if (filter.test(KIND_TOOLS_LIST))
         {
-            caches.put(KIND_TOOLS_LIST, new McpListCache(KIND_TOOLS_LIST, STORE_KEY_TOOLS, STORE_LOCK_KEY_TOOLS));
+            final McpToolSearchIndex searchIndex = cache.tools != null
+                ? new McpToolSearchIndexFactory().create(cache.tools.search)
+                : null;
+            final List<String> searchFields = cache.tools != null && cache.tools.search != null
+                ? cache.tools.search.fields
+                : null;
+            caches.put(KIND_TOOLS_LIST,
+                new McpListCache(KIND_TOOLS_LIST, STORE_KEY_TOOLS, STORE_LOCK_KEY_TOOLS, searchIndex, searchFields));
         }
         if (filter.test(KIND_RESOURCES_LIST))
         {
@@ -260,6 +270,8 @@ public final class McpProxyCache
         private final String storeKey;
         private final String storeLockKey;
         private final Map<String, String> fragments;
+        private final McpToolSearchIndex searchIndex;
+        private final List<String> searchFields;
         private Map<CharSequence, List<String>> scopesByName = Collections.emptyMap();
         private long lastChecksum = -1L;
         private String lockToken;
@@ -282,15 +294,32 @@ public final class McpProxyCache
             return scopesByName;
         }
 
+        public McpToolSearchIndex searchIndex()
+        {
+            return searchIndex;
+        }
+
         private McpListCache(
             int kind,
             String storeKey,
             String storeLockKey)
         {
+            this(kind, storeKey, storeLockKey, null, null);
+        }
+
+        private McpListCache(
+            int kind,
+            String storeKey,
+            String storeLockKey,
+            McpToolSearchIndex searchIndex,
+            List<String> searchFields)
+        {
             this.kind = kind;
             this.storeKey = storeKey;
             this.storeLockKey = storeLockKey;
             this.fragments = new TreeMap<>();
+            this.searchIndex = searchIndex;
+            this.searchFields = searchFields;
         }
 
         public void putFragment(
@@ -356,6 +385,10 @@ public final class McpProxyCache
             final boolean changed = lastChecksum != -1L && lastChecksum != newChecksum;
             lastChecksum = newChecksum;
             scopesByName = indexScopesByName(value);
+            if (searchIndex != null)
+            {
+                searchIndex.index(McpToolSearchDocumentScanner.scan(value, searchFields));
+            }
             store.put(storeKey, value, STORE_TTL_FOREVER, completion.andThen(this::checkPut)
                 .andThen(k -> onSettled.accept(kind, changed, value)));
         }
@@ -409,6 +442,10 @@ public final class McpProxyCache
                 changed = lastChecksum != -1L && lastChecksum != newChecksum;
                 lastChecksum = newChecksum;
                 scopesByName = indexScopesByName(value);
+                if (searchIndex != null)
+                {
+                    searchIndex.index(McpToolSearchDocumentScanner.scan(value, searchFields));
+                }
             }
             else
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchDocument.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchDocument.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.search;
+
+import java.util.Map;
+
+public final class McpToolSearchDocument
+{
+    public final String name;
+    private final Map<String, String> fields;
+
+    public McpToolSearchDocument(
+        String name,
+        Map<String, String> fields)
+    {
+        this.name = name;
+        this.fields = fields;
+    }
+
+    public String field(
+        String name)
+    {
+        return fields.get(name);
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndex.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndex.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.search;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A ranking backend behind {@code options.cache.tools.search}.
+ * <p>
+ * Instances are single-threaded, owned by the worker that rebuilds and queries the warm
+ * tool-search index; {@link #index(Collection)} replaces the prior contents entirely.
+ * </p>
+ */
+public interface McpToolSearchIndex
+{
+    /**
+     * Rebuilds the index from the current warm catalog.
+     *
+     * @param documents  the full set of searchable tool documents
+     */
+    void index(
+        Collection<McpToolSearchDocument> documents);
+
+    /**
+     * Ranks every indexed document against the given query text.
+     * <p>
+     * Returns every document with a non-zero match, sorted by descending relevance, with no
+     * limit applied — callers apply {@code limit} after any additional filtering (e.g.
+     * per-session authorization).
+     * </p>
+     *
+     * @param text  the query text
+     * @return matches sorted by descending relevance; empty if nothing matches
+     */
+    List<McpToolSearchMatch> query(
+        String text);
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndexFactorySpi.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchIndexFactorySpi.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.search;
+
+import java.util.List;
+import java.util.Map;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfig;
+
+/**
+ * Service provider interface for a pluggable {@link McpToolSearchIndex} implementation.
+ * <p>
+ * Each ranking backend provides an implementation, registered via {@link java.util.ServiceLoader}
+ * in {@code META-INF/services/io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi}.
+ * The binding selects the correct factory by matching {@link #type()} against a configured
+ * indexer's {@code type} field value.
+ * </p>
+ */
+public interface McpToolSearchIndexFactorySpi
+{
+    /**
+     * Returns the index type name this factory handles, e.g. {@code "keyword"}.
+     * <p>
+     * Must match the {@link McpToolSearchIndexConfig#type} value of the indexer configuration.
+     * </p>
+     *
+     * @return the index type name
+     */
+    String type();
+
+    /**
+     * Creates a new {@link McpToolSearchIndex} instance for the given indexer configuration.
+     *
+     * @param config   the type-specific indexer configuration
+     * @param fields   the shared list of document fields to index, in configuration order
+     * @param weights  the shared per-field relative importance, keyed by field name
+     * @return a new index instance
+     */
+    McpToolSearchIndex create(
+        McpToolSearchIndexConfig config,
+        List<String> fields,
+        Map<String, Double> weights);
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchMatch.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/search/McpToolSearchMatch.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.search;
+
+public final class McpToolSearchMatch
+{
+    public final String name;
+    public final double score;
+
+    public McpToolSearchMatch(
+        String name,
+        double score)
+    {
+        this.name = name;
+        this.score = score;
+    }
+}

--- a/runtime/binding-mcp/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp/src/main/moditect/module-info.java
@@ -18,10 +18,12 @@ module io.aklivity.zilla.runtime.binding.mcp
     requires io.aklivity.zilla.runtime.engine;
 
     exports io.aklivity.zilla.runtime.binding.mcp.config;
+    exports io.aklivity.zilla.runtime.binding.mcp.search;
 
     opens io.aklivity.zilla.runtime.binding.mcp.internal.codec;
 
     uses io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi;
+    uses io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi;
 
     provides io.aklivity.zilla.runtime.engine.binding.BindingFactorySpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.McpBindingFactorySpi;
@@ -37,4 +39,7 @@ module io.aklivity.zilla.runtime.binding.mcp
 
     provides io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.config.McpKeywordToolSearchIndexConfigAdapterSpi;
+
+    provides io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi
+        with io.aklivity.zilla.runtime.binding.mcp.internal.search.McpKeywordToolSearchIndexFactorySpi;
 }

--- a/runtime/binding-mcp/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp/src/main/moditect/module-info.java
@@ -21,6 +21,8 @@ module io.aklivity.zilla.runtime.binding.mcp
 
     opens io.aklivity.zilla.runtime.binding.mcp.internal.codec;
 
+    uses io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi;
+
     provides io.aklivity.zilla.runtime.engine.binding.BindingFactorySpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.McpBindingFactorySpi;
 
@@ -32,4 +34,7 @@ module io.aklivity.zilla.runtime.binding.mcp
 
     provides io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.config.McpWithConfigAdapter;
+
+    provides io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi
+        with io.aklivity.zilla.runtime.binding.mcp.internal.config.McpKeywordToolSearchIndexConfigAdapterSpi;
 }

--- a/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi
+++ b/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.binding.mcp.internal.config.McpKeywordToolSearchIndexConfigAdapterSpi

--- a/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi
+++ b/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndexFactorySpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.binding.mcp.internal.search.McpKeywordToolSearchIndexFactorySpi

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpOptionsConfigAdapterTest.java
@@ -15,11 +15,14 @@
 package io.aklivity.zilla.runtime.binding.mcp.internal.config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.time.Duration;
+import java.util.List;
 
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -28,6 +31,7 @@ import jakarta.json.bind.JsonbConfig;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpOptionsConfig;
 import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.config.OptionsConfig;
@@ -127,6 +131,118 @@ public class McpOptionsConfigAdapterTest
         assertThat(text, equalTo(
                 """
                 server: "http://localhost:8080/mcp"
+                """));
+    }
+
+    @Test
+    public void shouldReadOptionsWithCacheToolsSearchMinimal()
+    {
+        String text =
+                """
+                cache:
+                  store: memory0
+                  tools:
+                    search:
+                      tool: zilla__search_tools
+                """;
+
+        McpOptionsConfig options = (McpOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
+
+        assertThat(options, not(nullValue()));
+        assertThat(options.cache, not(nullValue()));
+        assertThat(options.cache.tools, not(nullValue()));
+        assertThat(options.cache.tools.search, not(nullValue()));
+        assertThat(options.cache.tools.search.tool, equalTo("zilla__search_tools"));
+        assertThat(options.cache.tools.search.limit, equalTo(5));
+        assertThat(options.cache.tools.search.fields, contains("name", "description"));
+        assertThat(options.cache.tools.search.indexes, hasSize(1));
+        assertThat(options.cache.tools.search.indexes.get(0).type, equalTo(McpKeywordToolSearchIndexConfig.NAME));
+    }
+
+    @Test
+    public void shouldReadOptionsWithCacheToolsSearchFlatType()
+    {
+        String text =
+                """
+                cache:
+                  store: memory0
+                  tools:
+                    search:
+                      tool: zilla__search_tools
+                      type: keyword
+                      limit: 10
+                      fields:
+                        - name
+                        - description
+                        - output-schema
+                      weights:
+                        name: 3
+                        description: 1
+                """;
+
+        McpOptionsConfig options = (McpOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
+
+        assertThat(options.cache.tools.search.limit, equalTo(10));
+        assertThat(options.cache.tools.search.fields, contains("name", "description", "output-schema"));
+        assertThat(options.cache.tools.search.weights.get("name"), equalTo(3.0));
+        assertThat(options.cache.tools.search.weights.get("description"), equalTo(1.0));
+        assertThat(options.cache.tools.search.indexes, hasSize(1));
+        assertThat(options.cache.tools.search.indexes.get(0).type, equalTo(McpKeywordToolSearchIndexConfig.NAME));
+    }
+
+    @Test
+    public void shouldReadOptionsWithCacheToolsSearchIndexArray()
+    {
+        String text =
+                """
+                cache:
+                  store: memory0
+                  tools:
+                    search:
+                      tool: zilla__search_tools
+                      index:
+                        - type: keyword
+                """;
+
+        McpOptionsConfig options = (McpOptionsConfig) jsonb.fromJson(text, OptionsConfig.class);
+
+        assertThat(options.cache.tools.search.indexes, hasSize(1));
+        assertThat(options.cache.tools.search.indexes.get(0).type, equalTo(McpKeywordToolSearchIndexConfig.NAME));
+    }
+
+    @Test
+    public void shouldWriteOptionsWithCacheToolsSearch()
+    {
+        McpOptionsConfig options = McpOptionsConfig.builder()
+                .cache()
+                    .store("memory0")
+                    .tools()
+                        .search()
+                            .tool("zilla__search_tools")
+                            .limit(5)
+                            .fields(List.of("name", "description"))
+                            .index(new McpKeywordToolSearchIndexConfig())
+                            .build()
+                        .build()
+                    .build()
+                .build();
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo(
+                """
+                cache:
+                  store: memory0
+                  tools:
+                    search:
+                      tool: zilla__search_tools
+                      limit: 5
+                      fields:
+                        - name
+                        - description
+                      index:
+                        - type: keyword
                 """));
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpKeywordToolSearchIndexTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+public class McpKeywordToolSearchIndexTest
+{
+    private static final List<String> FIELDS = List.of("name", "description");
+
+    @Test
+    public void shouldReturnEmptyForNoDocuments()
+    {
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+
+        index.index(List.of());
+
+        assertThat(index.query("kafka"), empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenNoMatch()
+    {
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+
+        index.index(List.of(document("github_create_pr", "create pr", "opens a pull request")));
+
+        assertThat(index.query("kafka"), empty());
+    }
+
+    @Test
+    public void shouldMatchExactTermInName()
+    {
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+
+        index.index(List.of(
+            document("github_create_pr", "github create pr", "opens a pull request"),
+            document("kafka_list_topics", "kafka list topics", "lists kafka topics")));
+
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, not(empty()));
+        assertThat(matches.get(0).name, equalTo("kafka_list_topics"));
+    }
+
+    @Test
+    public void shouldRankHigherWeightFieldHigher()
+    {
+        Map<String, Double> weights = Map.of("name", 3.0, "description", 1.0);
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, weights);
+
+        index.index(List.of(
+            document("kafka_tool", "kafka topic manager", "manages message queues"),
+            document("other_tool", "generic manager", "manages kafka message queues")));
+
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, hasSize(2));
+        assertThat(matches.get(0).name, equalTo("kafka_tool"));
+        assertThat(matches.get(0).score, greaterThan(matches.get(1).score));
+    }
+
+    @Test
+    public void shouldFindTermInsideCamelCaseCompoundToken()
+    {
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+
+        index.index(List.of(document("createKafkaTopic", "createKafkaTopic", null)));
+
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, hasSize(1));
+        assertThat(matches.get(0).name, equalTo("createKafkaTopic"));
+    }
+
+    @Test
+    public void shouldReturnResultsSortedByScoreDescending()
+    {
+        McpKeywordToolSearchIndex index = new McpKeywordToolSearchIndex(FIELDS, Map.of());
+
+        index.index(List.of(
+            document("weak_match", "list resources", "kafka appears once here"),
+            document("strong_match", "kafka kafka kafka", "kafka topic tool"),
+            document("no_match", "unrelated tool", "does something else entirely")));
+
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, hasSize(2));
+        assertThat(matches.get(0).name, equalTo("strong_match"));
+        assertThat(matches.get(0).score, greaterThan(matches.get(1).score));
+    }
+
+    private static McpToolSearchDocument document(
+        String name,
+        String nameField,
+        String descriptionField)
+    {
+        Map<String, String> fields = new HashMap<>();
+        fields.put("name", nameField);
+        fields.put("description", descriptionField);
+        return new McpToolSearchDocument(name, fields);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallScannerTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolCallScannerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+
+public class McpSearchToolCallScannerTest
+{
+    @Test
+    public void shouldScanQuery()
+    {
+        McpSearchToolCallArgs args = scan("{\"name\":\"zilla__search_tools\",\"arguments\":{\"query\":\"weather\"}}");
+
+        assertThat(args.query, equalTo("weather"));
+        assertThat(args.maxResults, equalTo(0));
+    }
+
+    @Test
+    public void shouldScanQueryAndMaxResults()
+    {
+        McpSearchToolCallArgs args = scan(
+            "{\"name\":\"zilla__search_tools\",\"arguments\":{\"query\":\"weather\",\"max_results\":3}}");
+
+        assertThat(args.query, equalTo("weather"));
+        assertThat(args.maxResults, equalTo(3));
+    }
+
+    @Test
+    public void shouldReturnNullQueryWhenMissing()
+    {
+        McpSearchToolCallArgs args = scan("{\"name\":\"zilla__search_tools\",\"arguments\":{}}");
+
+        assertThat(args.query, nullValue());
+    }
+
+    @Test
+    public void shouldReturnNullForMalformedJson()
+    {
+        McpSearchToolCallArgs args = scan("not valid json at all");
+
+        assertThat(args, nullValue());
+    }
+
+    private static McpSearchToolCallArgs scan(
+        String json)
+    {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        return McpSearchToolCallScanner.scan(new UnsafeBufferEx(bytes), 0, bytes.length);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolDescriptorTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolDescriptorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+import org.junit.Test;
+
+public class McpSearchToolDescriptorTest
+{
+    @Test
+    public void shouldBuildToolWithConfiguredName()
+    {
+        byte[] bytes = McpSearchToolDescriptor.build("zilla__search_tools");
+
+        JsonObject tool = parse(bytes);
+
+        assertThat(tool.getString("name"), equalTo("zilla__search_tools"));
+        assertThat(tool.containsKey("description"), equalTo(true));
+    }
+
+    @Test
+    public void shouldBuildInputSchemaRequiringQuery()
+    {
+        byte[] bytes = McpSearchToolDescriptor.build("zilla__search_tools");
+
+        JsonObject tool = parse(bytes);
+        JsonObject inputSchema = tool.getJsonObject("inputSchema");
+
+        assertThat(inputSchema.getString("type"), equalTo("object"));
+        assertThat(inputSchema.getJsonObject("properties").containsKey("query"), equalTo(true));
+        assertThat(inputSchema.getJsonArray("required").getString(0), equalTo("query"));
+        assertThat(inputSchema.getJsonArray("required"), hasItem(Json.createValue("query")));
+    }
+
+    private static JsonObject parse(
+        byte[] bytes)
+    {
+        return Json.createReader(new StringReader(new String(bytes, StandardCharsets.UTF_8))).readObject();
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolInjectorTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpSearchToolInjectorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class McpSearchToolInjectorTest
+{
+    @Test
+    public void shouldInjectIntoEmptyArray()
+    {
+        byte[] json = "{\"tools\":[]}".getBytes(StandardCharsets.UTF_8);
+        byte[] tool = "{\"name\":\"zilla__search_tools\"}".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = McpSearchToolInjector.inject(json, tool);
+
+        assertThat(new String(result, StandardCharsets.UTF_8),
+            equalTo("{\"tools\":[{\"name\":\"zilla__search_tools\"}]}"));
+    }
+
+    @Test
+    public void shouldInjectIntoNonEmptyArrayWithComma()
+    {
+        byte[] json = "{\"tools\":[{\"name\":\"get_weather\"}]}".getBytes(StandardCharsets.UTF_8);
+        byte[] tool = "{\"name\":\"zilla__search_tools\"}".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = McpSearchToolInjector.inject(json, tool);
+
+        assertThat(new String(result, StandardCharsets.UTF_8),
+            equalTo("{\"tools\":[{\"name\":\"get_weather\"},{\"name\":\"zilla__search_tools\"}]}"));
+    }
+
+    @Test
+    public void shouldInjectAfterMultipleExistingTools()
+    {
+        byte[] json = "{\"tools\":[{\"name\":\"a\"},{\"name\":\"b\"}]}".getBytes(StandardCharsets.UTF_8);
+        byte[] tool = "{\"name\":\"c\"}".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = McpSearchToolInjector.inject(json, tool);
+
+        assertThat(new String(result, StandardCharsets.UTF_8),
+            equalTo("{\"tools\":[{\"name\":\"a\"},{\"name\":\"b\"},{\"name\":\"c\"}]}"));
+    }
+
+    @Test
+    public void shouldReturnOriginalWhenToolBytesNull()
+    {
+        byte[] json = "{\"tools\":[]}".getBytes(StandardCharsets.UTF_8);
+
+        byte[] result = McpSearchToolInjector.inject(json, null);
+
+        assertThat(result, sameInstance(json));
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpTextTokenizerTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpTextTokenizerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class McpTextTokenizerTest
+{
+    @Test
+    public void shouldTokenizeCamelCase()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("createKafkaTopic");
+
+        assertThat(tokens, contains("create", "kafka", "topic"));
+    }
+
+    @Test
+    public void shouldTokenizeAcronymBoundary()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("parseXMLDocument");
+
+        assertThat(tokens, contains("parse", "xml", "document"));
+    }
+
+    @Test
+    public void shouldTokenizeSnakeCase()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("get_weather_data");
+
+        assertThat(tokens, contains("get", "weather", "data"));
+    }
+
+    @Test
+    public void shouldTokenizeDotNamespace()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("github.createPullRequest");
+
+        assertThat(tokens, contains("github", "create", "pull", "request"));
+    }
+
+    @Test
+    public void shouldLowercaseFullyUppercaseWord()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("KAFKA");
+
+        assertThat(tokens, contains("kafka"));
+    }
+
+    @Test
+    public void shouldRemoveStopwords()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("the quick fox");
+
+        assertThat(tokens, contains("quick", "fox"));
+    }
+
+    @Test
+    public void shouldSplitOnPunctuation()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("get-weather.data");
+
+        assertThat(tokens, contains("get", "weather", "data"));
+    }
+
+    @Test
+    public void shouldReturnEmptyForNull()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize(null);
+
+        assertThat(tokens, empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyForEmptyString()
+    {
+        List<String> tokens = McpTextTokenizer.tokenize("");
+
+        assertThat(tokens, empty());
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchDocumentScannerTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchDocumentScannerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+
+public class McpToolSearchDocumentScannerTest
+{
+    @Test
+    public void shouldScanNameAndDescription()
+    {
+        String json =
+                """
+                {"tools":[
+                    {"name":"get_weather","description":"Get current weather for a location",
+                     "inputSchema":{"type":"object"}}
+                ]}
+                """;
+
+        List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(json, List.of("name", "description"));
+
+        assertThat(documents, hasSize(1));
+        assertThat(documents.get(0).name, equalTo("get_weather"));
+        assertThat(documents.get(0).field("name"), equalTo("get_weather"));
+        assertThat(documents.get(0).field("description"), equalTo("Get current weather for a location"));
+    }
+
+    @Test
+    public void shouldFlattenOutputSchemaObjectToText()
+    {
+        String json =
+                """
+                {"tools":[
+                    {"name":"list_repos","description":"List repositories",
+                     "outputSchema":{"type":"object","properties":{"repos":{"type":"array",
+                     "description":"matching repositories"}}}}
+                ]}
+                """;
+
+        List<McpToolSearchDocument> documents =
+            McpToolSearchDocumentScanner.scan(json, List.of("name", "output-schema"));
+
+        assertThat(documents, hasSize(1));
+        String flattened = documents.get(0).field("output-schema");
+        assertThat(flattened, containsString("repos"));
+        assertThat(flattened, containsString("matching repositories"));
+        // description wasn't requested, so it must not be captured even though present in the JSON
+        assertThat(documents.get(0).field("description"), nullValue());
+    }
+
+    @Test
+    public void shouldIgnoreUnrequestedFields()
+    {
+        String json =
+                """
+                {"tools":[
+                    {"name":"get_weather","description":"Get current weather for a location"}
+                ]}
+                """;
+
+        List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(json, List.of("name"));
+
+        assertThat(documents.get(0).field("name"), equalTo("get_weather"));
+        assertThat(documents.get(0).field("description"), nullValue());
+    }
+
+    @Test
+    public void shouldScanMultipleTools()
+    {
+        String json =
+                """
+                {"tools":[
+                    {"name":"tool_one","description":"first tool"},
+                    {"name":"tool_two","description":"second tool"}
+                ]}
+                """;
+
+        List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(json, List.of("name", "description"));
+
+        assertThat(documents, hasSize(2));
+        assertThat(documents.get(0).name, equalTo("tool_one"));
+        assertThat(documents.get(1).name, equalTo("tool_two"));
+    }
+
+    @Test
+    public void shouldReturnEmptyForNoToolsArray()
+    {
+        String json = "{\"resources\":[]}";
+
+        List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(json, List.of("name", "description"));
+
+        assertThat(documents, empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyForMalformedJson()
+    {
+        List<McpToolSearchDocument> documents =
+            McpToolSearchDocumentScanner.scan("not valid json at all", List.of("name", "description"));
+
+        assertThat(documents, empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyForNoFields()
+    {
+        String json = "{\"tools\":[{\"name\":\"get_weather\"}]}";
+
+        List<McpToolSearchDocument> documents = McpToolSearchDocumentScanner.scan(json, List.of());
+
+        assertThat(documents, empty());
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactoryTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchIndexFactoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchDocument;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchIndex;
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+public class McpToolSearchIndexFactoryTest
+{
+    private final McpToolSearchIndexFactory factory = new McpToolSearchIndexFactory();
+
+    @Test
+    public void shouldReturnNullWhenSearchNotConfigured()
+    {
+        assertThat(factory.create(null), nullValue());
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoIndexesConfigured()
+    {
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .tool("zilla__search_tools")
+            .fields(List.of("name", "description"))
+            .build();
+
+        assertThat(factory.create(search), nullValue());
+    }
+
+    @Test
+    public void shouldCreateWorkingIndexForSingleConfiguredType()
+    {
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .tool("zilla__search_tools")
+            .fields(List.of("name", "description"))
+            .index(new McpKeywordToolSearchIndexConfig())
+            .build();
+
+        McpToolSearchIndex index = factory.create(search);
+
+        assertThat(index, not(nullValue()));
+
+        index.index(List.of(document("kafka_tool", "kafka topic manager", "manages kafka topics")));
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, hasSize(1));
+        assertThat(matches.get(0).name, equalTo("kafka_tool"));
+    }
+
+    @Test
+    public void shouldComposeMultipleConfiguredIndexes()
+    {
+        McpCacheToolsSearchConfig search = McpCacheToolsSearchConfig.builder()
+            .tool("zilla__search_tools")
+            .fields(List.of("name", "description"))
+            .index(new McpKeywordToolSearchIndexConfig())
+            .index(new McpKeywordToolSearchIndexConfig())
+            .build();
+
+        McpToolSearchIndex index = factory.create(search);
+
+        index.index(List.of(
+            document("kafka_tool", "kafka topic manager", "manages kafka topics"),
+            document("other_tool", "generic manager", "does something unrelated")));
+        List<McpToolSearchMatch> matches = index.query("kafka");
+
+        assertThat(matches, hasSize(1));
+        assertThat(matches.get(0).name, equalTo("kafka_tool"));
+    }
+
+    private static McpToolSearchDocument document(
+        String name,
+        String nameField,
+        String descriptionField)
+    {
+        Map<String, String> fields = new HashMap<>();
+        fields.put("name", nameField);
+        fields.put("description", descriptionField);
+        return new McpToolSearchDocument(name, fields);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchRankFusionTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/search/McpToolSearchRankFusionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.search.McpToolSearchMatch;
+
+public class McpToolSearchRankFusionTest
+{
+    @Test
+    public void shouldPreserveOrderForSingleRanking()
+    {
+        List<McpToolSearchMatch> ranking = List.of(
+            new McpToolSearchMatch("a", 9.0),
+            new McpToolSearchMatch("b", 5.0),
+            new McpToolSearchMatch("c", 1.0));
+
+        List<McpToolSearchMatch> fused = McpToolSearchRankFusion.fuse(List.of(ranking));
+
+        assertThat(names(fused), contains("a", "b", "c"));
+    }
+
+    @Test
+    public void shouldBoostItemsAppearingInMultipleRankings()
+    {
+        List<McpToolSearchMatch> ranking1 = List.of(
+            new McpToolSearchMatch("a", 9.0),
+            new McpToolSearchMatch("b", 5.0),
+            new McpToolSearchMatch("c", 1.0));
+        List<McpToolSearchMatch> ranking2 = List.of(
+            new McpToolSearchMatch("a", 9.0),
+            new McpToolSearchMatch("d", 5.0),
+            new McpToolSearchMatch("e", 1.0));
+
+        List<McpToolSearchMatch> fused = McpToolSearchRankFusion.fuse(List.of(ranking1, ranking2));
+
+        assertThat(names(fused).get(0), equalTo("a"));
+    }
+
+    @Test
+    public void shouldReturnEmptyForNoRankings()
+    {
+        List<McpToolSearchMatch> fused = McpToolSearchRankFusion.fuse(List.of());
+
+        assertThat(fused, empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenAllRankingsEmpty()
+    {
+        List<McpToolSearchMatch> fused = McpToolSearchRankFusion.fuse(List.of(List.of(), List.of()));
+
+        assertThat(fused, empty());
+    }
+
+    private static List<String> names(
+        List<McpToolSearchMatch> matches)
+    {
+        return matches.stream().map(match -> match.name).collect(Collectors.toList());
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -217,6 +217,16 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.tools.search.serve.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.search/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsSearch() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.toolkit.filter.yaml")
     @Specification({
         "${app}/cache.serve.tools.list.toolkit.filtered/server",

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -28,6 +28,59 @@ the classpath, one per installed component. The result is a single aggregated
 schema that reflects exactly the components present in the running Zilla
 instance — no component contributes schema for types that are not installed.
 
+### Nested extension points within a component's own schema
+
+Some components define further-pluggable sub-concepts inside their own
+`options` — for example, a binding might maintain an internal registry of
+named sub-behaviors (index types, transform types, etc.) that other,
+independently-versioned modules should be able to extend without ever editing
+the owning component's schema patch. This is a different problem from the
+top-level `type` discriminator (`$defs/binding`, `$defs/guard`, etc.) above,
+since a sub-concept's implementations may ship from other modules, or from
+another repository entirely.
+
+The convention is a dedicated top-level `$defs` scaffold per component kind:
+`$defs/binding-ext`, `$defs/guard-ext`, `$defs/vault-ext`, `$defs/catalog-ext`,
+`$defs/store-ext`, `$defs/exporter-ext`, `$defs/model-ext`. These are
+pre-seeded as empty objects in the base engine schema, exactly like
+`$defs/guard`/`$defs/vault`/`$defs/models` are pre-seeded for the top-level
+discriminators. Pre-seeding is what makes them safe for independent,
+unordered contributions: JSON Patch's `add` operation replaces an existing
+key's value wholesale, so a parent that multiple unrelated modules might add
+sub-keys under must already exist before any of them run — otherwise whichever
+patch applies second silently wipes out the first's contribution.
+
+A component that owns a sub-concept adds its own key under the relevant
+`-ext` scaffold, once, in its own schema patch:
+
+```json
+{ "op": "add", "path": "/$defs/binding-ext/mcp", "value": {
+    "indexes": { "properties": { "type": { "enum": [] } }, "allOf": [] }
+} }
+```
+
+This `add` is safe even though `binding-ext` itself is shared, because
+`binding-mcp` is the only thing that will ever name the `mcp` key underneath
+it. Each pluggable implementation of that sub-concept — in-tree or from a
+separate module or repository — then contributes its own patch appending into
+the now-existing scaffold, using the same append-only idiom as the top-level
+discriminators:
+
+```json
+{ "op": "add", "path": "/$defs/binding-ext/mcp/indexes/properties/type/enum/-", "value": "keyword" },
+{ "op": "add", "path": "/$defs/binding-ext/mcp/indexes/allOf/-", "value": {
+    "if": { "properties": { "type": { "const": "keyword" } } },
+    "then": { "additionalProperties": false }
+} }
+```
+
+Path shape: `/$defs/<kind>-ext/<type>/<extension-point-name>`, where `<kind>`
+is the owning component's kind (`binding`, `guard`, `vault`, `catalog`,
+`store`, `exporter`, `model`) and `<type>` is that component's own `type`
+value (e.g. `mcp`). This keeps every component's sub-extension points
+consistently namespaced and discoverable by grepping for `-ext`, regardless
+of which module or repository ends up contributing to them.
+
 ### Schema file locations
 
 Each component's JSON schema patch is checked in once, in the spec project:

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.index.additional.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.index.additional.invalid.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+            index:
+              - type: keyword
+                model: model0
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.index.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.index.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+            index:
+              - type: keyword
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.serve.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.serve.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+    options:
+      entries:
+        tools: |-
+          {"tools":[{"name": "get_weather","title": "Weather Information Provider","description": "Get current weather information for a location","inputSchema": {"type": "object","properties": {"location": {"type": "string","description": "City name or zip code"}},"required": ["location"]},"icons": [{"src": "https://example.com/weather-icon.png","mimeType": "image/png","sizes": ["48x48"]}],"execution": {"taskSupport": "optional"}}]}
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.tool.missing.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.tool.missing.invalid.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            type: keyword
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.index.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.index.invalid.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+            type: keyword
+            index:
+              - type: keyword
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.invalid.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+            type: bm25
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.type.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+            type: keyword
+            limit: 5
+            fields: [ name, description, output-schema ]
+            weights:
+              name: 3
+              description: 1
+              output-schema: 1
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.search.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          search:
+            tool: zilla__search_tools
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -279,6 +279,74 @@
                                                     },
                                                     "additionalProperties": false,
                                                     "maxProperties": 1
+                                                },
+                                                "tools":
+                                                {
+                                                    "title": "Tools",
+                                                    "type": "object",
+                                                    "properties":
+                                                    {
+                                                        "search":
+                                                        {
+                                                            "title": "Search",
+                                                            "type": "object",
+                                                            "properties":
+                                                            {
+                                                                "tool":
+                                                                {
+                                                                    "title": "Tool",
+                                                                    "type": "string"
+                                                                },
+                                                                "limit":
+                                                                {
+                                                                    "title": "Limit",
+                                                                    "type": "integer",
+                                                                    "default": 5
+                                                                },
+                                                                "fields":
+                                                                {
+                                                                    "title": "Fields",
+                                                                    "type": "array",
+                                                                    "items":
+                                                                    {
+                                                                        "enum": [ "name", "description", "output-schema" ]
+                                                                    },
+                                                                    "default": [ "name", "description" ]
+                                                                },
+                                                                "weights":
+                                                                {
+                                                                    "title": "Weights",
+                                                                    "type": "object",
+                                                                    "patternProperties":
+                                                                    {
+                                                                        "^[a-zA-Z0-9_-]+$":
+                                                                        {
+                                                                            "type": "number"
+                                                                        }
+                                                                    },
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type":
+                                                                {
+                                                                    "title": "Type",
+                                                                    "$ref": "#/$defs/binding-ext/mcp/indexes/flat"
+                                                                },
+                                                                "index":
+                                                                {
+                                                                    "title": "Index",
+                                                                    "type": "array",
+                                                                    "items":
+                                                                    {
+                                                                        "$ref": "#/$defs/binding-ext/mcp/indexes"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [ "tool" ],
+                                                            "not": { "required": [ "type", "index" ] },
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
                                             },
                                             "required": [ "store" ],
@@ -377,6 +445,59 @@
                         }
                     }
                 ]
+            }
+        }
+    },
+    {
+        "op": "add",
+        "path": "/$defs/binding-ext/mcp",
+        "value":
+        {
+            "indexes":
+            {
+                "type": "object",
+                "properties":
+                {
+                    "type":
+                    {
+                        "title": "Type",
+                        "type": "string",
+                        "enum": [ "keyword" ]
+                    }
+                },
+                "required": [ "type" ],
+                "allOf":
+                [
+                    {
+                        "if":
+                        {
+                            "properties":
+                            {
+                                "type":
+                                {
+                                    "const": "keyword"
+                                }
+                            }
+                        },
+                        "then":
+                        {
+                            "properties":
+                            {
+                                "type":
+                                {
+                                    "const": "keyword"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "flat":
+                {
+                    "title": "Type",
+                    "type": "string",
+                    "enum": [ "keyword" ]
+                }
             }
         }
     }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search/client.rpt
@@ -1,0 +1,64 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("agent-1")
+                               .name("zilla__search_tools")
+                               .contentLength(63)
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"zilla__search_tools",'
+        '"arguments":'
+        '{'
+          '"query": "weather"'
+        '}'
+      '}'
+
+read  '{"content":[{"type":"tool_reference","tool_name":"get_weather"}],"isError":false}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search/server.rpt
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("agent-1")
+                              .name("zilla__search_tools")
+                              .contentLength(63)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"zilla__search_tools",'
+        '"arguments":'
+        '{'
+          '"query": "weather"'
+        '}'
+      '}'
+
+write flush
+
+write '{"content":[{"type":"tool_reference","tool_name":"get_weather"}],"isError":false}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
@@ -140,4 +140,52 @@ public class SchemaTest
     {
         schema.validate("proxy.headers.invalid.yaml");
     }
+
+    @Test
+    public void shouldValidateProxyCacheToolsSearch()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.search.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyCacheToolsSearchWithType()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.search.type.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyCacheToolsSearchWithIndex()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.search.index.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsSearchWithUnknownType()
+    {
+        schema.validate("proxy.cache.tools.search.type.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsSearchWithTypeAndIndex()
+    {
+        schema.validate("proxy.cache.tools.search.type.index.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsSearchIndexWithAdditionalProperty()
+    {
+        schema.validate("proxy.cache.tools.search.index.additional.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsSearchMissingTool()
+    {
+        schema.validate("proxy.cache.tools.search.tool.missing.invalid.yaml");
+    }
 }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
@@ -110,6 +110,15 @@ public class ProxyCacheIT
 
     @Test
     @Specification({
+        "${app}/cache.serve.tools.search/client",
+        "${app}/cache.serve.tools.search/server" })
+    public void shouldServeToolsSearch() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/cache.refresh.tools/client",
         "${app}/cache.refresh.tools/server" })
     public void shouldRefreshTools() throws Exception

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
@@ -537,6 +537,9 @@
             [
             ]
         },
+        "binding-ext":
+        {
+        },
         "validate":
         {
             "oneOf":


### PR DESCRIPTION
## Description

Adds an agent-callable tool search capability to the `mcp` proxy binding's `cache`, so an agent can discover tools by relevance instead of scanning a full `tools/list` response.

Configuration (`options.cache.tools.search`) lets an operator name a synthetic search tool (e.g. `zilla__search_tools`), choose which tool fields are indexed (`name`, `description`, `output-schema`), set a default result `limit`, and optionally weight fields or configure multiple index backends. A nested `/$defs/binding-ext/mcp` schema extension point was added to the engine schema so index-backend types can be contributed independently of the `binding-mcp` module itself.

At runtime:
- The cached `tools/list` response is indexed (BM25, K1=1.2/B=0.75) whenever the cache is populated or refreshed, and the synthetic search tool descriptor is injected into every served `tools/list` response (subject to the same per-session scope filtering as any other tool).
- A new `McpToolSearchServer` stream handler intercepts `tools/call` requests whose `name` matches the configured search tool, bypassing routing and any upstream `McpClient` entirely. It parses `query`/`max_results` from the buffered request, ranks against the warm index, filters per-session via the existing guard/scope mechanism, and returns MCP `tool_reference` content blocks (or a `-32602 Invalid params` reset when `query` is missing).
- Multiple configured index backends are combined via Reciprocal Rank Fusion (K=60.0); a single backend bypasses fusion.
- Index backends are pluggable via a new `McpToolSearchIndexFactorySpi`/`McpToolSearchIndex` SPI, with `keyword` (the BM25 index) as the in-tree implementation.

Spec/test coverage follows the repo's test-first discipline: schema validation tests, config adapter unit tests, ranking/tokenizer/fusion unit tests, and new `.rpt` scenarios (peer-to-peer self-consistency plus real-engine `McpProxyCacheIT`) for serving the search tool and answering `tools/call` against it.

Fixes #1969


---
_Generated by [Claude Code](https://claude.ai/code/session_01FCrNXQHrfCEsPGs8NUag4Z)_