### PR TITLE
fix(binding-mcp): thread inherited authorization into guard fallback calls

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -2783,7 +2783,7 @@ public final class McpClientFactory implements McpStreamFactory
             if (sessionId == GuardHandler.NEEDS_PREAUTHORIZE && session.binding.needsCredentials)
             {
                 final String preauthorizeUrl =
-                    guard.preauthorize(traceId, session.binding.id, authorization, session.authCallback);
+                    guard.preauthorize(traceId, session.binding.id, initialId, authorization, session.authCallback);
                 if (preauthorizeUrl == null)
                 {
                     doAppReset(traceId, authorization);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1732,10 +1732,20 @@ public final class McpClientFactory implements McpStreamFactory
             final GuardHandler guard = binding.guard;
             if (guard != null)
             {
-                final long sessionId = guard.reauthorize(traceId, binding.id, initialId, null);
-                if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
+                final String resolved = (authorization & GuardHandler.MASK_AUTHORIZED) != 0L
+                    ? guard.credentials(authorization)
+                    : null;
+                if (resolved != null)
                 {
-                    credentials = guard.credentials(sessionId);
+                    credentials = resolved;
+                }
+                else
+                {
+                    final long sessionId = guard.reauthorize(traceId, binding.id, authorization, null);
+                    if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
+                    {
+                        credentials = guard.credentials(sessionId);
+                    }
                 }
             }
             return true;
@@ -2754,11 +2764,15 @@ public final class McpClientFactory implements McpStreamFactory
 
             if ((authorization & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
-                credentials = guard.credentials(authorization);
-                return true;
+                final String resolved = guard.credentials(authorization);
+                if (resolved != null)
+                {
+                    credentials = resolved;
+                    return true;
+                }
             }
 
-            final long sessionId = guard.reauthorize(traceId, session.binding.id, initialId, null);
+            final long sessionId = guard.reauthorize(traceId, session.binding.id, authorization, null);
 
             if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
@@ -2769,7 +2783,7 @@ public final class McpClientFactory implements McpStreamFactory
             if (sessionId == GuardHandler.NEEDS_PREAUTHORIZE && session.binding.needsCredentials)
             {
                 final String preauthorizeUrl =
-                    guard.preauthorize(traceId, session.binding.id, initialId, session.authCallback);
+                    guard.preauthorize(traceId, session.binding.id, authorization, session.authCallback);
                 if (preauthorizeUrl == null)
                 {
                     doAppReset(traceId, authorization);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
@@ -256,6 +256,34 @@ public interface GuardHandler
     }
 
     /**
+     * Sessioned variant of {@link #preauthorize(long, long, long, String)} for guards that
+     * delegate identity resolution to another guard (e.g. via a {@code via} reference), so the
+     * pre-authorization step can be bound to the caller's already-established session instead of
+     * relying on {@code contextId} for that purpose. The default implementation ignores
+     * {@code sessionId} and delegates to the non-sessioned overload.
+     *
+     * @param traceId    the trace identifier for diagnostics
+     * @param bindingId  the binding identifier requesting authorization
+     * @param contextId  a context identifier (e.g., connection id), or {@code 0} if none
+     * @param sessionId  a session id already established for the request by another guard,
+     *                   or {@code 0} if none; the format and use are guard-specific
+     * @param callback   the URL the upstream should redirect the user back to once the
+     *                   pre-authorization step is complete; the guard treats this as
+     *                   opaque and embeds it on the returned URL in whatever form the
+     *                   upstream protocol requires
+     * @return the URL the user must visit, or {@code null} if not applicable
+     */
+    default String preauthorize(
+        long traceId,
+        long bindingId,
+        long contextId,
+        long sessionId,
+        String callback)
+    {
+        return preauthorize(traceId, bindingId, contextId, callback);
+    }
+
+    /**
      * Generic completion handler for asynchronous guard operations, modelled after
      * {@link java.nio.channels.CompletionHandler}. The {@code contextId} supplied by
      * the caller is echoed back to both methods so a single shared callback instance

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
@@ -240,31 +240,6 @@ public interface GuardHandler
      * @param traceId    the trace identifier for diagnostics
      * @param bindingId  the binding identifier requesting authorization
      * @param contextId  a context identifier (e.g., connection id), or {@code 0} if none
-     * @param callback   the URL the upstream should redirect the user back to once the
-     *                   pre-authorization step is complete; the guard treats this as
-     *                   opaque and embeds it on the returned URL in whatever form the
-     *                   upstream protocol requires
-     * @return the URL the user must visit, or {@code null} if not applicable
-     */
-    default String preauthorize(
-        long traceId,
-        long bindingId,
-        long contextId,
-        String callback)
-    {
-        return null;
-    }
-
-    /**
-     * Sessioned variant of {@link #preauthorize(long, long, long, String)} for guards that
-     * delegate identity resolution to another guard (e.g. via a {@code via} reference), so the
-     * pre-authorization step can be bound to the caller's already-established session instead of
-     * relying on {@code contextId} for that purpose. The default implementation ignores
-     * {@code sessionId} and delegates to the non-sessioned overload.
-     *
-     * @param traceId    the trace identifier for diagnostics
-     * @param bindingId  the binding identifier requesting authorization
-     * @param contextId  a context identifier (e.g., connection id), or {@code 0} if none
      * @param sessionId  a session id already established for the request by another guard,
      *                   or {@code 0} if none; the format and use are guard-specific
      * @param callback   the URL the upstream should redirect the user back to once the
@@ -280,7 +255,7 @@ public interface GuardHandler
         long sessionId,
         String callback)
     {
-        return preauthorize(traceId, bindingId, contextId, callback);
+        return null;
     }
 
     /**

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
@@ -48,7 +48,7 @@ public final class GuardFactoryTest
         GuardConfig config = GuardConfig.builder().namespace("test").name("test").type("test").build();
         GuardHandler handler = new TestGuardHandler(new TestGuardConfig(config));
 
-        assertThat(handler.preauthorize(0L, 0L, 0L, null), nullValue());
+        assertThat(handler.preauthorize(0L, 0L, 0L, 0L, null), nullValue());
     }
 
     @Test

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -389,7 +389,7 @@ final class TestBindingFactory implements BindingHandler
         private void doPreauthorizeAndCallback(
             long traceId)
         {
-            String url = guard.preauthorize(traceId, routedId, 0, callbackUri);
+            String url = guard.preauthorize(traceId, routedId, 0, 0, callbackUri);
             if (url == null)
             {
                 onAuthorized(traceId, NOT_AUTHORIZED);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -37,7 +37,6 @@ public final class TestGuardHandler implements GuardHandler
 {
     private static final String REDIRECT_URI_PLACEHOLDER = "replace.me";
     private static final Pattern REDIRECT_URI_PARAM_PATTERN = Pattern.compile("redirect_uri=[^&]*");
-    private static final String CONTEXT_ID_PLACEHOLDER = "{contextId}";
 
     private final String credentials;
     private final Duration challenge;
@@ -48,7 +47,6 @@ public final class TestGuardHandler implements GuardHandler
     private final String preauthorize;
 
     private final Long2LongHashMap sessions;
-    private final Long2LongHashMap contextsById;
     private final MutableLong nextSessionId;
 
     public TestGuardHandler(
@@ -61,7 +59,6 @@ public final class TestGuardHandler implements GuardHandler
         this.roles = config.options != null ? config.options.roles : null;
         this.preauthorize = config.options != null ? config.options.preauthorize : null;
         this.sessions = new Long2LongHashMap(-1L);
-        this.contextsById = new Long2LongHashMap(-1L);
         this.nextSessionId = new MutableLong(1L);
         this.attributes = config.options != null ? config.options.attributes : null;
     }
@@ -78,11 +75,6 @@ public final class TestGuardHandler implements GuardHandler
         if (this.credentials != null && this.credentials.equals(credentials))
         {
             sessionId = createSession();
-        }
-        else if (credentials == null && this.credentials != null && this.credentials.contains(CONTEXT_ID_PLACEHOLDER))
-        {
-            sessionId = createSession();
-            contextsById.put(sessionId, contextId);
         }
         else if (preauthorize != null)
         {
@@ -134,7 +126,6 @@ public final class TestGuardHandler implements GuardHandler
         long sessionId)
     {
         sessions.remove(sessionId);
-        contextsById.remove(sessionId);
     }
 
     @Override
@@ -156,14 +147,7 @@ public final class TestGuardHandler implements GuardHandler
     public String credentials(
         long sessionId)
     {
-        String result = credentials;
-
-        if (result != null && result.contains(CONTEXT_ID_PLACEHOLDER) && contextsById.containsKey(sessionId))
-        {
-            result = result.replace(CONTEXT_ID_PLACEHOLDER, Long.toString(contextsById.get(sessionId)));
-        }
-
-        return result;
+        return credentials;
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -96,6 +96,7 @@ public final class TestGuardHandler implements GuardHandler
         long traceId,
         long bindingId,
         long contextId,
+        long sessionId,
         String callback)
     {
         String result = preauthorize;

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -37,6 +37,7 @@ public final class TestGuardHandler implements GuardHandler
 {
     private static final String REDIRECT_URI_PLACEHOLDER = "replace.me";
     private static final Pattern REDIRECT_URI_PARAM_PATTERN = Pattern.compile("redirect_uri=[^&]*");
+    private static final String CONTEXT_ID_PLACEHOLDER = "{contextId}";
 
     private final String credentials;
     private final Duration challenge;
@@ -47,6 +48,7 @@ public final class TestGuardHandler implements GuardHandler
     private final String preauthorize;
 
     private final Long2LongHashMap sessions;
+    private final Long2LongHashMap contextsById;
     private final MutableLong nextSessionId;
 
     public TestGuardHandler(
@@ -59,6 +61,7 @@ public final class TestGuardHandler implements GuardHandler
         this.roles = config.options != null ? config.options.roles : null;
         this.preauthorize = config.options != null ? config.options.preauthorize : null;
         this.sessions = new Long2LongHashMap(-1L);
+        this.contextsById = new Long2LongHashMap(-1L);
         this.nextSessionId = new MutableLong(1L);
         this.attributes = config.options != null ? config.options.attributes : null;
     }
@@ -75,6 +78,11 @@ public final class TestGuardHandler implements GuardHandler
         if (this.credentials != null && this.credentials.equals(credentials))
         {
             sessionId = createSession();
+        }
+        else if (credentials == null && this.credentials != null && this.credentials.contains(CONTEXT_ID_PLACEHOLDER))
+        {
+            sessionId = createSession();
+            contextsById.put(sessionId, contextId);
         }
         else if (preauthorize != null)
         {
@@ -126,6 +134,7 @@ public final class TestGuardHandler implements GuardHandler
         long sessionId)
     {
         sessions.remove(sessionId);
+        contextsById.remove(sessionId);
     }
 
     @Override
@@ -147,7 +156,14 @@ public final class TestGuardHandler implements GuardHandler
     public String credentials(
         long sessionId)
     {
-        return credentials;
+        String result = credentials;
+
+        if (result != null && result.contains(CONTEXT_ID_PLACEHOLDER) && contextsById.containsKey(sessionId))
+        {
+            result = result.replace(CONTEXT_ID_PLACEHOLDER, Long.toString(contextsById.get(sessionId)));
+        }
+
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## Description

`binding-mcp`'s client-side credential fallback tries `guard.credentials(authorization)` before falling back to `guard.reauthorize(...)`, so a guard that already recognizes the inherited `authorization` value doesn't need to redo the full reauthorize/preauthorize dance on every request. Both fallback call sites now pass the inherited `authorization` (rather than `initialId`) into `reauthorize`/`preauthorize`, since that's the value guards use to look up an already-established session.

`GuardHandler.preauthorize` gains an explicit `sessionId` parameter alongside the existing `contextId`. Previously a guard that delegates identity resolution to another guard (e.g. one configured with a `via` reference to a second guard) had no parameter to receive the caller's already-established session id at pre-authorization time, other than overloading `contextId` — which is documented as an opaque, caller-optional token used only to correlate an async completion, with no guaranteed meaning. This gave `binding-mcp` (and any other caller) a well-defined parameter to pass an existing session id through, instead of repurposing `contextId` for something it isn't meant to carry.

Since the full set of `GuardHandler` implementations lives in this repo, `preauthorize`'s signature is changed directly (not via an additive overload); `TestGuardHandler` and its test call sites are updated to match.

### Test plan

- [x] `./mvnw -pl runtime/engine clean verify` — unit + integration tests pass (aside from a pre-existing, unrelated `TrustedTest.shouldConfigureTrustViaCacerts` environment failure)
- [x] `./mvnw -pl runtime/binding-mcp clean verify` — 68 unit + 251 integration tests pass, coverage checks met

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_016FBuPeUhS7zhs8ezqB6BnQ)_