### PR TITLE
feat(common-json,binding-openapi): OpenAPI Overlay Specification support

### DIFF
--- a/runtime/binding-openapi/pom.xml
+++ b/runtime/binding-openapi/pom.xml
@@ -43,6 +43,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>common-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>common-openapi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapter.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapter.java
@@ -54,6 +54,7 @@ public final class OpenapiOptionsConfigAdapter implements OptionsConfigAdapterSp
     private static final String SUBJECT_NAME = "subject";
     private static final String VERSION_NAME = "version";
     private static final String SECURITY_NAME = "security";
+    private static final String OVERLAY_NAME = "overlay";
 
     private OptionsConfigAdapter tlsOptions;
     private OptionsConfigAdapter httpOptions;
@@ -119,6 +120,20 @@ public final class OpenapiOptionsConfigAdapter implements OptionsConfigAdapterSp
                     subjectObject.add(catalog.name, schemaObject);
                 }
                 catalogObject.add(CATALOG_NAME, subjectObject);
+
+                if (openapiConfig.overlay != null)
+                {
+                    final JsonObjectBuilder overlaySchema = Json.createObjectBuilder();
+                    overlaySchema.add(SUBJECT_NAME, openapiConfig.overlay.subject);
+                    if (openapiConfig.overlay.version != null)
+                    {
+                        overlaySchema.add(VERSION_NAME, openapiConfig.overlay.version);
+                    }
+
+                    final JsonObjectBuilder overlaySubject = Json.createObjectBuilder();
+                    overlaySubject.add(openapiConfig.overlay.name, overlaySchema);
+                    catalogObject.add(OVERLAY_NAME, overlaySubject);
+                }
 
                 if (openapiConfig.servers != null && !openapiConfig.servers.isEmpty())
                 {
@@ -236,7 +251,29 @@ public final class OpenapiOptionsConfigAdapter implements OptionsConfigAdapterSp
                     }
                 }
 
-                openapiOptions.spec(new OpenapiSpecificationConfig(apiLabel, server, servers, catalogs, security));
+                OpenapiCatalogConfig overlay = null;
+                if (specObject.containsKey(OVERLAY_NAME))
+                {
+                    final JsonObject overlayObject = specObject.getJsonObject(OVERLAY_NAME);
+                    final Map.Entry<String, JsonValue> overlayEntry = overlayObject.entrySet().iterator().next();
+                    final JsonObject overlaySchemaObject = overlayEntry.getValue().asJsonObject();
+
+                    OpenapiCatalogConfigBuilder<OpenapiCatalogConfig> overlayBuilder = OpenapiCatalogConfig.builder();
+                    overlayBuilder.name(overlayEntry.getKey());
+
+                    if (overlaySchemaObject.containsKey(SUBJECT_NAME))
+                    {
+                        overlayBuilder.subject(overlaySchemaObject.getString(SUBJECT_NAME));
+                    }
+
+                    if (overlaySchemaObject.containsKey(VERSION_NAME))
+                    {
+                        overlayBuilder.version(overlaySchemaObject.getString(VERSION_NAME));
+                    }
+                    overlay = overlayBuilder.build();
+                }
+
+                openapiOptions.spec(new OpenapiSpecificationConfig(apiLabel, server, servers, catalogs, security, overlay));
             }
         }
 

--- a/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeGenerator.java
+++ b/runtime/binding-openapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiCompositeGenerator.java
@@ -41,6 +41,7 @@ import io.aklivity.zilla.runtime.binding.openapi.internal.config.OpenapiBindingC
 import io.aklivity.zilla.runtime.binding.openapi.internal.config.OpenapiCompositeConfig;
 import io.aklivity.zilla.runtime.catalog.inline.config.InlineOptionsConfig;
 import io.aklivity.zilla.runtime.catalog.inline.config.InlineOptionsConfigBuilder;
+import io.aklivity.zilla.runtime.common.json.JsonOverlay;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiParser;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiSchemaConfig;
@@ -53,6 +54,7 @@ import io.aklivity.zilla.runtime.common.openapi.view.OpenapiRequestBodyView;
 import io.aklivity.zilla.runtime.common.openapi.view.OpenapiResponseView;
 import io.aklivity.zilla.runtime.common.openapi.view.OpenapiSchemaView;
 import io.aklivity.zilla.runtime.common.openapi.view.OpenapiView;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.config.BindingConfigBuilder;
 import io.aklivity.zilla.runtime.engine.config.GuardedConfigBuilder;
@@ -91,11 +93,12 @@ public abstract class OpenapiCompositeGenerator
                 final CatalogHandler handler = binding.supplyCatalog.apply(catalogId);
                 final int schemaId = handler.resolve(catalog.subject, catalog.version);
                 final String payload = handler.resolve(schemaId);
+                final String materialized = materialize(binding, specification, payload);
                 final List<OpenapiServerConfig> configs =
                     specification.servers == null || specification.servers.isEmpty()
                         ? List.of(OpenapiServerConfig.builder().build())
                         : specification.servers;
-                final OpenapiView openapi = OpenapiView.of(tagIndex++, label, parser.parse(payload), configs);
+                final OpenapiView openapi = OpenapiView.of(tagIndex++, label, parser.parse(materialized), configs);
 
                 unresolved.addAll(openapi.unresolvedRefs());
 
@@ -104,6 +107,27 @@ public abstract class OpenapiCompositeGenerator
         }
 
         return generate(binding, schemas);
+    }
+
+    private String materialize(
+        OpenapiBindingConfig binding,
+        OpenapiSpecificationConfig specification,
+        String payload)
+    {
+        String materialized = payload;
+        if (specification.overlay != null)
+        {
+            final long catalogId = binding.resolveId.applyAsLong(specification.overlay.name);
+            final CatalogHandler handler = binding.supplyCatalog.apply(catalogId);
+            final int schemaId = handler.resolve(specification.overlay.subject, specification.overlay.version);
+            final String overlayPayload = handler.resolve(schemaId);
+
+            final JsonObject document = YamlJson.createReader(new StringReader(payload)).readObject();
+            final JsonObject overlayDocument = YamlJson.createReader(new StringReader(overlayPayload)).readObject();
+            materialized = JsonOverlay.of(overlayDocument).apply(document).toString();
+        }
+
+        return materialized;
     }
 
     public final Collection<String> unresolvedRefs()

--- a/runtime/binding-openapi/src/main/moditect/module-info.java
+++ b/runtime/binding-openapi/src/main/moditect/module-info.java
@@ -14,6 +14,7 @@
  */
 module io.aklivity.zilla.runtime.binding.openapi
 {
+    requires io.aklivity.zilla.runtime.common.json;
     requires transitive io.aklivity.zilla.runtime.common.openapi;
     requires io.aklivity.zilla.runtime.common.yaml;
 

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/OpenapiOptionsConfigAdapterTest.java
@@ -89,6 +89,32 @@ public class OpenapiOptionsConfigAdapterTest
     }
 
     @Test
+    public void shouldReadOptionsWithOverlay()
+    {
+        String text =
+            """
+            specs:
+              petstore:
+                catalog:
+                  catalog0:
+                    subject: petstore
+                    version: latest
+                overlay:
+                  catalog0:
+                    subject: petstore-overlay
+                    version: latest
+            """;
+
+        OpenapiOptionsConfig options = jsonb.fromJson(text, OpenapiOptionsConfig.class);
+
+        OpenapiSpecificationConfig spec = options.specs.get(0);
+        assertThat(spec.overlay, not(nullValue()));
+        assertEquals("catalog0", spec.overlay.name);
+        assertEquals("petstore-overlay", spec.overlay.subject);
+        assertEquals("latest", spec.overlay.version);
+    }
+
+    @Test
     public void shouldWriteOptions()
     {
         String expected =
@@ -113,6 +139,39 @@ public class OpenapiOptionsConfigAdapterTest
             .tls(tls)
             .spec(new OpenapiSpecificationConfig("test",
                 of(new OpenapiCatalogConfig("catalog0", "petstore", "latest"))))
+            .build();
+
+        String text = jsonb.toJson(options);
+
+        assertThat(text, not(nullValue()));
+        assertEquals(expected, text);
+    }
+
+    @Test
+    public void shouldWriteOptionsWithOverlay()
+    {
+        String expected =
+            """
+            specs:
+              test:
+                catalog:
+                  catalog0:
+                    subject: petstore
+                    version: latest
+                overlay:
+                  catalog0:
+                    subject: petstore-overlay
+                    version: latest
+            """;
+
+        OpenapiOptionsConfig options = OpenapiOptionsConfig.builder()
+            .spec(new OpenapiSpecificationConfig(
+                "test",
+                null,
+                of(),
+                of(new OpenapiCatalogConfig("catalog0", "petstore", "latest")),
+                null,
+                new OpenapiCatalogConfig("catalog0", "petstore-overlay", "latest")))
             .build();
 
         String text = jsonb.toJson(options);

--- a/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiServerGeneratorTest.java
+++ b/runtime/binding-openapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/internal/config/composite/OpenapiServerGeneratorTest.java
@@ -80,6 +80,27 @@ public class OpenapiServerGeneratorTest
         }
         """;
 
+    private static final String OVERLAY =
+        """
+        {
+          "overlay": "1.0.0",
+          "info": { "title": "test-overlay", "version": "1.0.0" },
+          "actions": [
+            {
+              "target": "$.paths",
+              "update": {
+                "/added": {
+                  "get": {
+                    "operationId": "added",
+                    "responses": { "200": { "description": "ok" } }
+                  }
+                }
+              }
+            }
+          ]
+        }
+        """;
+
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
@@ -123,6 +144,29 @@ public class OpenapiServerGeneratorTest
                     List.of(),
                     List.of(new OpenapiCatalogConfig("catalog0", "test", "latest")),
                     security))
+                .build())
+            .exit("openapi0")
+            .build();
+        binding.resolveId = resolveId;
+        return binding;
+    }
+
+    private BindingConfig bindingWithOverlay(
+        Map<String, String> security)
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("composite0")
+            .type("openapi")
+            .kind(SERVER)
+            .options(OpenapiOptionsConfig.builder()
+                .spec(new OpenapiSpecificationConfig(
+                    "petstore",
+                    null,
+                    List.of(),
+                    List.of(new OpenapiCatalogConfig("catalog0", "test", "latest")),
+                    security,
+                    new OpenapiCatalogConfig("catalog0", "test-overlay", "latest")))
                 .build())
             .exit("openapi0")
             .build();
@@ -191,5 +235,18 @@ public class OpenapiServerGeneratorTest
             Map.of("bearerAuth", "guard0"))));
 
         assertThat(composite, notNullValue());
+    }
+
+    @Test
+    public void shouldApplyOverlayBeforeGeneratingRoutes()
+    {
+        lenient().when(catalog.resolve(eq("test-overlay"), eq("latest"))).thenReturn(8);
+        lenient().when(catalog.resolve(eq(8))).thenReturn(OVERLAY);
+
+        OpenapiCompositeConfig composite = generator.generate(new OpenapiBindingConfig(context, bindingWithOverlay(null)));
+
+        RouteConfig route = routeFor(composite, "/added");
+
+        assertThat(route.guarded, empty());
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlay.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlay.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonPointer;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+
+/**
+ * Applies an OpenAPI Overlay Specification (1.0.0) document to a target {@link JsonValue}
+ * document, producing the materialized result. Each action's {@code target} JSONPath (see
+ * {@link JsonPath}) is re-evaluated against the document as it stands after every preceding
+ * action, so later actions observe earlier edits.
+ * <p>
+ * For a matched node that is an object, {@code update} is recursively merged into it
+ * (existing properties are overwritten, new properties are added). For a matched node that
+ * is an array, {@code update} is appended as a new element. For any other matched node
+ * (a scalar or {@code null}), {@code update} replaces it outright. A {@code remove} action
+ * deletes every matched node from its containing object or array; when a single action
+ * matches multiple array elements, removal proceeds from the highest index to the lowest so
+ * earlier indices remain valid. A target that matches nothing is a no-op.
+ */
+public final class JsonOverlay
+{
+    private final List<JsonOverlayAction> actions;
+
+    private JsonOverlay(
+        List<JsonOverlayAction> actions)
+    {
+        this.actions = actions;
+    }
+
+    public static JsonOverlay of(
+        List<JsonOverlayAction> actions)
+    {
+        if (actions.isEmpty())
+        {
+            throw new IllegalArgumentException("Overlay must contain at least one action");
+        }
+        return new JsonOverlay(new ArrayList<>(actions));
+    }
+
+    public static JsonOverlay of(
+        JsonValue document)
+    {
+        JsonObject object = document.asJsonObject();
+        if (!object.containsKey("overlay") || object.getString("overlay", "").isEmpty())
+        {
+            throw new IllegalArgumentException("Overlay document missing required \"overlay\" version field");
+        }
+
+        JsonArray actionsArray = object.containsKey("actions") ? object.getJsonArray("actions") : null;
+        if (actionsArray == null || actionsArray.isEmpty())
+        {
+            throw new IllegalArgumentException("Overlay document must contain at least one action");
+        }
+
+        List<JsonOverlayAction> actions = new ArrayList<>(actionsArray.size());
+        for (JsonValue actionValue : actionsArray)
+        {
+            JsonObject actionObject = actionValue.asJsonObject();
+            if (!actionObject.containsKey("target"))
+            {
+                throw new IllegalArgumentException("Overlay action missing required \"target\" field");
+            }
+            String target = actionObject.getString("target");
+            JsonValue update = actionObject.get("update");
+            boolean remove = actionObject.getBoolean("remove", false);
+            actions.add(new JsonOverlayAction(target, update, remove));
+        }
+
+        return of(actions);
+    }
+
+    public JsonValue apply(
+        JsonValue document)
+    {
+        JsonStructure result = (JsonStructure) document;
+        for (JsonOverlayAction action : actions)
+        {
+            result = applyAction(action, result);
+        }
+        return result;
+    }
+
+    private static JsonStructure applyAction(
+        JsonOverlayAction action,
+        JsonStructure document)
+    {
+        List<String> pointers = JsonPath.compile(action.target()).matches(document);
+
+        JsonStructure result = document;
+        if (action.remove())
+        {
+            List<String> reversed = new ArrayList<>(pointers);
+            Collections.reverse(reversed);
+            for (String pointer : reversed)
+            {
+                result = Json.createPointer(pointer).remove(result);
+            }
+        }
+        else if (action.update() != null)
+        {
+            for (String pointer : pointers)
+            {
+                JsonPointer target = Json.createPointer(pointer);
+                JsonValue merged = merge(target.getValue(result), action.update());
+                result = target.replace(result, merged);
+            }
+        }
+        return result;
+    }
+
+    private static JsonValue merge(
+        JsonValue existing,
+        JsonValue update)
+    {
+        JsonValue merged;
+        if (existing.getValueType() == JsonValue.ValueType.OBJECT && update.getValueType() == JsonValue.ValueType.OBJECT)
+        {
+            JsonObject existingObject = existing.asJsonObject();
+            JsonObjectBuilder builder = Json.createObjectBuilder(existingObject);
+            for (Map.Entry<String, JsonValue> entry : update.asJsonObject().entrySet())
+            {
+                JsonValue existingChild = existingObject.get(entry.getKey());
+                JsonValue mergedChild = existingChild != null ? merge(existingChild, entry.getValue()) : entry.getValue();
+                builder.add(entry.getKey(), mergedChild);
+            }
+            merged = builder.build();
+        }
+        else if (existing.getValueType() == JsonValue.ValueType.ARRAY)
+        {
+            merged = Json.createArrayBuilder(existing.asJsonArray()).add(update).build();
+        }
+        else
+        {
+            merged = update;
+        }
+        return merged;
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlayAction.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlayAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import jakarta.json.JsonValue;
+
+/**
+ * A single action of an OpenAPI Overlay Specification (1.0.0) document: a JSONPath
+ * {@code target} paired with either an {@code update} value to merge/append/replace at each
+ * matched node, or a {@code remove} flag to delete each matched node from its containing
+ * object or array. When {@code remove} is {@code true}, {@code update} is ignored.
+ */
+public final class JsonOverlayAction
+{
+    private final String target;
+    private final JsonValue update;
+    private final boolean remove;
+
+    public JsonOverlayAction(
+        String target,
+        JsonValue update,
+        boolean remove)
+    {
+        this.target = target;
+        this.update = update;
+        this.remove = remove;
+    }
+
+    public String target()
+    {
+        return target;
+    }
+
+    public JsonValue update()
+    {
+        return update;
+    }
+
+    public boolean remove()
+    {
+        return remove;
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPath.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPath.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+/**
+ * A restricted JSONPath (RFC 9535) expression evaluator, compiled once and matched against a
+ * {@link JsonValue} document tree to yield RFC 6901 JSON Pointer strings for each matched node.
+ * <p>
+ * Only the subset of JSONPath needed to express OpenAPI Overlay Specification targets is
+ * supported: the root selector ({@code $}), dot and bracket member selectors (including
+ * single- or double-quoted bracket names for keys containing reserved characters), integer
+ * array indices (including negative indices counted from the end), and the wildcard selector
+ * ({@code .*} or {@code [*]}) over object values or array elements. Descendant segments,
+ * filter expressions, slices and unions are not supported.
+ */
+public final class JsonPath
+{
+    private final List<Segment> segments;
+
+    private JsonPath(
+        List<Segment> segments)
+    {
+        this.segments = segments;
+    }
+
+    public static JsonPath compile(
+        String expression)
+    {
+        return new JsonPath(new Parser(expression).parse());
+    }
+
+    public List<String> matches(
+        JsonValue root)
+    {
+        List<List<String>> matched = new ArrayList<>();
+        match(root, 0, new ArrayList<>(), matched);
+
+        List<String> pointers = new ArrayList<>(matched.size());
+        for (List<String> tokens : matched)
+        {
+            pointers.add(toPointer(tokens));
+        }
+        return pointers;
+    }
+
+    private void match(
+        JsonValue node,
+        int index,
+        List<String> path,
+        List<List<String>> matched)
+    {
+        if (index == segments.size())
+        {
+            matched.add(new ArrayList<>(path));
+        }
+        else
+        {
+            segments.get(index).match(node, (token, child) ->
+            {
+                path.add(token);
+                match(child, index + 1, path, matched);
+                path.remove(path.size() - 1);
+            });
+        }
+    }
+
+    private static String toPointer(
+        List<String> tokens)
+    {
+        StringBuilder pointer = new StringBuilder();
+        for (String token : tokens)
+        {
+            pointer.append('/').append(escape(token));
+        }
+        return pointer.toString();
+    }
+
+    private static String escape(
+        String token)
+    {
+        return token.indexOf('~') == -1 && token.indexOf('/') == -1
+            ? token
+            : token.replace("~", "~0").replace("/", "~1");
+    }
+
+    @FunctionalInterface
+    private interface Segment
+    {
+        void match(
+            JsonValue node,
+            BiConsumer<String, JsonValue> emit);
+    }
+
+    private static final class NameSegment implements Segment
+    {
+        private final String name;
+
+        private NameSegment(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public void match(
+            JsonValue node,
+            BiConsumer<String, JsonValue> emit)
+        {
+            if (node.getValueType() == JsonValue.ValueType.OBJECT)
+            {
+                JsonObject object = node.asJsonObject();
+                if (object.containsKey(name))
+                {
+                    emit.accept(name, object.get(name));
+                }
+            }
+        }
+    }
+
+    private static final class IndexSegment implements Segment
+    {
+        private final int index;
+
+        private IndexSegment(
+            int index)
+        {
+            this.index = index;
+        }
+
+        @Override
+        public void match(
+            JsonValue node,
+            BiConsumer<String, JsonValue> emit)
+        {
+            if (node.getValueType() == JsonValue.ValueType.ARRAY)
+            {
+                JsonArray array = node.asJsonArray();
+                int resolved = index >= 0 ? index : array.size() + index;
+                if (resolved >= 0 && resolved < array.size())
+                {
+                    emit.accept(String.valueOf(resolved), array.get(resolved));
+                }
+            }
+        }
+    }
+
+    private static final class WildcardSegment implements Segment
+    {
+        @Override
+        public void match(
+            JsonValue node,
+            BiConsumer<String, JsonValue> emit)
+        {
+            if (node.getValueType() == JsonValue.ValueType.OBJECT)
+            {
+                node.asJsonObject().forEach(emit::accept);
+            }
+            else if (node.getValueType() == JsonValue.ValueType.ARRAY)
+            {
+                JsonArray array = node.asJsonArray();
+                for (int i = 0; i < array.size(); i++)
+                {
+                    emit.accept(String.valueOf(i), array.get(i));
+                }
+            }
+        }
+    }
+
+    private static final class Parser
+    {
+        private final String expression;
+        private int position;
+
+        private Parser(
+            String expression)
+        {
+            this.expression = expression;
+        }
+
+        private List<Segment> parse()
+        {
+            if (expression.isEmpty() || expression.charAt(0) != '$')
+            {
+                throw new IllegalArgumentException("JSONPath expression must start with '$': " + expression);
+            }
+            position = 1;
+
+            List<Segment> segments = new ArrayList<>();
+            while (position < expression.length())
+            {
+                char c = expression.charAt(position);
+                if (c == '.')
+                {
+                    position++;
+                    segments.add(parseDotSegment());
+                }
+                else if (c == '[')
+                {
+                    segments.add(parseBracketSegment());
+                }
+                else
+                {
+                    throw new IllegalArgumentException("Unexpected character at " + position + " in: " + expression);
+                }
+            }
+            return segments;
+        }
+
+        private Segment parseDotSegment()
+        {
+            Segment segment;
+            if (position < expression.length() && expression.charAt(position) == '*')
+            {
+                position++;
+                segment = new WildcardSegment();
+            }
+            else
+            {
+                int start = position;
+                while (position < expression.length() && isNameChar(expression.charAt(position)))
+                {
+                    position++;
+                }
+                if (position == start)
+                {
+                    throw new IllegalArgumentException("Expected property name at " + position + " in: " + expression);
+                }
+                segment = new NameSegment(expression.substring(start, position));
+            }
+            return segment;
+        }
+
+        private Segment parseBracketSegment()
+        {
+            position++;
+            if (position >= expression.length())
+            {
+                throw new IllegalArgumentException("Unterminated '[' in: " + expression);
+            }
+
+            char c = expression.charAt(position);
+            Segment segment;
+            if (c == '\'' || c == '"')
+            {
+                segment = new NameSegment(parseQuotedName(c));
+            }
+            else if (c == '*')
+            {
+                position++;
+                segment = new WildcardSegment();
+            }
+            else
+            {
+                segment = new IndexSegment(parseIndex());
+            }
+
+            if (position >= expression.length() || expression.charAt(position) != ']')
+            {
+                throw new IllegalArgumentException("Expected ']' at " + position + " in: " + expression);
+            }
+            position++;
+
+            return segment;
+        }
+
+        private String parseQuotedName(
+            char quote)
+        {
+            position++;
+            int start = position;
+            while (position < expression.length() && expression.charAt(position) != quote)
+            {
+                position++;
+            }
+            if (position >= expression.length())
+            {
+                throw new IllegalArgumentException("Unterminated quoted name in: " + expression);
+            }
+            String name = expression.substring(start, position);
+            position++;
+            return name;
+        }
+
+        private int parseIndex()
+        {
+            int start = position;
+            if (position < expression.length() && expression.charAt(position) == '-')
+            {
+                position++;
+            }
+            while (position < expression.length() && Character.isDigit(expression.charAt(position)))
+            {
+                position++;
+            }
+            if (position == start || position == start + 1 && expression.charAt(start) == '-')
+            {
+                throw new IllegalArgumentException("Expected array index at " + position + " in: " + expression);
+            }
+            return Integer.parseInt(expression.substring(start, position));
+        }
+
+        private static boolean isNameChar(
+            char c)
+        {
+            return Character.isLetterOrDigit(c) || c == '_' || c == '-';
+        }
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonOverlayTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonOverlayTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.List;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+
+import org.junit.jupiter.api.Test;
+
+class JsonOverlayTest
+{
+    @Test
+    void shouldMergeUpdateIntoMatchedObject()
+    {
+        JsonValue document = read("{\"info\":{\"title\":\"a\",\"version\":\"1.0\"}}");
+        JsonOverlayAction action = new JsonOverlayAction("$.info", read("{\"version\":\"2.0\"}"), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"info\":{\"title\":\"a\",\"version\":\"2.0\"}}", result.toString());
+    }
+
+    @Test
+    void shouldRecursivelyMergeNestedObjects()
+    {
+        JsonValue document = read("{\"a\":{\"b\":{\"x\":1,\"y\":2},\"c\":3}}");
+        JsonOverlayAction action = new JsonOverlayAction("$.a", read("{\"b\":{\"y\":9}}"), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"a\":{\"b\":{\"x\":1,\"y\":9},\"c\":3}}", result.toString());
+    }
+
+    @Test
+    void shouldAddNewPropertyWhenMerging()
+    {
+        JsonValue document = read("{\"info\":{\"title\":\"a\"}}");
+        JsonOverlayAction action = new JsonOverlayAction("$.info", read("{\"version\":\"2.0\"}"), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"info\":{\"title\":\"a\",\"version\":\"2.0\"}}", result.toString());
+    }
+
+    @Test
+    void shouldReplaceScalarWhenTargetIsScalar()
+    {
+        JsonValue document = read("{\"info\":{\"title\":\"a\",\"version\":\"1.0\"}}");
+        JsonOverlayAction action = new JsonOverlayAction("$.info.version", read("\"2.0\""), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"info\":{\"title\":\"a\",\"version\":\"2.0\"}}", result.toString());
+    }
+
+    @Test
+    void shouldAppendUpdateEntryToMatchedArray()
+    {
+        JsonValue document = read("{\"tags\":[\"a\",\"b\"]}");
+        JsonOverlayAction action = new JsonOverlayAction("$.tags", read("\"c\""), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"tags\":[\"a\",\"b\",\"c\"]}", result.toString());
+    }
+
+    @Test
+    void shouldApplyUpdateToEveryWildcardMatchedObject()
+    {
+        JsonValue document = read("{\"paths\":{\"/a\":{\"get\":{}},\"/b\":{\"get\":{}}}}");
+        JsonOverlayAction action = new JsonOverlayAction("$.paths[*].get", read("{\"deprecated\":true}"), false);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"paths\":{\"/a\":{\"get\":{\"deprecated\":true}},\"/b\":{\"get\":{\"deprecated\":true}}}}",
+            result.toString());
+    }
+
+    @Test
+    void shouldRemoveMatchedObjectProperty()
+    {
+        JsonValue document = read("{\"a\":1,\"b\":2}");
+        JsonOverlayAction action = new JsonOverlayAction("$.b", null, true);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"a\":1}", result.toString());
+    }
+
+    @Test
+    void shouldRemoveMatchedArrayItem()
+    {
+        JsonValue document = read("{\"items\":[\"a\",\"b\",\"c\"]}");
+        JsonOverlayAction action = new JsonOverlayAction("$.items[1]", null, true);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"items\":[\"a\",\"c\"]}", result.toString());
+    }
+
+    @Test
+    void shouldReEvaluateTargetAgainstTheEvolvingDocumentForEachAction()
+    {
+        JsonValue document = read("{\"items\":[\"a\",\"b\",\"c\",\"d\"]}");
+        JsonOverlayAction removeIndex2 = new JsonOverlayAction("$.items[2]", null, true);
+        JsonOverlayAction removeIndex0OfRemainder = new JsonOverlayAction("$.items[0]", null, true);
+
+        JsonValue result = JsonOverlay.of(List.of(removeIndex2, removeIndex0OfRemainder)).apply(document);
+
+        assertEquals("{\"items\":[\"b\",\"d\"]}", result.toString());
+    }
+
+    @Test
+    void shouldRemoveAllWildcardMatchesInSingleActionHighestIndexFirst()
+    {
+        JsonValue document = read("{\"items\":[\"a\",\"b\",\"c\",\"d\"]}");
+        JsonOverlayAction action = new JsonOverlayAction("$.items[*]", null, true);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{\"items\":[]}", result.toString());
+    }
+
+    @Test
+    void shouldBeNoOpWhenTargetDoesNotMatch()
+    {
+        JsonValue document = read("{\"a\":1}");
+        JsonOverlayAction update = new JsonOverlayAction("$.missing", read("{\"x\":1}"), false);
+        JsonOverlayAction remove = new JsonOverlayAction("$.alsoMissing", null, true);
+
+        JsonValue result = JsonOverlay.of(List.of(update, remove)).apply(document);
+
+        assertEquals("{\"a\":1}", result.toString());
+    }
+
+    @Test
+    void shouldApplyActionsInOrderSoLaterActionsSeeEarlierEdits()
+    {
+        JsonValue document = read("{}");
+        JsonOverlayAction first = new JsonOverlayAction("$", read("{\"info\":{\"title\":\"a\"}}"), false);
+        JsonOverlayAction second = new JsonOverlayAction("$.info", read("{\"version\":\"1.0\"}"), false);
+
+        JsonValue result = JsonOverlay.of(List.of(first, second)).apply(document);
+
+        assertEquals("{\"info\":{\"title\":\"a\",\"version\":\"1.0\"}}", result.toString());
+    }
+
+    @Test
+    void shouldParseOverlayDocumentAndApplyActionsInOrder()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.0.0\",\"info\":{\"title\":\"t\",\"version\":\"1.0\"}," +
+            "\"actions\":[" +
+                "{\"target\":\"$.info\",\"update\":{\"version\":\"2.0\"}}," +
+                "{\"target\":\"$.deprecated\",\"remove\":true}" +
+            "]}");
+        JsonValue document = read("{\"info\":{\"title\":\"a\",\"version\":\"1.0\"},\"deprecated\":true}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"info\":{\"title\":\"a\",\"version\":\"2.0\"}}", result.toString());
+    }
+
+    @Test
+    void shouldRejectOverlayDocumentMissingVersion()
+    {
+        JsonValue overlayDoc = read(
+            "{\"info\":{\"title\":\"t\",\"version\":\"1.0\"},\"actions\":[{\"target\":\"$\",\"remove\":true}]}");
+
+        assertThrows(IllegalArgumentException.class, () -> JsonOverlay.of(overlayDoc));
+    }
+
+    @Test
+    void shouldRejectOverlayDocumentWithNoActions()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.0.0\",\"info\":{\"title\":\"t\",\"version\":\"1.0\"},\"actions\":[]}");
+
+        assertThrows(IllegalArgumentException.class, () -> JsonOverlay.of(overlayDoc));
+    }
+
+    @Test
+    void shouldTreatRemoveTrueAsTakingPrecedenceOverUpdate()
+    {
+        JsonValue document = read("{\"a\":1}");
+        JsonOverlayAction action = new JsonOverlayAction("$.a", read("2"), true);
+
+        JsonValue result = JsonOverlay.of(List.of(action)).apply(document);
+
+        assertEquals("{}", result.toString());
+        assertTrue(action.remove());
+    }
+
+    private static JsonValue read(
+        String text)
+    {
+        return Json.createReader(new StringReader(text)).readValue();
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPathTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.StringReader;
+import java.util.List;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+
+import org.junit.jupiter.api.Test;
+
+class JsonPathTest
+{
+    @Test
+    void shouldMatchRootOnly()
+    {
+        assertEquals(List.of(""), matches("$", "{\"a\":1}"));
+    }
+
+    @Test
+    void shouldMatchTopLevelProperty()
+    {
+        assertEquals(List.of("/name"), matches("$.name", "{\"name\":\"x\",\"other\":2}"));
+    }
+
+    @Test
+    void shouldMatchNestedProperty()
+    {
+        assertEquals(List.of("/a/b"), matches("$.a.b", "{\"a\":{\"b\":1,\"c\":2}}"));
+    }
+
+    @Test
+    void shouldNotMatchMissingProperty()
+    {
+        assertEquals(List.of(), matches("$.missing", "{\"a\":1}"));
+    }
+
+    @Test
+    void shouldMatchQuotedBracketPropertyContainingSlash()
+    {
+        assertEquals(List.of("/paths/~1pets"), matches("$.paths['/pets']", "{\"paths\":{\"/pets\":{}}}"));
+    }
+
+    @Test
+    void shouldMatchDoubleQuotedBracketProperty()
+    {
+        assertEquals(List.of("/a"), matches("$[\"a\"]", "{\"a\":1}"));
+    }
+
+    @Test
+    void shouldMatchArrayIndex()
+    {
+        assertEquals(List.of("/items/1"), matches("$.items[1]", "{\"items\":[\"a\",\"b\",\"c\"]}"));
+    }
+
+    @Test
+    void shouldMatchNegativeArrayIndexFromEnd()
+    {
+        assertEquals(List.of("/items/2"), matches("$.items[-1]", "{\"items\":[\"a\",\"b\",\"c\"]}"));
+    }
+
+    @Test
+    void shouldNotMatchOutOfBoundsArrayIndex()
+    {
+        assertEquals(List.of(), matches("$.items[5]", "{\"items\":[\"a\",\"b\",\"c\"]}"));
+    }
+
+    @Test
+    void shouldMatchObjectWildcardTopLevel()
+    {
+        assertEquals(List.of("/a", "/b"), matches("$.*", "{\"a\":1,\"b\":2}"));
+    }
+
+    @Test
+    void shouldMatchArrayWildcard()
+    {
+        assertEquals(List.of("/items/0", "/items/1"), matches("$.items[*]", "{\"items\":[10,20]}"));
+    }
+
+    @Test
+    void shouldMatchBracketWildcard()
+    {
+        assertEquals(List.of("/a", "/b"), matches("$[*]", "{\"a\":1,\"b\":2}"));
+    }
+
+    @Test
+    void shouldMatchChainedSegmentsAcrossWildcardAndBracket()
+    {
+        assertEquals(List.of("/paths/~1pets/get/parameters/0/name", "/paths/~1pets/get/parameters/1/name"),
+            matches("$.paths['/pets'].get.parameters[*].name",
+                "{\"paths\":{\"/pets\":{\"get\":{\"parameters\":" +
+                    "[{\"name\":\"limit\"},{\"name\":\"offset\"}]}}}}"));
+    }
+
+    @Test
+    void shouldStopDescendingIntoScalarWhenDeeperSegmentRemains()
+    {
+        assertEquals(List.of(), matches("$.a.b", "{\"a\":5}"));
+    }
+
+    @Test
+    void shouldRejectExpressionNotStartingWithRoot()
+    {
+        assertThrows(IllegalArgumentException.class, () -> JsonPath.compile("a.b"));
+    }
+
+    @Test
+    void shouldRejectUnterminatedBracket()
+    {
+        assertThrows(IllegalArgumentException.class, () -> JsonPath.compile("$.items[0"));
+    }
+
+    @Test
+    void shouldRejectUnterminatedQuotedBracket()
+    {
+        assertThrows(IllegalArgumentException.class, () -> JsonPath.compile("$['a"));
+    }
+
+    private static List<String> matches(
+        String expression,
+        String document)
+    {
+        JsonValue root = Json.createReader(new StringReader(document)).readValue();
+        return JsonPath.compile(expression).matches(root);
+    }
+}

--- a/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiSpecificationConfig.java
+++ b/runtime/common-openapi/src/main/java/io/aklivity/zilla/runtime/common/openapi/config/OpenapiSpecificationConfig.java
@@ -26,6 +26,23 @@ public class OpenapiSpecificationConfig
     public final List<OpenapiServerConfig> servers;
     public final List<OpenapiCatalogConfig> catalogs;
     public final Map<String, String> security;
+    public final OpenapiCatalogConfig overlay;
+
+    public OpenapiSpecificationConfig(
+        String label,
+        String server,
+        List<OpenapiServerConfig> servers,
+        List<OpenapiCatalogConfig> catalogs,
+        Map<String, String> security,
+        OpenapiCatalogConfig overlay)
+    {
+        this.label = label;
+        this.server = server;
+        this.servers = servers;
+        this.catalogs = catalogs;
+        this.security = security;
+        this.overlay = overlay;
+    }
 
     public OpenapiSpecificationConfig(
         String label,
@@ -34,11 +51,7 @@ public class OpenapiSpecificationConfig
         List<OpenapiCatalogConfig> catalogs,
         Map<String, String> security)
     {
-        this.label = label;
-        this.server = server;
-        this.servers = servers;
-        this.catalogs = catalogs;
-        this.security = security;
+        this(label, server, servers, catalogs, security, null);
     }
 
     public OpenapiSpecificationConfig(
@@ -47,7 +60,7 @@ public class OpenapiSpecificationConfig
         List<OpenapiServerConfig> servers,
         List<OpenapiCatalogConfig> catalogs)
     {
-        this(label, server, servers, catalogs, null);
+        this(label, server, servers, catalogs, null, null);
     }
 
     public OpenapiSpecificationConfig(
@@ -55,13 +68,13 @@ public class OpenapiSpecificationConfig
         List<OpenapiServerConfig> servers,
         List<OpenapiCatalogConfig> catalogs)
     {
-        this(label, null, servers, catalogs, null);
+        this(label, null, servers, catalogs, null, null);
     }
 
     public OpenapiSpecificationConfig(
         String apiLabel,
         List<OpenapiCatalogConfig> catalogs)
     {
-        this(apiLabel, null, emptyList(), catalogs, null);
+        this(apiLabel, null, emptyList(), catalogs, null, null);
     }
 }

--- a/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/schema/openapi.schema.patch.json
+++ b/specs/binding-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/schema/openapi.schema.patch.json
@@ -129,6 +129,36 @@
                                                     },
                                                     "additionalProperties": false
                                                 }
+                                            },
+                                            "overlay":
+                                            {
+                                                "title": "Overlay",
+                                                "type": "object",
+                                                "patternProperties":
+                                                {
+                                                    "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                    {
+                                                        "type": "object",
+                                                        "properties":
+                                                        {
+                                                            "subject":
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            "version":
+                                                            {
+                                                                "type": "string",
+                                                                "default": "latest"
+                                                            }
+                                                        },
+                                                        "required":
+                                                        [
+                                                            "subject"
+                                                        ],
+                                                        "additionalProperties": false
+                                                    },
+                                                    "additionalProperties": false
+                                                }
                                             }
                                         },
                                         "additionalProperties": false


### PR DESCRIPTION
## Description

Implements the JSONPath-targeted actions engine from the OpenAPI Overlay Specification (1.0.0) and wires it into `binding-openapi` as the reference integration.

**`common-json` (new, generic, protocol-agnostic):**
- `JsonPath` — a JSONPath (RFC 9535) subset scoped to exactly what Overlay targets need: root (`$`), dot/bracket member access (including quoted keys for reserved characters), integer array indices (including negative, counted from the end), and wildcards (`.*` / `[*]`). No JSONPath library dependency is added — the runtime module system forbids non-modular dependencies anywhere in `runtime/`, and most JSONPath libraries ship as automatic modules, so the small subset is hand-rolled instead, consistent with how this module already hand-rolls its own `JsonProvider`/JSON-Schema engine rather than depending on external libraries.
- `JsonOverlay` / `JsonOverlayAction` — applies a sequence of Overlay actions to a `JsonValue` document. `update` recursively merges into a matched object, appends to a matched array, or replaces a matched scalar; `remove` deletes matched nodes (highest array index first, so one wildcard-matched removal doesn't corrupt later indices). Each action's `target` is re-evaluated against the document as edited by prior actions. Built on this module's existing `JsonPatch`/`JsonPointer` support — no new machinery needed there.
- 33 new unit tests (`JsonPathTest`, `JsonOverlayTest`).

**`binding-openapi` (reference wiring):**
- New `options.specs.<label>.overlay` config, shaped identically to the existing `specs.<label>.catalog` reference (`{ <catalogName>: { subject, version } }`) and resolved through the same `CatalogHandler`.
- Applied in `OpenapiCompositeGenerator` at the seam described in the issue — between resolving the raw spec payload and `parser.parse()` — via `YamlJson` (to handle YAML or JSON spec text) and `JsonOverlay`.
- `common-openapi`'s shared `OpenapiSpecificationConfig` gets a new (additive, backward-compatible) `overlay` field; existing callers in `binding-openapi-asyncapi` are unaffected.
- JSON schema patch, config adapter, module-info/pom dependency updates, and new tests: `OpenapiOptionsConfigAdapterTest` (read/write round-trip) and `OpenapiServerGeneratorTest.shouldApplyOverlayBeforeGeneratingRoutes` (proves an overlay-added path reaches the generated composite).

**Scoped out of this PR:** wiring the same `overlay` field into `binding-asyncapi`, `binding-openapi-asyncapi`, and `binding-mcp-openapi`. The mechanism and config shape are established here; extending to the other three bindings is mechanical repetition of this pattern, called out as follow-up so an unreviewed config-surface decision doesn't spread across four public schemas in one shot.

Fixes #2127

## Test plan

- [x] `./mvnw test -pl runtime/common-json` — 33 new tests pass, no regressions (4916 total)
- [x] `./mvnw test -pl runtime/binding-openapi` — new adapter + generator tests pass, no regressions (20 total)
- [x] `./mvnw test -pl runtime/common-openapi,runtime/binding-openapi-asyncapi,runtime/binding-mcp-openapi` — unaffected, no regressions
- [x] `./mvnw checkstyle:check` clean on all touched modules
- [x] `./mvnw clean install -pl runtime/binding-openapi` — confirms `module-info.java` change produces a valid modular jar
