### PR TITLE
fix(engine): defer k3po startable until engine start to close IT startup races

### DIFF
--- a/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyIT.java
+++ b/runtime/binding-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiProxyIT.java
@@ -47,6 +47,7 @@ public class AsyncapiProxyIT
         .external("asyncapi_kafka0")
         .configure(ENGINE_VERBOSE, false)
         .configure(ENGINE_VERBOSE_COMPOSITES, false)
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaFetchProxyIT.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaFetchProxyIT.java
@@ -45,6 +45,7 @@ public class GrpcKafkaFetchProxyIT
         .configure(ENGINE_DRAIN_ON_CLOSE, false)
         .configurationRoot("io/aklivity/zilla/specs/binding/grpc/kafka/config")
         .external("kafka0")
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule

--- a/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaProduceProxyIT.java
+++ b/runtime/binding-grpc-kafka/src/test/java/io/aklivity/zilla/runtime/blinding/grpc/kafka/internal/stream/GrpcKafkaProduceProxyIT.java
@@ -43,6 +43,7 @@ public class GrpcKafkaProduceProxyIT
         .configure(ENGINE_BUFFER_SLOT_CAPACITY, 8192)
         .configurationRoot("io/aklivity/zilla/specs/binding/grpc/kafka/config")
         .external("kafka0")
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule

--- a/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerIT.java
+++ b/runtime/binding-kafka-grpc/src/test/java/io/aklivity/zilla/runtime/binding/kafka/grpc/internal/stream/KafkaGrpcRemoteServerIT.java
@@ -46,6 +46,7 @@ public class KafkaGrpcRemoteServerIT
         .configurationRoot("io/aklivity/zilla/specs/binding/kafka/grpc/config")
         .external("grpc0")
         .external("kafka0")
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -64,6 +64,7 @@ public class MqttKafkaSessionProxyIT
             "io.aklivity.zilla.runtime.binding.mqtt.kafka.internal.stream.MqttKafkaSessionProxyIT::supplyWillId")
         .configurationRoot("io/aklivity/zilla/specs/binding/mqtt/kafka/config")
         .external("kafka0")
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSubscribeProxyIT.java
@@ -48,6 +48,7 @@ public class MqttKafkaSubscribeProxyIT
         .configure(ENGINE_DRAIN_ON_CLOSE, false)
         .configurationRoot("io/aklivity/zilla/specs/binding/mqtt/kafka/config")
         .external("kafka0")
+        .aroundStart(k3po::deferStartable)
         .clean();
 
     @Rule


### PR DESCRIPTION
## Description

`RuleChain.outerRule(engine).around(k3po)` runs `engine.before()` before k3po's accept listener is guaranteed to be bound. Any binding that opens a stream eagerly on attach (`onAttached()`, or `attach()` scheduling an immediate signal) races k3po's listener — the first connect attempt gets RESET/ABORT, reconnect backoff eats wall-clock, and under load this can nondeterministically exceed the test's `Timeout` rule.

The fix wires `EngineRule.aroundStart(Supplier<Runnable>)` to `K3poRule.deferStartable()` — a one-shot gate that blocks engine start until k3po's listeners are confirmed live, then releases it once the engine has attached its bindings. This pattern already exists in the codebase and is proven in `binding-mcp`'s `McpProxyCacheIT`; this PR applies it to the remaining IT classes affected by the same race:

- `KafkaGrpcRemoteServerIT` (binding-kafka-grpc) — tightest margin, 2s timeout
- `GrpcKafkaFetchProxyIT`, `GrpcKafkaProduceProxyIT` (binding-grpc-kafka)
- `AsyncapiProxyIT` (binding-asyncapi) — closes out an observed flake
- `MqttKafkaSessionProxyIT`, `MqttKafkaSubscribeProxyIT` (binding-mqtt-kafka) — both factories eagerly open a Kafka stream in `onAttached()` under default config (`willAvailable`/`bootstrapAvailable`)

Also audited `binding-kafka`'s `ClientGroupIT`/`ClientGroupSaslIT` and `CacheBootstrapIT` for the same gap: `ClientGroupFactory.onAttached()` only populates a map (no eager stream open, not the same race), and `CacheBootstrapIT` already uses the opposite rule order (k3po before engine) — neither needs the fix.

No dependency changes; `EngineRule.aroundStart` and `K3poRule.deferStartable` are both already on the classpath.

Companion fix in `aklivity/zilla-plus` for `binding-smux` ITs affected by the same race.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3dWAHwrZfw9dFRmAN39Hp)_