### PR TITLE
feat(binding-mcp): add telemetry events for session lifecycle, bearer auth, and elicitation timeout

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventContext.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal;
+
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.AUTHORIZATION_FAILED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.ELICITATION_TIMEOUT;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.SESSION_CLOSED;
+import static io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventType.SESSION_ESTABLISHED;
+
+import java.nio.ByteBuffer;
+import java.time.Clock;
+
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.EventFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventExFW;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+
+public final class McpEventContext
+{
+    private static final int EVENT_BUFFER_CAPACITY = 1024;
+
+    private final MutableDirectBufferEx eventBuffer = new UnsafeBufferEx(ByteBuffer.allocate(EVENT_BUFFER_CAPACITY));
+    private final MutableDirectBufferEx extensionBuffer = new UnsafeBufferEx(ByteBuffer.allocate(EVENT_BUFFER_CAPACITY));
+    private final EventFW.Builder eventRW = new EventFW.Builder();
+    private final McpEventExFW.Builder mcpEventExRW = new McpEventExFW.Builder();
+    private final int mcpTypeId;
+    private final int sessionEstablishedEventId;
+    private final int sessionClosedEventId;
+    private final int authorizationFailedEventId;
+    private final int elicitationTimeoutEventId;
+    private final MessageConsumer eventWriter;
+    private final Clock clock;
+
+    public McpEventContext(
+        EngineContext context)
+    {
+        this.mcpTypeId = context.supplyTypeId(McpBinding.NAME);
+        this.sessionEstablishedEventId = context.supplyEventId("binding.mcp.session.established");
+        this.sessionClosedEventId = context.supplyEventId("binding.mcp.session.closed");
+        this.authorizationFailedEventId = context.supplyEventId("binding.mcp.authorization.failed");
+        this.elicitationTimeoutEventId = context.supplyEventId("binding.mcp.elicitation.timeout");
+        this.eventWriter = context.supplyEventWriter();
+        this.clock = context.clock();
+    }
+
+    public void sessionEstablished(
+        long traceId,
+        long bindingId,
+        String sessionId)
+    {
+        McpEventExFW extension = mcpEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .sessionEstablished(e -> e
+                .typeId(SESSION_ESTABLISHED.value())
+                .sessionId(sessionId))
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(sessionEstablishedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(mcpTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void sessionClosed(
+        long traceId,
+        long bindingId,
+        String sessionId,
+        String reason)
+    {
+        McpEventExFW extension = mcpEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .sessionClosed(e -> e
+                .typeId(SESSION_CLOSED.value())
+                .sessionId(sessionId)
+                .reason(reason))
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(sessionClosedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(mcpTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void authorizationFailed(
+        long traceId,
+        long bindingId,
+        String realm,
+        String scopes,
+        String resourceMetadata,
+        McpAuthorizationError error)
+    {
+        McpEventExFW extension = mcpEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .authorizationFailed(e -> e
+                .typeId(AUTHORIZATION_FAILED.value())
+                .realm(realm)
+                .scopes(scopes)
+                .resourceMetadata(resourceMetadata)
+                .error(s -> s.set(error)))
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(authorizationFailedEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(mcpTypeId, event.buffer(), event.offset(), event.limit());
+    }
+
+    public void elicitationTimeout(
+        long traceId,
+        long bindingId,
+        String sessionId,
+        String elicitationId)
+    {
+        McpEventExFW extension = mcpEventExRW
+            .wrap(extensionBuffer, 0, extensionBuffer.capacity())
+            .elicitationTimeout(e -> e
+                .typeId(ELICITATION_TIMEOUT.value())
+                .sessionId(sessionId)
+                .elicitationId(elicitationId))
+            .build();
+        EventFW event = eventRW
+            .wrap(eventBuffer, 0, eventBuffer.capacity())
+            .id(elicitationTimeoutEventId)
+            .timestamp(clock.millis())
+            .traceId(traceId)
+            .namespacedId(bindingId)
+            .extension(extension.buffer(), extension.offset(), extension.limit())
+            .build();
+        eventWriter.accept(mcpTypeId, event.buffer(), event.offset(), event.limit());
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal;
+
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.StringFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.EventFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationFailedExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpElicitationTimeoutExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpEventExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpSessionClosedExFW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpSessionEstablishedExFW;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.event.EventFormatterSpi;
+
+public final class McpEventFormatter implements EventFormatterSpi
+{
+    private final EventFW eventRO = new EventFW();
+    private final McpEventExFW mcpEventExRO = new McpEventExFW();
+
+    McpEventFormatter(
+        Configuration config)
+    {
+    }
+
+    public String format(
+        DirectBufferEx buffer,
+        int index,
+        int length)
+    {
+        final EventFW event = eventRO.wrap(buffer, index, index + length);
+        final McpEventExFW extension = mcpEventExRO
+            .wrap(event.extension().buffer(), event.extension().offset(), event.extension().limit());
+        String result = null;
+        switch (extension.kind())
+        {
+        case SESSION_ESTABLISHED:
+        {
+            McpSessionEstablishedExFW ex = extension.sessionEstablished();
+            result = String.format("MCP session (%s) was established.",
+                    asString(ex.sessionId()));
+            break;
+        }
+        case SESSION_CLOSED:
+        {
+            McpSessionClosedExFW ex = extension.sessionClosed();
+            result = String.format("MCP session (%s) was closed. %s",
+                    asString(ex.sessionId()),
+                    asString(ex.reason()));
+            break;
+        }
+        case AUTHORIZATION_FAILED:
+        {
+            McpAuthorizationFailedExFW ex = extension.authorizationFailed();
+            result = String.format("MCP bearer authorization failed (%s) for realm (%s).",
+                    ex.error().get(),
+                    asString(ex.realm()));
+            break;
+        }
+        case ELICITATION_TIMEOUT:
+        {
+            McpElicitationTimeoutExFW ex = extension.elicitationTimeout();
+            result = String.format("Elicitation (%s) timed out for session (%s).",
+                    asString(ex.elicitationId()),
+                    asString(ex.sessionId()));
+            break;
+        }
+        }
+        return result;
+    }
+
+    private static String asString(
+        StringFW stringFW)
+    {
+        String s = stringFW.asString();
+        return s == null ? "" : s;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal;
+
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi;
+
+public final class McpEventFormatterFactory implements EventFormatterFactorySpi
+{
+    @Override
+    public McpEventFormatter create(
+        Configuration config)
+    {
+        return new McpEventFormatter(config);
+    }
+
+    @Override
+    public String type()
+    {
+        return McpBinding.NAME;
+    }
+}

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -48,6 +48,7 @@ import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.collections.Object2ObjectHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpEventContext;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.internal.transform.McpSchemeInjector;
@@ -55,6 +56,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.HttpHeaderFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.String16FW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.BeginFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ChallengeFW;
@@ -237,6 +239,7 @@ public final class McpClientFactory implements McpStreamFactory
     private final Map<String, McpStream> sessions = new Object2ObjectHashMap<>();
     private final Int2ObjectHashMap<McpSessionIdResolver> resolvers;
     private final Int2ObjectHashMap<McpRequestStreamFactory> requestFactories;
+    private final McpEventContext events;
 
     public McpClientFactory(
         McpConfiguration config,
@@ -287,6 +290,7 @@ public final class McpClientFactory implements McpStreamFactory
         requestFactories.put(KIND_RESOURCES_READ, McpResourcesReadStream::new);
         requestFactories.put(KIND_RESOURCES_TEMPLATES_LIST, McpResourcesTemplatesListStream::new);
         this.requestFactories = requestFactories;
+        this.events = new McpEventContext(context);
     }
 
     private McpLifecycleStream lookupSession(
@@ -2977,6 +2981,7 @@ public final class McpClientFactory implements McpStreamFactory
                 decoder = decodeRequestEnd;
                 emitElicitComplete(traceId, authorization);
                 doAppAbort(traceId, authorization);
+                events.elicitationTimeout(traceId, routedId, session.transportSessionId(), elicitElicitationId);
                 return;
             }
 
@@ -3764,6 +3769,8 @@ public final class McpClientFactory implements McpStreamFactory
                     .build();
                 mcp.doAppReset(traceId, authorization, mcpResetEx);
                 doNetReset(traceId, authorization);
+                events.authorizationFailed(traceId, mcp.routedId, realm, scopes, resourceMetadata,
+                    McpAuthorizationError.valueOf(error.name()));
             }
             else
             {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -39,6 +39,7 @@ import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.collections.Object2ObjectHashMap;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
+import io.aklivity.zilla.runtime.binding.mcp.internal.McpEventContext;
 import io.aklivity.zilla.runtime.binding.mcp.internal.codec.McpInitializeParams;
 import io.aklivity.zilla.runtime.binding.mcp.internal.codec.McpNotifyCanceledParams;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpAuthorizationResult;
@@ -50,6 +51,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.HttpHeaderFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.String16FW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.String8FW;
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.BeginFW;
 import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.ChallengeFW;
@@ -256,6 +258,7 @@ public final class McpServerFactory implements McpStreamFactory
     private final McpConfiguration config;
     private final Long2ObjectHashMap<McpBindingConfig> bindings;
     private final Map<String, McpServerFactory.McpLifecycleStream> sessions;
+    private final McpEventContext events;
 
     public McpServerFactory(
         McpConfiguration config,
@@ -289,6 +292,7 @@ public final class McpServerFactory implements McpStreamFactory
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.sessions = new Object2ObjectHashMap<>();
         this.parserFactory = JsonEx.createParserFactory(Map.of());
+        this.events = new McpEventContext(context);
     }
 
     @Override
@@ -1808,6 +1812,8 @@ public final class McpServerFactory implements McpStreamFactory
                 final String status = bearerChallengeStatus(error);
                 final String wwwAuthenticate = bearerChallengeHeader(realm, scopes, resourceMetadata, error);
                 doNetBeginRejectedBearer(traceId, authorization, status, wwwAuthenticate);
+                events.authorizationFailed(traceId, routedId, realm, scopes, resourceMetadata,
+                    McpAuthorizationError.valueOf(error.name()));
                 rejected = true;
             }
             return rejected;
@@ -2073,6 +2079,7 @@ public final class McpServerFactory implements McpStreamFactory
             long authorization)
         {
             assert session != null;
+            events.sessionEstablished(traceId, routedId, session.sessionId);
         }
 
         private int onDecodeInitialize(
@@ -3861,6 +3868,7 @@ public final class McpServerFactory implements McpStreamFactory
                 }
                 doAppEnd(traceId, authorization);
                 sessions.remove(sessionId);
+                events.sessionClosed(traceId, routedId, sessionId, "inactivity timeout");
             }
             else
             {
@@ -4265,6 +4273,8 @@ public final class McpServerFactory implements McpStreamFactory
                     .inject(this::injectAltSvc)
                     .build());
                 doNetEnd(traceId, authorization);
+                events.authorizationFailed(traceId, routedId, realm, scopes, resourceMetadata,
+                    McpAuthorizationError.valueOf(error.name()));
                 rejected = true;
             }
             return rejected;

--- a/runtime/binding-mcp/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp/src/main/moditect/module-info.java
@@ -37,6 +37,9 @@ module io.aklivity.zilla.runtime.binding.mcp
     provides io.aklivity.zilla.runtime.engine.config.WithConfigAdapterSpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.config.McpWithConfigAdapter;
 
+    provides io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
+        with io.aklivity.zilla.runtime.binding.mcp.internal.McpEventFormatterFactory;
+
     provides io.aklivity.zilla.runtime.binding.mcp.config.McpToolSearchIndexConfigAdapterSpi
         with io.aklivity.zilla.runtime.binding.mcp.internal.config.McpKeywordToolSearchIndexConfigAdapterSpi;
 

--- a/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
+++ b/runtime/binding-mcp/src/main/resources/META-INF/services/io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.binding.mcp.internal.McpEventFormatterFactory

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/McpEventFormatterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.mcp.internal.types.event.McpAuthorizationError;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+
+public class McpEventFormatterTest
+{
+    private final EngineContext context = mock(EngineContext.class);
+    private final AtomicReference<DirectBufferEx> captured = new AtomicReference<>();
+
+    private McpEventContext newEvents()
+    {
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        MessageConsumer writer = (msgTypeId, buffer, index, length) ->
+        {
+            MutableDirectBufferEx copy = new UnsafeBufferEx(new byte[length]);
+            copy.putBytes(0, buffer, index, length);
+            captured.set(copy);
+        };
+        when(context.supplyEventWriter()).thenReturn(writer);
+        return new McpEventContext(context);
+    }
+
+    private String format()
+    {
+        McpEventFormatterFactory factory = new McpEventFormatterFactory();
+        assertEquals(McpBinding.NAME, factory.type());
+        McpEventFormatter formatter = factory.create(new Configuration());
+
+        DirectBufferEx event = captured.get();
+        return formatter.format(event, 0, event.capacity());
+    }
+
+    @Test
+    public void shouldFormatSessionEstablishedEvent()
+    {
+        McpEventContext events = newEvents();
+        events.sessionEstablished(0L, 0L, "session-1");
+
+        assertEquals("MCP session (session-1) was established.", format());
+    }
+
+    @Test
+    public void shouldFormatSessionClosedEvent()
+    {
+        McpEventContext events = newEvents();
+        events.sessionClosed(0L, 0L, "session-1", "inactivity timeout");
+
+        assertEquals("MCP session (session-1) was closed. inactivity timeout", format());
+    }
+
+    @Test
+    public void shouldFormatAuthorizationFailedEvent()
+    {
+        McpEventContext events = newEvents();
+        events.authorizationFailed(0L, 0L, "realm-1", "tools:read", null, McpAuthorizationError.INVALID_TOKEN);
+
+        assertEquals("MCP bearer authorization failed (INVALID_TOKEN) for realm (realm-1).", format());
+    }
+
+    @Test
+    public void shouldFormatElicitationTimeoutEvent()
+    {
+        McpEventContext events = newEvents();
+        events.elicitationTimeout(0L, 0L, "session-1", "elicit-1");
+
+        assertEquals("Elicitation (elicit-1) timed out for session (session-1).", format());
+    }
+}

--- a/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
+++ b/specs/binding-mcp.spec/src/main/resources/META-INF/zilla/mcp.idl
@@ -236,4 +236,55 @@ scope mcp
             McpElicitAction action;
         }
     }
+
+    scope event
+    {
+        enum McpEventType (uint8)
+        {
+            SESSION_ESTABLISHED (1),
+            SESSION_CLOSED (2),
+            AUTHORIZATION_FAILED (3),
+            ELICITATION_TIMEOUT (4)
+        }
+
+        struct McpSessionEstablishedEx extends core::stream::Extension
+        {
+            string16 sessionId;
+        }
+
+        struct McpSessionClosedEx extends core::stream::Extension
+        {
+            string16 sessionId;
+            string16 reason = null;
+        }
+
+        enum McpAuthorizationError (uint8)
+        {
+            INVALID_REQUEST(0),
+            INVALID_TOKEN(1),
+            INSUFFICIENT_SCOPE(2)
+        }
+
+        struct McpAuthorizationFailedEx extends core::stream::Extension
+        {
+            string16 realm = null;
+            string16 scopes = null;
+            string16 resourceMetadata = null;
+            McpAuthorizationError error;
+        }
+
+        struct McpElicitationTimeoutEx extends core::stream::Extension
+        {
+            string16 sessionId;
+            string16 elicitationId = null;
+        }
+
+        union McpEventEx switch (McpEventType)
+        {
+            case SESSION_ESTABLISHED: McpSessionEstablishedEx sessionEstablished;
+            case SESSION_CLOSED: McpSessionClosedEx sessionClosed;
+            case AUTHORIZATION_FAILED: McpAuthorizationFailedEx authorizationFailed;
+            case ELICITATION_TIMEOUT: McpElicitationTimeoutEx elicitationTimeout;
+        }
+    }
 }


### PR DESCRIPTION
## Description

`binding-mcp` previously had zero `BindingEvent` telemetry coverage — every other actively-maintained binding with a comparable protocol surface (`binding-mqtt`, `binding-tls`, `binding-kafka`, `guard-jwt`) captures at least connection/session-lifecycle boundaries and auth-rejection reasons via the event system.

This adds four events, each mapped to a confirmed existing call site (no speculative instrumentation):

- `SESSION_ESTABLISHED` — fires from `McpServerFactory.McpLifecycleStream.onLifecycleInitialized`, the point the client's `notifications/initialized` completes the MCP handshake (direct analog to MQTT's post-CONNACK `CLIENT_CONNECTED`)
- `SESSION_CLOSED` — fires from the inactivity-timeout signal branch in `onAppSignal`, alongside `doAppEnd`/`sessions.remove`
- `AUTHORIZATION_FAILED` — fires from `doNetRejectBearer` (server-side inbound reject, both the primary and SSE-resume occurrences) and from the client-side upstream 401/403 bearer-challenge parsing in `McpClientFactory`
- `ELICITATION_TIMEOUT` — fires from the elicitation request stream's `ELICIT_TIMEOUT_SIGNAL_ID` branch in `McpClientFactory`, distinct from the separate `onElicitFailed()` path which this event does not cover

Selection criteria (surveyed all 19 modules in the repo that already define events to find deliberate, recurring patterns rather than inventing criteria from scratch): fire alongside a real consequence (reset/abort/disconnect), use `traceId=0` only for config-time diagnostics, carry structured fields pointing at the actionable resource (`sessionId`, `realm`, `elicitationId`), collapse same-consequence sub-causes into one event via a `reason`/enum field, and never define an event without a confirmed call site. A few other candidates (malformed HTTP request rejects, JSON-RPC parse errors, tool-call invalid-params) were considered and deliberately excluded — no precedent for the first two exists anywhere else in the codebase, and the third is already visible to the caller as a JSON-RPC rejection and covered by `metrics-mcp` counters.

Design discussion: #2070

Fixes #2070

## Test plan

- [x] `McpEventFormatterTest` (written before the production classes existed) — asserts exact formatted output for all 4 events against a mocked `EngineContext`
- [x] Full `./mvnw verify -pl runtime/binding-mcp` — all 257 existing integration tests (`McpServerIT`, `McpClientIT`, `McpProxyIT`, `McpProxyCacheIT`, `McpProxyLifecycleIT`) pass unchanged, confirming the new call sites don't regress the bearer-reject, lifecycle-initialize, inactivity-timeout, and elicit-timeout scenarios they're wired into
- [x] JaCoCo coverage gate passes
- [x] `./mvnw checkstyle:check` and `./mvnw license:check` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea9aphwfzYQjv1EcsTNYXJ)_