### PR TITLE
fix(engine,manager,common-json): remove parsson from the modular runtime

### DIFF
--- a/cloud/docker-image/src/main/docker/assembly.xml
+++ b/cloud/docker-image/src/main/docker/assembly.xml
@@ -49,7 +49,6 @@
         <include>jakarta/json/**</include>
         <include>jakarta/inject/**</include>
         <include>org/snakeyaml/snakeyaml-engine/**</include>
-        <include>org/eclipse/parsson/**</include>
         <include>org/eclipse/yasson/**</include>
         <include>org/glassfish/**</include>
         <include>com/github/rvesse/**</include>

--- a/manager/NOTICE
+++ b/manager/NOTICE
@@ -18,7 +18,6 @@ This project includes:
   Apache Commons Lang under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
-  Eclipse Parsson under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   error-prone annotations under Apache 2.0
   Gson under Apache-2.0
   Jakarta Dependency Injection under The Apache Software License, Version 2.0

--- a/manager/NOTICE
+++ b/manager/NOTICE
@@ -12,6 +12,7 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
+  agrona under The Apache License, Version 2.0
   Airline - IO Library under The Apache License, Version 2.0
   Airline - Library under The Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
@@ -54,6 +55,8 @@ This project includes:
   Sisu-Inject-Plexus : legacy wrapper under Eclipse Public License, Version 1.0
   SLF4J API Module under MIT
   Yasson under Eclipse Public License v. 2.0 or Eclipse Distribution License v. 1.0
+  zilla::runtime::common-agrona under The Apache Software License, Version 2.0
+  zilla::runtime::common-json under Aklivity Community License Agreement
 
 
 This project also includes code under copyright of the following entities:

--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>yasson</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>common-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
       <version>${maven.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,16 @@
         <groupId>org.eclipse</groupId>
         <artifactId>yasson</artifactId>
         <version>3.0.4</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonParserFactoryImpl.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.json.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,7 +53,7 @@ public final class JsonParserFactoryImpl implements JsonParserFactory
     public JsonParser createParser(
         InputStream in)
     {
-        return new JsonParserImpl(in, config);
+        return new JsonParserImpl(marked(in), config);
     }
 
     @Override
@@ -60,7 +61,7 @@ public final class JsonParserFactoryImpl implements JsonParserFactory
         InputStream in,
         Charset charset)
     {
-        return new JsonParserImpl(in, config);
+        return new JsonParserImpl(marked(in), config);
     }
 
     @Override
@@ -75,6 +76,12 @@ public final class JsonParserFactoryImpl implements JsonParserFactory
         JsonArray array)
     {
         return JsonValues.parser(array);
+    }
+
+    private static InputStream marked(
+        InputStream in)
+    {
+        return in.markSupported() ? in : new BufferedInputStream(in);
     }
 
     private static InputStream readAll(

--- a/runtime/engine/pom.xml
+++ b/runtime/engine/pom.xml
@@ -76,12 +76,6 @@
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish</groupId>
-          <artifactId>jakarta.json</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/specs/engine.spec/pom.xml
+++ b/specs/engine.spec/pom.xml
@@ -63,12 +63,6 @@
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish</groupId>
-          <artifactId>jakarta.json</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.aklivity.k3po</groupId>


### PR DESCRIPTION
## Description

`common-json` was already wired in as a `jakarta.json.spi.JsonProvider` replacement for `org.eclipse.parsson`, but `parsson` kept showing up in the resolved dependency graph because it arrived transitively through `org.eclipse:yasson` (yasson's JSON-B implementation needs a JSON-P provider), and nothing excluded it.

Changes:
- Aggregate the yasson exclusion set (`org.glassfish:jakarta.json`, `org.eclipse.parsson:parsson`) once in the root `pom.xml` `dependencyManagement` entry so `runtime/engine`, `specs/engine.spec`, and `manager` all inherit it without redeclaring local exclusions that would otherwise silently override the managed set.
- Drop the `org/eclipse/parsson/**` include from `cloud/docker-image/src/main/docker/assembly.xml` as a backstop — if parsson ever gets reintroduced, the docker image build fails loudly (module not found) instead of silently repackaging it.
- Add the `common-json` dependency to `manager/pom.xml`, which previously had no `jakarta.json.spi.JsonProvider` implementation of its own and relied entirely on parsson arriving via yasson.
- Fix a real bug in `common-json` uncovered once yasson was forced onto its `JsonProvider`: `JsonParserFactoryImpl.createParser(InputStream)` passed the raw stream straight to `JsonParserImpl`, which requires mark/reset support, instead of wrapping non-mark-supporting streams in a `BufferedInputStream` the way `JsonProviderImpl.createParser(InputStream)` already does.
- Regenerated `manager/NOTICE` to match the updated dependency tree.

## Verification so far

- `dependency:tree` confirms `org.eclipse.parsson` and `org.glassfish:jakarta.json` are absent from `runtime/engine`, `manager`, and `specs/engine.spec`.
- Full reactor build (`clean install -DskipITs`) passes across all 129 modules with only one unrelated pre-existing environment failure (`TrustedTest.shouldConfigureTrustViaCacerts`, a sandbox TLS truststore artifact, not something reachable in CI).
- Ran the actual `zpm install --debug --instrument --exclude-remote-repositories` step from `cloud/docker-image`'s Dockerfile natively (no Docker daemon available in the dev sandbox) against the fully-built local repo. The resolved module list and provider list confirm `org.eclipse.parsson` is completely absent from the real linked runtime image, and `common-json` is genuinely serving as yasson's `JsonProvider`:
  ```
  org.eclipse.yasson provides jakarta.json.bind.spi.JsonbProvider used by jakarta.json.bind
  io.aklivity.zilla.runtime.common.json provides jakarta.json.spi.JsonProvider used by jakarta.json
  ```

This draft PR is to let CI build the actual Docker image (real daemon) and run the `examples/` matrix against it, to confirm end-to-end behavior holds without parsson in a real container, not just in local verification.

## Test plan

- [ ] CI `build` job passes (full reactor build + Docker image build)
- [ ] CI `setup-examples` / example matrix jobs pass against the built image


---
_Generated by [Claude Code](https://claude.ai/code/session_016mCc46muzE9m5taBuonh4H)_