### PR TITLE
fix(binding-mcp): fall back to shared cache credentials for hydration south connections

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -693,9 +693,28 @@ public final class McpBindingConfig
         return credentials;
     }
 
+    // resolves the effective session for a route's south connections: its own with.cache.credentials
+    // override when configured, otherwise the shared session already established via
+    // options.cache.authorization. Callers must first confirm cache != null.
+    public long routeCacheAuthorization(
+        long traceId,
+        long routedId)
+    {
+        long authorization = cache.authorization;
+        if (cache.guard != null)
+        {
+            final String credentials = routeCacheCredentials(routedId);
+            if (credentials != null)
+            {
+                authorization = cache.routeAuthorization(traceId, routedId, credentials);
+            }
+        }
+        return authorization;
+    }
+
     public List<McpRoutePrefix> resolveAll(
-        int kind,
-        long authorization)
+        long traceId,
+        int kind)
     {
         final String capability = McpRouteConfig.capabilityOf(kind);
         final List<McpRoutePrefix> result = new ArrayList<>();
@@ -704,6 +723,7 @@ public final class McpBindingConfig
         {
             for (McpRouteConfig route : routes)
             {
+                final long authorization = routeCacheAuthorization(traceId, route.id);
                 if (route.authorized(authorization) && route.serves(capability))
                 {
                     result.add(new McpRoutePrefix(route.id, new String8FW(route.prefix(kind)), route));

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -158,6 +158,7 @@ public final class McpProxyCacheHydrater
                     cache.authorization = cache.guard != null
                         ? cache.guard.reauthorize(traceId, cache.bindingId, 0L, cache.credentials)
                         : 0L;
+                    cache.resetRouteAuthorizations();
                     lifecycle = lifecycleFactory.newHydrationLifecycle(
                         supplyBinding.apply(cache.bindingId), this::onLifecycleMessage,
                         cache.bindingId, cache.authorization);
@@ -330,9 +331,9 @@ public final class McpProxyCacheHydrater
         private void startRoutes()
         {
             final long traceId = supplyTraceId.getAsLong();
+            final McpBindingConfig binding = supplyBinding.apply(handler.cache.bindingId);
             final McpProxyListFactory listFactory = listFactories.get(kind);
-            final List<McpRoutePrefix> routes =
-                supplyBinding.apply(handler.cache.bindingId).resolveAll(kind, handler.cache.authorization);
+            final List<McpRoutePrefix> routes = binding.resolveAll(traceId, kind);
 
             for (McpRoutePrefix route : routes)
             {
@@ -348,10 +349,11 @@ public final class McpProxyCacheHydrater
                 pending = routes.size();
                 for (McpRoutePrefix route : routes)
                 {
+                    final long authorization = binding.routeCacheAuthorization(traceId, route.resolvedId());
                     final McpListRouteSink sink = new McpListRouteSink(this, route.prefix().asString());
                     sinks.add(sink);
                     sink.server = listFactory.newHydrationList(
-                        handler.lifecycle, sink::onMessage, handler.cache.authorization,
+                        handler.lifecycle, sink::onMessage, authorization,
                         bufferPool.slotCapacity(), route, traceId);
                 }
             }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -934,14 +934,9 @@ final class McpProxyLifecycleFactory implements BindingHandler
         {
             if (!McpState.initialOpening(state))
             {
-                if (server.hydration && server.binding.cache != null && server.binding.cache.guard != null)
+                if (server.hydration && server.binding.cache != null)
                 {
-                    final String credentials = server.binding.routeCacheCredentials(routedId);
-                    if (credentials != null)
-                    {
-                        authorization = server.binding.cache.guard.reauthorize(
-                            traceId, server.binding.cache.bindingId, 0L, credentials);
-                    }
+                    authorization = server.binding.routeCacheAuthorization(traceId, routedId);
                 }
 
                 final int clientCapabilities = server.clientCapabilities;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -38,6 +38,7 @@ import java.util.zip.CRC32;
 import jakarta.json.stream.JsonParser;
 
 import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.collections.Long2LongHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheToolsEagerConfig;
@@ -87,6 +88,7 @@ public final class McpProxyCache
 
     private final StoreHandler store;
     private final Int2ObjectHashMap<McpListCache> caches;
+    private final Long2LongHashMap routeAuthorizations;
     private final List<Runnable> awaiters;
     private final CRC32 crc32 = new CRC32();
     private String lockToken;
@@ -125,6 +127,7 @@ public final class McpProxyCache
         this.cacheTtl = cache.ttl;
         this.awaiters = new ArrayList<>();
         this.caches = new Int2ObjectHashMap<>();
+        this.routeAuthorizations = new Long2LongHashMap(-1L);
 
         final IntPredicate filter = config.hydrateFilter();
         if (filter.test(KIND_TOOLS_LIST))
@@ -169,6 +172,22 @@ public final class McpProxyCache
     public Int2ObjectHashMap<McpListCache> caches()
     {
         return caches;
+    }
+
+    // memoizes the reauthorized session for a route's own with.cache.credentials override, so
+    // multiple south connections for the same route within one hydration attempt share one session
+    // instead of each minting a fresh one from the guard
+    public long routeAuthorization(
+        long traceId,
+        long routedId,
+        String credentials)
+    {
+        return routeAuthorizations.computeIfAbsent(routedId, id -> guard.reauthorize(traceId, bindingId, 0L, credentials));
+    }
+
+    public void resetRouteAuthorizations()
+    {
+        routeAuthorizations.clear();
     }
 
     public void register(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
@@ -24,6 +24,13 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.List;
@@ -31,8 +38,19 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
 import io.aklivity.zilla.runtime.binding.mcp.config.McpConditionConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpOptionsConfig;
+import io.aklivity.zilla.runtime.binding.mcp.config.McpWithConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.KindConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
+import io.aklivity.zilla.runtime.engine.config.RouteConfigBuilder;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
+import io.aklivity.zilla.runtime.engine.store.StoreHandler;
 
 public class McpBindingConfigTest
 {
@@ -56,6 +74,64 @@ public class McpBindingConfigTest
             .build();
         config.id = id;
         return new McpRouteConfig(config);
+    }
+
+    private static RouteConfig rawRoute(
+        long id,
+        String withCredentials)
+    {
+        RouteConfigBuilder<RouteConfig> builder = RouteConfig.builder()
+            .exit("test")
+            .when(McpConditionConfig.builder()
+                .toolkit("alpha")
+                .tools(List.of("*"))
+                .build());
+        if (withCredentials != null)
+        {
+            builder.with(McpWithConfig.builder()
+                .cache()
+                    .credentials(withCredentials)
+                    .build()
+                .build());
+        }
+        RouteConfig config = builder.build();
+        config.id = id;
+        return config;
+    }
+
+    private static McpBindingConfig binding(
+        GuardHandler guard,
+        String sharedCredentials,
+        List<RouteConfig> routes)
+    {
+        final McpCacheConfig cacheConfig = McpCacheConfig.builder()
+            .store("memory0")
+            .authorization()
+                .name("test_guard")
+                .credentials(sharedCredentials)
+                .build()
+            .build();
+        final McpOptionsConfig options = McpOptionsConfig.builder()
+            .cache(cacheConfig)
+            .build();
+
+        BindingConfig config = BindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp")
+            .kind(KindConfig.PROXY)
+            .options(options)
+            .routes(routes)
+            .build();
+        config.id = 1L;
+        config.resolveId = name -> 1L;
+
+        EngineContext context = mock(EngineContext.class);
+        when(context.supplyStore(anyLong())).thenReturn(mock(StoreHandler.class));
+        when(context.supplyGuard(anyLong())).thenReturn(guard);
+        when(context.writeBuffer()).thenReturn(new UnsafeBufferEx(new byte[8192]));
+
+        return new McpBindingConfig(config, new McpConfiguration(), context);
     }
 
     @Test
@@ -157,5 +233,37 @@ public class McpBindingConfigTest
     public void shouldKeepAuthorityWithoutPort()
     {
         assertThat(naturalAuthority("localhost", "https"), equalTo("localhost"));
+    }
+
+    @Test
+    public void shouldUseSharedAuthorizationWhenRouteHasNoOverride()
+    {
+        GuardHandler guard = mock(GuardHandler.class);
+
+        RouteConfig noOverride = rawRoute(100L, null);
+        McpBindingConfig binding = binding(guard, "{shared}", List.of(noOverride));
+        binding.cache.authorization = 3L;
+
+        long authorization = binding.routeCacheAuthorization(0L, 100L);
+
+        assertThat(authorization, equalTo(3L));
+        verify(guard, times(0)).reauthorize(anyLong(), anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    public void shouldUseRouteOverrideAuthorizationWhenConfigured()
+    {
+        GuardHandler guard = mock(GuardHandler.class);
+        when(guard.reauthorize(anyLong(), anyLong(), anyLong(), eq("{shared}"))).thenReturn(3L);
+        when(guard.reauthorize(anyLong(), anyLong(), anyLong(), eq("{override}"))).thenReturn(9L);
+
+        RouteConfig overridden = rawRoute(200L, "{override}");
+        McpBindingConfig binding = binding(guard, "{shared}", List.of(overridden));
+
+        long authorization = binding.routeCacheAuthorization(0L, 200L);
+
+        assertThat(authorization, equalTo(9L));
+        verify(guard, times(1)).reauthorize(anyLong(), anyLong(), anyLong(), eq("{override}"));
+        verify(guard, times(0)).reauthorize(anyLong(), anyLong(), anyLong(), eq("{shared}"));
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCacheTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.config.McpCacheConfig;
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.KindConfig;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
+import io.aklivity.zilla.runtime.engine.store.StoreHandler;
+
+public class McpProxyCacheTest
+{
+    private GuardHandler guard;
+    private McpProxyCache cache;
+
+    @Before
+    public void setup()
+    {
+        guard = mock(GuardHandler.class);
+
+        EngineContext context = mock(EngineContext.class);
+        when(context.supplyStore(anyLong())).thenReturn(mock(StoreHandler.class));
+        when(context.supplyGuard(anyLong())).thenReturn(guard);
+
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp")
+            .kind(KindConfig.PROXY)
+            .build();
+        binding.id = 1L;
+        binding.resolveId = name -> 1L;
+
+        McpCacheConfig cacheConfig = McpCacheConfig.builder()
+            .store("memory0")
+            .authorization()
+                .name("test_guard")
+                .credentials("{token}")
+                .build()
+            .build();
+
+        cache = new McpProxyCache(binding, new McpConfiguration(), context, cacheConfig);
+    }
+
+    @Test
+    public void shouldMemoizeRouteAuthorizationForSameRoute()
+    {
+        when(guard.reauthorize(anyLong(), anyLong(), anyLong(), anyString())).thenReturn(7L, 9L);
+
+        long first = cache.routeAuthorization(1L, 100L, "token-a");
+        long second = cache.routeAuthorization(1L, 100L, "token-a");
+
+        assertThat(first, equalTo(7L));
+        assertThat(second, equalTo(7L));
+        verify(guard, times(1)).reauthorize(anyLong(), anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    public void shouldReauthorizeIndependentlyPerRoute()
+    {
+        when(guard.reauthorize(anyLong(), anyLong(), anyLong(), anyString())).thenReturn(7L, 9L);
+
+        long routeA = cache.routeAuthorization(1L, 100L, "token-a");
+        long routeB = cache.routeAuthorization(1L, 200L, "token-b");
+
+        assertThat(routeA, equalTo(7L));
+        assertThat(routeB, equalTo(9L));
+        verify(guard, times(2)).reauthorize(anyLong(), anyLong(), anyLong(), anyString());
+    }
+
+    @Test
+    public void shouldReauthorizeAgainAfterReset()
+    {
+        when(guard.reauthorize(anyLong(), anyLong(), anyLong(), anyString())).thenReturn(7L, 9L);
+
+        cache.routeAuthorization(1L, 100L, "token-a");
+        cache.resetRouteAuthorizations();
+        cache.routeAuthorization(1L, 100L, "token-a");
+
+        verify(guard, times(2)).reauthorize(anyLong(), anyLong(), anyLong(), anyString());
+    }
+}


### PR DESCRIPTION
## Description

For an `mcp` binding with `kind: proxy`, `routes[].with.cache.credentials` had no fallback: a guarded route without its own override left that route's south connection anonymous during hydration, even when `options.cache.authorization` already established a valid shared credential.

This PR resolves the fallback with a memoized, per-route design rather than a naive "reauthorize again with the shared credential string":

- `McpBindingConfig.routeCacheAuthorization(traceId, routedId)` is the single resolver now used by **both** streams a route opens during hydration:
  - the lifecycle-handshake stream (`McpProxyLifecycleFactory.doClientBegin`)
  - the list-fetch stream (`McpProxyCacheHydrater.startRoutes` → `McpProxyListFactory.newHydrationList`), which previously ignored `with.cache.credentials` entirely and always used the shared session unconditionally
- **Implicit/shared case** (no override): reuses the already-established `options.cache.authorization` session directly — zero extra guard calls, since re-authorizing with the same credential string would otherwise mint a fresh, non-deterministic session from the guard.
- **Explicit override case**: reauthorized once per hydration attempt and memoized on `McpProxyCache.routeAuthorizations`, reset whenever a fresh hydration lease is acquired, so multiple south connections for the same route (handshake + list-fetch, or repeated list-kind probes) share one session instead of calling the guard repeatedly.
- `resolveAll(traceId, kind)` gating is now per-route for the same reason: a route's own override can now qualify it for hydration candidacy independently of the shared identity, instead of every route being gated against one uniform shared session regardless of its own override.

`routes[].with.cache.credentials` remains available purely as an override for routes whose south exit genuinely needs a different credential; it is no longer required when the shared credential is sufficient.

### Testing

- `McpProxyCacheTest` (new) — unit tests on `McpProxyCache.routeAuthorization`/`resetRouteAuthorizations` asserting guard call counts via Mockito (same-route memoization, independent per-route calls, reset behavior).
- `McpBindingConfigTest` — new cases asserting `routeCacheAuthorization` reuses the shared session with zero guard calls when no override is configured, and calls the guard exactly once for an explicit override while never touching the shared credential.
- Full `runtime/binding-mcp` module: `./mvnw clean verify` — 117 unit tests + 257 ITs, 0 checkstyle violations, all coverage checks met.

Note: the k3po IT harness has no assertion primitive for which authorization value a stream actually carries (`option zilla:authorization` on `accept` is not a strict inbound gate in this test transport), so the call-count behavior is verified at the unit level instead, against a mocked `GuardHandler`.

Fixes #2062


---
_Generated by [Claude Code](https://claude.ai/code/session_013me469VXsbBEEeP9FsYEod)_