### PR TITLE
fix(engine): stop readonly Engine attach from zeroing live event ring buffers (backport)

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -176,7 +176,7 @@ public final class Engine implements Collector, AutoCloseable
         }
         this.tuning = tuning;
 
-        this.eventWriter = new EventWriter(config.directory().resolve("events"), config.eventsBufferCapacity());
+        this.eventWriter = new EventWriter(config.directory().resolve("events"), config.eventsBufferCapacity(), readonly);
 
         this.boss = new EngineBoss(config, diagnoseOnError, bindings);
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/Info.java
@@ -120,7 +120,7 @@ public final class Info implements AutoCloseable
                 {
                     byte[] bytes = Files.readAllBytes(path);
                     ByteBuffer byteBuf = ByteBuffer
-                        .wrap(bytes, Long.BYTES, SIZEOF_INFO)
+                        .wrap(bytes, Long.BYTES, SIZEOF_INFO - Long.BYTES)
                         .order(nativeOrder());
 
                     Instant startTime =

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriter.java
@@ -38,14 +38,17 @@ public final class EventWriter implements AutoCloseable
     private final Path basePath;
     private final List<EventAccessor> accessors;
     private final Supplier<String> timestamp;
+    private final boolean readonly;
 
     private EventWriterEntry activeEntry;
 
     public EventWriter(
         Path basePath,
-        long capacity)
+        long capacity,
+        boolean readonly)
     {
         this.basePath = basePath;
+        this.readonly = readonly;
         this.activeEntry = new EventWriterEntry(basePath, capacity);
         this.accessors = new ArrayList<>();
 
@@ -107,6 +110,7 @@ public final class EventWriter implements AutoCloseable
             this.layout = new EventsLayout.Builder()
                 .path(path)
                 .capacity(capacity)
+                .readonly(readonly)
                 .build();
         }
 
@@ -148,6 +152,7 @@ public final class EventWriter implements AutoCloseable
                 layout = new EventsLayout.Builder()
                     .path(path)
                     .capacity(capacity)
+                    .readonly(readonly)
                     .build();
                 return this;
             }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/layouts/EventsLayout.java
@@ -81,6 +81,7 @@ public final class EventsLayout implements AutoCloseable
     {
         private long capacity;
         private Path path;
+        private boolean readonly;
 
         public Builder capacity(
             long capacity)
@@ -96,10 +97,20 @@ public final class EventsLayout implements AutoCloseable
             return this;
         }
 
+        public Builder readonly(
+            boolean readonly)
+        {
+            this.readonly = readonly;
+            return this;
+        }
+
         public EventsLayout build()
         {
             final File layoutFile = path.toFile();
-            CloseHelper.close(createEmptyFile(layoutFile, capacity + RingBufferDescriptor.TRAILER_LENGTH));
+            if (!readonly)
+            {
+                CloseHelper.close(createEmptyFile(layoutFile, capacity + RingBufferDescriptor.TRAILER_LENGTH));
+            }
             final MappedByteBuffer mappedBuffer = mapExistingFile(layoutFile, "events");
             final AtomicBuffer atomicBuffer = new UnsafeBuffer(mappedBuffer);
             final RingBuffer ringBuffer = new OneToOneRingBuffer(atomicBuffer);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -364,7 +364,8 @@ public class EngineWorker implements EngineContext, Agent
 
         this.eventWriter = new EventWriter(
                 config.directory().resolve(String.format("events%d", index)),
-                config.eventsBufferCapacity());
+                config.eventsBufferCapacity(),
+                readonly);
 
         this.eventNames = new Int2ObjectHashMap<>();
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +39,7 @@ import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageReader;
 import io.aklivity.zilla.runtime.engine.ext.EngineExtContext;
 import io.aklivity.zilla.runtime.engine.ext.EngineExtSpi;
+import io.aklivity.zilla.runtime.engine.internal.event.EngineEventContext;
 
 public class EngineTest
 {
@@ -275,6 +277,45 @@ public class EngineTest
         {
             assertThat(errors, empty());
         }
+    }
+
+    @Test
+    public void shouldPreserveEventsWhenAttachingReadonlyEngine()
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+            new EngineEventContext(engine).started();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCount = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCount[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
+        assertThat(eventCount[0], greaterThan(0));
     }
 
     public static final class TestEngineExt implements EngineExtSpi

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class InfoTest
+{
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void shouldReadInfoWrittenByLiveEngine() throws Exception
+    {
+        // GIVEN
+        Path directory = folder.getRoot().toPath();
+        try (Info written = new Info.Builder()
+            .directory(directory)
+            .workers(4)
+            .readonly(false)
+            .build())
+        {
+            assertThat(written.workers(), equalTo(4));
+        }
+
+        // WHEN
+        try (Info read = new Info.Builder()
+            .directory(directory)
+            .readonly(true)
+            .build())
+        {
+            // THEN
+            assertThat(read.workers(), equalTo(4));
+        }
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/InfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/event/io/EventWriterTest.java
@@ -47,7 +47,7 @@ public class EventWriterTest
     {
         Path path = tempFolder.getRoot().toPath().resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             writer.writeEvent(42, new UnsafeBuffer(), 0, 0);
             msgTypeId = 0;
@@ -66,7 +66,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             EventAccessor accessor = writer.createEventAccessor();
 
@@ -108,7 +108,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        try (EventWriter writer = new EventWriter(path, CAPACITY))
+        try (EventWriter writer = new EventWriter(path, CAPACITY, false))
         {
             EventAccessor accessor1 = writer.createEventAccessor();
             EventAccessor accessor2 = writer.createEventAccessor();
@@ -151,7 +151,7 @@ public class EventWriterTest
         Path dir = tempFolder.getRoot().toPath();
         Path path = dir.resolve("events");
 
-        EventWriter writer = new EventWriter(path, CAPACITY);
+        EventWriter writer = new EventWriter(path, CAPACITY, false);
         writer.createEventAccessor();
 
         // fill buffer and trigger rotation — accessor has not drained the rotated entry


### PR DESCRIPTION
## Description

Backport of #2134 to `support/1.x`, cherry-picked clean (no conflicts) from commit 4278b002361c1f69d65e18b7f8ee81b6ff423dce.

`EventsLayout.Builder.build()` unconditionally zero-filled the shared events ring buffer file on every `Engine` construction, unlike every sibling layout (`StreamsLayout`, `BufferPoolLayout`, the metrics layouts) which already gate file creation behind `readonly`. As a result, attaching any readonly `Engine` to a running instance's directory — including the existing `zilla metrics` command — wiped out already-recorded events (e.g. `engine.started`) and desynced the live engine's in-memory ring buffer position from the file's on-disk trailer.

This also fixes a related bug in `Info.Builder`'s readonly read path: it wrapped `SIZEOF_INFO` bytes starting at offset `Long.BYTES`, which requires the `info` file to be `Long.BYTES` longer than what the write path actually persists — throwing `IndexOutOfBoundsException` on every readonly attach.

Both fixes thread `readonly` through in the same shape the sibling layouts already use (`readonly(boolean)` builder method, gating `createEmptyFile`).

### Testing

- Added `InfoTest.shouldReadInfoWrittenByLiveEngine` — writes an `Info` via a live (non-readonly) instance, then confirms a fresh readonly attach reads it back correctly. Fails with `IndexOutOfBoundsException` without the fix.
- Added `EngineTest.shouldPreserveEventsWhenAttachingReadonlyEngine` — starts an engine, records a real `engine.started` event via `EngineEventContext`, closes it, then attaches a second readonly `Engine` to the same directory and confirms the event is still readable. Fails (reads zero events) without the fix.
- Could not run `./mvnw verify` locally against `support/1.x` in this environment — it depends on a private snapshot artifact (`flyweight-maven-plugin:1.x-SNAPSHOT`) not reachable here; relying on CI to verify.

Fixes #2137

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmXjB6PECyGNBWd3cnYJ8w)_