### PR TITLE
feat(binding-asyncapi,binding-openapi-asyncapi): align route when/with vocabulary with mcp-openapi

### DIFF
--- a/examples/asyncapi.http.kafka.proxy/etc/zilla.yaml
+++ b/examples/asyncapi.http.kafka.proxy/etc/zilla.yaml
@@ -35,17 +35,17 @@ bindings:
               subject: kafka
     routes:
       - when:
-          - api-id: http_api
-            operation-id: createPets
+          - spec: http_api
+            operation: createPets
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: addPet
+          spec: kafka_api
+          operation: addPet
       - when:
-          - api-id: http_api
+          - spec: http_api
         exit: south_kafka_client
         with:
-          api-id: kafka_api
+          spec: kafka_api
   south_kafka_client:
     type: asyncapi
     kind: client

--- a/examples/asyncapi.mqtt.kafka.proxy/etc/zilla.yaml
+++ b/examples/asyncapi.mqtt.kafka.proxy/etc/zilla.yaml
@@ -40,40 +40,40 @@ bindings:
           messages: mqttMessages
     routes:
       - when:
-          - api-id: mqtt_api
-            operation-id: turnOn
+          - spec: mqtt_api
+            operation: turnOn
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: toStreetlightData
+          spec: kafka_api
+          operation: toStreetlightData
       - when:
-          - api-id: mqtt_api
-            operation-id: receiveLightMeasurement
+          - spec: mqtt_api
+            operation: receiveLightMeasurement
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: onStreetlightData
+          spec: kafka_api
+          operation: onStreetlightData
       - when:
-          - api-id: mqtt_api
-            operation-id: sendLightMeasurement
+          - spec: mqtt_api
+            operation: sendLightMeasurement
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: toStreetlightData
+          spec: kafka_api
+          operation: toStreetlightData
       - when:
-          - api-id: mqtt_api
-            operation-id: turnOff
+          - spec: mqtt_api
+            operation: turnOff
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: toStreetlightData
+          spec: kafka_api
+          operation: toStreetlightData
       - when:
-          - api-id: mqtt_api
-            operation-id: dimLight
+          - spec: mqtt_api
+            operation: dimLight
         exit: south_kafka_client
         with:
-          api-id: kafka_api
-          operation-id: toStreetlightData
+          spec: kafka_api
+          operation: toStreetlightData
   south_kafka_client:
     type: asyncapi
     kind: client

--- a/examples/asyncapi.sse.kafka.proxy/etc/zilla.yaml
+++ b/examples/asyncapi.sse.kafka.proxy/etc/zilla.yaml
@@ -35,10 +35,10 @@ bindings:
               subject: kafka
     routes:
       - when:
-          - api-id: sse_api
+          - spec: sse_api
         exit: south_kafka_client
         with:
-          api-id: kafka_api
+          spec: kafka_api
   south_kafka_client:
     type: asyncapi
     kind: client

--- a/examples/openapi.asyncapi.kakfa.proxy/etc/zilla.yaml
+++ b/examples/openapi.asyncapi.kakfa.proxy/etc/zilla.yaml
@@ -38,9 +38,9 @@ bindings:
     routes:
       - exit: south_asyncapi_client
         when:
-          - api-id: my-openapi-spec
+          - spec: my-openapi-spec
         with:
-          api-id: my-asyncapi-spec
+          spec: my-asyncapi-spec
   south_asyncapi_client:
     type: asyncapi
     kind: client

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfig.java
@@ -18,34 +18,34 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 
 public class AsyncapiConditionConfig extends ConditionConfig
 {
-    public final String apiId;
-    public final String operationId;
+    public final String spec;
+    public final String operation;
 
     public AsyncapiConditionConfig(
-        String apiId,
-        String operationId)
+        String spec,
+        String operation)
     {
-        this.apiId = apiId;
-        this.operationId = operationId;
+        this.spec = spec;
+        this.operation = operation;
     }
 
     public boolean matches(
         String apiId,
         String operationId)
     {
-        return matchesApiId(apiId) &&
-            matchesOperationId(operationId);
+        return matchesSpec(apiId) &&
+            matchesOperation(operationId);
     }
 
-    private boolean matchesApiId(
+    private boolean matchesSpec(
         String apiId)
     {
-        return this.apiId == null || this.apiId.equals(apiId);
+        return this.spec == null || this.spec.equals(apiId);
     }
 
-    private boolean matchesOperationId(
+    private boolean matchesOperation(
         String operationId)
     {
-        return this.operationId == null || this.operationId.equals(operationId);
+        return this.operation == null || this.operation.equals(operationId);
     }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapter.java
@@ -25,8 +25,8 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfigAdapterSpi;
 
 public class AsyncapiConditionConfigAdapter implements ConditionConfigAdapterSpi, JsonbAdapter<ConditionConfig, JsonObject>
 {
-    private static final String API_ID_NAME = "api-id";
-    private static final String OPERATION_ID_NAME = "operation-id";
+    private static final String SPEC_NAME = "spec";
+    private static final String OPERATION_NAME = "operation";
 
     @Override
     public String type()
@@ -41,11 +41,11 @@ public class AsyncapiConditionConfigAdapter implements ConditionConfigAdapterSpi
         AsyncapiConditionConfig asyncapiCondition = (AsyncapiConditionConfig) condition;
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        object.add(API_ID_NAME, asyncapiCondition.apiId);
+        object.add(SPEC_NAME, asyncapiCondition.spec);
 
-        if (asyncapiCondition.operationId != null)
+        if (asyncapiCondition.operation != null)
         {
-            object.add(OPERATION_ID_NAME, asyncapiCondition.operationId);
+            object.add(OPERATION_NAME, asyncapiCondition.operation);
         }
         return object.build();
     }
@@ -54,14 +54,14 @@ public class AsyncapiConditionConfigAdapter implements ConditionConfigAdapterSpi
     public ConditionConfig adaptFromJson(
         JsonObject object)
     {
-        String apiId = object.containsKey(API_ID_NAME)
-            ? object.getString(API_ID_NAME)
+        String spec = object.containsKey(SPEC_NAME)
+            ? object.getString(SPEC_NAME)
             : null;
 
-        String operationId = object.containsKey(OPERATION_ID_NAME)
-            ? object.getString(OPERATION_ID_NAME)
+        String operation = object.containsKey(OPERATION_NAME)
+            ? object.getString(OPERATION_NAME)
             : null;
 
-        return new AsyncapiConditionConfig(apiId, operationId);
+        return new AsyncapiConditionConfig(spec, operation);
     }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiRouteConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiRouteConfig.java
@@ -54,4 +54,11 @@ public final class AsyncapiRouteConfig
     {
         return when.isEmpty() || when.stream().anyMatch(m -> m.matches(apiId, operationId));
     }
+
+    public boolean isBulk()
+    {
+        return with.tag != null ||
+            with.operation == null ||
+            with.operation.indexOf('*') != -1;
+    }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfig.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfig.java
@@ -18,14 +18,17 @@ import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
 public class AsyncapiWithConfig extends WithConfig
 {
-    public final String apiId;
-    public final String operationId;
+    public final String spec;
+    public final String operation;
+    public final String tag;
 
     public AsyncapiWithConfig(
-        String apiId,
-        String operationId)
+        String spec,
+        String operation,
+        String tag)
     {
-        this.apiId = apiId;
-        this.operationId = operationId;
+        this.spec = spec;
+        this.operation = operation;
+        this.tag = tag;
     }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapter.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapter.java
@@ -25,8 +25,9 @@ import io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi;
 
 public class AsyncapiWithConfigAdapter implements WithConfigAdapterSpi, JsonbAdapter<WithConfig, JsonObject>
 {
-    private static final String API_ID_NAME = "api-id";
-    private static final String OPERATION_ID_NAME = "operation-id";
+    private static final String SPEC_NAME = "spec";
+    private static final String OPERATION_NAME = "operation";
+    private static final String TAG_NAME = "tag";
 
     @Override
     public String type()
@@ -42,14 +43,19 @@ public class AsyncapiWithConfigAdapter implements WithConfigAdapterSpi, JsonbAda
 
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        if (config.apiId != null)
+        if (config.spec != null)
         {
-            object.add(API_ID_NAME, config.apiId);
+            object.add(SPEC_NAME, config.spec);
         }
 
-        if (config.operationId != null)
+        if (config.operation != null)
         {
-            object.add(OPERATION_ID_NAME, config.operationId);
+            object.add(OPERATION_NAME, config.operation);
+        }
+
+        if (config.tag != null)
+        {
+            object.add(TAG_NAME, config.tag);
         }
 
         return object.build();
@@ -59,14 +65,18 @@ public class AsyncapiWithConfigAdapter implements WithConfigAdapterSpi, JsonbAda
     public WithConfig adaptFromJson(
         JsonObject object)
     {
-        String apiId = object.containsKey(API_ID_NAME)
-            ? object.getString(API_ID_NAME)
+        String spec = object.containsKey(SPEC_NAME)
+            ? object.getString(SPEC_NAME)
             : null;
 
-        String operationId = object.containsKey(OPERATION_ID_NAME)
-            ? object.getString(OPERATION_ID_NAME)
+        String operation = object.containsKey(OPERATION_NAME)
+            ? object.getString(OPERATION_NAME)
             : null;
 
-        return new AsyncapiWithConfig(apiId, operationId);
+        String tag = object.containsKey(TAG_NAME)
+            ? object.getString(TAG_NAME)
+            : null;
+
+        return new AsyncapiWithConfig(spec, operation, tag);
     }
 }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiProxyGenerator.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/composite/AsyncapiProxyGenerator.java
@@ -33,6 +33,7 @@ import io.aklivity.zilla.runtime.binding.asyncapi.internal.config.AsyncapiCompos
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.config.AsyncapiCompositeConfig;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.config.AsyncapiCompositeRouteConfig;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.config.AsyncapiRouteConfig;
+import io.aklivity.zilla.runtime.binding.asyncapi.internal.config.AsyncapiWithConfig;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.model.bindings.http.AsyncapiHttpOperationBindingEx;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.model.bindings.http.kafka.AsyncapiHttpKafkaFilterEx;
 import io.aklivity.zilla.runtime.binding.asyncapi.internal.model.bindings.http.kafka.AsyncapiHttpKafkaOperationBindingEx;
@@ -82,8 +83,8 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
             .flatMap(r -> r.when.stream()
                 .map(w ->
                     new ProxyMapping(
-                        schemasByApiId.get(w.apiId),
-                        schemasByApiId.get(r.with.apiId))))
+                        schemasByApiId.get(w.spec),
+                        schemasByApiId.get(r.with.spec))))
             .distinct()
             .toList();
 
@@ -162,19 +163,66 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                     .inject(mqttKafka::injectAll);
             }
 
+            private Map<String, AsyncapiOperationView> bulkCandidates(
+                Map<String, AsyncapiOperationView> kafkaOpsById,
+                AsyncapiWithConfig with)
+            {
+                final Predicate<AsyncapiOperationView> matches;
+                if (with.tag != null)
+                {
+                    matches = operation -> operation.tags != null && operation.tags.contains(with.tag);
+                }
+                else if (with.operation != null)
+                {
+                    final Pattern pattern = compileGlob(with.operation);
+                    matches = operation -> operation.name != null && pattern.matcher(operation.name).matches();
+                }
+                else
+                {
+                    matches = operation -> true;
+                }
+
+                return kafkaOpsById.entrySet().stream()
+                    .filter(entry -> matches.test(entry.getValue()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+
+            private Pattern compileGlob(
+                String glob)
+            {
+                final StringBuilder regex = new StringBuilder();
+                final String[] literals = glob.split("\\*", -1);
+                for (int index = 0; index < literals.length; index++)
+                {
+                    if (index > 0)
+                    {
+                        regex.append(".*");
+                    }
+                    if (!literals[index].isEmpty())
+                    {
+                        regex.append(Pattern.quote(literals[index]));
+                    }
+                }
+                return Pattern.compile(regex.toString());
+            }
+
             private final class ProxyRouteHelper
             {
                 private final List<ProxyOperationHelper> when;
                 private final ProxyOperationHelper with;
+                private final AsyncapiWithConfig withConfig;
+                private final boolean bulk;
 
                 private ProxyRouteHelper(
                     AsyncapiRouteConfig route)
                 {
                     this.when = route.when.stream()
-                            .filter(c -> mapping.when.apiLabel.equals(c.apiId))
-                            .map(c -> new ProxyOperationHelper(mapping.when, c.operationId))
+                            .filter(c -> mapping.when.apiLabel.equals(c.spec))
+                            .map(c -> new ProxyOperationHelper(mapping.when, c.operation))
                             .toList();
-                    this.with = new ProxyOperationHelper(mapping.with, route.with.operationId);
+                    this.with = new ProxyOperationHelper(mapping.with, route.with.operation);
+                    this.withConfig = route.with;
+                    this.bulk = route.isBulk();
                 }
 
                 private boolean hasWhenProtocol(
@@ -299,6 +347,9 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                     for (ProxyRouteHelper route : mqttKafkaRoutes)
                     {
                         Map<String, AsyncapiOperationView> kafkaOpsById = route.with.schema.asyncapi.operations;
+                        Map<String, AsyncapiOperationView> candidateKafkaOpsById = route.bulk
+                            ? bulkCandidates(kafkaOpsById, route.withConfig)
+                            : kafkaOpsById;
 
                         for (ProxyOperationHelper condition : route.when)
                         {
@@ -309,11 +360,11 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             {
                                 for (AsyncapiOperationView mqttAnyOp : mqttOpsById.values())
                                 {
-                                    String kafkaOpId = route.with.operationId != null
-                                        ? route.with.operationId
-                                        : mqttAnyOp.name;
+                                    String kafkaOpId = route.bulk
+                                        ? mqttAnyOp.name
+                                        : route.withConfig.operation;
 
-                                    AsyncapiOperationView kafkaOp = kafkaOpsById.get(kafkaOpId);
+                                    AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
 
                                     if (kafkaOp != null)
                                     {
@@ -323,7 +374,10 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             }
                             else
                             {
-                                AsyncapiOperationView kafkaOp = kafkaOpsById.get(route.with.operationId);
+                                String kafkaOpId = route.bulk
+                                    ? mqttOp.name
+                                    : route.withConfig.operation;
+                                AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
                                 binding.inject(b -> injectMqttKafkaRoute(b, mqttOp, kafkaOp));
                             }
                         }
@@ -400,6 +454,9 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                     for (ProxyRouteHelper route : sseKafkaRoutes)
                     {
                         Map<String, AsyncapiOperationView> kafkaOpsById = route.with.schema.asyncapi.operations;
+                        Map<String, AsyncapiOperationView> candidateKafkaOpsById = route.bulk
+                            ? bulkCandidates(kafkaOpsById, route.withConfig)
+                            : kafkaOpsById;
 
                         for (ProxyOperationHelper condition : route.when)
                         {
@@ -410,11 +467,11 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             {
                                 for (AsyncapiOperationView httpAnyOp : httpOpsById.values())
                                 {
-                                    String kafkaOpId = route.with.operationId != null
-                                        ? route.with.operationId
-                                        : httpAnyOp.name;
+                                    String kafkaOpId = route.bulk
+                                        ? httpAnyOp.name
+                                        : route.withConfig.operation;
 
-                                    AsyncapiOperationView kafkaOp = kafkaOpsById.get(kafkaOpId);
+                                    AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
 
                                     if (kafkaOp != null)
                                     {
@@ -424,7 +481,10 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             }
                             else
                             {
-                                AsyncapiOperationView kafkaOp = kafkaOpsById.get(route.with.operationId);
+                                String kafkaOpId = route.bulk
+                                    ? httpOp.name
+                                    : route.withConfig.operation;
+                                AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
                                 binding.inject(b -> injectSseKafkaRoute(b, httpOp, kafkaOp));
                             }
                         }
@@ -596,6 +656,9 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                     for (ProxyRouteHelper route : httpKafkaRoutes)
                     {
                         Map<String, AsyncapiOperationView> kafkaOpsById = route.with.schema.asyncapi.operations;
+                        Map<String, AsyncapiOperationView> candidateKafkaOpsById = route.bulk
+                            ? bulkCandidates(kafkaOpsById, route.withConfig)
+                            : kafkaOpsById;
 
                         for (ProxyOperationHelper condition : route.when)
                         {
@@ -606,11 +669,11 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             {
                                 for (AsyncapiOperationView httpAnyOp : httpOpsById.values())
                                 {
-                                    String kafkaOpId = route.with.operationId != null
-                                        ? route.with.operationId
-                                        : httpAnyOp.name;
+                                    String kafkaOpId = route.bulk
+                                        ? httpAnyOp.name
+                                        : route.withConfig.operation;
 
-                                    AsyncapiOperationView kafkaOp = kafkaOpsById.get(kafkaOpId);
+                                    AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
 
                                     if (kafkaOp != null)
                                     {
@@ -620,7 +683,10 @@ public final class AsyncapiProxyGenerator extends AsyncapiCompositeGenerator
                             }
                             else
                             {
-                                AsyncapiOperationView kafkaOp = kafkaOpsById.get(route.with.operationId);
+                                String kafkaOpId = route.bulk
+                                    ? httpOp.name
+                                    : route.withConfig.operation;
+                                AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
                                 binding.inject(b -> injectHttpKafkaRoute(b, httpOp, kafkaOp));
                             }
                         }

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyFactory.java
@@ -179,10 +179,10 @@ public final class AsyncapiProxyFactory implements AsyncapiStreamFactory
                     if (route != null)
                     {
                         final long resolvedId = route.id;
-                        final long resolvedApiId = composite.resolveApiId(route.with.apiId);
-                        final String resolvedOperationId = route.with.operationId != null
-                            ? route.with.operationId
-                            : operationId;
+                        final long resolvedApiId = composite.resolveApiId(route.with.spec);
+                        final String resolvedOperationId = route.isBulk()
+                            ? operationId
+                            : route.with.operation;
 
                         newStream = new CompositeClientStream(
                             receiver,
@@ -201,8 +201,8 @@ public final class AsyncapiProxyFactory implements AsyncapiStreamFactory
                     // JRF: can we remove this? current used by will stream which arrives proactively, so no compositeId
                     Optional<AsyncapiRouteConfig> routeRef = binding.routes.stream().findFirst();
                     final long resolvedId = routeRef.map(r -> r.id).orElse(0L);
-                    final long resolvedApiId = routeRef.map(r -> composite.resolveApiId(r.with.apiId)).orElse(0L);
-                    final String resolvedOperationId = routeRef.map(r -> r.with.operationId).orElse(null);
+                    final long resolvedApiId = routeRef.map(r -> composite.resolveApiId(r.with.spec)).orElse(0L);
+                    final String resolvedOperationId = routeRef.map(r -> r.with.operation).orElse(null);
 
                     newStream = new CompositeClientStream(
                         receiver,

--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiServerFactory.java
@@ -187,11 +187,11 @@ public final class AsyncapiServerFactory implements AsyncapiStreamFactory
                         final long resolvedId = route.id;
                         final long resolvedApiId = composite.resolveApiId(
                             route.with != null
-                                ? route.with.apiId
+                                ? route.with.spec
                                 : apiId);
                         final String resolvedOperationId =
-                            route.with != null
-                                ? route.with.operationId
+                            route.with != null && !route.isBulk()
+                                ? route.with.operation
                                 : operationId;
 
                         newStream = new CompositeStream(

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiConditionConfigAdapterTest.java
@@ -43,15 +43,15 @@ public class AsyncapiConditionConfigAdapterTest
     {
         String text =
             "{" +
-                "\"api-id\":\"test\"," +
-                "\"operation-id\":\"testOperationId\"" +
+                "\"spec\":\"test\"," +
+                "\"operation\":\"testOperationId\"" +
             "}";
 
         AsyncapiConditionConfig condition = jsonb.fromJson(text, AsyncapiConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
-        assertThat(condition.apiId, equalTo("test"));
-        assertThat(condition.operationId, equalTo("testOperationId"));
+        assertThat(condition.spec, equalTo("test"));
+        assertThat(condition.operation, equalTo("testOperationId"));
     }
 
     @Test
@@ -64,8 +64,8 @@ public class AsyncapiConditionConfigAdapterTest
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
             "{" +
-                    "\"api-id\":\"test\"," +
-                    "\"operation-id\":\"testOperationId\"" +
+                    "\"spec\":\"test\"," +
+                    "\"operation\":\"testOperationId\"" +
                 "}"));
     }
 }

--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapterTest.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/config/AsyncapiWithConfigAdapterTest.java
@@ -41,22 +41,34 @@ public class AsyncapiWithConfigAdapterTest
     @Test
     public void shouldReadWith()
     {
-        String text = "{\"api-id\":\"test\",\"operation-id\":\"testOperation\"}";
+        String text = "{\"spec\":\"test\",\"operation\":\"testOperation\"}";
 
         AsyncapiWithConfig with = jsonb.fromJson(text, AsyncapiWithConfig.class);
 
         assertThat(with, not(nullValue()));
-        assertThat(with.apiId, equalTo("test"));
+        assertThat(with.spec, equalTo("test"));
+    }
+
+    @Test
+    public void shouldReadWithTag()
+    {
+        String text = "{\"spec\":\"test\",\"tag\":\"pets\"}";
+
+        AsyncapiWithConfig with = jsonb.fromJson(text, AsyncapiWithConfig.class);
+
+        assertThat(with, not(nullValue()));
+        assertThat(with.spec, equalTo("test"));
+        assertThat(with.tag, equalTo("pets"));
     }
 
     @Test
     public void shouldWriteWith()
     {
-        AsyncapiWithConfig with = new AsyncapiWithConfig("test", "testOperation");
+        AsyncapiWithConfig with = new AsyncapiWithConfig("test", "testOperation", null);
 
         String text = jsonb.toJson(with);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"api-id\":\"test\",\"operation-id\":\"testOperation\"}"));
+        assertThat(text, equalTo("{\"spec\":\"test\",\"operation\":\"testOperation\"}"));
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfig.java
@@ -18,34 +18,34 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfig;
 
 public class OpenapiAsyncapiConditionConfig extends ConditionConfig
 {
-    public final String apiId;
-    public final String operationId;
+    public final String spec;
+    public final String operation;
 
     public OpenapiAsyncapiConditionConfig(
-        String apiId,
-        String operationId)
+        String spec,
+        String operation)
     {
-        this.apiId = apiId;
-        this.operationId = operationId;
+        this.spec = spec;
+        this.operation = operation;
     }
 
     public boolean matches(
         String apiId,
         String operationId)
     {
-        return matchesApiId(apiId) &&
-            matchesOperationId(operationId);
+        return matchesSpec(apiId) &&
+            matchesOperation(operationId);
     }
 
-    private boolean matchesApiId(
+    private boolean matchesSpec(
         String apiId)
     {
-        return this.apiId == null || this.apiId.equals(apiId);
+        return this.spec == null || this.spec.equals(apiId);
     }
 
-    private boolean matchesOperationId(
+    private boolean matchesOperation(
         String operationId)
     {
-        return this.operationId == null || this.operationId.equals(operationId);
+        return this.operation == null || this.operation.equals(operationId);
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapter.java
@@ -26,8 +26,8 @@ import io.aklivity.zilla.runtime.engine.config.ConditionConfigAdapterSpi;
 public final class OpenapiAsyncapiConditionConfigAdapter implements ConditionConfigAdapterSpi,
     JsonbAdapter<ConditionConfig, JsonObject>
 {
-    private static final String API_ID_NAME = "api-id";
-    private static final String OPERATION_ID_NAME = "operation-id";
+    private static final String SPEC_NAME = "spec";
+    private static final String OPERATION_NAME = "operation";
 
     @Override
     public String type()
@@ -42,11 +42,11 @@ public final class OpenapiAsyncapiConditionConfigAdapter implements ConditionCon
         OpenapiAsyncapiConditionConfig asyncapiCondition = (OpenapiAsyncapiConditionConfig) condition;
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        object.add(API_ID_NAME, asyncapiCondition.apiId);
+        object.add(SPEC_NAME, asyncapiCondition.spec);
 
-        if (asyncapiCondition.operationId != null)
+        if (asyncapiCondition.operation != null)
         {
-            object.add(OPERATION_ID_NAME, asyncapiCondition.operationId);
+            object.add(OPERATION_NAME, asyncapiCondition.operation);
         }
 
         return object.build();
@@ -56,14 +56,14 @@ public final class OpenapiAsyncapiConditionConfigAdapter implements ConditionCon
     public ConditionConfig adaptFromJson(
         JsonObject object)
     {
-        String apiId = object.containsKey(API_ID_NAME)
-            ? object.getString(API_ID_NAME)
+        String spec = object.containsKey(SPEC_NAME)
+            ? object.getString(SPEC_NAME)
             : null;
 
-        String operationId = object.containsKey(OPERATION_ID_NAME)
-            ? object.getString(OPERATION_ID_NAME)
+        String operation = object.containsKey(OPERATION_NAME)
+            ? object.getString(OPERATION_NAME)
             : null;
 
-        return new OpenapiAsyncapiConditionConfig(apiId, operationId);
+        return new OpenapiAsyncapiConditionConfig(spec, operation);
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiRouteConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiRouteConfig.java
@@ -54,4 +54,11 @@ public final class OpenapiAsyncapiRouteConfig
     {
         return when.isEmpty() || when.stream().anyMatch(m -> m.matches(apiId, operationId));
     }
+
+    public boolean isBulk()
+    {
+        return with.tag != null ||
+            with.operation == null ||
+            with.operation.indexOf('*') != -1;
+    }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfig.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfig.java
@@ -18,14 +18,17 @@ import io.aklivity.zilla.runtime.engine.config.WithConfig;
 
 public class OpenapiAsyncapiWithConfig extends WithConfig
 {
-    public final String apiId;
-    public final String operationId;
+    public final String spec;
+    public final String operation;
+    public final String tag;
 
     public OpenapiAsyncapiWithConfig(
-        String apiId,
-        String operationId)
+        String spec,
+        String operation,
+        String tag)
     {
-        this.apiId = apiId;
-        this.operationId = operationId;
+        this.spec = spec;
+        this.operation = operation;
+        this.tag = tag;
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapter.java
@@ -25,8 +25,9 @@ import io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi;
 
 public class OpenapiAsyncapiWithConfigAdapter implements WithConfigAdapterSpi, JsonbAdapter<WithConfig, JsonObject>
 {
-    private static final String API_ID_NAME = "api-id";
-    private static final String OPERATION_ID_NAME = "operation-id";
+    private static final String SPEC_NAME = "spec";
+    private static final String OPERATION_NAME = "operation";
+    private static final String TAG_NAME = "tag";
 
     @Override
     public String type()
@@ -42,14 +43,19 @@ public class OpenapiAsyncapiWithConfigAdapter implements WithConfigAdapterSpi, J
 
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        if (config.apiId != null)
+        if (config.spec != null)
         {
-            object.add(API_ID_NAME, config.apiId);
+            object.add(SPEC_NAME, config.spec);
         }
 
-        if (config.operationId != null)
+        if (config.operation != null)
         {
-            object.add(OPERATION_ID_NAME, config.operationId);
+            object.add(OPERATION_NAME, config.operation);
+        }
+
+        if (config.tag != null)
+        {
+            object.add(TAG_NAME, config.tag);
         }
 
         return object.build();
@@ -59,14 +65,18 @@ public class OpenapiAsyncapiWithConfigAdapter implements WithConfigAdapterSpi, J
     public WithConfig adaptFromJson(
         JsonObject object)
     {
-        String apiId = object.containsKey(API_ID_NAME)
-            ? object.getString(API_ID_NAME)
+        String spec = object.containsKey(SPEC_NAME)
+            ? object.getString(SPEC_NAME)
             : null;
 
-        String operationId = object.containsKey(OPERATION_ID_NAME)
-            ? object.getString(OPERATION_ID_NAME)
+        String operation = object.containsKey(OPERATION_NAME)
+            ? object.getString(OPERATION_NAME)
             : null;
 
-        return new OpenapiAsyncapiWithConfig(apiId, operationId);
+        String tag = object.containsKey(TAG_NAME)
+            ? object.getString(TAG_NAME)
+            : null;
+
+        return new OpenapiAsyncapiWithConfig(spec, operation, tag);
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
@@ -39,6 +39,7 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.Openap
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiCompositeConfig;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiCompositeRouteConfig;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiRouteConfig;
+import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiWithConfig;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaFilter;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaOperationEx;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSchemaConfig;
@@ -76,8 +77,8 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
             .flatMap(r -> r.when.stream()
                 .map(w ->
                     new ProxyMapping(
-                        openapisByApiId.get(w.apiId),
-                        asyncapisByApiId.get(r.with.apiId))))
+                        openapisByApiId.get(w.spec),
+                        asyncapisByApiId.get(r.with.spec))))
             .distinct()
             .toList();
 
@@ -155,15 +156,17 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
             {
                 private final List<ProxyWhenHelper> when;
                 private final ProxyWithHelper with;
+                private final boolean bulk;
 
                 private ProxyRouteHelper(
                     OpenapiAsyncapiRouteConfig route)
                 {
                     this.when = route.when.stream()
-                            .filter(c -> mapping.when.apiLabel.equals(c.apiId))
-                            .map(c -> new ProxyWhenHelper(mapping.when, c.operationId))
+                            .filter(c -> mapping.when.apiLabel.equals(c.spec))
+                            .map(c -> new ProxyWhenHelper(mapping.when, c.operation))
                             .toList();
-                    this.with = new ProxyWithHelper(mapping.with, route.with.operationId);
+                    this.with = new ProxyWithHelper(mapping.with, route.with);
+                    this.bulk = route.isBulk();
                 }
 
                 private boolean hasWithProtocol(
@@ -197,14 +200,14 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
             private final class ProxyWithHelper
             {
                 private final AsyncapiSchemaConfig schema;
-                private final String operationId;
+                private final OpenapiAsyncapiWithConfig config;
 
                 private ProxyWithHelper(
                     AsyncapiSchemaConfig schema,
-                    String operationId)
+                    OpenapiAsyncapiWithConfig config)
                 {
                     this.schema = schema;
-                    this.operationId = operationId;
+                    this.config = config;
                 }
             }
 
@@ -264,6 +267,9 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
                     for (ProxyRouteHelper route : httpKafkaRoutes)
                     {
                         Map<String, AsyncapiOperationView> kafkaOpsById = route.with.schema.asyncapi.operations;
+                        Map<String, AsyncapiOperationView> candidateKafkaOpsById = route.bulk
+                            ? bulkCandidates(kafkaOpsById, route.with.config)
+                            : kafkaOpsById;
 
                         for (ProxyWhenHelper condition : route.when)
                         {
@@ -274,11 +280,11 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
                             {
                                 for (OpenapiOperationView httpAnyOp : httpOpsById.values())
                                 {
-                                    String kafkaOpId = route.with.operationId != null
-                                        ? route.with.operationId
-                                        : httpAnyOp.id;
+                                    String kafkaOpId = route.bulk
+                                        ? httpAnyOp.id
+                                        : route.with.config.operation;
 
-                                    AsyncapiOperationView kafkaOp = kafkaOpsById.get(kafkaOpId);
+                                    AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
 
                                     if (kafkaOp == null)
                                     {
@@ -295,7 +301,7 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
 
                                         if (httpFormatOp != null)
                                         {
-                                            kafkaOp = kafkaOpsById.get(httpFormatOp.id);
+                                            kafkaOp = candidateKafkaOpsById.get(httpFormatOp.id);
                                         }
                                     }
 
@@ -307,13 +313,59 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
                             }
                             else
                             {
-                                AsyncapiOperationView kafkaOp = kafkaOpsById.get(route.with.operationId);
+                                String kafkaOpId = route.bulk
+                                    ? httpOp.id
+                                    : route.with.config.operation;
+                                AsyncapiOperationView kafkaOp = candidateKafkaOpsById.get(kafkaOpId);
                                 binding.inject(b -> injectHttpKafkaRoute(b, httpOp, kafkaOp));
                             }
                         }
                     }
 
                     return binding;
+                }
+
+                private Map<String, AsyncapiOperationView> bulkCandidates(
+                    Map<String, AsyncapiOperationView> kafkaOpsById,
+                    OpenapiAsyncapiWithConfig with)
+                {
+                    final Predicate<AsyncapiOperationView> matches;
+                    if (with.tag != null)
+                    {
+                        matches = operation -> operation.tags != null && operation.tags.contains(with.tag);
+                    }
+                    else if (with.operation != null)
+                    {
+                        final Pattern pattern = compileGlob(with.operation);
+                        matches = operation -> operation.name != null && pattern.matcher(operation.name).matches();
+                    }
+                    else
+                    {
+                        matches = operation -> true;
+                    }
+
+                    return kafkaOpsById.entrySet().stream()
+                        .filter(entry -> matches.test(entry.getValue()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                }
+
+                private Pattern compileGlob(
+                    String glob)
+                {
+                    final StringBuilder regex = new StringBuilder();
+                    final String[] literals = glob.split("\\*", -1);
+                    for (int index = 0; index < literals.length; index++)
+                    {
+                        if (index > 0)
+                        {
+                            regex.append(".*");
+                        }
+                        if (!literals[index].isEmpty())
+                        {
+                            regex.append(Pattern.quote(literals[index]));
+                        }
+                    }
+                    return Pattern.compile(regex.toString());
                 }
 
                 private <C> BindingConfigBuilder<C> injectHttpKafkaRoute(

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiProxyFactory.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/streams/OpenapiAsyncapiProxyFactory.java
@@ -179,10 +179,10 @@ public final class OpenapiAsyncapiProxyFactory implements OpenapiAsyncapiStreamF
                     if (route != null)
                     {
                         final long resolvedId = route.id;
-                        final long resolvedApiId = composite.resolveApiId(route.with.apiId);
-                        final String resolvedOperationId = route.with.operationId != null
-                            ? route.with.operationId
-                            : operationId;
+                        final long resolvedApiId = composite.resolveApiId(route.with.spec);
+                        final String resolvedOperationId = route.isBulk()
+                            ? operationId
+                            : route.with.operation;
 
                         newStream = new CompositeClientStream(
                             receiver,

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiConditionConfigAdapterTest.java
@@ -43,15 +43,15 @@ public class OpenapiAsyncapiConditionConfigAdapterTest
     {
         String text =
             "{" +
-                "\"api-id\":\"test\"," +
-                "\"operation-id\":\"o-id\"" +
+                "\"spec\":\"test\"," +
+                "\"operation\":\"o-id\"" +
             "}";
 
         OpenapiAsyncapiConditionConfig condition = jsonb.fromJson(text, OpenapiAsyncapiConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
-        assertThat(condition.apiId, equalTo("test"));
-        assertThat(condition.operationId, equalTo("o-id"));
+        assertThat(condition.spec, equalTo("test"));
+        assertThat(condition.operation, equalTo("o-id"));
     }
 
     @Test
@@ -64,8 +64,8 @@ public class OpenapiAsyncapiConditionConfigAdapterTest
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo(
             "{" +
-                    "\"api-id\":\"test\"," +
-                    "\"operation-id\":\"o-id\"" +
+                    "\"spec\":\"test\"," +
+                    "\"operation\":\"o-id\"" +
                 "}"));
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapterTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiWithConfigAdapterTest.java
@@ -41,23 +41,35 @@ public class OpenapiAsyncapiWithConfigAdapterTest
     @Test
     public void shouldReadWith()
     {
-        String text = "{\"api-id\":\"test\",\"operation-id\":\"o-id\"}";
+        String text = "{\"spec\":\"test\",\"operation\":\"o-id\"}";
 
         OpenapiAsyncapiWithConfig with = jsonb.fromJson(text, OpenapiAsyncapiWithConfig.class);
 
         assertThat(with, not(nullValue()));
-        assertThat(with.apiId, equalTo("test"));
-        assertThat(with.operationId, equalTo("o-id"));
+        assertThat(with.spec, equalTo("test"));
+        assertThat(with.operation, equalTo("o-id"));
+    }
+
+    @Test
+    public void shouldReadWithTag()
+    {
+        String text = "{\"spec\":\"test\",\"tag\":\"pets\"}";
+
+        OpenapiAsyncapiWithConfig with = jsonb.fromJson(text, OpenapiAsyncapiWithConfig.class);
+
+        assertThat(with, not(nullValue()));
+        assertThat(with.spec, equalTo("test"));
+        assertThat(with.tag, equalTo("pets"));
     }
 
     @Test
     public void shouldWriteWith()
     {
-        OpenapiAsyncapiWithConfig with = new OpenapiAsyncapiWithConfig("test", "o-id");
+        OpenapiAsyncapiWithConfig with = new OpenapiAsyncapiWithConfig("test", "o-id", null);
 
         String text = jsonb.toJson(with);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"api-id\":\"test\",\"operation-id\":\"o-id\"}"));
+        assertThat(text, equalTo("{\"spec\":\"test\",\"operation\":\"o-id\"}"));
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTag.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTag.java
@@ -14,18 +14,7 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
-import java.util.List;
-import java.util.Map;
-
-public class AsyncapiOperation extends AbstractAsyncapiResolvable
+public class AsyncapiTag
 {
-    public AsyncapiChannel channel;
-    public String action;
-    public AsyncapiReply reply;
-    public List<AsyncapiMessage> messages;
-    public List<AsyncapiSecurityScheme> security;
-    public List<AsyncapiTag> tags;
-    public Map<String, Object> bindings;
-
-    public Map<String, Object> extensions;
+    public String name;
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiOperationView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiOperationView.java
@@ -32,6 +32,7 @@ public final class AsyncapiOperationView
     public final AsyncapiReplyView reply;
     public final List<AsyncapiMessageView> messages;
     public final List<AsyncapiSecuritySchemeView> security;
+    public final List<String> tags;
 
     private final Map<String, Object> bindings;
     private final Map<String, Object> extensions;
@@ -97,6 +98,11 @@ public final class AsyncapiOperationView
         this.security = resolved.security != null
                 ? resolved.security.stream()
                     .map(scheme -> new AsyncapiSecuritySchemeView(resolver, scheme))
+                    .toList()
+                : null;
+        this.tags = resolved.tags != null
+                ? resolved.tags.stream()
+                    .map(tag -> tag.name)
                     .toList()
                 : null;
     }

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.glob.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.glob.yaml
@@ -34,7 +34,7 @@ catalogs:
               host: localhost:1883
               protocol: mqtt
           defaultContentType: application/json
-  
+
           channels:
             sensors:
               address: "sensors/{sensorId}"
@@ -45,18 +45,13 @@ catalogs:
               messages:
                 items:
                   $ref: '#/components/messages/item'
-  
+
           operations:
             sendEvents:
               action: send
               channel:
                 $ref: '#/channels/sensors'
-  
-            receiveEvents:
-              action: receive
-              channel:
-                $ref: '#/channels/sensors'
-  
+
           components:
             parameters:
               sensorId:
@@ -93,10 +88,6 @@ catalogs:
             protocol: kafka
 
         operations:
-          onSensorData:
-            action: receive
-            channel:
-              $ref: '#/channels/sensorData'
           toSensorData:
             action: send
             channel:
@@ -160,11 +151,4 @@ bindings:
         exit: asyncapi_kafka0
         with:
           spec: kafka_api
-          operation: toSensorData
-      - when:
-          - spec: mqtt_api
-            operation: receiveEvents
-        exit: asyncapi_kafka0
-        with:
-          spec: kafka_api
-          operation: onSensorData
+          operation: "toSensor*"

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.async.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.async.yaml
@@ -258,9 +258,9 @@ bindings:
               version: latest
     routes:
       - when:
-          - api-id: http_api
-            operation-id: createCustomer
+          - spec: http_api
+            operation: createCustomer
         exit: asyncapi_kafka0
         with:
-          api-id: kafka_api
-          operation-id: createCustomer
+          spec: kafka_api
+          operation: createCustomer

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.http.kafka.yaml
@@ -215,7 +215,7 @@ bindings:
               version: latest
     routes:
       - when:
-          - api-id: http_api
+          - spec: http_api
         exit: asyncapi_kafka0
         with:
-          api-id: kafka_api
+          spec: kafka_api

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.sse.kafka.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.sse.kafka.yaml
@@ -170,7 +170,7 @@ bindings:
               version: latest
     routes:
       - when:
-          - api-id: sse_api
+          - spec: sse_api
         exit: asyncapi_kafka0
         with:
-          api-id: kafka_api
+          spec: kafka_api

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.tag.and.operation.invalid.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.tag.and.operation.invalid.yaml
@@ -34,7 +34,7 @@ catalogs:
               host: localhost:1883
               protocol: mqtt
           defaultContentType: application/json
-  
+
           channels:
             sensors:
               address: "sensors/{sensorId}"
@@ -45,18 +45,13 @@ catalogs:
               messages:
                 items:
                   $ref: '#/components/messages/item'
-  
+
           operations:
             sendEvents:
               action: send
               channel:
                 $ref: '#/channels/sensors'
-  
-            receiveEvents:
-              action: receive
-              channel:
-                $ref: '#/channels/sensors'
-  
+
           components:
             parameters:
               sensorId:
@@ -93,14 +88,12 @@ catalogs:
             protocol: kafka
 
         operations:
-          onSensorData:
-            action: receive
-            channel:
-              $ref: '#/channels/sensorData'
           toSensorData:
             action: send
             channel:
               $ref: '#/channels/sensorData'
+            tags:
+              - name: sensors
 
         channels:
           sensorData:
@@ -160,11 +153,5 @@ bindings:
         exit: asyncapi_kafka0
         with:
           spec: kafka_api
-          operation: toSensorData
-      - when:
-          - spec: mqtt_api
-            operation: receiveEvents
-        exit: asyncapi_kafka0
-        with:
-          spec: kafka_api
-          operation: onSensorData
+          tag: sensors
+          operation: "toSensor*"

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.tag.yaml
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/config/proxy.tag.yaml
@@ -34,7 +34,7 @@ catalogs:
               host: localhost:1883
               protocol: mqtt
           defaultContentType: application/json
-  
+
           channels:
             sensors:
               address: "sensors/{sensorId}"
@@ -45,18 +45,13 @@ catalogs:
               messages:
                 items:
                   $ref: '#/components/messages/item'
-  
+
           operations:
             sendEvents:
               action: send
               channel:
                 $ref: '#/channels/sensors'
-  
-            receiveEvents:
-              action: receive
-              channel:
-                $ref: '#/channels/sensors'
-  
+
           components:
             parameters:
               sensorId:
@@ -93,14 +88,12 @@ catalogs:
             protocol: kafka
 
         operations:
-          onSensorData:
-            action: receive
-            channel:
-              $ref: '#/channels/sensorData'
           toSensorData:
             action: send
             channel:
               $ref: '#/channels/sensorData'
+            tags:
+              - name: sensors
 
         channels:
           sensorData:
@@ -160,11 +153,4 @@ bindings:
         exit: asyncapi_kafka0
         with:
           spec: kafka_api
-          operation: toSensorData
-      - when:
-          - spec: mqtt_api
-            operation: receiveEvents
-        exit: asyncapi_kafka0
-        with:
-          spec: kafka_api
-          operation: onSensorData
+          tag: sensors

--- a/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/schema/asyncapi.schema.patch.json
+++ b/specs/binding-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/asyncapi/schema/asyncapi.schema.patch.json
@@ -226,14 +226,14 @@
                                         "additionalProperties": false,
                                         "properties":
                                         {
-                                            "api-id":
+                                            "spec":
                                             {
-                                                "title": "Spec API Id",
+                                                "title": "Spec",
                                                 "type": "string"
                                             },
-                                            "operation-id":
+                                            "operation":
                                             {
-                                                "title": "MQTT Operation Id",
+                                                "title": "Operation",
                                                 "type": "string"
                                             }
                                         }
@@ -243,18 +243,27 @@
                                 {
                                     "properties":
                                     {
-                                        "api-id":
+                                        "spec":
                                         {
-                                            "title": "Spec API Id",
+                                            "title": "Spec",
                                             "type": "string"
                                         },
-                                        "operation-id":
+                                        "operation":
                                         {
-                                            "title": "MQTT Operation Id",
+                                            "title": "Operation Id or glob pattern",
+                                            "type": "string"
+                                        },
+                                        "tag":
+                                        {
+                                            "title": "Tag",
                                             "type": "string"
                                         }
                                     },
-                                    "additionalProperties": false
+                                    "additionalProperties": false,
+                                    "not":
+                                    {
+                                        "required": [ "tag", "operation" ]
+                                    }
                                 }
                             }
                         }

--- a/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/config/SchemaTest.java
+++ b/specs/binding-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/asyncapi/config/SchemaTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -137,5 +138,27 @@ public class SchemaTest
         JsonObject config = schema.validate("proxy.mqtt.kafka.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateAsyncapiProxyWithTag()
+    {
+        JsonObject config = schema.validate("proxy.tag.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateAsyncapiProxyWithGlobOperation()
+    {
+        JsonObject config = schema.validate("proxy.glob.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectAsyncapiProxyWithTagAndOperation()
+    {
+        schema.validate("proxy.tag.and.operation.invalid.yaml");
     }
 }

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy-async.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy-async.yaml
@@ -267,7 +267,7 @@ bindings:
                 version: latest
     routes:
       - when:
-          - api-id: openapi-id
+          - spec: openapi-id
         exit: asyncapi_client0
         with:
-          api-id: asyncapi-id
+          spec: asyncapi-id

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.glob.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.glob.yaml
@@ -50,26 +50,6 @@ catalogs:
                       application/json:
                         schema:
                           $ref: "#/components/schemas/Error"
-              post:
-                summary: Create a pet
-                operationId: createPets
-                tags:
-                  - pets
-                requestBody:
-                  content:
-                    application/json:
-                      schema:
-                        $ref: '#/components/schemas/Pet'
-                  required: true
-                responses:
-                  '201':
-                    description: Null response
-                  default:
-                    description: unexpected error
-                    content:
-                      application/json:
-                        schema:
-                          $ref: "#/components/schemas/Error"
           components:
             schemas:
               Pet:
@@ -117,11 +97,6 @@ catalogs:
             host: 'localhost:9092'
             protocol: kafka-secure
             description: Test broker
-            tags:
-              - name: 'kind:remote'
-                description: This server is a remote server. Not exposed by the application.
-              - name: 'visibility:private'
-                description: This resource is private and only available to certain users.
         channels:
           petstore:
             address: 'petstore'
@@ -136,18 +111,6 @@ catalogs:
               $ref: '#/channels/petstore'
             summary: >-
               List all pets.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
-            messages:
-              - $ref: '#/channels/petstore/messages/pet'
-          createPets:
-            action: send
-            channel:
-              $ref: '#/channels/petstore'
-            summary: >-
-              Create a pet.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
             messages:
               - $ref: '#/channels/petstore/messages/pet'
         components:
@@ -158,8 +121,6 @@ catalogs:
               summary: >-
                 Inform about Pet.
               contentType: application/json
-              traits:
-                - $ref: '#/components/messageTraits/commonHeaders'
               payload:
                 $ref: '#/components/schemas/petPayload'
           schemas:
@@ -173,26 +134,6 @@ catalogs:
                 name:
                   type: string
                   description: Pet name.
-                tag:
-                  type: string
-                  description: Tag.
-          messageTraits:
-            commonHeaders:
-              headers:
-                type: object
-                properties:
-                  my-app-header:
-                    type: integer
-                    minimum: 0
-                    maximum: 100
-          operationTraits:
-            kafka:
-              bindings:
-                kafka:
-                  clientId:
-                    type: string
-                    enum:
-                      - my-app-id
 
 bindings:
   composite0:
@@ -218,3 +159,4 @@ bindings:
         exit: asyncapi_client0
         with:
           spec: asyncapi-id
+          operation: "list*"

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.tag.and.operation.invalid.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.tag.and.operation.invalid.yaml
@@ -50,26 +50,6 @@ catalogs:
                       application/json:
                         schema:
                           $ref: "#/components/schemas/Error"
-              post:
-                summary: Create a pet
-                operationId: createPets
-                tags:
-                  - pets
-                requestBody:
-                  content:
-                    application/json:
-                      schema:
-                        $ref: '#/components/schemas/Pet'
-                  required: true
-                responses:
-                  '201':
-                    description: Null response
-                  default:
-                    description: unexpected error
-                    content:
-                      application/json:
-                        schema:
-                          $ref: "#/components/schemas/Error"
           components:
             schemas:
               Pet:
@@ -117,11 +97,6 @@ catalogs:
             host: 'localhost:9092'
             protocol: kafka-secure
             description: Test broker
-            tags:
-              - name: 'kind:remote'
-                description: This server is a remote server. Not exposed by the application.
-              - name: 'visibility:private'
-                description: This resource is private and only available to certain users.
         channels:
           petstore:
             address: 'petstore'
@@ -136,18 +111,8 @@ catalogs:
               $ref: '#/channels/petstore'
             summary: >-
               List all pets.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
-            messages:
-              - $ref: '#/channels/petstore/messages/pet'
-          createPets:
-            action: send
-            channel:
-              $ref: '#/channels/petstore'
-            summary: >-
-              Create a pet.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
+            tags:
+              - name: pets
             messages:
               - $ref: '#/channels/petstore/messages/pet'
         components:
@@ -158,8 +123,6 @@ catalogs:
               summary: >-
                 Inform about Pet.
               contentType: application/json
-              traits:
-                - $ref: '#/components/messageTraits/commonHeaders'
               payload:
                 $ref: '#/components/schemas/petPayload'
           schemas:
@@ -173,26 +136,6 @@ catalogs:
                 name:
                   type: string
                   description: Pet name.
-                tag:
-                  type: string
-                  description: Tag.
-          messageTraits:
-            commonHeaders:
-              headers:
-                type: object
-                properties:
-                  my-app-header:
-                    type: integer
-                    minimum: 0
-                    maximum: 100
-          operationTraits:
-            kafka:
-              bindings:
-                kafka:
-                  clientId:
-                    type: string
-                    enum:
-                      - my-app-id
 
 bindings:
   composite0:
@@ -218,3 +161,5 @@ bindings:
         exit: asyncapi_client0
         with:
           spec: asyncapi-id
+          tag: pets
+          operation: "list*"

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.tag.yaml
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/proxy.tag.yaml
@@ -50,26 +50,6 @@ catalogs:
                       application/json:
                         schema:
                           $ref: "#/components/schemas/Error"
-              post:
-                summary: Create a pet
-                operationId: createPets
-                tags:
-                  - pets
-                requestBody:
-                  content:
-                    application/json:
-                      schema:
-                        $ref: '#/components/schemas/Pet'
-                  required: true
-                responses:
-                  '201':
-                    description: Null response
-                  default:
-                    description: unexpected error
-                    content:
-                      application/json:
-                        schema:
-                          $ref: "#/components/schemas/Error"
           components:
             schemas:
               Pet:
@@ -117,11 +97,6 @@ catalogs:
             host: 'localhost:9092'
             protocol: kafka-secure
             description: Test broker
-            tags:
-              - name: 'kind:remote'
-                description: This server is a remote server. Not exposed by the application.
-              - name: 'visibility:private'
-                description: This resource is private and only available to certain users.
         channels:
           petstore:
             address: 'petstore'
@@ -136,18 +111,8 @@ catalogs:
               $ref: '#/channels/petstore'
             summary: >-
               List all pets.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
-            messages:
-              - $ref: '#/channels/petstore/messages/pet'
-          createPets:
-            action: send
-            channel:
-              $ref: '#/channels/petstore'
-            summary: >-
-              Create a pet.
-            traits:
-              - $ref: '#/components/operationTraits/kafka'
+            tags:
+              - name: pets
             messages:
               - $ref: '#/channels/petstore/messages/pet'
         components:
@@ -158,8 +123,6 @@ catalogs:
               summary: >-
                 Inform about Pet.
               contentType: application/json
-              traits:
-                - $ref: '#/components/messageTraits/commonHeaders'
               payload:
                 $ref: '#/components/schemas/petPayload'
           schemas:
@@ -173,26 +136,6 @@ catalogs:
                 name:
                   type: string
                   description: Pet name.
-                tag:
-                  type: string
-                  description: Tag.
-          messageTraits:
-            commonHeaders:
-              headers:
-                type: object
-                properties:
-                  my-app-header:
-                    type: integer
-                    minimum: 0
-                    maximum: 100
-          operationTraits:
-            kafka:
-              bindings:
-                kafka:
-                  clientId:
-                    type: string
-                    enum:
-                      - my-app-id
 
 bindings:
   composite0:
@@ -218,3 +161,4 @@ bindings:
         exit: asyncapi_client0
         with:
           spec: asyncapi-id
+          tag: pets

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/schema/openapi.asyncapi.schema.patch.json
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/schema/openapi.asyncapi.schema.patch.json
@@ -160,14 +160,14 @@
                                         "type": "object",
                                         "properties":
                                         {
-                                            "api-id":
+                                            "spec":
                                             {
-                                                "title": "ApiId",
+                                                "title": "Spec",
                                                 "type": "string"
                                             },
-                                            "operation-id":
+                                            "operation":
                                             {
-                                                "title": "OperationId",
+                                                "title": "Operation",
                                                 "type": "string"
                                             }
                                         },
@@ -178,16 +178,25 @@
                                 {
                                     "properties":
                                     {
-                                        "api-id":
+                                        "spec":
                                         {
-                                            "title": "ApiId",
+                                            "title": "Spec",
                                             "type": "string"
                                         },
-                                        "operation-id":
+                                        "operation":
                                         {
-                                            "title": "OperationId",
+                                            "title": "Operation Id or glob pattern",
+                                            "type": "string"
+                                        },
+                                        "tag":
+                                        {
+                                            "title": "Tag",
                                             "type": "string"
                                         }
+                                    },
+                                    "not":
+                                    {
+                                        "required": [ "tag", "operation" ]
                                     }
                                 }
                             },

--- a/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/SchemaTest.java
+++ b/specs/binding-openapi-asyncapi.spec/src/test/java/io/aklivity/zilla/specs/binding/openapi/asyncapi/config/SchemaTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -41,5 +42,27 @@ public class SchemaTest
         JsonObject config = schema.validate("proxy.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyWithTag()
+    {
+        JsonObject config = schema.validate("proxy.tag.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateProxyWithGlobOperation()
+    {
+        JsonObject config = schema.validate("proxy.glob.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyWithTagAndOperation()
+    {
+        schema.validate("proxy.tag.and.operation.invalid.yaml");
     }
 }


### PR DESCRIPTION
## Description

Part of #2067 (openapi / asyncapi / mcp-openapi config consistency). Aligns `openapi-asyncapi` and `asyncapi` route `when`/`with` vocabulary with `binding-mcp-openapi`'s:

- Rename `api-id` → `spec`, `operation-id` → `operation` on both bindings' route `when`/`with` (breaking rename, no deprecation window, per discussion on the issue).
- Add `with.tag` (match every target operation whose spec tag contains the given value) and glob-pattern matching on `with.operation` (e.g. `operation: list*`), mirroring `McpOpenapiCompositeGenerator`'s `isBulk()`/glob-compilation logic.
- Generalize the composite generators' per-protocol route fan-out (http-kafka for `openapi-asyncapi`; http-kafka/mqtt-kafka/sse-kafka for `asyncapi`) to resolve target operations from a tag/glob-filtered candidate set instead of a single literal `operationId`, so a bulk-matched route now fans out to one generated route per matched operation at composite-generation time (mirroring mcp-openapi's one-route-generates-many model).
- Adds `tags` support to the AsyncAPI operation model (`AsyncapiOperation`, `AsyncapiOperationView`) since tag-based bulk selection needs to filter target operations by their AsyncAPI tags — AsyncAPI operations didn't expose tags before this change, unlike OpenAPI operations which already did.

Out of scope for this PR (see issue discussion):
- `binding-openapi`'s dead `when`/`with` scaffolding is left untouched.
- No `capability`-style filtering analog — that concept stays mcp-specific.

## Testing

- Added/updated JSON-schema validation fixtures and `SchemaTest` cases for both bindings covering the renamed properties, `tag`-based bulk selection, glob-pattern `operation`, and the `tag`+`operation` mutual-exclusion rejection.
- Updated adapter unit tests for the renamed fields and new `tag` property.
- `./mvnw clean verify` passes for `common-asyncapi`, `binding-openapi-asyncapi`, `binding-asyncapi`, and their two spec modules — unit tests, k3po integration tests (including `AsyncapiProxyIT`, `AsyncapiClientIT`, `AsyncapiServerIT`, `OpenapiAsyncapiIT`, which exercise the renamed fixtures end-to-end), JaCoCo coverage, checkstyle, and license headers all green.

Fixes #2067 (partially — tracks the `openapi-asyncapi`/`asyncapi` half of the alignment; `binding-openapi`'s scope was explicitly deferred per issue discussion).
