### PR TITLE
fix(engine): stop readonly Engine attach from resetting the live tuning file

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -167,7 +167,10 @@ public final class Engine implements Collector, AutoCloseable
         IntFunction<ToIntFunction<KindConfig>> maxWorkers = maxWorkersByBindingType::get;
 
         Tuning tuning = new Tuning(config.directory(), workerCount);
-        tuning.reset();
+        if (!readonly)
+        {
+            tuning.reset();
+        }
         for (EngineAffinity affinity : affinities)
         {
             int namespaceId = labels.supplyLabelId(affinity.namespace);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -445,6 +447,43 @@ public class EngineTest
 
         assertThat(errors, empty());
         assertThat(eventCountAfterClose[0], equalTo(eventCountBeforeClose[0]));
+    }
+
+    @Test
+    public void shouldNotResetTuningWhenAttachingReadonlyEngine() throws Exception
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+
+            Path tuning = config.directory().resolve("tuning");
+            Object fileKeyBefore = Files.readAttributes(tuning, "unix:ino").get("ino");
+
+            try (Engine readonlyEngine = Engine.builder()
+                    .config(config)
+                    .errorHandler(errors::add)
+                    .readonly()
+                    .build())
+            {
+                readonlyEngine.start();
+            }
+
+            Object fileKeyAfter = Files.readAttributes(tuning, "unix:ino").get("ino");
+
+            assertThat(fileKeyAfter, equalTo(fileKeyBefore));
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
     }
 
     public static final class TestEngineExt implements EngineExtSpi


### PR DESCRIPTION
Fixes #2143

## Summary

- `Engine`'s constructor called `Tuning.reset()` unconditionally, regardless of the `readonly` flag.
- `Tuning.reset()` deletes the existing `tuning` file and creates a brand new memory-mapped replacement (`Files.deleteIfExists` + `mapCreateReadWrite`, which itself calls `IoUtil.delete` before remapping).
- As a result, every readonly `Engine` attach (`zilla logs`, `zilla metrics`) destroyed the live engine's existing `tuning` mmap out from under it.
- The live engine then crashed with a genuine memory-access fault the next time it wrote a binding affinity through the now-invalid mapping:
  ```
  java.lang.InternalError: a fault occurred in an unsafe memory access operation
      at java.base/jdk.internal.misc.Unsafe.putLong(Native Method)
      ...
      at io.aklivity.zilla.runtime.engine.internal.Tuning.affinity(Tuning.java:108)
      at io.aklivity.zilla.runtime.engine.internal.registry.EngineManager.process(EngineManager.java:533)
  ```
- Reproduced via a real Docker Compose stack: the live engine container reliably crashed and restarted (`RestartCount` incrementing) whenever the `zilla logs` healthcheck ran concurrently with normal config processing.

Fix: gate `tuning.reset()` behind `if (!readonly)`, matching the existing `manager.start()`/`manager.close()` readonly gates and the `EventsLayout`/`EventWriter`/`Info` readonly fixes from #2134/#2139.

## Test plan

- [x] Added `EngineTest#shouldNotResetTuningWhenAttachingReadonlyEngine` — starts a live engine, records the `tuning` file's inode, attaches and closes a readonly engine, then asserts the inode is unchanged (i.e. the file was not deleted/recreated).
- [x] Verified the test fails against the pre-fix code (inode changes on every readonly attach)
- [x] Verified the test passes with the fix applied
- [x] `./mvnw test -pl runtime/engine` — full engine unit test suite passes
- [x] `./mvnw checkstyle:check -pl runtime/engine` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_015gEjFBcrpmGxgfvigBdCSa)_