### PR TITLE
fix(docker-image): package binding-mcp-http and binding-mcp-openapi modules

### DIFF
--- a/cloud/docker-image/pom.xml
+++ b/cloud/docker-image/pom.xml
@@ -141,6 +141,18 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>binding-mcp-http</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>binding-mcp-openapi</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>binding-mqtt</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/cloud/docker-image/src/main/docker/zpm.json.template
+++ b/cloud/docker-image/src/main/docker/zpm.json.template
@@ -26,6 +26,8 @@
     "io.aklivity.zilla:binding-kafka-grpc",
     "io.aklivity.zilla:binding-kafka",
     "io.aklivity.zilla:binding-mcp",
+    "io.aklivity.zilla:binding-mcp-http",
+    "io.aklivity.zilla:binding-mcp-openapi",
     "io.aklivity.zilla:binding-mqtt",
     "io.aklivity.zilla:binding-mqtt-kafka",
     "io.aklivity.zilla:binding-openapi",

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -149,6 +149,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>binding-mcp-http</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>binding-mcp-openapi</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
## Description

`binding-mcp-http` and `binding-mcp-openapi` are declared reactor modules (`runtime/pom.xml`) and build correctly, but were never listed as dependencies of `cloud/docker-image` (`pom.xml`) or in `zpm.json.template`. As a result the jlinked runtime image never included their modules — confirmed via `java --list-modules` inside the built image, which showed only `io.aklivity.zilla.runtime.binding.mcp` and `io.aklivity.zilla.runtime.metrics.mcp`, with `io.aklivity.zilla.runtime.binding.mcp.http` and `...openapi` entirely absent.

The practical effect: **any `zilla.yaml` using `type: mcp_http` or `type: mcp_openapi` fails engine startup** with `instance failed every anyOf subschema` for the `type` property, because those types' schema patches never get the chance to register with the aggregated JSON schema — their `BindingFactorySpi`/`Binding.type()` never runs since the modules aren't on the module path at all. This is silent: `Objects::nonNull` filtering in `Engine.java` drops the missing schema contribution without any warning, and each binding's own isolated `SchemaTest` still passes (it doesn't exercise the full multi-module classpath), so the gap wasn't caught there. I found this while verifying an unrelated example PR's CI failure and reproduced it independently of that PR's changes — it also reproduces against `develop` HEAD before that PR, and even further back, so it's a pre-existing packaging gap, not a regression from recent commits.

### Fix

- `runtime/pom.xml`: add the missing `binding-mcp-http` entry to `dependencyManagement` (it jumped straight from `binding-mcp` to `binding-mcp-openapi`), so `zpm install` can resolve it.
- `cloud/docker-image/pom.xml`: add `binding-mcp-http` and `binding-mcp-openapi` as `runtime`-scope dependencies, so Maven's reactor build order includes them ahead of `cloud/docker-image` and jlink bundles their modules.
- `cloud/docker-image/src/main/docker/zpm.json.template`: add both to the packaged module list.

### Verification

This module has no existing test infrastructure (no `src/test/` in `cloud/docker-image`) and the previous packaging gap wasn't reachable from any per-module `SchemaTest`, since those don't build the full multi-module image. Verified directly:

1. Built `cloud/docker-image` from source before the fix — `java --list-modules` inside the image showed `io.aklivity.zilla.runtime.binding.mcp` but not `.mcp.http`/`.mcp.openapi`; a config using `type: mcp_http` failed with `Engine configuration failed` / `instance failed every anyOf subschema`.
2. Applied this fix and rebuilt — `java --list-modules` now lists `io.aklivity.zilla.runtime.binding.mcp.http` and `io.aklivity.zilla.runtime.binding.mcp.openapi`.
3. Started the engine with a full config exercising both `mcp_http` and `mcp_openapi` bindings (guards, routes, resource templates) — clean `ENGINE_STARTED Engine Started.` with no config errors.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBYucWXKGcjrzpZmB6GRge)_