### PR TITLE
fix(engine): stop readonly Engine attach from resetting the live tuning file (backport)

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -166,7 +166,10 @@ public final class Engine implements Collector, AutoCloseable
         IntFunction<ToIntFunction<KindConfig>> maxWorkers = maxWorkersByBindingType::get;
 
         Tuning tuning = new Tuning(config.directory(), workerCount);
-        tuning.reset();
+        if (!readonly)
+        {
+            tuning.reset();
+        }
         for (EngineAffinity affinity : affinities)
         {
             int namespaceId = labels.supplyLabelId(affinity.namespace);

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -372,6 +374,43 @@ public class EngineTest
 
         assertThat(errors, empty());
         assertThat(eventCountAfterClose[0], equalTo(eventCountBeforeClose[0]));
+    }
+
+    @Test
+    public void shouldNotResetTuningWhenAttachingReadonlyEngine() throws Exception
+    {
+        List<Throwable> errors = new LinkedList<>();
+        EngineConfiguration config = new EngineConfiguration(properties);
+
+        try (Engine engine = Engine.builder()
+                .config(config)
+                .errorHandler(errors::add)
+                .build())
+        {
+            engine.start();
+
+            Path tuning = config.directory().resolve("tuning");
+            Object fileKeyBefore = Files.readAttributes(tuning, "unix:ino").get("ino");
+
+            try (Engine readonlyEngine = Engine.builder()
+                    .config(config)
+                    .errorHandler(errors::add)
+                    .readonly()
+                    .build())
+            {
+                readonlyEngine.start();
+            }
+
+            Object fileKeyAfter = Files.readAttributes(tuning, "unix:ino").get("ino");
+
+            assertThat(fileKeyAfter, equalTo(fileKeyBefore));
+        }
+        catch (Throwable ex)
+        {
+            errors.add(ex);
+        }
+
+        assertThat(errors, empty());
     }
 
     public static final class TestEngineExt implements EngineExtSpi


### PR DESCRIPTION
## Description

Backport of #2142 to `support/1.x`, cherry-picked from `develop` commit 503045d44 (squash-merge commit of #2142). Applied cleanly, no conflicts.

`Engine`'s constructor called `Tuning.reset()` unconditionally, regardless of the `readonly` flag. `Tuning.reset()` deletes the existing `tuning` file and creates a brand new memory-mapped replacement (`Files.deleteIfExists` + `mapCreateReadWrite`, which itself calls `IoUtil.delete` before remapping).

As a result, every readonly `Engine` attach (`zilla logs`, `zilla metrics`) destroyed the live engine's existing `tuning` mmap out from under it. The live engine then crashed with a genuine memory-access fault the next time it wrote a binding affinity through the now-invalid mapping:

```
java.lang.InternalError: a fault occurred in an unsafe memory access operation
    at java.base/jdk.internal.misc.Unsafe.putLong(Native Method)
    ...
    at io.aklivity.zilla.runtime.engine.internal.Tuning.affinity(Tuning.java:108)
    at io.aklivity.zilla.runtime.engine.internal.registry.EngineManager.process(EngineManager.java:533)
```

Fix: gate `tuning.reset()` behind `if (!readonly)`, matching the existing `manager.start()`/`manager.close()` readonly gates and the `EventsLayout`/`EventWriter`/`Info` readonly fixes already backported in #2138/#2141.

Fixes #2143

## Test plan

- [x] `./mvnw clean install -DskipTests` from repo root against `support/1.x` — installs the `1.x-SNAPSHOT` `flyweight-maven-plugin` and all dependent modules locally so `runtime/engine` builds standalone
- [x] `./mvnw test -pl runtime/engine -Dtest=EngineTest` — 12 tests pass, including the cherry-picked `shouldNotResetTuningWhenAttachingReadonlyEngine`
- [x] `./mvnw checkstyle:check -pl runtime/engine` — 0 violations
