### PR TITLE
fix(binding-mcp): allow anonymous requests to reach unguarded mcp kind:server routes

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -799,23 +799,29 @@ public final class McpBindingConfig
                 .map(h -> h.value().asString())
                 .orElse(null);
 
-            final Matcher credentialsMatcher = authorizationHeader != null
-                ? credentialsPattern.matcher(authorizationHeader)
-                : null;
+            // No Authorization header at all is not itself a rejection: leave authorization
+            // unresolved (anonymous) and let a downstream guarded route decide, exactly as
+            // an unauthenticated http request reaches an unguarded route. A header that was
+            // sent but does not match the configured credentials pattern, or a credential
+            // that fails reauthorization, are active (if unsuccessful) attempts to authenticate
+            // and are rejected here.
+            if (authorizationHeader != null)
+            {
+                final Matcher credentialsMatcher = credentialsPattern.matcher(authorizationHeader);
+                final String credentials = credentialsMatcher.matches()
+                    ? credentialsMatcher.group("credentials")
+                    : null;
 
-            final String credentials = credentialsMatcher != null && credentialsMatcher.matches()
-                ? credentialsMatcher.group("credentials")
-                : null;
+                final long sessionAuth = credentials != null
+                    ? guard.reauthorize(traceId, routedId, initialId, credentials)
+                    : GuardHandler.NOT_AUTHORIZED;
 
-            final long sessionAuth = credentials != null
-                ? guard.reauthorize(traceId, routedId, initialId, credentials)
-                : GuardHandler.NOT_AUTHORIZED;
-
-            result = (sessionAuth & GuardHandler.MASK_AUTHORIZED) != 0L
-                ? new McpAuthorizationResult(sessionAuth, null)
-                : new McpAuthorizationResult(authorization, credentials == null
-                    ? McpBearerError.INVALID_REQUEST
-                    : McpBearerError.INVALID_TOKEN);
+                result = (sessionAuth & GuardHandler.MASK_AUTHORIZED) != 0L
+                    ? new McpAuthorizationResult(sessionAuth, null)
+                    : new McpAuthorizationResult(authorization, credentials == null
+                        ? McpBearerError.INVALID_REQUEST
+                        : McpBearerError.INVALID_TOKEN);
+            }
         }
         return result;
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -115,8 +115,9 @@ public class McpServerIT
     @Test
     @Configuration("server.guarded.yaml")
     @Specification({
-        "${net}/lifecycle.initialize.reject.bearer.missing/client"})
-    public void shouldRejectLifecycleInitializeWithMissingBearer() throws Exception
+        "${net}/lifecycle.initialize.anonymous/client",
+        "${app}/lifecycle.initialize.anonymous/server"})
+    public void shouldInitializeLifecycleAnonymouslyWithMissingBearer() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.anonymous/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.anonymous/server.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.anonymous/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.anonymous/client.rpt
@@ -35,8 +35,10 @@ write close
 
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
-                           .header(":status", "401")
-                           .header("www-authenticate", "Bearer error=\"invalid_request\"")
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
                            .build()}
 
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.anonymous/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.anonymous/server.rpt
@@ -26,7 +26,6 @@ read zilla:begin.ext ${http:matchBeginEx()
                            .header("content-type", "application/json")
                            .header("accept", "application/json, text/event-stream")
                            .header("mcp-protocol-version", "2025-11-25")
-                           .headerMissing("authorization")
                            .build()}
 
 connected
@@ -36,9 +35,13 @@ read closed
 
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
-                            .header(":status", "401")
-                            .header("www-authenticate", "Bearer error=\"invalid_request\"")
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
                             .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
 write flush
 
 write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -101,9 +101,9 @@ public class NetworkIT
 
     @Test
     @Specification({
-        "${net}/lifecycle.initialize.reject.bearer.missing/client",
-        "${net}/lifecycle.initialize.reject.bearer.missing/server"})
-    public void shouldRejectLifecycleInitializeWithMissingBearer() throws Exception
+        "${net}/lifecycle.initialize.anonymous/client",
+        "${net}/lifecycle.initialize.anonymous/server"})
+    public void shouldInitializeLifecycleAnonymouslyWithMissingBearer() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
## Description

`c20ea8b9` (#2050) made `mcp` `kind:server` reject every request with a missing or invalid bearer token whenever a guard is configured, even when the target route is unguarded. This breaks the deferred-authorization model `http kind:server` already uses: an absent credential should only matter once a guarded route is actually reached, not up front for every request.

This change updates `McpBindingConfig.authorize(...)` so that:

- A request with **no** `Authorization` header at all is left with an unresolved (anonymous) authorization result and allowed to proceed to routing, exactly as an unauthenticated `http` request reaches an unguarded route.
- A request that **does** send an `Authorization` header, but one that doesn't match the configured credentials pattern, or whose credentials fail guard reauthorization, is still rejected as before (`INVALID_REQUEST` / `INVALID_TOKEN`).

### Test changes

Following test-first discipline, this replaces the `lifecycle.initialize.reject.bearer.missing` spec scenario (which encoded the now-incorrect "missing token → reject" behavior) with a new `lifecycle.initialize.anonymous` scenario asserting a successful `initialize` when no bearer token is present, in both:

- `specs/binding-mcp.spec` (`network/` + `application/` fixtures, `NetworkIT`)
- `runtime/binding-mcp` (`McpServerIT`)

The sibling `lifecycle.initialize.reject.bearer.invalid` scenario is unchanged — a genuinely wrong/malformed token still correctly rejects with a 401.

Verified via `./mvnw verify -pl runtime/binding-mcp` and `./mvnw verify -pl specs/binding-mcp.spec` (checkstyle, unit tests, and all ITs passing).

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBYucWXKGcjrzpZmB6GRge)_