### PR TITLE
feat(binding-mcp): configurable eager tool set under cache.tools.eager

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsConfigBuilder.java
@@ -23,6 +23,7 @@ public final class McpCacheToolsConfigBuilder<T> extends ConfigBuilder<T, McpCac
     private final Function<McpCacheToolsConfig, T> mapper;
 
     private McpCacheToolsSearchConfig search;
+    private McpCacheToolsEagerConfig eager;
 
     McpCacheToolsConfigBuilder(
         Function<McpCacheToolsConfig, T> mapper)
@@ -49,9 +50,21 @@ public final class McpCacheToolsConfigBuilder<T> extends ConfigBuilder<T, McpCac
         return McpCacheToolsSearchConfig.builder(this::search);
     }
 
+    public McpCacheToolsConfigBuilder<T> eager(
+        McpCacheToolsEagerConfig eager)
+    {
+        this.eager = eager;
+        return this;
+    }
+
+    public McpCacheToolsEagerConfigBuilder<McpCacheToolsConfigBuilder<T>> eager()
+    {
+        return McpCacheToolsEagerConfig.builder(this::eager);
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new McpCacheToolsConfig(search));
+        return mapper.apply(new McpCacheToolsConfig(search, eager));
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerConfig.java
@@ -16,29 +16,30 @@ package io.aklivity.zilla.runtime.binding.mcp.config;
 
 import static java.util.function.Function.identity;
 
+import java.util.List;
 import java.util.function.Function;
 
-public final class McpCacheToolsConfig
+public final class McpCacheToolsEagerConfig
 {
-    public final McpCacheToolsSearchConfig search;
-    public final McpCacheToolsEagerConfig eager;
+    public final McpCacheToolsEagerPolicy policy;
+    public final List<String> match;
 
-    McpCacheToolsConfig(
-        McpCacheToolsSearchConfig search,
-        McpCacheToolsEagerConfig eager)
+    McpCacheToolsEagerConfig(
+        McpCacheToolsEagerPolicy policy,
+        List<String> match)
     {
-        this.search = search;
-        this.eager = eager;
+        this.policy = policy;
+        this.match = match;
     }
 
-    public static McpCacheToolsConfigBuilder<McpCacheToolsConfig> builder()
+    public static McpCacheToolsEagerConfigBuilder<McpCacheToolsEagerConfig> builder()
     {
-        return new McpCacheToolsConfigBuilder<>(identity());
+        return new McpCacheToolsEagerConfigBuilder<>(identity());
     }
 
-    public static <T> McpCacheToolsConfigBuilder<T> builder(
-        Function<McpCacheToolsConfig, T> mapper)
+    public static <T> McpCacheToolsEagerConfigBuilder<T> builder(
+        Function<McpCacheToolsEagerConfig, T> mapper)
     {
-        return new McpCacheToolsConfigBuilder<>(mapper);
+        return new McpCacheToolsEagerConfigBuilder<>(mapper);
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerConfigBuilder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerConfigBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.aklivity.zilla.runtime.engine.config.ConfigBuilder;
+
+public final class McpCacheToolsEagerConfigBuilder<T> extends ConfigBuilder<T, McpCacheToolsEagerConfigBuilder<T>>
+{
+    private final Function<McpCacheToolsEagerConfig, T> mapper;
+
+    private McpCacheToolsEagerPolicy policy = McpCacheToolsEagerPolicy.NONE;
+    private List<String> match;
+
+    McpCacheToolsEagerConfigBuilder(
+        Function<McpCacheToolsEagerConfig, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<McpCacheToolsEagerConfigBuilder<T>> thisType()
+    {
+        return (Class<McpCacheToolsEagerConfigBuilder<T>>) getClass();
+    }
+
+    public McpCacheToolsEagerConfigBuilder<T> policy(
+        McpCacheToolsEagerPolicy policy)
+    {
+        this.policy = policy;
+        return this;
+    }
+
+    public McpCacheToolsEagerConfigBuilder<T> match(
+        List<String> match)
+    {
+        this.match = match;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        return mapper.apply(new McpCacheToolsEagerConfig(policy, match));
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerPolicy.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/config/McpCacheToolsEagerPolicy.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.config;
+
+public enum McpCacheToolsEagerPolicy
+{
+    NONE,
+    ALL,
+    EXPLICIT
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpCacheToolsConfigAdapter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpCacheToolsConfigAdapter.java
@@ -27,6 +27,8 @@ import jakarta.json.JsonValue;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsConfigBuilder;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsEagerConfigBuilder;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsEagerPolicy;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsSearchConfigBuilder;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpKeywordToolSearchIndexConfig;
@@ -44,6 +46,10 @@ public final class McpCacheToolsConfigAdapter
     private static final String SEARCH_TYPE_NAME = "type";
     private static final String SEARCH_INDEX_NAME = "index";
     private static final String SEARCH_TYPE_DEFAULT = McpKeywordToolSearchIndexConfig.NAME;
+    private static final String EAGER_NAME = "eager";
+    private static final String EAGER_POLICY_NAME = "policy";
+    private static final String EAGER_POLICY_DEFAULT = "none";
+    private static final String EAGER_MATCH_NAME = "match";
 
     private final McpToolSearchIndexConfigAdapter index = new McpToolSearchIndexConfigAdapter();
 
@@ -81,6 +87,21 @@ public final class McpCacheToolsConfigAdapter
             }
 
             object.add(SEARCH_NAME, searchObject);
+        }
+
+        if (tools.eager != null)
+        {
+            JsonObjectBuilder eagerObject = Json.createObjectBuilder()
+                .add(EAGER_POLICY_NAME, tools.eager.policy.name().toLowerCase());
+
+            if (tools.eager.match != null)
+            {
+                JsonArrayBuilder match = Json.createArrayBuilder();
+                tools.eager.match.forEach(match::add);
+                eagerObject.add(EAGER_MATCH_NAME, match);
+            }
+
+            object.add(EAGER_NAME, eagerObject);
         }
 
         return object.build();
@@ -132,6 +153,25 @@ public final class McpCacheToolsConfigAdapter
             }
 
             searchBuilder.build();
+        }
+
+        if (object.containsKey(EAGER_NAME))
+        {
+            JsonObject eager = object.getJsonObject(EAGER_NAME);
+
+            McpCacheToolsEagerConfigBuilder<McpCacheToolsConfigBuilder<McpCacheToolsConfig>> eagerBuilder = builder.eager()
+                .policy(McpCacheToolsEagerPolicy.valueOf(eager.getString(EAGER_POLICY_NAME, EAGER_POLICY_DEFAULT)
+                    .toUpperCase()));
+
+            if (eager.containsKey(EAGER_MATCH_NAME))
+            {
+                List<String> match = eager.getJsonArray(EAGER_MATCH_NAME).getValuesAs(JsonString.class).stream()
+                    .map(JsonString::getString)
+                    .collect(Collectors.toList());
+                eagerBuilder.match(match);
+            }
+
+            eagerBuilder.build();
         }
 
         return builder.build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFa
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpLifecycleServer;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyLifecycleFactory.McpRouteRequest;
 import io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache.McpProxyCache;
+import io.aklivity.zilla.runtime.binding.mcp.internal.transform.McpEagerFilter;
 import io.aklivity.zilla.runtime.binding.mcp.internal.transform.McpScopeFilter;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
@@ -132,6 +133,17 @@ abstract class McpProxyListFactory implements BindingHandler
     private final MutableDirectBufferEx scopeSourceBuffer = new UnsafeBufferEx();
     private final MutableDirectBufferEx scopeTargetBuffer = new UnsafeBufferEx();
     private byte[] scopeTargetArray = new byte[0];
+
+    // reusable per-worker eager/cold partition machinery; reconfigured per list response, never reallocated
+    private final McpEagerFilter eagerFilter = new McpEagerFilter();
+    private final JsonParserEx eagerParser = JsonEx.createParser();
+    private final JsonGeneratorEx eagerGenerator = JsonEx.createGenerator();
+    private final JsonPipeline eagerPipeline = JsonEx.stream(eagerParser)
+        .transform(eagerFilter)
+        .into(eagerGenerator);
+    private final MutableDirectBufferEx eagerSourceBuffer = new UnsafeBufferEx();
+    private final MutableDirectBufferEx eagerTargetBuffer = new UnsafeBufferEx();
+    private byte[] eagerTargetArray = new byte[0];
 
     McpProxyListFactory(
         McpConfiguration config,
@@ -2150,7 +2162,8 @@ abstract class McpProxyListFactory implements BindingHandler
             if (value != null)
             {
                 final byte[] filtered = filterByScopes(value);
-                final byte[] bytes = McpSearchToolInjector.inject(filtered, cache.searchToolBytes());
+                final byte[] eagerFiltered = applyEagerPolicy(filtered);
+                final byte[] bytes = McpSearchToolInjector.inject(eagerFiltered, cache.searchToolBytes());
                 cachedBuf = new UnsafeBufferEx(bytes);
                 cachedLen = bytes.length;
             }
@@ -2194,6 +2207,43 @@ abstract class McpProxyListFactory implements BindingHandler
 
                 output = new byte[produced];
                 scopeTargetBuffer.getBytes(0, output);
+            }
+            return output;
+        }
+
+        private byte[] applyEagerPolicy(
+            byte[] json)
+        {
+            byte[] output = json;
+            if (cache.eagerConfigured())
+            {
+                eagerFilter.init(arrayKey(), cache::eager, cache.searchToolBytes() != null);
+
+                // annotating cold items can grow the output; a cold item's added "defer_loading":true member
+                // is a small, fixed cost against the item's own JSON, so doubling the source is ample headroom
+                final int capacity = json.length * 2 + 4096;
+                if (eagerTargetArray.length < capacity)
+                {
+                    eagerTargetArray = new byte[capacity];
+                }
+                eagerSourceBuffer.wrap(json);
+                eagerTargetBuffer.wrap(eagerTargetArray);
+                int produced = 0;
+
+                eagerPipeline.reset();
+                JsonPipelineResult result =
+                    eagerPipeline.transform(eagerSourceBuffer, 0, json.length, true, eagerTargetBuffer, 0, capacity);
+                produced += result.produced();
+
+                while (result.status() == JsonPipeline.Status.SUSPENDED)
+                {
+                    result = eagerPipeline.transform(
+                        eagerSourceBuffer, 0, json.length, true, eagerTargetBuffer, produced, capacity);
+                    produced += result.produced();
+                }
+
+                output = new byte[produced];
+                eagerTargetBuffer.getBytes(0, output);
             }
             return output;
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -31,6 +31,8 @@ import java.util.TreeMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntPredicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
 import jakarta.json.stream.JsonParser;
@@ -38,6 +40,8 @@ import jakarta.json.stream.JsonParser;
 import org.agrona.collections.Int2ObjectHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsEagerConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsEagerPolicy;
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpSearchToolDescriptor;
 import io.aklivity.zilla.runtime.binding.mcp.internal.search.McpToolSearchDocumentScanner;
@@ -134,9 +138,10 @@ public final class McpProxyCache
             final byte[] searchToolBytes = cache.tools != null && cache.tools.search != null
                 ? McpSearchToolDescriptor.build(cache.tools.search.tool)
                 : null;
+            final McpCacheToolsEagerConfig eager = cache.tools != null ? cache.tools.eager : null;
             caches.put(KIND_TOOLS_LIST,
                 new McpListCache(KIND_TOOLS_LIST, STORE_KEY_TOOLS, STORE_LOCK_KEY_TOOLS,
-                    searchIndex, searchFields, searchToolBytes));
+                    searchIndex, searchFields, searchToolBytes, eager));
         }
         if (filter.test(KIND_RESOURCES_LIST))
         {
@@ -278,6 +283,8 @@ public final class McpProxyCache
         private final McpToolSearchIndex searchIndex;
         private final List<String> searchFields;
         private final byte[] searchToolBytes;
+        private final McpCacheToolsEagerPolicy eagerPolicy;
+        private final List<Pattern> eagerMatch;
         private Map<CharSequence, List<String>> scopesByName = Collections.emptyMap();
         private long lastChecksum = -1L;
         private String lockToken;
@@ -310,12 +317,43 @@ public final class McpProxyCache
             return searchToolBytes;
         }
 
+        public boolean eagerConfigured()
+        {
+            return eagerPolicy != null && eagerPolicy != McpCacheToolsEagerPolicy.NONE;
+        }
+
+        public boolean eager(
+            CharSequence name)
+        {
+            return switch (eagerPolicy)
+            {
+            case ALL -> false;
+            case EXPLICIT -> admitsEager(name);
+            default -> true;
+            };
+        }
+
+        private boolean admitsEager(
+            CharSequence name)
+        {
+            boolean admitted = false;
+            for (Pattern pattern : eagerMatch)
+            {
+                if (pattern.matcher(name).matches())
+                {
+                    admitted = true;
+                    break;
+                }
+            }
+            return admitted;
+        }
+
         private McpListCache(
             int kind,
             String storeKey,
             String storeLockKey)
         {
-            this(kind, storeKey, storeLockKey, null, null, null);
+            this(kind, storeKey, storeLockKey, null, null, null, null);
         }
 
         private McpListCache(
@@ -324,7 +362,8 @@ public final class McpProxyCache
             String storeLockKey,
             McpToolSearchIndex searchIndex,
             List<String> searchFields,
-            byte[] searchToolBytes)
+            byte[] searchToolBytes,
+            McpCacheToolsEagerConfig eager)
         {
             this.kind = kind;
             this.storeKey = storeKey;
@@ -333,6 +372,35 @@ public final class McpProxyCache
             this.searchIndex = searchIndex;
             this.searchFields = searchFields;
             this.searchToolBytes = searchToolBytes;
+            this.eagerPolicy = eager != null ? eager.policy : McpCacheToolsEagerPolicy.NONE;
+            this.eagerMatch = eager != null && eager.match != null ? compileEagerMatch(eager.match) : null;
+        }
+
+        private List<Pattern> compileEagerMatch(
+            List<String> globs)
+        {
+            return globs.stream()
+                .map(McpListCache::compileGlob)
+                .collect(Collectors.toList());
+        }
+
+        private static Pattern compileGlob(
+            String glob)
+        {
+            final StringBuilder regex = new StringBuilder();
+            final String[] literals = glob.split("\\*", -1);
+            for (int index = 0; index < literals.length; index++)
+            {
+                if (index > 0)
+                {
+                    regex.append(".*");
+                }
+                if (!literals[index].isEmpty())
+                {
+                    regex.append(Pattern.quote(literals[index]));
+                }
+            }
+            return Pattern.compile(regex.toString());
         }
 
         public void putFragment(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilter.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.transform;
+
+import java.math.BigDecimal;
+import java.util.function.Predicate;
+
+import jakarta.json.stream.JsonLocation;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonController;
+import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.JsonSource;
+import io.aklivity.zilla.runtime.common.json.JsonTransform;
+import io.aklivity.zilla.runtime.common.json.JsonVerbatim;
+
+/**
+ * Partitions items in a JSON-RPC list response into eager (copied through verbatim) and cold, per an
+ * operator-configured eager policy. A cold item is either annotated with a synthetic
+ * {@code "defer_loading":true} member (when {@code omitCold} is {@code false}, so it remains discoverable
+ * in the response) or dropped entirely (when {@code omitCold} is {@code true}, so it is reachable only via
+ * a companion search tool). Assumes {@code name} is the first member of each item object, matching
+ * {@link McpScopeFilter}.
+ */
+public final class McpEagerFilter implements JsonTransform
+{
+    private static final String NAME_KEY = "name";
+    private static final String DEFER_LOADING_KEY = "defer_loading";
+
+    @FunctionalInterface
+    private interface State
+    {
+        Status apply(
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink);
+    }
+
+    private String arrayKey;
+    private Predicate<CharSequence> eager;
+    private boolean omitCold;
+    private final KeySource keySource = new KeySource();
+    private final Control mediator = new Control();
+    private final Control inject = new Control(true);
+
+    private final State outer = this::onOuter;
+    private final State items = this::onItems;
+    private final State pending = this::onPending;
+    private final State copying = this::onCopying;
+    private final State skipping = this::onSkipping;
+
+    private State state = outer;
+    private int depth;
+    private int itemDepth;
+    private boolean itemsArmed;
+    private boolean nameArmed;
+
+    public void init(
+        String arrayKey,
+        Predicate<CharSequence> eager,
+        boolean omitCold)
+    {
+        this.arrayKey = arrayKey;
+        this.eager = eager;
+        this.omitCold = omitCold;
+        reset();
+    }
+
+    @Override
+    public void reset()
+    {
+        state = outer;
+        depth = 0;
+        itemDepth = 0;
+        itemsArmed = false;
+        nameArmed = false;
+    }
+
+    @Override
+    public Status transform(
+        JsonController control,
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        mediator.delegate = control;
+        return state.apply(source, event, sink);
+    }
+
+    // outside the target array: pass everything through, arming when the target array key is seen
+    private Status onOuter(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        switch (event)
+        {
+        case START_OBJECT:
+        case START_ARRAY:
+            depth++;
+            if (itemsArmed && event == JsonEvent.START_ARRAY)
+            {
+                itemsArmed = false;
+                itemDepth = 0;
+                state = items;
+            }
+            break;
+        case END_OBJECT:
+        case END_ARRAY:
+            depth--;
+            break;
+        case KEY_NAME:
+            itemsArmed = depth == 1 && arrayKey.contentEquals(source.getStringView());
+            break;
+        default:
+            break;
+        }
+        return sink.transform(mediator, source, event);
+    }
+
+    // between items in the target array: each item object defers its emission until its name resolves
+    private Status onItems(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        Status status;
+        switch (event)
+        {
+        case START_OBJECT:
+            itemDepth = 1;
+            nameArmed = false;
+            state = pending;
+            status = Status.ADVANCED;
+            break;
+        case END_ARRAY:
+            state = outer;
+            status = sink.transform(mediator, source, event);
+            break;
+        default:
+            status = sink.transform(mediator, source, event);
+            break;
+        }
+        return status;
+    }
+
+    // inside an item whose eager/cold disposition is undecided: swallow events until the name value is seen
+    private Status onPending(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        Status status;
+        switch (event)
+        {
+        case START_OBJECT:
+        case START_ARRAY:
+            itemDepth++;
+            status = sink.transform(mediator, source, event);
+            break;
+        case END_OBJECT:
+            itemDepth--;
+            status = sink.transform(mediator, source, event);
+            if (itemDepth == 0)
+            {
+                state = items;
+            }
+            break;
+        case END_ARRAY:
+            itemDepth--;
+            status = sink.transform(mediator, source, event);
+            break;
+        case KEY_NAME:
+            if (itemDepth == 1)
+            {
+                nameArmed = NAME_KEY.contentEquals(source.getStringView());
+                status = Status.ADVANCED;
+            }
+            else
+            {
+                status = sink.transform(mediator, source, event);
+            }
+            break;
+        case VALUE_STRING:
+            status = nameArmed
+                ? resolveItem(source, event, sink)
+                : sink.transform(mediator, source, event);
+            break;
+        default:
+            status = Status.ADVANCED;
+            break;
+        }
+        return status;
+    }
+
+    // inside a kept item: copy its remaining content through verbatim
+    private Status onCopying(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        switch (event)
+        {
+        case START_OBJECT:
+        case START_ARRAY:
+            itemDepth++;
+            break;
+        case END_ARRAY:
+            itemDepth--;
+            break;
+        case END_OBJECT:
+            itemDepth--;
+            if (itemDepth == 0)
+            {
+                state = items;
+            }
+            break;
+        default:
+            break;
+        }
+        return sink.transform(mediator, source, event);
+    }
+
+    // inside a cold, omitted item: swallow its remaining content
+    private Status onSkipping(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        switch (event)
+        {
+        case START_OBJECT:
+        case START_ARRAY:
+            itemDepth++;
+            break;
+        case END_ARRAY:
+            itemDepth--;
+            break;
+        case END_OBJECT:
+            itemDepth--;
+            if (itemDepth == 0)
+            {
+                state = items;
+            }
+            break;
+        default:
+            break;
+        }
+        return Status.ADVANCED;
+    }
+
+    private Status resolveItem(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        final CharSequence name = source.getStringView();
+        final boolean admitted = eager.test(name);
+
+        nameArmed = false;
+
+        Status status;
+        if (!admitted && omitCold)
+        {
+            state = skipping;
+            status = Status.ADVANCED;
+        }
+        else
+        {
+            // re-emit the elided object start and name key as synthetic events carrying no source bytes,
+            // then resume the real name value through the byte-tracking mediator
+            status = sink.transform(inject, source, JsonEvent.START_OBJECT);
+            if (status == Status.ADVANCED)
+            {
+                status = sink.transform(inject, keySource.with(NAME_KEY), JsonEvent.KEY_NAME);
+            }
+            if (status == Status.ADVANCED)
+            {
+                status = sink.transform(mediator, source, event);
+            }
+            if (status == Status.ADVANCED && !admitted)
+            {
+                status = sink.transform(inject, keySource.with(DEFER_LOADING_KEY), JsonEvent.KEY_NAME);
+                if (status == Status.ADVANCED)
+                {
+                    status = sink.transform(inject, keySource, JsonEvent.VALUE_TRUE);
+                }
+            }
+            state = copying;
+        }
+        return status;
+    }
+
+    private static final class Control implements JsonController
+    {
+        private final boolean synthetic;
+
+        private JsonController delegate;
+
+        private Control()
+        {
+            this(false);
+        }
+
+        private Control(
+            boolean synthetic)
+        {
+            this.synthetic = synthetic;
+        }
+
+        @Override
+        public void segmentable()
+        {
+        }
+
+        @Override
+        public void verbatim()
+        {
+        }
+
+        @Override
+        public void consumed(
+            int sourceBytes)
+        {
+            if (!synthetic)
+            {
+                delegate.consumed(sourceBytes);
+            }
+        }
+    }
+
+    private static final class KeySource implements JsonSource
+    {
+        private CharSequence key;
+
+        private KeySource with(
+            CharSequence key)
+        {
+            this.key = key;
+            return this;
+        }
+
+        @Override
+        public String getString()
+        {
+            return key == null ? null : key.toString();
+        }
+
+        @Override
+        public CharSequence getStringView()
+        {
+            return key;
+        }
+
+        @Override
+        public BigDecimal getBigDecimal()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isIntegralNumber()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getInt()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLong()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JsonLocation getLocation()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DirectBufferEx getSegment()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JsonVerbatim getVerbatim(
+            int limit)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void skipValue()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deferredBytes()
+        {
+            return false;
+        }
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -227,6 +227,46 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.tools.eager.serve.all.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.all/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsListEagerAll() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.cache.tools.eager.serve.explicit.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.explicit/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsListEagerExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.cache.tools.eager.serve.explicit.search.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.explicit.search/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsListEagerExplicitWithSearch() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.cache.tools.eager.serve.explicit.search.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.search.eager.cold/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsSearchEagerCold() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.toolkit.filter.yaml")
     @Specification({
         "${app}/cache.serve.tools.list.toolkit.filtered/server",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -227,6 +227,16 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.tools.eager.serve.none.yaml")
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.none/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldServeToolsListEagerNone() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.tools.eager.serve.all.yaml")
     @Specification({
         "${app}/cache.serve.tools.list.eager.all/client" })

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.additional.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.additional.invalid.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+            match:
+              - github__list_repos
+            unknown: true
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.all.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.all.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: all
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.match.empty.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.match.empty.invalid.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+            match: []
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.match.missing.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.match.missing.invalid.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.explicit.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+            match:
+              - github__list_repos
+              - github__get_current_user
+              - "slack__*"
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.none.match.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.none.match.invalid.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: none
+            match:
+              - github__list_repos
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.policy.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.policy.invalid.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: sometimes
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.all.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.all.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+    options:
+      entries:
+        tools: |-
+          {"tools":[{"name": "github__list_repos","description": "List repositories"},{"name": "github__delete_repo","description": "Delete a repository"}]}
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: all
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.explicit.search.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.explicit.search.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+    options:
+      entries:
+        tools: |-
+          {"tools":[{"name": "github__list_repos","description": "List repositories"},{"name": "github__delete_repo","description": "Delete a repository"}]}
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+            match:
+              - github__list_repos
+          search:
+            tool: zilla__search_tools
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.explicit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.explicit.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+    options:
+      entries:
+        tools: |-
+          {"tools":[{"name": "github__list_repos","description": "List repositories"},{"name": "github__delete_repo","description": "Delete a repository"}]}
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: explicit
+            match:
+              - github__list_repos
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.none.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.serve.none.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+stores:
+  memory0:
+    type: test
+    options:
+      entries:
+        tools: |-
+          {"tools":[{"name": "github__list_repos","description": "List repositories"},{"name": "github__delete_repo","description": "Delete a repository"}]}
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: none
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.tools.eager.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp
+    kind: proxy
+    options:
+      cache:
+        store: memory0
+        tools:
+          eager:
+            policy: none
+    exit: app1

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -344,6 +344,50 @@
                                                             "required": [ "tool" ],
                                                             "not": { "required": [ "type", "index" ] },
                                                             "additionalProperties": false
+                                                        },
+                                                        "eager":
+                                                        {
+                                                            "title": "Eager",
+                                                            "type": "object",
+                                                            "properties":
+                                                            {
+                                                                "policy":
+                                                                {
+                                                                    "title": "Policy",
+                                                                    "enum": [ "none", "all", "explicit" ],
+                                                                    "default": "none"
+                                                                },
+                                                                "match":
+                                                                {
+                                                                    "title": "Match",
+                                                                    "type": "array",
+                                                                    "items":
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "minItems": 1
+                                                                }
+                                                            },
+                                                            "if":
+                                                            {
+                                                                "required": [ "policy" ],
+                                                                "properties":
+                                                                {
+                                                                    "policy":
+                                                                    {
+                                                                        "const": "explicit"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "then":
+                                                            {
+                                                                "required": [ "match" ]
+                                                            },
+                                                            "else":
+                                                            {
+                                                                "not": { "required": [ "match" ] }
+                                                            },
+                                                            "additionalProperties": false
                                                         }
                                                     },
                                                     "additionalProperties": false

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.all/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.all/client.rpt
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"defer_loading":true,'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"github__delete_repo",'
+            '"defer_loading":true,'
+            '"description":"Delete a repository"'
+          '}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.all/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.all/server.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"defer_loading":true,'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"github__delete_repo",'
+            '"defer_loading":true,'
+            '"description":"Delete a repository"'
+          '}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit.search/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit.search/client.rpt
@@ -1,0 +1,74 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"zilla__search_tools",'
+            '"description":"Search the tool catalog by relevance and return references to matching tools.",'
+            '"inputSchema":{'
+              '"type":"object",'
+              '"properties":{'
+                '"query":{"type":"string","description":"Natural-language search query"},'
+                '"max_results":{"type":"integer","description":"Maximum number of results to return"}'
+              '},'
+              '"required":["query"]'
+            '}'
+          '}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit.search/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit.search/server.rpt
@@ -1,0 +1,78 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"zilla__search_tools",'
+            '"description":"Search the tool catalog by relevance and return references to matching tools.",'
+            '"inputSchema":{'
+              '"type":"object",'
+              '"properties":{'
+                '"query":{"type":"string","description":"Natural-language search query"},'
+                '"max_results":{"type":"integer","description":"Maximum number of results to return"}'
+              '},'
+              '"required":["query"]'
+            '}'
+          '}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit/client.rpt
@@ -1,0 +1,67 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"github__delete_repo",'
+            '"defer_loading":true,'
+            '"description":"Delete a repository"'
+          '}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.explicit/server.rpt
@@ -1,0 +1,71 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{'
+            '"name":"github__list_repos",'
+            '"description":"List repositories"'
+          '}'
+          ','
+          '{'
+            '"name":"github__delete_repo",'
+            '"defer_loading":true,'
+            '"description":"Delete a repository"'
+          '}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.none/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.none/client.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{'
+            '"name": "github__list_repos",'
+            '"description": "List repositories"'
+          '}'
+          ','
+          '{'
+            '"name": "github__delete_repo",'
+            '"description": "Delete a repository"'
+          '}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.none/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.eager.none/server.rpt
@@ -1,0 +1,70 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{'
+            '"name": "github__list_repos",'
+            '"description": "List repositories"'
+          '}'
+          ','
+          '{'
+            '"name": "github__delete_repo",'
+            '"description": "Delete a repository"'
+          '}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search.eager.cold/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search.eager.cold/client.rpt
@@ -1,0 +1,64 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("agent-1")
+                               .name("zilla__search_tools")
+                               .contentLength(62)
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"zilla__search_tools",'
+        '"arguments":'
+        '{'
+          '"query": "delete"'
+        '}'
+      '}'
+
+read  '{"content":[{"type":"tool_reference","tool_name":"github__delete_repo"}],"isError":false}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search.eager.cold/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.search.eager.cold/server.rpt
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2024 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("agent-1")
+                              .name("zilla__search_tools")
+                              .contentLength(62)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"zilla__search_tools",'
+        '"arguments":'
+        '{'
+          '"query": "delete"'
+        '}'
+      '}'
+
+write flush
+
+write '{"content":[{"type":"tool_reference","tool_name":"github__delete_repo"}],"isError":false}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
@@ -188,4 +188,58 @@ public class SchemaTest
     {
         schema.validate("proxy.cache.tools.search.tool.missing.invalid.yaml");
     }
+
+    @Test
+    public void shouldValidateProxyCacheToolsEager()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.eager.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyCacheToolsEagerAll()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.eager.all.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyCacheToolsEagerExplicit()
+    {
+        JsonObject config = schema.validate("proxy.cache.tools.eager.explicit.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsEagerWithUnknownPolicy()
+    {
+        schema.validate("proxy.cache.tools.eager.policy.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsEagerExplicitMissingMatch()
+    {
+        schema.validate("proxy.cache.tools.eager.explicit.match.missing.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsEagerExplicitEmptyMatch()
+    {
+        schema.validate("proxy.cache.tools.eager.explicit.match.empty.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsEagerNoneWithMatch()
+    {
+        schema.validate("proxy.cache.tools.eager.none.match.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyCacheToolsEagerWithAdditionalProperty()
+    {
+        schema.validate("proxy.cache.tools.eager.additional.invalid.yaml");
+    }
 }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
@@ -209,6 +209,15 @@ public class ProxyCacheIT
 
     @Test
     @Specification({
+        "${app}/cache.serve.tools.list.eager.none/client",
+        "${app}/cache.serve.tools.list.eager.none/server" })
+    public void shouldServeToolsListEagerNone() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/cache.serve.tools.list.eager.all/client",
         "${app}/cache.serve.tools.list.eager.all/server" })
     public void shouldServeToolsListEagerAll() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
@@ -209,6 +209,42 @@ public class ProxyCacheIT
 
     @Test
     @Specification({
+        "${app}/cache.serve.tools.list.eager.all/client",
+        "${app}/cache.serve.tools.list.eager.all/server" })
+    public void shouldServeToolsListEagerAll() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.explicit/client",
+        "${app}/cache.serve.tools.list.eager.explicit/server" })
+    public void shouldServeToolsListEagerExplicit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/cache.serve.tools.list.eager.explicit.search/client",
+        "${app}/cache.serve.tools.list.eager.explicit.search/server" })
+    public void shouldServeToolsListEagerExplicitWithSearch() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/cache.serve.tools.search.eager.cold/client",
+        "${app}/cache.serve.tools.search.eager.cold/server" })
+    public void shouldServeToolsSearchEagerCold() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/cache.serve.tools.list.10k/client",
         "${app}/cache.serve.tools.list.10k/server" })
     public void shouldServeToolsList10k() throws Exception


### PR DESCRIPTION
## Description

Adds `options.cache.tools.eager` to the `mcp` binding's `proxy` kind, letting the operator choose which tools ship eagerly in `tools/list` and which are cold, so large federated catalogs fit inside the agent's context budget without losing reachability.

- `policy: none` (default) — every authorized tool is eager; nothing is cold; backwards-compatible.
- `policy: all` — nothing is eager; every authorized tool is cold.
- `policy: explicit` — eager set is the operator-configured `match:` glob allowlist (`*`-wildcard, same convention as `McpConditionMatcher`) intersected with the session's authorized catalog.

Cold tools appear in `tools/list` with `defer_loading: true` when no proxy search tool (#1969) is configured, or are omitted from `tools/list` entirely (still reachable via the proxy search tool's `tool_reference` results) when one is configured. `eager` and `search` are independent config sections — all four combinations (eager × search present/absent) are implemented and covered by tests.

Eager/cold partitioning runs after per-session scope filtering (#1831), so the eager set is always a subset of the session-authorized set, and after search-tool indexing (which always scans the full pre-filter catalog), so cold-omitted tools stay discoverable via search.

### Changes

- `McpCacheToolsEagerConfig`/`McpCacheToolsEagerPolicy` config model + builder + JSON adapter (`options.cache.tools.eager.policy`, `.match`)
- JSON schema patch: `policy` enum (`none|all|explicit`), `match` required+non-empty only when `policy: explicit`, rejected otherwise
- `McpEagerFilter`: new streaming JSON transform (mirrors `McpScopeFilter`) that partitions `tools/list` items into eager/cold, annotating or dropping cold items
- `McpProxyCache.McpListCache`: compiles `match` globs once per cache and exposes `eager(name)`/`eagerConfigured()`
- Wired into `McpProxyListFactory.onStoreResult` between scope filtering and search-tool injection

Fixes #1970

## Test plan

- [x] `SchemaTest`: valid/invalid fixtures for `none`/`all`/`explicit`, missing/empty `match`, `match` rejected outside `explicit`, unknown property rejected
- [x] New `.rpt` spec scenarios + `ProxyCacheIT` (peer-to-peer) and `McpProxyCacheIT` (live engine) methods covering all 4 eager × search composition cases, including the explicit `policy: none` passthrough case and the coherence check that a cold-omitted tool is still reachable via the search tool
- [x] `./mvnw clean verify` green for `runtime/binding-mcp` (112 unit + 256 IT) and `specs/binding-mcp.spec` (120 unit + 232 IT)
- [x] `checkstyle:check` and `license:check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01BhwTEntpRaDYssAmcwCEvF)_