### PR TITLE
fix(engine): stop readonly Engine close from writing engine.stopped event (backport)

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -326,7 +326,10 @@ public final class Engine implements Collector, AutoCloseable
 
         final List<Throwable> errors = new ArrayList<>();
 
-        manager.close();
+        if (!readonly)
+        {
+            manager.close();
+        }
 
         try
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_WORKER_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
@@ -316,6 +317,61 @@ public class EngineTest
 
         assertThat(errors, empty());
         assertThat(eventCount[0], greaterThan(0));
+    }
+
+    @Test
+    public void shouldNotWriteEventWhenClosingReadonlyEngine()
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+            new EngineEventContext(engine).started();
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCountBeforeClose = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCountBeforeClose[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        int[] eventCountAfterClose = { 0 };
+        try (Engine readonlyEngine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .readonly()
+                .build())
+        {
+            readonlyEngine.start();
+            MessageReader events = readonlyEngine.supplyEventReader();
+            events.read((msgTypeId, buffer, index, length) -> eventCountAfterClose[0]++, 10);
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
+        assertThat(eventCountAfterClose[0], equalTo(eventCountBeforeClose[0]));
     }
 
     public static final class TestEngineExt implements EngineExtSpi


### PR DESCRIPTION
## Description

Backport of #2139 to `support/1.x`, cherry-picked from `develop` commit b79d9a0df4d30c18561851d7cfd539638e96dae7. Applied cleanly, no conflicts.

`Engine.close()` called `manager.close()` unconditionally, unlike `Engine.start()` which already gates `manager.start()` behind `if (!readonly)`.

`EngineManager.close()` unconditionally writes an `engine.stopped` event via `events.stopped()`.

As a result, every readonly `Engine` attach that closes (e.g. `zilla logs`, `zilla metrics`) was injecting a spurious `engine.stopped` event into the live engine's shared event ring buffer, corrupting its event log with events that don't correspond to any real engine lifecycle transition.

This follow-up to #2138 (backport of #2134, readonly attach no longer zeroes the events ring buffer) closes the remaining gap: readonly attach must not *write* to the live engine's state on close either.

Fix: gate `manager.close()` behind `if (!readonly)` in `Engine.close()`, mirroring the existing `start()` gate.

Fixes #2140

## Test plan

- [x] `./mvnw test -pl runtime/engine -Dtest=EngineTest` — 11 tests pass, including `shouldNotWriteEventWhenClosingReadonlyEngine`
- [x] `./mvnw checkstyle:check -pl runtime/engine` — clean (ran as part of `test`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9VJJKUB7QJsUsamh6NqkE)_