### PR TITLE
fix(engine): stop readonly Engine close from writing engine.stopped event

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -339,7 +339,10 @@ public final class Engine implements Collector, AutoCloseable
 
         final List<Throwable> errors = new ArrayList<>();
 
-        manager.close();
+        if (!readonly)
+        {
+            manager.close();
+        }
 
         try
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -391,6 +391,61 @@ public class EngineTest
         assertThat(eventCount[0], greaterThan(0));
     }
 
+    @Test
+    public void shouldNotWriteEventWhenClosingReadonlyEngine()
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+            new EngineEventContext(engine).started();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCountBeforeClose = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCountBeforeClose[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCountAfterClose = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCountAfterClose[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
+        assertThat(eventCountAfterClose[0], equalTo(eventCountBeforeClose[0]));
+    }
+
     public static final class TestEngineExt implements EngineExtSpi
     {
         public static volatile CountDownLatch registerLatch = new CountDownLatch(1);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Fixes #2140

## Summary

- `Engine.close()` called `manager.close()` unconditionally, unlike `Engine.start()` which already gates `manager.start()` behind `if (!readonly)`.
- `EngineManager.close()` unconditionally writes an `engine.stopped` event via `events.stopped()`.
- As a result, every readonly `Engine` attach that closes (e.g. `zilla logs`, `zilla metrics`) was injecting a spurious `engine.stopped` event into the live engine's shared event ring buffer, corrupting its event log with events that don't correspond to any real engine lifecycle transition.
- This follow-up to #2134 (readonly attach no longer zeroes the events ring buffer) closes the remaining gap: readonly attach must not *write* to the live engine's state on close either.

Fix: gate `manager.close()` behind `if (!readonly)` in `Engine.close()`, mirroring the existing `start()` gate.

## Test plan

- [x] Added `EngineTest#shouldNotWriteEventWhenClosingReadonlyEngine` — attaches a readonly engine, reads and counts events, closes it, attaches a second readonly engine and counts events again; asserts the count is unchanged (no new event written by the close).
- [x] Verified the new test fails against the pre-fix code (event count off by one, from the spurious `engine.stopped`)
- [x] Verified the new test passes with the fix applied
- [x] `./mvnw test -pl runtime/engine` — full engine unit test suite passes
- [x] `./mvnw checkstyle:check -pl runtime/engine` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_015gEjFBcrpmGxgfvigBdCSa)_