### PR TITLE
fix(engine): stop readonly Engine attach from zeroing live event ring buffers

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -177,7 +177,7 @@ public final class Engine implements Collector, AutoCloseable
         }
         this.tuning = tuning;
 
-        this.eventWriter = new EventWriter(config.directory().resolve("events"), config.eventsBufferCapacity());
+        this.eventWriter = new EventWriter(config.directory().resolve("events"), config.eventsBufferCapacity(), readonly);
 
         this.boss = new EngineBoss(config, diagnoseOnError, bindings);
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
@@ -120,7 +120,7 @@ public final class Info implements AutoCloseable
                 {
                     byte[] bytes = Files.readAllBytes(path);
                     ByteBuffer byteBuf = ByteBuffer
-                        .wrap(bytes, Long.BYTES, SIZEOF_INFO)
+                        .wrap(bytes, Long.BYTES, SIZEOF_INFO - Long.BYTES)
                         .order(nativeOrder());
 
                     Instant startTime =

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
@@ -37,14 +37,17 @@ public final class EventWriter implements AutoCloseable
     private final Path basePath;
     private final List<EventAccessor> accessors;
     private final Supplier<String> timestamp;
+    private final boolean readonly;
 
     private EventWriterEntry activeEntry;
 
     public EventWriter(
         Path basePath,
-        long capacity)
+        long capacity,
+        boolean readonly)
     {
         this.basePath = basePath;
+        this.readonly = readonly;
         this.activeEntry = new EventWriterEntry(basePath, capacity);
         this.accessors = new ArrayList<>();
 
@@ -106,6 +109,7 @@ public final class EventWriter implements AutoCloseable
             this.layout = new EventsLayout.Builder()
                 .path(path)
                 .capacity(capacity)
+                .readonly(readonly)
                 .build();
         }
 
@@ -147,6 +151,7 @@ public final class EventWriter implements AutoCloseable
                 layout = new EventsLayout.Builder()
                     .path(path)
                     .capacity(capacity)
+                    .readonly(readonly)
                     .build();
                 return this;
             }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
@@ -81,6 +81,7 @@ public final class EventsLayout implements AutoCloseable
     {
         private long capacity;
         private Path path;
+        private boolean readonly;
 
         public Builder capacity(
             long capacity)
@@ -96,10 +97,20 @@ public final class EventsLayout implements AutoCloseable
             return this;
         }
 
+        public Builder readonly(
+            boolean readonly)
+        {
+            this.readonly = readonly;
+            return this;
+        }
+
         public EventsLayout build()
         {
             final File layoutFile = path.toFile();
-            CloseHelper.close(createEmptyFile(layoutFile, capacity + RingBufferDescriptor.TRAILER_LENGTH));
+            if (!readonly)
+            {
+                CloseHelper.close(createEmptyFile(layoutFile, capacity + RingBufferDescriptor.TRAILER_LENGTH));
+            }
             final MappedByteBuffer mappedBuffer = mapExistingFile(layoutFile, "events");
             final AtomicBufferEx atomicBuffer = new UnsafeBufferEx(mappedBuffer).asNative();
             final RingBufferEx ringBuffer = new OneToOneRingBuffer(atomicBuffer);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -372,7 +372,8 @@ public class EngineWorker implements EngineContext, Agent
 
         this.eventWriter = new EventWriter(
                 config.directory().resolve(String.format("events%d", index)),
-                config.eventsBufferCapacity());
+                config.eventsBufferCapacity(),
+                readonly);
 
         this.eventNames = new Int2ObjectHashMap<>();
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +39,7 @@ import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
 import io.aklivity.zilla.runtime.engine.ext.EngineExtContext;
 import io.aklivity.zilla.runtime.engine.ext.EngineExtSpi;
+import io.aklivity.zilla.runtime.engine.internal.event.EngineEventContext;
 
 public class EngineTest
 {
@@ -348,6 +350,45 @@ public class EngineTest
         {
             assertThat(errors, empty());
         }
+    }
+
+    @Test
+    public void shouldPreserveEventsWhenAttachingReadonlyEngine()
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+            new EngineEventContext(engine).started();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCount = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCount[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
+        assertThat(eventCount[0], greaterThan(0));
     }
 
     public static final class TestEngineExt implements EngineExtSpi

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class InfoTest
+{
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void shouldReadInfoWrittenByLiveEngine() throws Exception
+    {
+        // GIVEN
+        Path directory = folder.getRoot().toPath();
+        try (Info written = new Info.Builder()
+            .directory(directory)
+            .workers(4)
+            .readonly(false)
+            .build())
+        {
+            assertThat(written.workers(), equalTo(4));
+        }
+
+        // WHEN
+        try (Info read = new Info.Builder()
+            .directory(directory)
+            .readonly(true)
+            .build())
+        {
+            // THEN
+            assertThat(read.workers(), equalTo(4));
+        }
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
@@ -48,7 +48,7 @@ public class EventWriterTest
     {
         Path path = tempFolder.getRoot().toPath().resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             writer.writeEvent(42, new UnsafeBufferEx(), 0, 0);
             msgTypeId = 0;
@@ -67,7 +67,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             EventAccessor accessor = writer.createEventAccessor();
 
@@ -109,7 +109,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             EventAccessor accessor1 = writer.createEventAccessor();
             EventAccessor accessor2 = writer.createEventAccessor();
@@ -152,7 +152,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        EventWriter writer = new EventWriter(path, CAPACITY);
+        EventWriter writer = new EventWriter(path, CAPACITY, false);
         writer.createEventAccessor();
 
         // fill buffer and trigger rotation — accessor has not drained the rotated entry


### PR DESCRIPTION
## Description

`EventsLayout.Builder.build()` unconditionally zero-filled the shared events ring buffer file on every `Engine` construction, unlike every sibling layout (`StreamsLayout`, `BufferPoolLayout`, the metrics layouts) which already gate file creation behind `readonly`. As a result, attaching **any** readonly `Engine` to a running instance&#39;s directory — including the existing `zilla metrics` command — wiped out already-recorded events (e.g. `engine.started`) and desynced the live engine&#39;s in-memory ring buffer position from the file&#39;s on-disk trailer.

This also fixes a related bug in `Info.Builder`&#39;s readonly read path: it wrapped `SIZEOF_INFO` bytes starting at offset `Long.BYTES`, which requires the `info` file to be `Long.BYTES` longer than what the write path actually persists — throwing `IndexOutOfBoundsException` on every readonly attach.

Both fixes thread `readonly` through in the same shape the sibling layouts already use (`readonly(boolean)` builder method, gating `createEmptyFile`), so there&#39;s no new pattern introduced.

### How this was found

While implementing a new `zilla logs --wait-for ` command (for #2131, to give Docker healthchecks a reliable readiness signal instead of a bare TCP-connect probe), a readonly attach never observed `engine.started` even though the live engine&#39;s own verbose stdout logging showed it had already fired. Tracing it down to `Engine`&#39;s constructor unconditionally reconstructing/zero-filling the shared events ring buffer file exposed this as a pre-existing bug independent of that feature work — reproduced here with a standalone regression test, without any dependency on the `zilla logs` command itself.

### Testing

- Added `InfoTest.shouldReadInfoWrittenByLiveEngine` — writes an `Info` via a live (non-readonly) instance, then confirms a fresh readonly attach reads it back correctly. Fails with `IndexOutOfBoundsException` without the fix.
- Added `EngineTest.shouldPreserveEventsWhenAttachingReadonlyEngine` — starts an engine, records a real `engine.started` event via `EngineEventContext`, closes it, then attaches a second readonly `Engine` to the same directory and confirms the event is still readable. Fails (reads zero events) without the fix.
- `./mvnw verify` passes locally for `runtime/engine` (207 ITs + unit tests + JaCoCo).

Fixes #2137


---
_Generated by [Claude Code](https://claude.ai/code/session_015gEjFBcrpmGxgfvigBdCSa)_