### PR TITLE
fix(build): don't fail PR on cleanup, skip cleanup if testing failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,13 +277,14 @@ jobs:
         run: docker compose down --remove-orphans
 
   cleanup:
-    if: always()
+    if: success()
     needs:
       - testing
     runs-on: ubuntu-latest
     steps:
       - name: Delete Docker image artifact
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
## Description

The `cleanup` job's "Delete Docker image artifact" step calls `deleteArtifact` via `actions/github-script`, which needs `actions: write`. GitHub Actions restricts `GITHUB_TOKEN` to read-only for Dependabot-triggered runs, so this step 403s (`Resource not accessible by integration`) on every Dependabot PR and fails the check — see [run 29060925912](https://github.com/aklivity/zilla/actions/runs/29060925912/job/86265932685?pr=1989).

Separately, `cleanup` ran with `if: always()`, so it deleted the `zilla-image` artifact even when `testing` failed — making it impossible to re-run a flaky test job afterward, since the image it depends on was already gone.

This changes:
- `cleanup` job: `if: always()` → `if: success()`, so it only runs (and deletes the artifact) when `testing` passed.
- Delete step: added `continue-on-error: true`, so an unexpected failure (e.g. Dependabot's read-only token) no longer fails the PR check — the artifact expires on its own (`retention-days: 1`) either way.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQDA6B7raEN7YdV3Q7cU3W)_