### PR TITLE
feat(common-json): apply decline-to-N key streaming to related consumers

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilter.java
@@ -107,29 +107,58 @@ public final class McpEagerFilter implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        switch (event)
+        Status status;
+        if (event == JsonEvent.KEY_NAME)
         {
-        case START_OBJECT:
-        case START_ARRAY:
-            depth++;
-            if (itemsArmed && event == JsonEvent.START_ARRAY)
-            {
-                itemsArmed = false;
-                itemDepth = 0;
-                state = items;
-            }
-            break;
-        case END_OBJECT:
-        case END_ARRAY:
-            depth--;
-            break;
-        case KEY_NAME:
-            itemsArmed = depth == 1 && arrayKey.contentEquals(source.getStringView());
-            break;
-        default:
-            break;
+            status = onOuterKey(source, sink);
         }
-        return sink.transform(mediator, source, event);
+        else
+        {
+            switch (event)
+            {
+            case START_OBJECT:
+            case START_ARRAY:
+                depth++;
+                if (itemsArmed && event == JsonEvent.START_ARRAY)
+                {
+                    itemsArmed = false;
+                    itemDepth = 0;
+                    state = items;
+                }
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                depth--;
+                break;
+            default:
+                break;
+            }
+            status = sink.transform(mediator, source, event);
+        }
+        return status;
+    }
+
+    // the arm key is forwarded either way (every outer key passes through unconditionally), so a fragmented
+    // key is declined until complete before the arm decision and forward, rather than deciding on a prefix
+    private Status onOuterKey(
+        JsonSource source,
+        JsonSink sink)
+    {
+        Status status;
+        if (depth == 1 && source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            if (depth == 1)
+            {
+                itemsArmed = arrayKey.contentEquals(source.getStringView());
+            }
+            status = sink.transform(mediator, source, JsonEvent.KEY_NAME);
+        }
+        return status;
     }
 
     // between items in the target array: each item object defers its emission until its name resolves
@@ -187,8 +216,7 @@ public final class McpEagerFilter implements JsonTransform
         case KEY_NAME:
             if (itemDepth == 1)
             {
-                nameArmed = NAME_KEY.contentEquals(source.getStringView());
-                status = Status.ADVANCED;
+                status = onNameKey(source);
             }
             else
             {
@@ -196,9 +224,19 @@ public final class McpEagerFilter implements JsonTransform
             }
             break;
         case VALUE_STRING:
-            status = nameArmed
-                ? resolveItem(source, event, sink)
-                : sink.transform(mediator, source, event);
+            if (nameArmed && source.deferredBytes())
+            {
+                // eager.test() needs the whole name value; decline the fragment so the source accumulates
+                // it whole and re-presents it complete on a later window, then resolve once total.
+                mediator.delegate.consumed(0);
+                status = Status.STARVED;
+            }
+            else
+            {
+                status = nameArmed
+                    ? resolveItem(source, event, sink)
+                    : sink.transform(mediator, source, event);
+            }
             break;
         default:
             status = Status.ADVANCED;
@@ -261,6 +299,27 @@ public final class McpEagerFilter implements JsonTransform
             break;
         }
         return Status.ADVANCED;
+    }
+
+    // the key is swallowed either way (a synthetic "name" key replaces it once resolveItem() fires, or it
+    // is simply dropped if some other key preceded "name"), so there is no forwarded content whose byte
+    // fidelity a fragmented key could compromise -- decline the fragment so the source accumulates it whole
+    // and re-presents it complete on a later window, then decide once total.
+    private Status onNameKey(
+        JsonSource source)
+    {
+        Status status;
+        if (source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            nameArmed = NAME_KEY.contentEquals(source.getStringView());
+            status = Status.ADVANCED;
+        }
+        return status;
     }
 
     private Status resolveItem(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeExcluder.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeExcluder.java
@@ -40,6 +40,18 @@ public final class McpSchemeExcluder implements JsonTransform
     private int depth;
     private int arrayDepth;
     private boolean armed;
+    // Zero-buffer incremental match of the arm key against arrayKey, spanning however many fragments the
+    // key takes to arrive: armMatching is true while a fragment of the current arm key is still pending,
+    // armMatchOffset is how many of arrayKey's chars have matched so far, armMatchDiverged latches once a
+    // char mismatches or the fragment runs longer than arrayKey -- the fragment is still forwarded live
+    // either way (arming never gates forwarding), so byte-preserving verbatim delivery is never sacrificed
+    // for this key.
+    private boolean armMatching;
+    private int armMatchOffset;
+    private boolean armMatchDiverged;
+    // True once the current element key (at arrayDepth + 1) has been declined across more than one
+    // fragment -- see onElementKey.
+    private boolean elementKeyFragmented;
 
     public McpSchemeExcluder(
         String arrayKey)
@@ -54,6 +66,10 @@ public final class McpSchemeExcluder implements JsonTransform
         depth = 0;
         arrayDepth = NO_DEPTH;
         armed = false;
+        armMatching = false;
+        armMatchOffset = 0;
+        armMatchDiverged = false;
+        elementKeyFragmented = false;
     }
 
     @Override
@@ -96,7 +112,7 @@ public final class McpSchemeExcluder implements JsonTransform
                 : downstream;
             break;
         case KEY_NAME:
-            status = onKey(source, event, sink);
+            status = onKey(control, source, event, sink);
             break;
         default:
             status = sink.transform(mediator, source, forward(event));
@@ -126,28 +142,106 @@ public final class McpSchemeExcluder implements JsonTransform
         return sink.flush(mediator, source);
     }
 
-    // arms array descent on the target key, then drops the securitySchemes member of a direct array element
+    // dispatches to whichever position-specific key check applies, or forwards immediately when neither
+    // the arm key nor a candidate element key is possible at the current depth
     private Status onKey(
+        JsonController control,
         JsonSource source,
         JsonEvent event,
         JsonSink sink)
     {
+        Status status;
         if (depth == 1)
         {
-            armed = arrayKey.contentEquals(source.getStringView());
+            status = onArmKey(source, event, sink);
         }
+        else if (arrayDepth != NO_DEPTH && depth == arrayDepth + 1)
+        {
+            status = onElementKey(control, source, event, sink);
+        }
+        else
+        {
+            status = sink.transform(mediator, source, forward(event));
+        }
+        return status;
+    }
+
+    // arms array descent on the target key. Arming never gates forwarding (every depth-1 key is forwarded
+    // regardless of match), so the key is always forwarded live, fragment by fragment, preserving verbatim
+    // bytes; the match itself is tracked incrementally (armMatchOffset/armMatchDiverged) across however many
+    // fragments the key takes, with no buffering of the key's content, and armed is only assigned once the
+    // key completes.
+    private Status onArmKey(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        CharSequence fragment = source.getStringView();
+        boolean complete = !source.deferredBytes();
+        if (!armMatching)
+        {
+            armMatchOffset = 0;
+            armMatchDiverged = false;
+        }
+        if (!armMatchDiverged)
+        {
+            if (fragment.length() > arrayKey.length() - armMatchOffset)
+            {
+                armMatchDiverged = true;
+            }
+            else
+            {
+                for (int i = 0; i < fragment.length(); i++)
+                {
+                    if (fragment.charAt(i) != arrayKey.charAt(armMatchOffset + i))
+                    {
+                        armMatchDiverged = true;
+                        break;
+                    }
+                }
+                armMatchOffset += fragment.length();
+            }
+        }
+        armMatching = !complete;
+        if (complete)
+        {
+            armed = !armMatchDiverged && armMatchOffset == arrayKey.length();
+        }
+        return sink.transform(mediator, source, forward(event));
+    }
+
+    // drops the securitySchemes member of a direct array element. The drop decision needs the whole key, so
+    // a fragmented key is declined (consumed(0)) rather than forwarded fragment by fragment -- byte-for-byte
+    // verbatim delivery is only physically possible for bytes forwarded as they arrive, so once the source
+    // re-presents this key complete, a key that fragmented and turns out NOT to be securitySchemes is
+    // forwarded canonically rather than verbatim (elementKeyFragmented), a narrow, deliberate trade-off in
+    // favor of never failing to withhold a matching key.
+    private Status onElementKey(
+        JsonController control,
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
         Status status;
-        if (arrayDepth != NO_DEPTH && depth == arrayDepth + 1 &&
-            SECURITY_SCHEMES.contentEquals(source.getStringView()))
+        if (source.deferredBytes())
+        {
+            elementKeyFragmented = true;
+            control.consumed(0);
+            status = Status.STARVED;
+        }
+        else if (SECURITY_SCHEMES.contentEquals(source.getStringView()))
         {
             // drop the matched member: the source advances past its key, separator, and value and folds in the
             // leading-separator trim, so no sub-event of the dropped value reaches this stage or the sink
+            elementKeyFragmented = false;
             source.skipValue();
             status = Status.ADVANCED;
         }
         else
         {
-            status = sink.transform(mediator, source, forward(event));
+            JsonEvent toForward = elementKeyFragmented ? event : forward(event);
+            elementKeyFragmented = false;
+            status = sink.transform(mediator, source, toForward);
         }
         return status;
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeInjector.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeInjector.java
@@ -104,29 +104,58 @@ public final class McpSchemeInjector implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        switch (event)
+        Status status;
+        if (event == JsonEvent.KEY_NAME)
         {
-        case START_OBJECT:
-        case START_ARRAY:
-            depth++;
-            if (itemsArmed && event == JsonEvent.START_ARRAY)
-            {
-                itemsArmed = false;
-                itemDepth = 0;
-                state = items;
-            }
-            break;
-        case END_OBJECT:
-        case END_ARRAY:
-            depth--;
-            break;
-        case KEY_NAME:
-            itemsArmed = depth == 1 && arrayKey.contentEquals(source.getStringView());
-            break;
-        default:
-            break;
+            status = onOuterKey(source, sink);
         }
-        return sink.transform(mediator, source, event);
+        else
+        {
+            switch (event)
+            {
+            case START_OBJECT:
+            case START_ARRAY:
+                depth++;
+                if (itemsArmed && event == JsonEvent.START_ARRAY)
+                {
+                    itemsArmed = false;
+                    itemDepth = 0;
+                    state = items;
+                }
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                depth--;
+                break;
+            default:
+                break;
+            }
+            status = sink.transform(mediator, source, event);
+        }
+        return status;
+    }
+
+    // the arm key is forwarded either way (every outer key passes through unconditionally), so a fragmented
+    // key is declined until complete before the arm decision and forward, rather than deciding on a prefix
+    private Status onOuterKey(
+        JsonSource source,
+        JsonSink sink)
+    {
+        Status status;
+        if (depth == 1 && source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            if (depth == 1)
+            {
+                itemsArmed = arrayKey.contentEquals(source.getStringView());
+            }
+            status = sink.transform(mediator, source, JsonEvent.KEY_NAME);
+        }
+        return status;
     }
 
     // between elements of the target array: a direct child object becomes an injection element
@@ -176,16 +205,10 @@ public final class McpSchemeInjector implements JsonTransform
             status = sink.transform(mediator, source, event);
             break;
         case KEY_NAME:
-            nameArmed = itemDepth == 1 && "name".contentEquals(source.getStringView());
-            status = sink.transform(mediator, source, event);
+            status = onElementKey(source, event, sink);
             break;
         case VALUE_STRING:
-            if (nameArmed)
-            {
-                itemRoles = rolesByTool.apply(source.getString());
-                nameArmed = false;
-            }
-            status = sink.transform(mediator, source, event);
+            status = onElementNameValue(source, event, sink);
             break;
         case END_OBJECT:
             itemDepth--;
@@ -206,6 +229,53 @@ public final class McpSchemeInjector implements JsonTransform
         default:
             status = sink.transform(mediator, source, event);
             break;
+        }
+        return status;
+    }
+
+    // every element key is forwarded live regardless of match, and this stage does not deliver verbatim
+    // bytes (Control#verbatim is a no-op), so a fragmented "name" key is simply declined until complete
+    // before the arm decision and forward, rather than deciding -- and forwarding -- on a prefix
+    private Status onElementKey(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        Status status;
+        if (itemDepth == 1 && source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            nameArmed = itemDepth == 1 && "name".contentEquals(source.getStringView());
+            status = sink.transform(mediator, source, event);
+        }
+        return status;
+    }
+
+    // rolesByTool needs the whole name value; a fragmenting value is declined the same way onElementKey
+    // declines a fragmenting key, then resolved and forwarded once complete
+    private Status onElementNameValue(
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        Status status;
+        if (nameArmed && source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            if (nameArmed)
+            {
+                itemRoles = rolesByTool.apply(source.getString());
+                nameArmed = false;
+            }
+            status = sink.transform(mediator, source, event);
         }
         return status;
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilter.java
@@ -98,29 +98,58 @@ public final class McpScopeFilter implements JsonTransform
         JsonEvent event,
         JsonSink sink)
     {
-        switch (event)
+        Status status;
+        if (event == JsonEvent.KEY_NAME)
         {
-        case START_OBJECT:
-        case START_ARRAY:
-            depth++;
-            if (itemsArmed && event == JsonEvent.START_ARRAY)
-            {
-                itemsArmed = false;
-                itemDepth = 0;
-                state = items;
-            }
-            break;
-        case END_OBJECT:
-        case END_ARRAY:
-            depth--;
-            break;
-        case KEY_NAME:
-            itemsArmed = depth == 1 && arrayKey.contentEquals(source.getStringView());
-            break;
-        default:
-            break;
+            status = onOuterKey(source, sink);
         }
-        return sink.transform(mediator, source, event);
+        else
+        {
+            switch (event)
+            {
+            case START_OBJECT:
+            case START_ARRAY:
+                depth++;
+                if (itemsArmed && event == JsonEvent.START_ARRAY)
+                {
+                    itemsArmed = false;
+                    itemDepth = 0;
+                    state = items;
+                }
+                break;
+            case END_OBJECT:
+            case END_ARRAY:
+                depth--;
+                break;
+            default:
+                break;
+            }
+            status = sink.transform(mediator, source, event);
+        }
+        return status;
+    }
+
+    // the arm key is forwarded either way (every outer key passes through unconditionally), so a fragmented
+    // key is declined until complete before the arm decision and forward, rather than deciding on a prefix
+    private Status onOuterKey(
+        JsonSource source,
+        JsonSink sink)
+    {
+        Status status;
+        if (depth == 1 && source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            if (depth == 1)
+            {
+                itemsArmed = arrayKey.contentEquals(source.getStringView());
+            }
+            status = sink.transform(mediator, source, JsonEvent.KEY_NAME);
+        }
+        return status;
     }
 
     // between items in the target array: each item object defers its emission until its name resolves
@@ -178,8 +207,7 @@ public final class McpScopeFilter implements JsonTransform
         case KEY_NAME:
             if (itemDepth == 1)
             {
-                nameArmed = "name".contentEquals(source.getStringView());
-                status = Status.ADVANCED;
+                status = onNameKey(source);
             }
             else
             {
@@ -187,9 +215,20 @@ public final class McpScopeFilter implements JsonTransform
             }
             break;
         case VALUE_STRING:
-            status = nameArmed
-                ? resolveItem(source, event, sink)
-                : sink.transform(mediator, source, event);
+            if (nameArmed && source.deferredBytes())
+            {
+                // admits.test()/scopesByName.get() need the whole name value; decline the fragment so the
+                // source accumulates it whole and re-presents it complete on a later window, then resolve
+                // once total.
+                mediator.delegate.consumed(0);
+                status = Status.STARVED;
+            }
+            else
+            {
+                status = nameArmed
+                    ? resolveItem(source, event, sink)
+                    : sink.transform(mediator, source, event);
+            }
             break;
         default:
             status = Status.ADVANCED;
@@ -252,6 +291,27 @@ public final class McpScopeFilter implements JsonTransform
             break;
         }
         return Status.ADVANCED;
+    }
+
+    // the key is swallowed either way (a synthetic "name" key replaces it once resolveItem() fires, or it
+    // is simply dropped if some other key preceded "name"), so there is no forwarded content whose byte
+    // fidelity a fragmented key could compromise -- decline the fragment so the source accumulates it whole
+    // and re-presents it complete on a later window, then decide once total.
+    private Status onNameKey(
+        JsonSource source)
+    {
+        Status status;
+        if (source.deferredBytes())
+        {
+            mediator.delegate.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            nameArmed = "name".contentEquals(source.getStringView());
+            status = Status.ADVANCED;
+        }
+        return status;
     }
 
     private Status resolveItem(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpEagerFilterTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.transform;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+
+public class McpEagerFilterTest
+{
+    @Test
+    public void shouldArmOnArrayKeyThatFragmentsAcrossInputWindows()
+    {
+        // the arm key is longer than the feed window and fragments across STARVED windows before
+        // onOuterKey's decline-until-complete resolves it; the eager/cold split it enables one level down
+        // must still fire correctly once the key completes. Every outer key is forwarded regardless of
+        // match, and this stage does not deliver verbatim bytes, so declining and forwarding the whole
+        // reassembled key afterward is safe.
+        String arrayKey = "x".repeat(40);
+        Predicate<CharSequence> eager = name -> "alpha".contentEquals(name);
+        String json = "{\"" + arrayKey + "\":[{\"name\":\"alpha\",\"x\":1},{\"name\":\"beta\",\"x\":2}]}";
+        assertEquals(
+            "{\"" + arrayKey + "\":[{\"name\":\"alpha\",\"x\":1},{\"name\":\"beta\",\"defer_loading\":true,\"x\":2}]}",
+            filterWindowed(arrayKey, eager, false, json, 12));
+    }
+
+    @Test
+    public void shouldResolveNameKeyThatFragmentsAcrossInputWindows()
+    {
+        // "name" (the item's own key, always swallowed and replaced by a synthetic constant regardless of
+        // outcome) fragments across STARVED windows before onNameKey's decline-until-complete resolves it.
+        // Values here are long enough that they never themselves fragment at this window, isolating the key
+        // fragmentation this test targets from McpEagerFilter's separate (also fixed) name-value handling.
+        Predicate<CharSequence> eager = name -> "alphabetagamma".contentEquals(name);
+        String json = "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1},{\"name\":\"deltaepsilonzeta\",\"x\":2}]}";
+        assertEquals(
+            "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1}," +
+                "{\"name\":\"deltaepsilonzeta\",\"defer_loading\":true,\"x\":2}]}",
+            filterWindowed("tools", eager, false, json, 3));
+    }
+
+    @Test
+    public void shouldOmitColdItemWhoseNameKeyFragments()
+    {
+        Predicate<CharSequence> eager = name -> "alphabetagamma".contentEquals(name);
+        String json = "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1},{\"name\":\"deltaepsilonzeta\",\"x\":2}]}";
+        assertEquals("{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1}]}",
+            filterWindowed("tools", eager, true, json, 3));
+    }
+
+    @Test
+    public void shouldResolveNameValueThatFragmentsAcrossInputWindows()
+    {
+        // the name VALUE itself (not just its key) is long enough to fragment across the feed window;
+        // resolveItem() must not evaluate eager.test() against a prefix -- a related bug in the same method
+        // fixed alongside the key-fragmentation issue this class targets
+        Predicate<CharSequence> eager = name -> "alphabetagammadelta".contentEquals(name);
+        String json = "{\"tools\":[{\"name\":\"alphabetagammadelta\",\"x\":1}]}";
+        assertEquals("{\"tools\":[{\"name\":\"alphabetagammadelta\",\"x\":1}]}",
+            filterWindowed("tools", eager, false, json, 6));
+    }
+
+    // Drives the filter through fixed-size input windows, carrying the unconsumed tail
+    // (pipeline.remaining()) across STARVED feeds the way a real caller does, so an over-window key
+    // fragments and reassembles before this stage matches or forwards it.
+    private static String filterWindowed(
+        String arrayKey,
+        Predicate<CharSequence> eager,
+        boolean omitCold,
+        String input,
+        int window)
+    {
+        McpEagerFilter filter = new McpEagerFilter();
+        filter.init(arrayKey, eager, omitCold);
+
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[4096]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(filter)
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        byte[] msg = input.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeExcluderTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeExcluderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.transform;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+
+public class McpSchemeExcluderTest
+{
+    @Test
+    public void shouldDropSecuritySchemesOfMatchedArrayElement()
+    {
+        assertEquals("{\"tools\":[{\"other\":1}]}",
+            exclude("tools", "{\"tools\":[{\"securitySchemes\":{\"a\":1},\"other\":1}]}", 1024));
+    }
+
+    @Test
+    public void shouldArmOnArrayKeyThatFragmentsAcrossInputWindows()
+    {
+        // the arm key itself is longer than the feed window and fragments across STARVED windows before
+        // onArmKey's incremental (zero-buffer) match completes; the drop decision it enables one level down
+        // must still fire correctly once the key completes. window=12 is chosen to clear a floor unrelated
+        // to this fix: JsonSource#skipValue() scans the dropped member's value in one shot with no ability
+        // to starve mid-value, so the window in which the (possibly reassembled) key completes must still
+        // have enough bytes left to also cover the whole dropped value -- the same pre-existing, orthogonal
+        // window-vs-content-size constraint JsonProjectorTest documents for MAX_VALUE_SIZE.
+        String arrayKey = "x".repeat(40);
+        String json = "{\"" + arrayKey + "\":[{\"securitySchemes\":{\"a\":1},\"other\":1}]}";
+        assertEquals("{\"" + arrayKey + "\":[{\"other\":1}]}", excludeWindowed(arrayKey, json, 12));
+    }
+
+    @Test
+    public void shouldDropSecuritySchemesKeyThatFragmentsAcrossInputWindows()
+    {
+        // "securitySchemes" itself is declined across STARVED windows before onElementKey can compare it
+        // complete; the member must still be dropped once the key finishes reassembling. window=9 clears the
+        // same skipValue() floor described above.
+        String json = "{\"tools\":[{\"securitySchemes\":{\"a\":1},\"other\":1}]}";
+        assertEquals("{\"tools\":[{\"other\":1}]}", excludeWindowed("tools", json, 9));
+    }
+
+    @Test
+    public void shouldForwardMismatchedElementKeyThatFragmentsAcrossInputWindows()
+    {
+        // an element key that is not securitySchemes but is long enough to fragment across the feed window
+        // must still be forwarded (with its full, correct content) rather than mistaken for a match or
+        // dropped outright
+        String key = "x".repeat(40);
+        String json = "{\"tools\":[{\"" + key + "\":1,\"other\":2}]}";
+        assertEquals("{\"tools\":[{\"" + key + "\":1,\"other\":2}]}", excludeWindowed("tools", json, 8));
+    }
+
+    private static String exclude(
+        String arrayKey,
+        String input,
+        int bufferCapacity)
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[bufferCapacity]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(new McpSchemeExcluder(arrayKey))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        byte[] bytes = input.getBytes(UTF_8);
+        pipeline.reset();
+        pipeline.transform(new UnsafeBufferEx(bytes), 0, bytes.length);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+
+    // Drives the exclusion through fixed-size input windows, carrying the unconsumed tail
+    // (pipeline.remaining()) across STARVED feeds the way a real caller does, so an over-window key
+    // fragments and reassembles before this stage matches or forwards it.
+    private static String excludeWindowed(
+        String arrayKey,
+        String input,
+        int window)
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[4096]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(new McpSchemeExcluder(arrayKey))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        byte[] msg = input.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeInjectorTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpSchemeInjectorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.transform;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+
+public class McpSchemeInjectorTest
+{
+    @Test
+    public void shouldArmOnArrayKeyThatFragmentsAcrossInputWindows()
+    {
+        // the arm key is longer than the feed window and fragments across STARVED windows before
+        // onOuterKey's decline-until-complete resolves it; the injection it enables one level down must
+        // still fire correctly once the key completes. Every outer key is forwarded regardless of match,
+        // and this stage does not deliver verbatim bytes, so declining and forwarding the whole reassembled
+        // key afterward is safe.
+        String arrayKey = "x".repeat(40);
+        Function<String, Map<String, List<String>>> rolesByTool =
+            name -> "alpha".equals(name) ? Map.of("g1", List.of("r1")) : Map.of();
+        String json = "{\"" + arrayKey + "\":[{\"name\":\"alpha\",\"x\":1}]}";
+        assertEquals(
+            "{\"" + arrayKey + "\":[{\"name\":\"alpha\",\"x\":1,\"securitySchemes\":" +
+                "[{\"type\":\"oauth2\",\"scopes\":[\"r1\"]}]}]}",
+            injectWindowed(arrayKey, rolesByTool, json, 12));
+    }
+
+    @Test
+    public void shouldResolveNameKeyThatFragmentsAcrossInputWindows()
+    {
+        // "name" fragments across STARVED windows before onElementKey's decline-until-complete resolves it.
+        // Values here are long enough that they never themselves fragment at this window, isolating the key
+        // fragmentation this test targets from the separate (also fixed) name-value handling.
+        Function<String, Map<String, List<String>>> rolesByTool =
+            name -> "alphabetagamma".equals(name) ? Map.of("g1", List.of("r1")) : Map.of();
+        String json = "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1}]}";
+        assertEquals(
+            "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1,\"securitySchemes\":" +
+                "[{\"type\":\"oauth2\",\"scopes\":[\"r1\"]}]}]}",
+            injectWindowed("tools", rolesByTool, json, 3));
+    }
+
+    @Test
+    public void shouldResolveNameValueThatFragmentsAcrossInputWindows()
+    {
+        // the name VALUE itself (not just its key) is long enough to fragment across the feed window;
+        // rolesByTool must not be invoked against a prefix -- a related bug in the same method fixed
+        // alongside the key-fragmentation issue this class targets
+        Function<String, Map<String, List<String>>> rolesByTool =
+            name -> "alphabetagammadelta".equals(name) ? Map.of("g1", List.of("r1")) : Map.of();
+        String json = "{\"tools\":[{\"name\":\"alphabetagammadelta\",\"x\":1}]}";
+        assertEquals(
+            "{\"tools\":[{\"name\":\"alphabetagammadelta\",\"x\":1,\"securitySchemes\":" +
+                "[{\"type\":\"oauth2\",\"scopes\":[\"r1\"]}]}]}",
+            injectWindowed("tools", rolesByTool, json, 6));
+    }
+
+    private static String injectWindowed(
+        String arrayKey,
+        Function<String, Map<String, List<String>>> rolesByTool,
+        String input,
+        int window)
+    {
+        McpSchemeInjector injector = new McpSchemeInjector(arrayKey, true, rolesByTool);
+
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[4096]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(injector)
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        byte[] msg = input.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilterTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.transform;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+
+public class McpScopeFilterTest
+{
+    private static final BiPredicate<CharSequence, List<String>> ADMIT_ALL = (name, scopes) -> true;
+
+    @Test
+    public void shouldArmOnArrayKeyThatFragmentsAcrossInputWindows()
+    {
+        // the arm key is longer than the feed window and fragments across STARVED windows before
+        // onOuterKey's decline-until-complete resolves it; items must still pass through correctly once
+        // the key completes. Every outer key is forwarded regardless of match, and this stage does not
+        // deliver verbatim bytes, so declining and forwarding the whole reassembled key afterward is safe.
+        String arrayKey = "x".repeat(40);
+        String json = "{\"" + arrayKey + "\":[{\"name\":\"alpha\",\"x\":1}]}";
+        assertEquals(json, filterWindowed(arrayKey, Map.of(), ADMIT_ALL, json, 12));
+    }
+
+    @Test
+    public void shouldResolveNameKeyThatFragmentsAcrossInputWindows()
+    {
+        // "name" (the item's own key, always swallowed and replaced by a synthetic constant regardless of
+        // outcome) fragments across STARVED windows before onNameKey's decline-until-complete resolves it.
+        // Values here are long enough that they never themselves fragment at this window, isolating the key
+        // fragmentation this test targets from the separate (also fixed) name-value handling.
+        String json = "{\"tools\":[{\"name\":\"alphabetagamma\",\"x\":1}]}";
+        assertEquals(json, filterWindowed("tools", Map.of(), ADMIT_ALL, json, 3));
+    }
+
+    @Test
+    public void shouldResolveNameValueThatFragmentsAcrossInputWindows()
+    {
+        // the name VALUE itself (not just its key) is long enough to fragment across the feed window;
+        // resolveItem() must not look up scopesByName/admits against a prefix -- a related bug in the same
+        // method fixed alongside the key-fragmentation issue this class targets
+        String json = "{\"tools\":[{\"name\":\"alphabetagammadelta\",\"x\":1}]}";
+        assertEquals(json, filterWindowed("tools", Map.of(), ADMIT_ALL, json, 6));
+    }
+
+    private static String filterWindowed(
+        String arrayKey,
+        Map<CharSequence, List<String>> scopesByName,
+        BiPredicate<CharSequence, List<String>> admits,
+        String input,
+        int window)
+    {
+        McpScopeFilter filter = new McpScopeFilter();
+        filter.init(arrayKey, scopesByName, admits);
+
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[4096]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(filter)
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        byte[] msg = input.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+}

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonParserImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonParserImpl.java
@@ -721,6 +721,14 @@ public final class AvroJsonParserImpl implements AvroParser
     // Pulls the next JSON event, skipping the document-framing START_DOCUMENT so the schema walk sees only
     // structural and value events. Returns null (and arms STARVED) when the window is exhausted mid-datum
     // and more input will follow; a truncation under last == true is a reject.
+    //
+    // A key or scalar value large enough to fragment across input windows is never exposed mid-fragment
+    // (json.deferredBytes() true): this parser never calls json.consumed(), so an undelivered fragment's
+    // chars stay in json's own accumulation buffer rather than being discarded, and looping back here for
+    // more re-presents the same logical event, growing, until it completes -- at which point every existing
+    // whole-token read in this class (contentEquals, parseLong, getStringView/getString) sees the complete
+    // content, exactly as if it had never fragmented. This also naturally starves (rather than spuriously
+    // matching or rejecting on a partial prefix) when the window itself runs out mid-fragment.
     private JsonEvent peek()
     {
         while (!havePending && !starved)
@@ -728,7 +736,7 @@ public final class AvroJsonParserImpl implements AvroParser
             if (advance())
             {
                 JsonEvent next = pull();
-                if (next != JsonEvent.START_DOCUMENT && next != JsonEvent.END_DOCUMENT)
+                if (next != JsonEvent.START_DOCUMENT && next != JsonEvent.END_DOCUMENT && !json.deferredBytes())
                 {
                     pendingEvent = next;
                     havePending = true;

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/json/AvroJsonChunkingTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/json/AvroJsonChunkingTest.java
@@ -142,6 +142,109 @@ public class AvroJsonChunkingTest
         assertEquals("{\"id\":\"123\",\"" + LONG_KEY + "\":\"OK\"}", drained.json);
     }
 
+    @Test
+    public void shouldMatchRecordFieldNameKeyThatFragmentsAcrossInputWindows()
+    {
+        // the field name key itself is longer than the JSON input feed window and fragments across STARVED
+        // windows before AvroJsonParserImpl's peek() reassembles it whole; the field must still match its
+        // schema position once the key completes
+        String json = Json.createObjectBuilder()
+            .add("id", "123")
+            .add(LONG_KEY, "OK")
+            .build()
+            .toString();
+        byte[] wire = jsonToAvroWindowed(longKeySchema, json, 8);
+
+        Drained drained = avroToJsonWindowed(longKeySchema, wire, 256);
+        assertEquals("{\"id\":\"123\",\"" + LONG_KEY + "\":\"OK\"}", drained.json);
+    }
+
+    @Test
+    public void shouldReadStringValueThatFragmentsAcrossInputWindows()
+    {
+        // the string value itself is longer than the JSON input feed window and fragments across STARVED
+        // windows before peek() reassembles it whole; readScalar() must see the complete value, not a prefix
+        String longValue = "x".repeat(80);
+        String json = Json.createObjectBuilder()
+            .add("st", longValue)
+            .add("by", Base64.getEncoder().encodeToString(new byte[] {1, 2, 3}))
+            .build()
+            .toString();
+        byte[] wire = jsonToAvroWindowed(schema, json, 8);
+
+        Drained drained = avroToJsonWindowed(wire, 8192);
+        JsonObject object = parse(drained.json);
+        assertEquals(longValue, object.getString("st"));
+        assertArrayEquals(new byte[] {1, 2, 3}, Base64.getDecoder().decode(object.getString("by")));
+    }
+
+    // Drives the JSON -> Avro direction (AvroJsonParserImpl) through fixed-size JSON input windows, carrying
+    // the unconsumed tail (pipeline.remaining()) across STARVED feeds the way a real caller does, so a key
+    // or value larger than the window fragments and reassembles before the schema walk reads it.
+    private byte[] jsonToAvroWindowed(
+        AvroSchema valueSchema,
+        String json,
+        int window)
+    {
+        byte[] jsonBytes = json.getBytes(UTF_8);
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[Math.max(256, jsonBytes.length * 4)]);
+        AvroGenerator generator = Avro.generator(valueSchema, out, 0);
+        AvroPipeline pipeline = AvroJson.stream(valueSchema, JsonEx.createParser()).into(AvroSink.of(generator));
+        pipeline.reset();
+
+        UnsafeBufferEx in = new UnsafeBufferEx(jsonBytes);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, jsonBytes.length);
+            boolean last = limit >= jsonBytes.length;
+            status = pipeline.transform(in, progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] avro = new byte[generator.length()];
+        out.getBytes(0, avro);
+        return avro;
+    }
+
+    private Drained avroToJsonWindowed(
+        AvroSchema valueSchema,
+        byte[] wire,
+        int window)
+    {
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[window]);
+        JsonGeneratorEx json = JsonEx.createGenerator();
+        AvroGenerator generator = AvroJson.generator(valueSchema, json, false).wrap(out, 0, window);
+        AvroPipeline pipeline = Avro.stream(Avro.parser(valueSchema)).into(AvroSink.of(generator));
+        pipeline.reset();
+
+        StringBuilder result = new StringBuilder();
+        UnsafeBufferEx in = new UnsafeBufferEx(wire);
+        int suspends = 0;
+        int guard = 0;
+        Status status = pipeline.transform(in, 0, wire.length);
+        while (status == Status.SUSPENDED && guard < 1_000_000)
+        {
+            assertTrue(generator.length() <= window, "chunk exceeded the generator limit");
+            result.append(chunk(out, generator.length()));
+            generator.wrap(out, 0, window);
+            suspends++;
+            guard++;
+            status = pipeline.transform(in, 0, wire.length);
+        }
+        assertEquals(Status.COMPLETED, status);
+        json.flush();
+        result.append(chunk(out, generator.length()));
+
+        return new Drained(result.toString(), suspends);
+    }
+
     private Drained avroToJsonBounded(
         AvroSchema valueSchema,
         byte[] wire,

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonFlattenerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonFlattenerImpl.java
@@ -161,6 +161,26 @@ public final class JsonFlattenerImpl implements JsonTransform
         JsonSource source,
         JsonSink sink)
     {
+        Status status;
+        if (source.deferredBytes())
+        {
+            // a fragmented key cannot be matched against the accessor trie until it is complete — the trie's
+            // children are compared as whole strings. Decline the fragment (consumed(0)) so the source
+            // accumulates it whole and re-presents it complete on a later window, then match it.
+            control.consumed(0);
+            status = Status.STARVED;
+        }
+        else
+        {
+            status = onCompleteKey(source, sink);
+        }
+        return status;
+    }
+
+    private Status onCompleteKey(
+        JsonSource source,
+        JsonSink sink)
+    {
         Node child = currentNode == null ? null : currentNode.children.get(source.getStringView().toString());
         Status status;
         if (child != null && child.target != null)

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonFlattenerImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonFlattenerImpl.java
@@ -69,6 +69,9 @@ public final class JsonFlattenerImpl implements JsonTransform
     // True from the moment a renamed key's forward begins until that KEY_NAME event fully completes --
     // spanning however many resume() calls a bounded output takes, not just the initial transform() call.
     private boolean keyInFlight;
+    // True once a key has been proven longer than every child at the current node (see onKey): the
+    // remaining fragments are drained without inspection until the key completes.
+    private boolean keySkipping;
 
     public JsonFlattenerImpl(
         Map<String, String> accessorTargets)
@@ -85,6 +88,7 @@ public final class JsonFlattenerImpl implements JsonTransform
         pendingIsTerminal = false;
         renamedKey = null;
         keyInFlight = false;
+        keySkipping = false;
         depth = 0;
         verbatimContainerDepth = 0;
     }
@@ -162,12 +166,33 @@ public final class JsonFlattenerImpl implements JsonTransform
         JsonSink sink)
     {
         Status status;
-        if (source.deferredBytes())
+        CharSequence view = source.getStringView();
+        boolean complete = !source.deferredBytes();
+        int maxKeyLength = currentNode == null ? 0 : currentNode.maxKeyLength;
+        if (keySkipping)
         {
-            // a fragmented key cannot be matched against the accessor trie until it is complete — the trie's
-            // children are compared as whole strings. Decline the fragment (consumed(0)) so the source
-            // accumulates it whole and re-presents it complete on a later window, then match it.
+            control.consumed(view.length());
+            keySkipping = !complete;
+            status = complete ? Status.ADVANCED : Status.STARVED;
+        }
+        else if (!complete && view.length() <= maxKeyLength)
+        {
+            // still short enough that some child could yet match once more of the key arrives; decline
+            // the fragment (consumed(0)) so the source accumulates it whole and re-presents it complete
+            // on a later window, then match it.
             control.consumed(0);
+            status = Status.STARVED;
+        }
+        else if (!complete)
+        {
+            // already longer than the longest child at this node, so no child can match regardless of
+            // what the rest of the key contains -- the same "unmatched dead branch" outcome onCompleteKey
+            // reaches below, which never forwards the key either, so drop the remaining fragments without
+            // ever buffering the key.
+            pendingIsTerminal = false;
+            pendingChild = null;
+            control.consumed(view.length());
+            keySkipping = true;
             status = Status.STARVED;
         }
         else
@@ -372,6 +397,7 @@ public final class JsonFlattenerImpl implements JsonTransform
     {
         private final Map<String, Node> children;
         private final String target;
+        private final int maxKeyLength;
 
         private Node(
             Map<String, Node> children,
@@ -379,6 +405,12 @@ public final class JsonFlattenerImpl implements JsonTransform
         {
             this.children = children;
             this.target = target;
+            int longest = 0;
+            for (String key : children.keySet())
+            {
+                longest = Math.max(longest, key.length());
+            }
+            this.maxKeyLength = longest;
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserImpl.java
@@ -713,9 +713,11 @@ public final class JsonParserImpl implements JsonParserEx
     @Override
     public void skipValue()
     {
-        // valid only at an object member boundary (current event is a delivered KEY_NAME); the value has not
-        // yet been read, so the member's leading-separator occupancy is still the key's
-        assert lastEvent == JsonEvent.KEY_NAME;
+        // valid only at an object member boundary (current event is a delivered, complete KEY_NAME); the
+        // value has not yet been read, so the member's leading-separator occupancy is still the key's. A
+        // caller must not drop a member on a still-fragmenting key (deferredBytes() true) — the key is only
+        // a prefix at that point, so the drop decision would be made on incomplete content.
+        assert lastEvent == JsonEvent.KEY_NAME && !deferredBytes();
         final boolean occupied = tokenizer.memberSeparated();
         // drive the value's events internally so the caller never sees them: a scalar is one event, a container
         // runs to its matching close

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -176,6 +176,12 @@ public final class JsonProjectorImpl implements JsonTransform
         {
             status = Status.SUSPENDED;
         }
+        else if (downstream == Status.STARVED)
+        {
+            // onKey declined an in-flight key fragment directly (no forward(), so rank() never sees it):
+            // the pump must wait for more input rather than treat this event as advanced.
+            status = Status.STARVED;
+        }
         else if (rootDone)
         {
             status = Status.COMPLETED;
@@ -249,38 +255,61 @@ public final class JsonProjectorImpl implements JsonTransform
         JsonSink sink)
     {
         boolean parentKeepAll = containers > 0 && frameKeepAll[containers - 1];
-        Node parentNode = containers > 0 ? frameNode[containers - 1] : root;
-        Decision d;
         if (parentKeepAll)
         {
+            // every child of a KEEP_ALL parent is retained regardless of its key content, so a key
+            // fragmented across input windows streams straight through with nothing to decide — the same
+            // as any other kept scalar/segment value.
             keyNode = null;
-            d = Decision.KEEP_ALL;
+            keyDecision = Decision.KEEP_ALL;
+            forwardKey(control, source, sink);
+        }
+        else if (source.deferredBytes())
+        {
+            // a fragmented key cannot be matched against the trie until it is complete — the trie's
+            // children are compared as whole strings. Decline the fragment (consumed(0)) so the source
+            // accumulates it whole (the same fallback a content-needing scalar value uses) and re-presents
+            // it complete on a later window, then decide once the final fragment arrives.
+            control.consumed(0);
+            downstream = Status.STARVED;
         }
         else
         {
+            Node parentNode = containers > 0 ? frameNode[containers - 1] : root;
             keyNode = lookup(parentNode, source.getStringView());
-            d = decide(keyNode);
-        }
-        keyDecision = d;
-        boolean parentEmit = containers == 0 || frameEmit[containers - 1];
-        if (parentEmit && d == Decision.KEEP_ALL)
-        {
-            // A KEEP_ALL value is always emitted, so the key is forwarded live from the still-valid view —
-            // no copy and no deferral. The match above also used the live view, so no ancestor key is
-            // retained. Then arm the kept value for verbatim segment delivery (best-effort, demand-gated).
-            forward(sink, source, JsonEvent.KEY_NAME);
-            pendingKey = null;
-            if (downstreamDemand)
+            Decision d = decide(keyNode);
+            keyDecision = d;
+            boolean parentEmit = containers == 0 || frameEmit[containers - 1];
+            if (parentEmit && d == Decision.KEEP_ALL)
             {
-                control.segmentable();
+                // A KEEP_ALL value is always emitted, so the key is forwarded live from the still-valid
+                // view — no copy and no deferral. The match above also used the live view, so no ancestor
+                // key is retained. Then arm the kept value for verbatim segment delivery (best-effort,
+                // demand-gated).
+                forwardKey(control, source, sink);
+            }
+            else
+            {
+                // A DESCEND key is buffered for deferral: its value's kind is still unknown, and a scalar
+                // under a deeper-only pointer is dropped, so the key cannot be forwarded until the value
+                // event. A SKIP key copies nothing.
+                pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
             }
         }
-        else
+    }
+
+    // Forwards a KEEP_ALL key live from the still-valid source view and arms the kept value for verbatim
+    // segment delivery (best-effort, demand-gated).
+    private void forwardKey(
+        JsonController control,
+        JsonSource source,
+        JsonSink sink)
+    {
+        forward(sink, source, JsonEvent.KEY_NAME);
+        pendingKey = null;
+        if (downstreamDemand)
         {
-            // A DESCEND key is buffered for deferral: its value's kind is still unknown, and a scalar under a
-            // deeper-only pointer is dropped, so the key cannot be forwarded until the value event. A SKIP
-            // key copies nothing.
-            pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
+            control.segmentable();
         }
     }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonProjectorImpl.java
@@ -37,10 +37,14 @@ import io.aklivity.zilla.runtime.common.json.JsonVerbatim;
  * state only; the downstream is bound once at assembly and supplied per event.
  * <p>
  * The retained pointer set is compiled once into a {@link Node trie}: each node has children keyed by
- * segment plus a {@code keepAll} terminal flag (a pointer ends here, so the whole subtree is retained).
- * Descent tracks a per-depth stack of node references ({@code frameNode}) rather than the absolute path,
- * so matching a key is an {@code O(children)} lookup of the live {@link JsonSource#getStringView()} in the
- * current node's children — no ancestor key chain is ever retained and no absolute pointer is manifested.
+ * segment plus a {@code keepAll} terminal flag (a pointer ends here, so the whole subtree is retained), and
+ * a {@code maxKeyLength} (the longest child key at that position). Descent tracks a per-depth stack of node
+ * references ({@code frameNode}) rather than the absolute path, so matching a key is an {@code O(children)}
+ * lookup of the live {@link JsonSource#getStringView()} in the current node's children — no ancestor key
+ * chain is ever retained and no absolute pointer is manifested. A key that fragments across input windows is
+ * declined (never buffered) while it is still short enough that some child could still match; once it
+ * strictly exceeds {@code maxKeyLength} while still incomplete, no child can possibly match regardless of
+ * what follows, so the remaining fragments are drained without ever being buffered or compared.
  */
 public final class JsonProjectorImpl implements JsonTransform
 {
@@ -85,6 +89,9 @@ public final class JsonProjectorImpl implements JsonTransform
     private JsonEvent deferredStart;
     private boolean scalarPending;
     private boolean scalarEmit;
+    // true once a key has been proven longer than every candidate at the current position (see onKey): the
+    // remaining fragments are drained without inspection until the key completes.
+    private boolean keySkipping;
     // true while a buffered key is being forwarded downstream: the parser delivered that key live and already
     // moved on, so the sink's consumed() pushback for it must be absorbed rather than relayed to the parser's
     // now-current (value) char cursor
@@ -116,6 +123,7 @@ public final class JsonProjectorImpl implements JsonTransform
         scalarPending = false;
         scalarEmit = false;
         forwardingKey = false;
+        keySkipping = false;
     }
 
     private void onDownstreamSegmentable()
@@ -137,9 +145,17 @@ public final class JsonProjectorImpl implements JsonTransform
         public void consumed(
             int sourceBytes)
         {
-            // a buffered key's pushback is absorbed (the parser already delivered that key live); a value's
-            // pushback relays to the parser so it re-exposes the value remainder on resume
-            if (!forwardingKey)
+            // a buffered key's consumed count is relative to keySource's own small, fully-materialized
+            // substitute, not the live upstream token, so it advances keySource's own offset (the
+            // "expose the remainder on resume" contract keySource implements locally) rather than the
+            // real upstream's cursor -- otherwise the real upstream would misinterpret it as progress
+            // against a token it never actually forwarded. A value's pushback relays to the parser so it
+            // re-exposes the value remainder on resume.
+            if (forwardingKey)
+            {
+                keySource.advance(sourceBytes);
+            }
+            else
             {
                 upstreamControl.consumed(sourceBytes);
             }
@@ -189,6 +205,28 @@ public final class JsonProjectorImpl implements JsonTransform
         else
         {
             status = Status.ADVANCED;
+        }
+        return status;
+    }
+
+    @Override
+    public Status resume(
+        JsonController control,
+        JsonSource source,
+        JsonEvent event,
+        JsonSink sink)
+    {
+        upstreamControl = control;
+        // a KEY_NAME still in flight from a buffered (matched) forward continues reading from keySource,
+        // whose own cursor tracks how much of it the sink has already written — not the live parser
+        // source, which has already moved on to the value by the time such a key is forwarded (it was
+        // copied into pendingKeyBuffer once complete, then the parser advanced past it).
+        JsonSource resumed = event == JsonEvent.KEY_NAME && forwardingKey ? keySource : source;
+        Status status = sink.resume(downstreamControl, resumed, event);
+        if (event == JsonEvent.KEY_NAME && status != Status.SUSPENDED)
+        {
+            forwardingKey = false;
+            pendingKey = null;
         }
         return status;
     }
@@ -264,37 +302,78 @@ public final class JsonProjectorImpl implements JsonTransform
             keyDecision = Decision.KEEP_ALL;
             forwardKey(control, source, sink);
         }
-        else if (source.deferredBytes())
-        {
-            // a fragmented key cannot be matched against the trie until it is complete — the trie's
-            // children are compared as whole strings. Decline the fragment (consumed(0)) so the source
-            // accumulates it whole (the same fallback a content-needing scalar value uses) and re-presents
-            // it complete on a later window, then decide once the final fragment arrives.
-            control.consumed(0);
-            downstream = Status.STARVED;
-        }
         else
         {
+            // parentNode is null for a container already decided SKIP as a whole (frameKeepAll false,
+            // its own valueNode was null) — every key beneath it drops too, regardless of content, so
+            // maxKeyLength defaults to 0 and the very first fragment already exceeds it.
             Node parentNode = containers > 0 ? frameNode[containers - 1] : root;
-            keyNode = lookup(parentNode, source.getStringView());
-            Decision d = decide(keyNode);
-            keyDecision = d;
-            boolean parentEmit = containers == 0 || frameEmit[containers - 1];
-            if (parentEmit && d == Decision.KEEP_ALL)
+            int maxKeyLength = parentNode == null ? 0 : parentNode.maxKeyLength;
+            CharSequence view = source.getStringView();
+            boolean complete = !source.deferredBytes();
+            if (keySkipping)
             {
-                // A KEEP_ALL value is always emitted, so the key is forwarded live from the still-valid
-                // view — no copy and no deferral. The match above also used the live view, so no ancestor
-                // key is retained. Then arm the kept value for verbatim segment delivery (best-effort,
-                // demand-gated).
-                forwardKey(control, source, sink);
+                onKeySkip(control, view, complete);
+            }
+            else if (!complete && view.length() <= maxKeyLength)
+            {
+                // still short enough that some child could yet match once more of the key arrives; decline
+                // the fragment (consumed(0)) so the source accumulates it whole and re-presents it on a
+                // later window, the same fallback a content-needing scalar value uses.
+                control.consumed(0);
+                downstream = Status.STARVED;
+            }
+            else if (!complete)
+            {
+                // already longer than the longest child at this position, so no child can match regardless
+                // of what the rest of the key contains — drop this fragment and every one that follows
+                // without ever buffering the key.
+                keyNode = null;
+                keyDecision = Decision.SKIP;
+                pendingKey = null;
+                control.consumed(view.length());
+                keySkipping = true;
+                downstream = Status.STARVED;
             }
             else
             {
-                // A DESCEND key is buffered for deferral: its value's kind is still unknown, and a scalar
-                // under a deeper-only pointer is dropped, so the key cannot be forwarded until the value
-                // event. A SKIP key copies nothing.
-                pendingKey = d == Decision.SKIP ? null : copyKey(source.getStringView());
+                keyNode = lookup(parentNode, view);
+                Decision d = decide(keyNode);
+                keyDecision = d;
+                boolean parentEmit = containers == 0 || frameEmit[containers - 1];
+                if (parentEmit && d == Decision.KEEP_ALL)
+                {
+                    // A KEEP_ALL value is always emitted, so the key is forwarded live from the still-valid
+                    // view, then arm the kept value for verbatim segment delivery (best-effort, demand-gated).
+                    forwardKey(control, source, sink);
+                }
+                else
+                {
+                    // A DESCEND key is buffered for deferral: its value's kind is still unknown, and a
+                    // scalar under a deeper-only pointer is dropped, so the key cannot be forwarded until
+                    // the value event. A SKIP key copies nothing.
+                    pendingKey = d == Decision.SKIP ? null : copyKey(view);
+                }
             }
+        }
+    }
+
+    // Drains a fragment of a key already proven longer than every child at this position, without ever
+    // inspecting or buffering it; keySkipping clears once the key completes, leaving keyNode/keyDecision
+    // (SKIP) already set from when the excess length was first detected.
+    private void onKeySkip(
+        JsonController control,
+        CharSequence view,
+        boolean complete)
+    {
+        control.consumed(view.length());
+        if (complete)
+        {
+            keySkipping = false;
+        }
+        else
+        {
+            downstream = Status.STARVED;
         }
     }
 
@@ -326,10 +405,16 @@ public final class JsonProjectorImpl implements JsonTransform
     {
         if (pendingKey != null)
         {
+            // stays true across however many resume() calls a bounded output takes to drain a long
+            // buffered key, cleared only once the write actually completes (not merely returns from this
+            // call) -- see resume().
             forwardingKey = true;
             forward(sink, keySource.with(pendingKey), JsonEvent.KEY_NAME);
-            forwardingKey = false;
-            pendingKey = null;
+            if (downstream != Status.SUSPENDED)
+            {
+                forwardingKey = false;
+                pendingKey = null;
+            }
         }
     }
 
@@ -571,7 +656,8 @@ public final class JsonProjectorImpl implements JsonTransform
     }
 
     // Matches an array index against a node's children, preferring an explicit canonical-index child over
-    // the "-" wildcard; the wildcard applies only to arrays, while an object key "-" matches via lookup.
+    // the "-" wildcard; the wildcard applies only to arrays, while an object key "-" matches via lookup
+    // like any other key.
     private static Node lookupIndex(
         Node node,
         int index)
@@ -672,12 +758,14 @@ public final class JsonProjectorImpl implements JsonTransform
     }
 
     // An immutable trie node: children are parallel key/node arrays scanned linearly (a handful of children
-    // per node), and keepAll marks a node where a retained pointer terminates.
+    // per node), keepAll marks a node where a retained pointer terminates, and maxKeyLength is the longest
+    // of this node's own children's keys — the bound onKey declines a fragmenting child key against.
     private static final class Node
     {
         private final String[] keys;
         private final Node[] nodes;
         private final boolean keepAll;
+        private final int maxKeyLength;
 
         private Node(
             String[] keys,
@@ -687,6 +775,12 @@ public final class JsonProjectorImpl implements JsonTransform
             this.keys = keys;
             this.nodes = nodes;
             this.keepAll = keepAll;
+            int longest = 0;
+            for (String key : keys)
+            {
+                longest = Math.max(longest, key.length());
+            }
+            this.maxKeyLength = longest;
         }
     }
 
@@ -720,24 +814,34 @@ public final class JsonProjectorImpl implements JsonTransform
     private static final class KeySource implements JsonSource
     {
         private CharSequence key;
+        private int offset;
 
         private KeySource with(
             CharSequence key)
         {
             this.key = key;
+            this.offset = 0;
             return this;
+        }
+
+        // advances past what the sink already consumed, so a resumed write continues from the
+        // unconsumed remainder rather than re-presenting the whole key
+        private void advance(
+            int consumed)
+        {
+            offset += consumed;
         }
 
         @Override
         public String getString()
         {
-            return key == null ? null : key.toString();
+            return key == null ? null : getStringView().toString();
         }
 
         @Override
         public CharSequence getStringView()
         {
-            return key;
+            return key == null ? null : key.subSequence(offset, key.length());
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2455,6 +2455,16 @@ public final class JsonSchemaImpl implements JsonSchema
                 // must route to a property schema / required-set by the whole key, so a fragmented key
                 // always needs reassembly. Decline the fragment (consumed(0), do not forward) so the source
                 // accumulates it and re-presents it whole on a later window; only then feed eval.
+                //
+                // A decline-to-N bound (as used by JsonProjectorImpl/JsonFlattenerImpl) is intentionally not
+                // applied here: this eval and every combinator branch fed alongside it (allOf/anyOf/oneOf,
+                // $ref, dependentSchemas, ...) independently track their own propertyKeys/requiredKeys via
+                // feedCombinators, all reading the same live JsonSource. A per-position bound would need to
+                // be the max across that entire branch tree, not just this eval's own simpleObject keys —
+                // deciding "no candidate can match" from a narrower bound risks feeding a still-fragmenting
+                // key to a sibling branch expecting the complete key, corrupting its property/required match.
+                // simpleObject (fastKeys) does not preclude sibling combinators being present, so no bound
+                // computed from this eval alone is safe. Reassembly stays bounded by maxValueSize instead.
                 control.consumed(0);
                 status = Status.STARVED;
             }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2449,6 +2449,15 @@ public final class JsonSchemaImpl implements JsonSchema
                     ? leniently(downstream)
                     : verdictStatus(verdict, downstream);
             }
+            else if (event == JsonEvent.KEY_NAME && source.deferredBytes())
+            {
+                // unlike a scalar value, a key has no needsContent-style shortcut — every object position
+                // must route to a property schema / required-set by the whole key, so a fragmented key
+                // always needs reassembly. Decline the fragment (consumed(0), do not forward) so the source
+                // accumulates it and re-presents it whole on a later window; only then feed eval.
+                control.consumed(0);
+                status = Status.STARVED;
+            }
             else
             {
                 // structural events and keys forward first, preserving the emit-then-reject ordering (e.g. a

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonTokenizer.java
@@ -293,15 +293,17 @@ public final class JsonTokenizer
     private boolean onScalarStarved()
     {
         final boolean midScalar =
-            (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER) && !segmenting;
+            (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.VALUE_NUMBER ||
+                resumeOp == ResumeOp.KEY_STRING) && !segmenting;
         boolean delivered = false;
         if (midScalar)
         {
             final long valueBytes = streamOffset - valueStreamStart;
-            // a kept scalar leaf fragments verbatim on any starve; a decoded value only once it fills the window
+            // a kept scalar leaf fragments verbatim on any starve; a decoded value (or key) only once it
+            // fills the window
             final boolean fragment =
                 !terminalEof && (scalarSegment || fragmenting || valueBytes >= windowLength);
-            if (fragment && resumeOp == ResumeOp.VALUE_STRING)
+            if (fragment && (resumeOp == ResumeOp.VALUE_STRING || resumeOp == ResumeOp.KEY_STRING))
             {
                 // rewind to the last complete code-point/escape boundary, leaving the partial unit for the caller
                 streamOffset = unitStartOffset;
@@ -318,8 +320,15 @@ public final class JsonTokenizer
                 {
                     valueStreamStart = fragmentStart;
                     valueStreamEnd = streamOffset;
-                    stringVerbatim = scalarSegment || segmenting;
-                    pendingEvent = JsonParser.Event.VALUE_STRING;
+                    if (resumeOp == ResumeOp.KEY_STRING)
+                    {
+                        pendingEvent = JsonParser.Event.KEY_NAME;
+                    }
+                    else
+                    {
+                        stringVerbatim = scalarSegment || segmenting;
+                        pendingEvent = JsonParser.Event.VALUE_STRING;
+                    }
                     // capture lazily: a verbatim/segmented consumer reads only getSegment() and never
                     // materializes the decoded chars, so leave them in scratch (cleared when the next
                     // fragment resumes) and let stringValue() take them on demand
@@ -573,13 +582,16 @@ public final class JsonTokenizer
         switch (resumeOp)
         {
         case KEY_STRING:
+            // keep the part of the prior fragment the consumer did not take (a decliner keeps all of it
+            // via consumed(0)) so the next fragment accumulates onto the remainder and the key is
+            // re-presented whole; a consumer that took the whole fragment drops it all, as before
+            scratch.delete(0, Math.min(scratchConsumed, scratch.length()));
+            scratchConsumed = 0;
+            fragmentStart = streamOffset;
             continueStringContent(in);
             if (!starved)
             {
-                pendingEvent = JsonParser.Event.KEY_NAME;
-                captureKey();
-                resumeOp = ResumeOp.NONE;
-                state = ParseState.OBJ_AFTER_KEY;
+                finishKeyValue();
             }
             break;
         case VALUE_STRING:
@@ -676,6 +688,22 @@ public final class JsonTokenizer
         fragmenting = false;
         resumeOp = ResumeOp.NONE;
         afterValueConsumed();
+    }
+
+    // Completes a KEY_STRING scan: continueStringContent only returns here once the closing quote is seen
+    // (otherwise onScalarStarved decides fragment-vs-reassemble), so the key is whole — the final fragment
+    // of a fragmented key, or a key that fit one window. captureKey() mirrors it into pathKeyChars for
+    // currentPath(); when the key fragmented and each fragment was fully consumed downstream (so scratch
+    // was trimmed each round rather than accumulating via consumed(0)), only the final fragment's chars are
+    // mirrored — currentPath() is not guaranteed exact mid-document for a window-spanning key, only once
+    // the surrounding container's traversal has moved on.
+    private void finishKeyValue()
+    {
+        pendingEvent = JsonParser.Event.KEY_NAME;
+        captureKey();
+        fragmenting = false;
+        resumeOp = ResumeOp.NONE;
+        state = ParseState.OBJ_AFTER_KEY;
     }
 
     private String takeScratch()
@@ -878,6 +906,10 @@ public final class JsonTokenizer
         {
             throw new JsonParsingException("Expected '\"' for key but got: " + describe(c), null);
         }
+        valueStreamStart = streamOffset - 1;
+        fragmentStart = streamOffset - 1;
+        valueLine = line;
+        valueColumn = column - 1;
         scratch.setLength(0);
         resumeEscape = false;
         resumeUnicodePending = 0;
@@ -885,10 +917,7 @@ public final class JsonTokenizer
         continueStringContent(in);
         if (!starved)
         {
-            pendingEvent = JsonParser.Event.KEY_NAME;
-            captureKey();
-            resumeOp = ResumeOp.NONE;
-            state = ParseState.OBJ_AFTER_KEY;
+            finishKeyValue();
         }
     }
 

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonFlattenerTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonFlattenerTest.java
@@ -109,20 +109,38 @@ class JsonFlattenerTest
         // directly (no upstream projector) so the fragmenting key reaches this stage's own onKey() rather
         // than being reassembled and decided by the projector first.
         String key = "x".repeat(40);
-        assertEquals("{\"y\":1}", flattenWindowed(Map.of(key, "y"), "{\"" + key + "\":1}", 8));
+        assertEquals("{\"y\":1}", flattenWindowed(Map.of(key, "y"), "{\"" + key + "\":1}", 8, -1));
+    }
+
+    @Test
+    void shouldDropHugeNonMatchingKeyWithoutHittingValueSizeCap()
+    {
+        // root's only child is "y" (maxKeyLength 1): a 500-char unrelated key can never match, so onKey
+        // decides "dead branch" as soon as the fragment exceeds 1 char and drains the rest without ever
+        // buffering it -- completion here never depends on MAX_VALUE_SIZE, set far smaller than the dropped
+        // key to prove it (see the matching JsonProjectorTest case for the shared, pre-existing constraint
+        // this value must still clear: one window's worth of scanned-but-undecided tokenizer content).
+        String hugeKey = "x".repeat(500);
+        assertEquals("{\"z\":2}",
+            flattenWindowed(Map.of("y", "z"), "{\"" + hugeKey + "\":1,\"y\":2}", 8, 50));
     }
 
     // Drives flatten() (without an upstream projector) through fixed-size input windows, carrying the
-    // unconsumed tail (pipeline.remaining()) across STARVED feeds the way a real caller does.
+    // unconsumed tail (pipeline.remaining()) across STARVED feeds the way a real caller does. maxValueSize
+    // configures the parser's MAX_VALUE_SIZE when non-negative, otherwise the parser default applies.
     private static String flattenWindowed(
         Map<String, String> accessorTargets,
         String input,
-        int window)
+        int window,
+        int maxValueSize)
     {
         JsonGeneratorEx gen = JsonEx.createGenerator();
         MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
         gen.wrap(buffer, 0, buffer.capacity());
-        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+        JsonParserEx parser = maxValueSize < 0
+            ? JsonEx.createParser()
+            : JsonEx.createParser(Map.of(JsonParserEx.MAX_VALUE_SIZE, maxValueSize));
+        JsonPipeline pipeline = JsonEx.stream(parser)
             .transform(JsonTransforms.flatten(accessorTargets))
             .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
         pipeline.reset();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonFlattenerTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonFlattenerTest.java
@@ -101,6 +101,53 @@ class JsonFlattenerTest
             flattenBounded(Map.of("e", "epsilon"), "{\"e\":1}", 4));
     }
 
+    @Test
+    void shouldFlattenAccessorKeyThatFragmentsAcrossInputWindows()
+    {
+        // the accessor key is longer than the feed window and fragments across STARVED windows before this
+        // stage can match it against the accessor trie; the match must still land once it completes. Driven
+        // directly (no upstream projector) so the fragmenting key reaches this stage's own onKey() rather
+        // than being reassembled and decided by the projector first.
+        String key = "x".repeat(40);
+        assertEquals("{\"y\":1}", flattenWindowed(Map.of(key, "y"), "{\"" + key + "\":1}", 8));
+    }
+
+    // Drives flatten() (without an upstream projector) through fixed-size input windows, carrying the
+    // unconsumed tail (pipeline.remaining()) across STARVED feeds the way a real caller does.
+    private static String flattenWindowed(
+        Map<String, String> accessorTargets,
+        String input,
+        int window)
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonTransforms.flatten(accessorTargets))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        byte[] msg = (input + " ").getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+
     private static String flatten(
         Map<String, String> accessorTargets,
         String input)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -217,6 +217,51 @@ class JsonProjectorTest
             projectWindowed(List.of("/kept"), "{\"" + key + "\":1,\"kept\":2}", 8));
     }
 
+    @Test
+    void shouldDropHugeNonMatchingKeyWithoutHittingValueSizeCap()
+    {
+        // "kept" (root's only child, maxKeyLength 4) can never match the 500-char "xxxx..." key: onKey
+        // decides SKIP as soon as the fragment exceeds 4 chars, and every further fragment of the huge
+        // non-matching key is consumed and discarded rather than retained, so completion never depends on
+        // MAX_VALUE_SIZE — set here far smaller than the dropped key (500 chars) to prove it, but comfortably
+        // above one window's worth of scanned-but-undecided content (the tokenizer only checks the
+        // fragment-vs-reassemble threshold once a window's bytes are already scanned into its retained
+        // buffer, so the cap must clear that floor regardless of this test — an orthogonal, pre-existing
+        // constraint on maxValueSize vs. window size, not something decline-to-N changes). A decline-and-cap
+        // approach would REJECT this well before scanning all 500 chars; decline-to-N does not accumulate
+        // the key's content at all.
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+        gen.wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.MAX_VALUE_SIZE, 50)))
+            .transform(JsonTransforms.projector(List.of("/kept")))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        String hugeKey = "x".repeat(500);
+        String json = "{\"" + hugeKey + "\":1,\"kept\":2}";
+        byte[] msg = json.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + 8, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals("{\"kept\":2}", new String(out, UTF_8));
+    }
+
     // Drives the projection through fixed-size input windows, carrying the unconsumed tail
     // (pipeline.remaining()) across STARVED feeds the way a real caller does, so an over-window key
     // fragments and reassembles before the projector matches it.

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonProjectorTest.java
@@ -197,6 +197,63 @@ class JsonProjectorTest
                 "{\"alpha\":1,\"beta\":2,\"gamma\":3,\"delta\":4,\"epsilon\":5}", 12));
     }
 
+    @Test
+    void shouldRetainValueUnderKeyThatFragmentsAcrossInputWindows()
+    {
+        // the retained key is longer than the feed window, so it fragments across STARVED windows before
+        // the projector can match it against the trie; the match must still land once it completes
+        String key = "x".repeat(40);
+        assertEquals("{\"" + key + "\":1}",
+            projectWindowed(List.of("/" + key), "{\"" + key + "\":1,\"other\":2}", 8));
+    }
+
+    @Test
+    void shouldDropValueUnderKeyThatFragmentsAcrossInputWindowsWhenNotRetained()
+    {
+        // the dropped member's own key is longer than the feed window and fragments; the sibling that
+        // follows must still render correctly once the dropped member's key/value are skipped
+        String key = "x".repeat(40);
+        assertEquals("{\"kept\":2}",
+            projectWindowed(List.of("/kept"), "{\"" + key + "\":1,\"kept\":2}", 8));
+    }
+
+    // Drives the projection through fixed-size input windows, carrying the unconsumed tail
+    // (pipeline.remaining()) across STARVED feeds the way a real caller does, so an over-window key
+    // fragments and reassembles before the projector matches it.
+    private static String projectWindowed(
+        List<String> retained,
+        String input,
+        int window)
+    {
+        JsonGeneratorEx gen = JsonEx.createGenerator();
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[1024]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonTransforms.projector(retained))
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        gen.wrap(buffer, 0, buffer.capacity());
+        pipeline.reset();
+
+        byte[] msg = (input + " ").getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        return new String(out, UTF_8);
+    }
+
     private static String project(
         List<String> retained,
         String input)

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorStreamingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonValidatorStreamingTest.java
@@ -146,4 +146,87 @@ class JsonValidatorStreamingTest
 
         assertEquals(Status.REJECTED, status);
     }
+
+    @Test
+    void shouldValidateRequiredPropertyWhoseKeyFragmentsAcrossWindows()
+    {
+        // unlike a scalar value, a key has no needsContent-style shortcut: it must always be reassembled
+        // whole to route to the right required/property entry, regardless of the applicable subschema
+        String key = "x".repeat(40);
+        String schema = "{\"type\":\"object\",\"required\":[\"" + key + "\"]}";
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(schema).validator())
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        String json = "{\"" + key + "\":1}";
+        Status status = feedWindowed(pipeline, json, 8);
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[gen.length()];
+        buffer.getBytes(0, out);
+        assertEquals(json, new String(out, UTF_8));
+    }
+
+    @Test
+    void shouldRejectMissingRequiredPropertyWhoseKeyFragmentsAcrossWindows()
+    {
+        String key = "x".repeat(40);
+        String schema = "{\"type\":\"object\",\"required\":[\"" + key + "\"]}";
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(schema).validator())
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        // a different (also window-spanning) key is present instead of the required one
+        String json = "{\"" + "y".repeat(40) + "\":1}";
+        Status status = feedWindowed(pipeline, json, 8);
+
+        assertEquals(Status.REJECTED, status);
+    }
+
+    @Test
+    void shouldRejectKeyLargerThanValueSizeCap()
+    {
+        // a key always needs reassembly to route/validate, so — like a content-needing scalar value — it
+        // still fails closed past MAX_VALUE_SIZE rather than being rejected solely for spanning windows
+        JsonGeneratorEx gen = JsonEx.createGenerator().wrap(buffer, 0, buffer.capacity());
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.MAX_VALUE_SIZE, 16)))
+            .transform(JsonSchema.of("{\"type\":\"object\"}").validator())
+            .into(JsonEx.createSink(gen, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        pipeline.reset();
+
+        String json = "{\"" + "x".repeat(40) + "\":1}";
+        Status status = feedWindowed(pipeline, json, 8);
+
+        assertEquals(Status.REJECTED, status);
+    }
+
+    // Drives the document through fixed-size input windows, carrying the unconsumed tail
+    // (pipeline.remaining()) across STARVED feeds the way a real caller does, so an over-window key
+    // fragments and reassembles before the validator routes it.
+    private static Status feedWindowed(
+        JsonPipeline pipeline,
+        String json,
+        int window)
+    {
+        byte[] msg = json.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        return status;
+    }
 }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -291,6 +291,74 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldNotAccumulateRawBytesAcrossRepeatedKeyDeclines()
+    {
+        // control.consumed(0) on a key fragment operates on the tokenizer's own decoded-char cursor
+        // (stringViewOffset -> JsonTokenizer.scratch), not on the caller's raw byte window: by the time a
+        // fragment is delivered, its raw bytes are already scanned (tokenizer.streamOffset() has moved
+        // past them), so parser.remaining() is governed solely by the tokenizer's own window-fill/
+        // reassemble-whole decision, never by what a downstream consumer does with the decoded view. The
+        // very first starve for a value/key that has not yet locked onto full-window fragmenting can still
+        // require re-presenting close to one window's worth of bytes (the ordinary reassemble-whole
+        // rewind, identical to a plain VALUE_STRING and unrelated to declining) — but once fragmenting
+        // engages, repeated declines must not make remaining() keep growing across further windows.
+        List<Integer> remainingPerStarve = new ArrayList<>();
+        JsonTransform decliner = (control, source, event, sink) ->
+        {
+            Status result;
+            if (event == JsonEvent.KEY_NAME && source.deferredBytes())
+            {
+                control.consumed(0);
+                result = Status.STARVED;
+            }
+            else
+            {
+                result = sink.transform(control, source, event);
+            }
+            return result;
+        };
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBufferEx output = new UnsafeBufferEx(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(decliner)
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        String key = "x".repeat(40);
+        String json = "{\"" + key + "\":1}";
+        byte[] msg = json.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + 8, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                int remaining = pipeline.remaining();
+                remainingPerStarve.add(remaining);
+                progress = limit - remaining;
+            }
+        }
+
+        assertTrue(remainingPerStarve.size() >= 3, "expected multiple STARVED windows while the key was declined");
+        // the first starve may re-present up to one window's worth of bytes (ordinary reassemble-whole,
+        // unrelated to declining); every starve after that must be at the pure-ASCII steady-state floor of
+        // zero, proving repeated declines do not accumulate raw bytes at the caller's byte-window level
+        List<Integer> steadyState = remainingPerStarve.subList(1, remainingPerStarve.size());
+        assertTrue(steadyState.stream().allMatch(r -> r == 0),
+            "remaining() must not grow across repeated declines: " + remainingPerStarve);
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        assertEquals(json, new String(out, UTF_8));
+    }
+
+    @Test
     void shouldFragmentLargeStringValueStructured()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineChunkingTest.java
@@ -31,6 +31,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
+import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
@@ -146,6 +147,18 @@ class JsonPipelineChunkingTest
     }
 
     @Test
+    void shouldChunkStructuredKeyAcrossInputAndOutputBounds()
+    {
+        // an object key larger than both the input window and the output bound: the tokenizer must starve
+        // on input (the key's own bytes fill the window) and the sink must suspend mid-fragment on output,
+        // reconstructing the key canonically from its decoded char view with no concatenation — the
+        // key-domain analog of shouldChunkStructuredStringAcrossInputAndOutputBounds
+        String key = ("aKey" + "x".repeat(6)).repeat(8);
+        String json = "{\"" + key + "\":1}";
+        assertEquals(json, chunkedWindowed(JsonSink.Delivery.STRUCTURED, json, 40, 24));
+    }
+
+    @Test
     void shouldStreamStringValueAcrossInputFrames()
     {
         JsonGeneratorEx generator = JsonEx.createGenerator();
@@ -193,6 +206,88 @@ class JsonPipelineChunkingTest
         // first fragment is mid-stream (more deferred); the closing fragment completes the value
         assertTrue(deferred.get(0));
         assertFalse(deferred.get(deferred.size() - 1));
+    }
+
+    @Test
+    void shouldReportDeferredBytesForKeyStreamingAcrossFrames()
+    {
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBufferEx output = new UnsafeBufferEx(new byte[256]);
+        List<Boolean> deferred = new ArrayList<>();
+        JsonTransform probe = (control, source, event, sink) ->
+        {
+            if (event == JsonEvent.KEY_NAME)
+            {
+                deferred.add(source.deferredBytes());
+            }
+            return sink.transform(control, source, event);
+        };
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(probe)
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        // small feed windows fragment the over-window key; each starve carries the unconsumed remainder
+        // forward (progress = limit - pipeline.remaining()) so the key resumes byte-correct
+        String json = "{\"" + "x".repeat(40) + "\":1}";
+        byte[] msg = json.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + 8, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+
+        // first fragment is mid-key (more deferred); the closing fragment completes the key
+        assertTrue(deferred.get(0));
+        assertFalse(deferred.get(deferred.size() - 1));
+    }
+
+    @Test
+    void shouldStreamKeyPastValueSizeCapWhenConsumedEagerly()
+    {
+        // no consumer declines a key fragment here (a plain passthrough sink always takes what fits), so the
+        // retained backlog never grows past MAX_VALUE_SIZE even though the whole key is far longer — the
+        // key-domain analog of JsonValidatorStreamingTest's shouldStreamUnconstrainedFragmentedRootValuePastValueSizeCap
+        JsonGeneratorEx generator = JsonEx.createGenerator();
+        MutableDirectBufferEx output = new UnsafeBufferEx(new byte[256]);
+        JsonPipeline pipeline = JsonEx.stream(JsonEx.createParser(Map.of(JsonParserEx.MAX_VALUE_SIZE, 16)))
+            .into(JsonEx.createSink(generator, Map.of(JsonSink.DELIVERY, JsonSink.Delivery.STRUCTURED)));
+        generator.wrap(output, 0, output.capacity());
+        pipeline.reset();
+
+        String key = "aaaaaaaaaabbbbbbbbbbcccccccccc";
+        String json = "{\"" + key + "\":1}";
+        byte[] msg = json.getBytes(UTF_8);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + 8, msg.length);
+            boolean last = limit >= msg.length;
+            status = pipeline.transform(new UnsafeBufferEx(msg), progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+
+        assertEquals(Status.COMPLETED, status);
+        byte[] out = new byte[generator.length()];
+        output.getBytes(0, out);
+        assertEquals(json, new String(out, UTF_8));
     }
 
     @Test
@@ -275,6 +370,16 @@ class JsonPipelineChunkingTest
         // small feed windows fragment the over-window value; the structured sink re-renders each fragment
         // canonically from getStringView() with no concatenation
         String json = "{\"data\":\"" + "x".repeat(40) + "\"}";
+        assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
+    }
+
+    @Test
+    void shouldReconstructWindowFragmentedKeyStructured()
+    {
+        // small feed windows fragment the over-window key; the structured sink re-renders each fragment
+        // canonically from getStringView() with no concatenation — the key-domain analog of
+        // shouldReconstructWindowFragmentedStringValueStructured
+        String json = "{\"" + "x".repeat(40) + "\":1}";
         assertEquals(json, feedWindowed(json, JsonSink.Delivery.STRUCTURED, 8));
     }
 

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
@@ -45,7 +45,11 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
  * {@link #resume} continues with the next window, exactly as the wire parser does. The translator carries no
  * document buffer; only the bounded per-message frame stack and a small pending-event ring. One JSON leaf value
  * must fit a single input window (it is read via the allocation-free {@link JsonParserEx#getStringView()}
- * view); message structure may split across windows at any token boundary.
+ * view); a field-name or map key is not subject to this limit — a key larger than the window fragments across
+ * multiple {@link JsonEvent#KEY_NAME} events (each with {@link JsonParserEx#deferredBytes()} true until the
+ * last), and {@code messageStep}/{@code mapStep} simply re-pull rather than act on an incomplete one, relying
+ * on the JSON parser's own accumulation to re-present it whole once complete; message structure may otherwise
+ * split across windows at any token boundary.
  * <p>
  * Allocation: scalar values and keys are read through the parser's non-owning char views and parsed/encoded
  * straight into a reused buffer — integers via {@code Long.parseLong(CharSequence, …)} — so no per-value
@@ -421,18 +425,25 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             }
             else if (token == JsonEvent.KEY_NAME)
             {
-                ProtobufField field = frame.message.field(parser.getStringView());
-                if (field == null)
+                // the field lookup needs the whole key; a fragment still incomplete (parser.deferredBytes())
+                // is left unacted-on and re-pulled next step -- parser's own accumulation reassembles it, so
+                // the eventually-delivered event carries the whole key, never a prefix, matching field()'s
+                // whole-name comparison
+                if (!parser.deferredBytes())
                 {
-                    if (rejectUnknownFields)
+                    ProtobufField field = frame.message.field(parser.getStringView());
+                    if (field == null)
                     {
-                        throw new ProtobufParsingException("unknown field " + parser.getStringView());
+                        if (rejectUnknownFields)
+                        {
+                            throw new ProtobufParsingException("unknown field " + parser.getStringView());
+                        }
+                        beginSkip();
                     }
-                    beginSkip();
-                }
-                else
-                {
-                    frame.pendingField = field;
+                    else
+                    {
+                        frame.pendingField = field;
+                    }
                 }
                 progress = true;
             }
@@ -521,13 +532,18 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             }
             else if (token == JsonEvent.KEY_NAME)
             {
-                ProtobufMessage entry = frame.message;
-                ProtobufField keyField = entry.field(1);
-                enqueue(ProtobufEvent.FIELD, frame.field, null);
-                enqueue(ProtobufEvent.START_MESSAGE, null, entry);
-                enqueue(ProtobufEvent.FIELD, keyField, null);
-                emitKey(keyField);
-                frame.mapStep = 1;
+                // the map key needs the whole key before it can stream/decode; a fragment still incomplete
+                // (parser.deferredBytes()) is left unacted-on and re-pulled next step, the same as messageStep
+                if (!parser.deferredBytes())
+                {
+                    ProtobufMessage entry = frame.message;
+                    ProtobufField keyField = entry.field(1);
+                    enqueue(ProtobufEvent.FIELD, frame.field, null);
+                    enqueue(ProtobufEvent.START_MESSAGE, null, entry);
+                    enqueue(ProtobufEvent.FIELD, keyField, null);
+                    emitKey(keyField);
+                    frame.mapStep = 1;
+                }
                 progress = true;
             }
             else

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonChunkingTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonChunkingTest.java
@@ -249,6 +249,74 @@ public class ProtobufJsonChunkingTest
         assertEquals("{\"id\":\"123\",\"" + LONG_KEY + "\":\"OK\"}", drained.json);
     }
 
+    @Test
+    public void shouldMatchFieldNameKeyThatFragmentsAcrossJsonInputWindows()
+    {
+        // the field name key itself is longer than the JSON input feed window and fragments across STARVED
+        // windows before messageStep()'s field lookup sees it complete; the field must still be found once
+        // the key finishes reassembling, rather than being rejected (or matched) on a prefix
+        String json = Json.createObjectBuilder()
+            .add("id", "123")
+            .add(LONG_KEY, "OK")
+            .build()
+            .toString();
+
+        byte[] wire = fromJsonInputWindowed("Event", json.getBytes(UTF_8), 8);
+
+        JsonObject object = parse(toJson("Event", wire));
+        assertEquals("123", object.getString("id"));
+        assertEquals("OK", object.getString(LONG_KEY));
+    }
+
+    @Test
+    public void shouldResolveMapKeyThatFragmentsAcrossJsonInputWindows()
+    {
+        // a string map key long enough to fragment across the JSON input feed window before mapStep() sees
+        // it complete; the map entry must still resolve to the correct (whole) key
+        String key = "the-quick-brown-fox-jumps-over-the-lazy-dog";
+        String json = "{\"props\":{\"" + key + "\":\"v\"}}";
+
+        byte[] wire = fromJsonInputWindowed("Props", json.getBytes(UTF_8), 4);
+
+        JsonObject object = parse(toJson("Props", wire));
+        assertEquals("v", object.getJsonObject("props").getString(key));
+    }
+
+    // Drives the JSON -> wire direction (ProtobufJsonParserImpl) through fixed-size JSON input windows,
+    // carrying the unconsumed tail (pipeline.remaining()) across STARVED feeds the way a real caller does, so
+    // a field-name or map key larger than the window fragments and reassembles before the schema walk reads it.
+    private byte[] fromJsonInputWindowed(
+        String messageName,
+        byte[] json,
+        int window)
+    {
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[Math.max(256, json.length * 4)]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(ProtobufJson.parser(JsonEx.createParser(), schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        UnsafeBufferEx in = new UnsafeBufferEx(json);
+        int progress = 0;
+        int limit = 0;
+        Status status = Status.STARVED;
+        int guard = 0;
+        while (status == Status.STARVED && guard++ < 10_000)
+        {
+            limit = Math.min(limit + window, json.length);
+            boolean last = limit >= json.length;
+            status = pipeline.transform(in, progress, limit, last);
+            if (status == Status.STARVED)
+            {
+                progress = limit - pipeline.remaining();
+            }
+        }
+        assertEquals(Status.COMPLETED, status);
+        byte[] wire = new byte[generator.length()];
+        out.getBytes(0, wire);
+        return wire;
+    }
+
     private Drained toJsonBounded(
         String messageName,
         byte[] wire,


### PR DESCRIPTION
## Description

Broadens the input-side key-streaming fix (`JsonTokenizer` fragmenting `KEY_STRING` the same as `VALUE_STRING`/`VALUE_NUMBER`) to every downstream consumer that compares a possibly-still-fragmenting key against a fixed candidate set before it's known to be complete — the same "assumes the whole key arrives in one event" bug, expressed differently per consumer.

**Decline-to-N**: rather than always buffering a fragmenting key until it's complete (bounded only by `maxValueSize`), decline (`consumed(0)`) only while the fragment-so-far could still be a prefix of some candidate (`fragment.length() <= maxCandidateLength` at that position). Once a fragment strictly exceeds every candidate's length, no candidate can possibly match regardless of what follows, so stop declining and fast-forward/drain the rest without ever buffering it.

Applied where safe:
- `JsonProjectorImpl` / `JsonFlattenerImpl` (`common-json`) — trie/accessor-map nodes now track `maxKeyLength`; `onKey` declines up to that bound, then forwards (matched) or drains (provably unmatched). Also fixes a latent, pre-existing bug this surfaced: `JsonProjectorImpl`'s buffered-key-forward path had no resumability cursor, so a bounded-output SUSPEND mid-forward of a long matched key could corrupt output.
- `JsonSchemaImpl` (`common-json`) — **intentionally exempted**, documented in `Validator.transform()`: sibling schema-combinator branches (`allOf`/`anyOf`/`oneOf`, `$ref`, `dependentSchemas`, ...) independently track their own candidate sets over the identical key stream, so a bound computed from one eval's own keys isn't globally safe. Kept the simpler decline-until-complete behavior here.
- `binding-mcp`: `McpSchemeExcluder`, `McpEagerFilter`, `McpScopeFilter`, `McpSchemeInjector` had the same bug in their arm-key/`"name"`-key comparisons. `McpSchemeExcluder` also does byte-preserving verbatim forwarding (only possible fragment-by-fragment, live), so its arm-key match uses a zero-buffer incremental comparator instead of buffering. Also found and fixed a related bug in the same methods: the `"name"` *value* (not just its key) had the identical whole-event assumption.
- `AvroJsonParserImpl` (`common-avro`) — fixed at the single `peek()` choke point: loop past any event with `deferredBytes() == true` instead of exposing it early. Fixes keys and, as a byproduct, scalar value reads that had the same bug.
- `ProtobufJsonParserImpl` (`common-protobuf`) — `messageStep()`/`mapStep()` re-pull rather than act on an incomplete `KEY_NAME`. The separately-documented one-leaf-value-per-window constraint is unrelated to keys and left unchanged.

All four affected modules (`common-json`, `common-avro`, `common-protobuf`, `binding-mcp`) build clean with `checkstyle:check` and full test suites (4882+126+133+188 tests, no regressions). New/updated tests drive fixed-size input windows through `STARVED`, asserting correct output once the fragmenting key/value completes, and that a non-matching key past its bound never accumulates unbounded memory.

See the [issue](https://github.com/aklivity/zilla/issues/1954) description for the full per-file breakdown and rationale.

Fixes #1954

## Test plan

- [x] `./mvnw -pl runtime/common-json checkstyle:check test` — 4882 tests pass
- [x] `./mvnw -pl runtime/common-avro checkstyle:check test` — 133 tests pass
- [x] `./mvnw -pl runtime/common-protobuf checkstyle:check test` — 188 tests pass
- [x] `./mvnw -pl runtime/binding-mcp checkstyle:check test` — 126 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_013JqMcdWMdkTTnoKk8UXLz9)_