### PR TITLE
feat(binding-mcp-openapi): support operator-declared guarded routes

### DIFF
--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiRouteConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiRouteConfig.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiConditionConfig;
 import io.aklivity.zilla.runtime.binding.mcp.openapi.config.McpOpenapiWithConfig;
+import io.aklivity.zilla.runtime.engine.config.GuardedConfig;
 import io.aklivity.zilla.runtime.engine.config.RouteConfig;
 
 public final class McpOpenapiRouteConfig
@@ -27,6 +28,7 @@ public final class McpOpenapiRouteConfig
     public final long id;
     public final List<McpOpenapiConditionConfig> when;
     public final McpOpenapiWithConfig with;
+    public final List<GuardedConfig> guarded;
 
     public McpOpenapiRouteConfig(
         RouteConfig route)
@@ -36,6 +38,7 @@ public final class McpOpenapiRouteConfig
             .map(McpOpenapiConditionConfig.class::cast)
             .collect(toList());
         this.with = (McpOpenapiWithConfig) route.with;
+        this.guarded = route.guarded;
     }
 
     public boolean isBulk()

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -75,6 +75,7 @@ import io.aklivity.zilla.runtime.common.openapi.view.OpenapiServerView;
 import io.aklivity.zilla.runtime.common.openapi.view.OpenapiView;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfigBuilder;
+import io.aklivity.zilla.runtime.engine.config.GuardedConfig;
 import io.aklivity.zilla.runtime.engine.config.GuardedConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.ModelConfig;
 import io.aklivity.zilla.runtime.engine.config.ModelConfigAdapter;
@@ -191,8 +192,10 @@ public final class McpOpenapiCompositeGenerator
                     continue;
                 }
 
+                final List<GuardedRef> guarded = combineGuarded(binding, route, resolution.guarded);
+
                 routed.add(new RoutedOperation(toolConfig(binding, routeTool), resourceConfig(binding, resource),
-                    operation, resolution.guarded, serverByLabel.get(with.spec), with.params, with.body));
+                    operation, guarded, serverByLabel.get(with.spec), with.params, with.body));
             }
         }
 
@@ -601,6 +604,34 @@ public final class McpOpenapiCompositeGenerator
         }
 
         return result;
+    }
+
+    private static List<GuardedRef> combineGuarded(
+        McpOpenapiBindingConfig binding,
+        McpOpenapiRouteConfig route,
+        List<GuardedRef> derived)
+    {
+        List<GuardedRef> combined = derived;
+
+        if (!route.guarded.isEmpty())
+        {
+            final Map<String, List<String>> rolesByQName = new LinkedHashMap<>();
+            for (GuardedRef ref : derived)
+            {
+                rolesByQName.computeIfAbsent(ref.qname, q -> new ArrayList<>()).addAll(ref.roles);
+            }
+            for (GuardedConfig guarded : route.guarded)
+            {
+                final String qname = binding.supplyQName.apply(binding.resolveId.applyAsLong(guarded.name));
+                rolesByQName.computeIfAbsent(qname, q -> new ArrayList<>()).addAll(guarded.roles);
+            }
+
+            combined = rolesByQName.entrySet().stream()
+                .map(e -> new GuardedRef(e.getKey(), e.getValue().stream().distinct().toList()))
+                .toList();
+        }
+
+        return combined;
     }
 
     private static GuardedResolution resolveAlternative(

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -1560,6 +1560,165 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
+    public void shouldGuardOperatorDeclaredRouteWithNoSpecSecurity()
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .resource("repo://{owner}/{repo}")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("repos/get")
+                    .build())
+                .guarded()
+                    .name("guard1")
+                    .role("read")
+                    .build()
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        RouteConfig getRoute = mcpHttp.routes.stream()
+            .filter(r -> "GET".equals(((McpHttpWithConfig) r.with).headers.get(":method")))
+            .findFirst()
+            .orElse(null);
+        List<GuardedConfig> guarded = getRoute.guarded;
+        assertThat(guarded, hasSize(1));
+        assertThat(guarded.get(0).name, equalTo("test1"));
+        assertThat(guarded.get(0).roles, containsInAnyOrder("read"));
+    }
+
+    @Test
+    public void shouldComposeOperatorDeclaredGuardWithDistinctSpecDerivedGuard()
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .security(Map.of("bearerAuth", "guard0", "oauthScheme", "guard0"))
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .tool("create_pr")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("pulls/create")
+                    .build())
+                .guarded()
+                    .name("guard1")
+                    .role("write")
+                    .build()
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        RouteConfig postRoute = mcpHttp.routes.stream()
+            .filter(r -> "POST".equals(((McpHttpWithConfig) r.with).headers.get(":method")))
+            .findFirst()
+            .orElse(null);
+        List<GuardedConfig> guarded = postRoute.guarded;
+        assertThat(guarded, hasSize(2));
+        GuardedConfig specDerived = guarded.stream().filter(g -> "test0".equals(g.name)).findFirst().orElse(null);
+        GuardedConfig operatorDeclared = guarded.stream().filter(g -> "test1".equals(g.name)).findFirst().orElse(null);
+        assertThat(specDerived, notNullValue());
+        assertThat(specDerived.roles, containsInAnyOrder("repo", "pr:write"));
+        assertThat(operatorDeclared, notNullValue());
+        assertThat(operatorDeclared.roles, containsInAnyOrder("write"));
+    }
+
+    @Test
+    public void shouldUnionOperatorDeclaredRolesWithSpecDerivedGuardForSameGuard()
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .security(Map.of("bearerAuth", "guard0", "oauthScheme", "guard0"))
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .tool("create_pr")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("pulls/create")
+                    .build())
+                .guarded()
+                    .name("guard0")
+                    .role("write")
+                    .build()
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+        RouteConfig postRoute = mcpHttp.routes.stream()
+            .filter(r -> "POST".equals(((McpHttpWithConfig) r.with).headers.get(":method")))
+            .findFirst()
+            .orElse(null);
+        List<GuardedConfig> guarded = postRoute.guarded;
+        assertThat(guarded, hasSize(1));
+        assertThat(guarded.get(0).name, equalTo("test0"));
+        assertThat(guarded.get(0).roles, containsInAnyOrder("repo", "pr:write", "write"));
+    }
+
+    @Test
     public void shouldDenyOperationRequiringMultipleDistinctGuards()
     {
         BindingConfig binding = BindingConfig.builder()

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -258,6 +258,20 @@
                                     {
                                         "required": [ "tag", "operation" ]
                                     }
+                                },
+                                "guarded":
+                                {
+                                    "title": "Guarded",
+                                    "type": "object",
+                                    "patternProperties":
+                                    {
+                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                        {
+                                            "title": "Roles",
+                                            "type": "array",
+                                            "items": { "title": "Role", "type": "string" }
+                                        }
+                                    }
                                 }
                             },
                             "required": [ "with" ],


### PR DESCRIPTION
## Description

Allows `guarded:` directly on `mcp_openapi`'s own `routes[]`, independent of the bundled OpenAPI spec's own `security`/`securitySchemes` declarations. Previously `guarded:` was rejected by `mcp_openapi`'s route schema (`additionalProperties: false` on the route item omitted it), so the only way a tool/resource route could end up guarded was by resolving the spec's `security` requirements against `options.specs[label].security` — which doesn't help when the underlying OpenAPI spec declares no security schemes at all.

When both an operator-declared `guarded:` and a spec-derived guard are present, they compose rather than one replacing the other:
- Same guard referenced by both → roles are unioned into a single entry
- Distinct guards → both entries are emitted on the generated `mcp_http0` route, which the engine already ANDs together

Changes:
- `specs/binding-mcp-openapi.spec` — schema patch now allows a `guarded` property on the route item, matching the engine's generic `$defs/binding.routes.items.properties.guarded` shape
- `runtime/binding-mcp-openapi` — `McpOpenapiRouteConfig` now carries the route's `guarded` list; `McpOpenapiCompositeGenerator` merges it with the existing spec-derived guard resolution before emitting the generated `mcp_http0` route's `guarded:`

## Testing

- Added 3 unit tests to `McpOpenapiCompositeGeneratorTest` covering: operator guard with no spec security, operator guard composing with a distinct spec-derived guard, and operator guard unioning roles into the same spec-derived guard
- `./mvnw clean verify -pl specs/binding-mcp-openapi.spec,runtime/binding-mcp-openapi` — all green (schema tests, unit tests, k3po ITs including the pre-existing spec-derived `proxy.guarded.yaml` scenarios)
- `./mvnw clean install -DskipTests` from the repo root — all modules build successfully (the only unrelated failure is `cloud::docker-image`, which requires a Docker daemon not present in the build environment)

Fixes #2103


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9pVSm36B2zdo5z9KxcBvm)_