### PR TITLE
test(binding-tcp): skip IPv6 tests when unavailable in the build environment

### DIFF
--- a/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
+++ b/runtime/binding-tcp/src/test/java/io/aklivity/zilla/runtime/binding/tcp/internal/streams/ClientIT.java
@@ -30,6 +30,7 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.function.LongSupplier;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -42,6 +43,7 @@ import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
+import io.aklivity.zilla.specs.binding.tcp.internal.IPv6Support;
 
 public class ClientIT
 {
@@ -207,6 +209,8 @@ public class ClientIT
     @ScriptProperty("address \"tcp://[::1]:12345\"")
     public void shouldEstablishConnectionIPv6() throws Exception
     {
+        Assume.assumeTrue(IPv6Support.isAvailable());
+
         k3po.finish();
     }
 

--- a/specs/binding-tcp.spec/pom.xml
+++ b/specs/binding-tcp.spec/pom.xml
@@ -133,6 +133,7 @@
         <configuration>
           <excludes>
             <exclude>io/aklivity/zilla/specs/binding/tcp/internal/types/**/*.class</exclude>
+            <exclude>io/aklivity/zilla/specs/binding/tcp/internal/IPv6Support.class</exclude>
           </excludes>
           <rules>
             <rule>

--- a/specs/binding-tcp.spec/src/main/java/io/aklivity/zilla/specs/binding/tcp/internal/IPv6Support.java
+++ b/specs/binding-tcp.spec/src/main/java/io/aklivity/zilla/specs/binding/tcp/internal/IPv6Support.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.specs.binding.tcp.internal;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+public final class IPv6Support
+{
+    public static boolean isAvailable()
+    {
+        boolean available;
+        try (ServerSocket socket = new ServerSocket(0, 0, InetAddress.getByName("::1")))
+        {
+            available = true;
+        }
+        catch (IOException ex)
+        {
+            available = false;
+        }
+        return available;
+    }
+
+    private IPv6Support()
+    {
+    }
+}

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationIT.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.specs.binding.tcp.streams;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -26,6 +27,7 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.specs.binding.tcp.internal.IPv6Support;
 
 /**
  * RFC-793
@@ -245,6 +247,8 @@ public class ApplicationIT
         "${app}/connection.established.ipv6/server" })
     public void shouldEstablishConnectionIPv6() throws Exception
     {
+        Assume.assumeTrue(IPv6Support.isAvailable());
+
         k3po.finish();
     }
 

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationRoutingIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/ApplicationRoutingIT.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.specs.binding.tcp.streams;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -26,6 +27,7 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.specs.binding.tcp.internal.IPv6Support;
 
 public class ApplicationRoutingIT
 {
@@ -81,6 +83,8 @@ public class ApplicationRoutingIT
         "${app}/client.connect.with.ipv6.extension/server" })
     public void shouldConnectClientWithIpv6Extension() throws Exception
     {
+        Assume.assumeTrue(IPv6Support.isAvailable());
+
         k3po.finish();
     }
 

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkRoutingIT.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/streams/NetworkRoutingIT.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.specs.binding.tcp.streams;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -26,6 +27,7 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.specs.binding.tcp.internal.IPv6Support;
 
 public class NetworkRoutingIT
 {
@@ -81,6 +83,8 @@ public class NetworkRoutingIT
         "${net}/client.connect.with.ipv6.extension/server" })
     public void shouldConnectClientWithIpv6Extension() throws Exception
     {
+        Assume.assumeTrue(IPv6Support.isAvailable());
+
         k3po.finish();
     }
 }


### PR DESCRIPTION
## Description

Some build environments have no access to IPv6 locally, which fails the IPv6-based `binding-tcp.spec` and `binding-tcp` k3po integration tests even though the implementation is correct.

This adds `IPv6Support.isAvailable()` in `binding-tcp.spec` — it probes IPv6 loopback by binding a `ServerSocket` to `::1` — and gates the four IPv6 tests with `Assume.assumeTrue(IPv6Support.isAvailable())` so they are skipped (not failed) when IPv6 isn't available:

- `specs/binding-tcp.spec`: `NetworkRoutingIT.shouldConnectClientWithIpv6Extension`, `ApplicationRoutingIT.shouldConnectClientWithIpv6Extension`, `ApplicationIT.shouldEstablishConnectionIPv6`
- `runtime/binding-tcp`: `ClientIT.shouldEstablishConnectionIPv6`

`binding-tcp` already depends on `binding-tcp.spec` (`provided` scope), so the single utility class is visible to both modules' tests without duplication.

Also added a jacoco exclude for `IPv6Support.class` in `binding-tcp.spec/pom.xml`, since that module enforces 100% instruction coverage and one branch of the availability probe is inherently environment-dependent (can't be hit in a single CI run either way).

Existing `@Ignore("GitHub Actions")` / `@Ignore("TODO")` annotations on other IPv6-related tests (`ServerIT`, `ClientRoutingIT`) are intentionally left unchanged.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nxtu5PtSguEe8D4L7jiAwf)_