### PR TITLE
feat(engine): support connect aborted zilla:reset.ext matcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <byteman.version>4.0.26</byteman.version>
     <jmock.version>2.6.0</jmock.version>
     <mockito.version>5.23.0</mockito.version>
-    <k3po.version>3.4.4</k3po.version>
+    <k3po.version>3.4.5</k3po.version>
     <jmh.version>1.37</jmh.version>
     <helm.version>3.16.4</helm.version>
   </properties>

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -1211,6 +1211,21 @@ final class ZillaTarget implements AutoCloseable
         private void onResetBeforeHandshake(
             ResetFW reset)
         {
+            final OctetsFW resetExt = reset.extension();
+
+            int resetExtBytes = resetExt.sizeof();
+            if (resetExtBytes != 0)
+            {
+                final DirectBufferEx buffer = resetExt.buffer();
+                final int offset = resetExt.offset();
+
+                // TODO: avoid allocation
+                final byte[] resetExtCopy = new byte[resetExtBytes];
+                buffer.getBytes(offset, resetExtCopy);
+
+                channel.writeExtBuffer(RESET, false).writeBytes(resetExtCopy);
+            }
+
             handshakeFuture.setFailure(new ChannelException("handshake failed"));
         }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/AbstractReadExtHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/AbstractReadExtHandler.java
@@ -25,9 +25,10 @@ import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelHandlerContext;
 
 import io.aklivity.k3po.runtime.driver.internal.behavior.handler.codec.ChannelDecoder;
+import io.aklivity.k3po.runtime.driver.internal.behavior.handler.codec.DecodingHandler;
 import io.aklivity.k3po.runtime.driver.internal.behavior.handler.event.AbstractEventHandler;
 
-public abstract class AbstractReadExtHandler extends AbstractEventHandler
+public abstract class AbstractReadExtHandler extends AbstractEventHandler implements DecodingHandler
 {
     protected final ChannelDecoder decoder;
 
@@ -46,6 +47,12 @@ public abstract class AbstractReadExtHandler extends AbstractEventHandler
     {
         super(expectedEvents);
         this.decoder = requireNonNull(decoder, "decoder");
+    }
+
+    @Override
+    public ChannelDecoder getDecoder()
+    {
+        return decoder;
     }
 
     protected final void doReadExtension(

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.reset.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/duplex/handshake.reset.ext.rejected/client.rpt
@@ -17,4 +17,4 @@
 connect "zilla://streams/server#0"
         option zilla:transmission "duplex"
         option zilla:window 8192
-connect aborted
+connect aborted zilla:reset.ext [0x12 0x34] [0x0c] "Hello, world"

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.reset.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/half.duplex/handshake.reset.ext.rejected/client.rpt
@@ -17,4 +17,4 @@
 connect "zilla://streams/server#0"
         option zilla:transmission "half-duplex"
         option zilla:window 8192
-connect aborted
+connect aborted zilla:reset.ext [0x12 0x34] [0x0c] "Hello, world"

--- a/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.reset.ext.rejected/client.rpt
+++ b/runtime/engine/src/test/scripts/io/aklivity/zilla/runtime/engine/test/k3po/ext/simplex/handshake.reset.ext.rejected/client.rpt
@@ -16,4 +16,4 @@
 
 connect "zilla://streams/server#0"
         option zilla:window 8192
-connect aborted
+connect aborted zilla:reset.ext [0x12 0x34] [0x0c] "Hello, world"


### PR DESCRIPTION
## Description

Wires zilla's k3po test transport into the `connect aborted zilla:reset.ext ...` matcher syntax added by [k3po#20](https://github.com/aklivity/k3po/pull/20) (fixes k3po#17), so scripts can assert the RESET extension bytes sent when a handshake is rejected, not just that the connect aborted.

- `ZillaTarget.Throttle.onResetBeforeHandshake` now captures the RESET extension bytes and writes them into the read-ext buffer, mirroring the existing mid-stream `onReset` handling.
- `AbstractReadExtHandler` now implements k3po driver's `DecodingHandler` marker interface, exposing its internal `ChannelDecoder` so `ConnectAbortedHandler` can reuse it to verify the extension.
- Updated the three `handshake.reset.ext.rejected` client scripts (duplex, half-duplex, simplex) to assert the RESET extension content instead of just `connect aborted`.
- Bumps `k3po.version` to `3.4.5`, which contains k3po#20.

## Test plan

- [x] `./mvnw -pl runtime/engine clean verify -Dit.test=DuplexIT,SimplexIT,HalfDuplexIT` — 0 failures against released k3po 3.4.5, including genuine byte-level verification of the RESET extension (confirmed with a negative control: a deliberately mismatched extension fails with a clear diff)
