### PR TITLE
fix(binding-kafka): don't reject cache fetch when partition leader isn't known yet (backport #2129)

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.binding.kafka.internal.stream;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_AUTHORITATIVE;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_CONTROL;
+import static io.aklivity.zilla.runtime.binding.kafka.internal.stream.KafkaCacheRoute.LEADER_UNKNOWN;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.stream.KafkaCacheServerFetchFactory.SIZE_OF_FLUSH_WITH_EXTENSION;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaIsolation.READ_COMMITTED;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaOffsetFW.Builder.DEFAULT_LATEST_OFFSET;
@@ -555,7 +556,7 @@ public final class KafkaCacheClientFetchFactory implements BindingHandler
             long traceId,
             KafkaCacheClientFetchStream member)
         {
-            if (member.leaderId != leaderId)
+            if (member.leaderId != leaderId && member.leaderId != LEADER_UNKNOWN)
             {
                 doClientFanoutInitialAbortIfNecessary(traceId);
                 doClientFanoutReplyResetIfNecessary(traceId);
@@ -997,7 +998,7 @@ public final class KafkaCacheClientFetchFactory implements BindingHandler
             final long traceId = begin.traceId();
             final long affinity = begin.affinity();
 
-            if (affinity != leaderId)
+            if (affinity != leaderId && leaderId != LEADER_UNKNOWN)
             {
                 cleanupClient(traceId, ERROR_NOT_LEADER_FOR_PARTITION);
             }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheRoute.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheRoute.java
@@ -31,6 +31,8 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.stream.KafkaCacheServerP
 
 public final class KafkaCacheRoute
 {
+    public static final int LEADER_UNKNOWN = Integer.MIN_VALUE;
+
     public final long resolvedId;
     public final Int2ObjectHashMap<KafkaCacheClientDescribeFanout> clientDescribeFanoutsByTopic;
     public final Int2ObjectHashMap<KafkaCacheServerDescribeFanout> serverDescribeFanoutsByTopic;
@@ -63,7 +65,7 @@ public final class KafkaCacheRoute
     public Int2IntHashMap supplyLeadersByPartitionId(
         String topic)
     {
-        return leadersByPartitionId.computeIfAbsent(topicKey(topic), k -> new Int2IntHashMap(Integer.MIN_VALUE));
+        return leadersByPartitionId.computeIfAbsent(topicKey(topic), k -> new Int2IntHashMap(LEADER_UNKNOWN));
     }
 
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCacheC
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_ABORTED;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_AUTHORITATIVE;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.cache.KafkaCachePartition.CACHE_ENTRY_FLAGS_CONTROL;
+import static io.aklivity.zilla.runtime.binding.kafka.internal.stream.KafkaCacheRoute.LEADER_UNKNOWN;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaOffsetFW.Builder.DEFAULT_LATEST_OFFSET;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaOffsetFW.Builder.DEFAULT_STABLE_OFFSET;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.types.KafkaOffsetType.LIVE;
@@ -207,7 +208,6 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         final long originId = begin.originId();
         final long routedId = begin.routedId();
         final long initialId = begin.streamId();
-        final long affinity = begin.affinity();
         final long authorization = begin.authorization();
 
         assert (initialId & 0x0000_0000_0000_0001L) != 0L;
@@ -235,6 +235,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             final long resolvedId = resolved.id;
             final KafkaCacheRoute cacheRoute = supplyCacheRoute.apply(resolvedId);
             final long partitionKey = cacheRoute.topicPartitionKey(topicName, partitionId);
+            final Int2IntHashMap leadersByPartitionId = cacheRoute.supplyLeadersByPartitionId(topicName);
+            final int leaderId = leadersByPartitionId.get(partitionId);
 
             KafkaCacheServerFetchFanout fanout = cacheRoute.serverFetchFanoutsByTopicPartition.get(partitionKey);
             if (fanout == null)
@@ -248,14 +250,11 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 final KafkaTopicType topicType = binding.resolveTopicType(topicName);
                 final KafkaCacheServerFetchFanout newFanout =
                     new KafkaCacheServerFetchFanout(routedId, resolvedId, authorization,
-                        affinity, partition, routeDeltaType, defaultOffset, topicType);
+                        leaderId, leadersByPartitionId, partition, routeDeltaType, defaultOffset, topicType);
 
                 cacheRoute.serverFetchFanoutsByTopicPartition.put(partitionKey, newFanout);
                 fanout = newFanout;
             }
-
-            final Int2IntHashMap leadersByPartitionId = cacheRoute.supplyLeadersByPartitionId(topicName);
-            final int leaderId = leadersByPartitionId.get(partitionId);
 
             newStream = new KafkaCacheServerFetchStream(
                     fanout,
@@ -480,6 +479,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         private final long originId;
         private final long routedId;
         private final long authorization;
+        private final Int2IntHashMap leadersByPartitionId;
         private final KafkaCachePartition partition;
         private final KafkaDeltaType deltaType;
         private final KafkaOffsetType defaultOffset;
@@ -521,6 +521,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             long routedId,
             long authorization,
             long leaderId,
+            Int2IntHashMap leadersByPartitionId,
             KafkaCachePartition partition,
             KafkaDeltaType deltaType,
             KafkaOffsetType defaultOffset,
@@ -529,6 +530,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             this.originId = originId;
             this.routedId = routedId;
             this.authorization = authorization;
+            this.leadersByPartitionId = leadersByPartitionId;
             this.partition = partition;
             this.deltaType = deltaType;
             this.defaultOffset = defaultOffset;
@@ -546,7 +548,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             long traceId,
             KafkaCacheServerFetchStream member)
         {
-            if (member.leaderId != leaderId)
+            if (member.leaderId != leaderId && member.leaderId != LEADER_UNKNOWN)
             {
                 doServerFanoutInitialAbortIfNecessary(traceId);
                 doServerFanoutReplyResetIfNecessary(traceId);
@@ -602,7 +604,42 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
 
             if (!KafkaState.initialOpening(state))
             {
-                doServerFanoutInitialBegin(traceId);
+                if (leaderId == LEADER_UNKNOWN)
+                {
+                    leaderId = leadersByPartitionId.get(partition.id());
+                }
+
+                if (leaderId != LEADER_UNKNOWN)
+                {
+                    doServerFanoutInitialBegin(traceId);
+                }
+                else
+                {
+                    doServerFanoutDiscoverLeaderIfNecessary(traceId);
+                }
+            }
+        }
+
+        private void doServerFanoutDiscoverLeaderIfNecessary(
+            long traceId)
+        {
+            if (reconnectDelay != 0 && !members.isEmpty())
+            {
+                if (KafkaConfiguration.DEBUG)
+                {
+                    System.out.format("[0x%016x] %s FETCH leader unknown, retry in %ds\n",
+                        initialId, partition, reconnectDelay);
+                }
+
+                if (reconnectAt != NO_CANCEL_ID)
+                {
+                    signaler.cancel(reconnectAt);
+                }
+
+                this.reconnectAt = signaler.signalAt(
+                    currentTimeMillis() + Math.min(50 << reconnectAttempt++, SECONDS.toMillis(reconnectDelay)),
+                    SIGNAL_RECONNECT,
+                    this::onServerFanoutSignal);
             }
         }
 
@@ -1382,7 +1419,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             final long traceId = begin.traceId();
             final long affinity = begin.affinity();
 
-            if (affinity != leaderId)
+            if (affinity != leaderId && leaderId != LEADER_UNKNOWN)
             {
                 cleanupServer(traceId, ERROR_NOT_LEADER_FOR_PARTITION);
             }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheBootstrapIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheBootstrapIT.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.kafka.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguration.KAFKA_CACHE_SEGMENT_BYTES;
 import static io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguration.KAFKA_CACHE_SEGMENT_INDEX_BYTES;
+import static io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfigurationTest.KAFKA_CACHE_SERVER_RECONNECT_DELAY_NAME;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_DRAIN_ON_CLOSE;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -32,6 +33,7 @@ import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 
 public class CacheBootstrapIT
 {
@@ -96,6 +98,32 @@ public class CacheBootstrapIT
         "${app}/unmerged.group.fetch.message.value/server"})
     public void shouldReceiveGroupMessageValue() throws Exception
     {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("cache.options.bootstrap.yaml")
+    @Configure(name = KAFKA_CACHE_SERVER_RECONNECT_DELAY_NAME, value = "1")
+    @Specification({
+        "${app}/unmerged.fetch.reconnect.after.describe.error/server"})
+    public void shouldReconnectBootstrapAfterDescribeError() throws Exception
+    {
+        Thread.sleep(500);
+        k3po.start();
+        k3po.awaitBarrier("RECEIVED_MESSAGE");
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("cache.options.bootstrap.yaml")
+    @Configure(name = KAFKA_CACHE_SERVER_RECONNECT_DELAY_NAME, value = "1")
+    @Specification({
+        "${app}/unmerged.fetch.reconnect.after.fetch.error/server"})
+    public void shouldReconnectBootstrapAfterFetchError() throws Exception
+    {
+        Thread.sleep(500);
+        k3po.start();
+        k3po.awaitBarrier("RECEIVED_MESSAGE");
         k3po.finish();
     }
 }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
@@ -91,6 +91,17 @@ public class CacheFetchIT
 
     @Test
     @Configuration("cache.yaml")
+    @Configure(name = KafkaConfigurationTest.KAFKA_CACHE_SERVER_RECONNECT_DELAY_NAME, value = "1")
+    @Specification({
+        "${app}/partition.leader.unknown/client",
+        "${app}/partition.leader.unknown/server"})
+    public void shouldServeClientFetchThatRacesAheadOfLeader() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("cache.yaml")
     @Specification({
         "${app}/compacted.message.with.message/client",
         "${app}/compact.message.with.message/server"})

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.unknown/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.unknown/client.rpt
@@ -1,0 +1,75 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -2)
+                                   .build()
+                               .build()}
+
+write notify SENT_FETCH
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .fetch()
+                                 .partition(0, 1, 1)
+                                 .build()
+                             .build()}
+read "Hello, world"
+
+connect await SENT_FETCH
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 1)
+                                 .build()
+                             .build()}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.unknown/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/partition.leader.unknown/server.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property deltaMillis 0L
+property newTimestamp ${kafka:timestamp() + deltaMillis}
+
+accept "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 1)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, -2)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, 1, 1)
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .timestamp(newTimestamp)
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.describe.error/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.describe.error/client.rpt
@@ -1,0 +1,171 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .describe()
+                                   .topic("test")
+                                   .config("cleanup.policy")
+                                   .config("max.message.bytes")
+                                   .config("segment.bytes")
+                                   .config("segment.index.bytes")
+                                   .config("segment.ms")
+                                   .config("retention.bytes")
+                                   .config("retention.ms")
+                                   .config("delete.retention.ms")
+                                   .config("min.compaction.lag.ms")
+                                   .config("max.compaction.lag.ms")
+                                   .config("min.cleanable.dirty.ratio")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:reset.ext ${kafka:resetEx()
+                           .typeId(zilla:id("kafka"))
+                           .error(-1)
+                           .build()}
+write aborted
+read abort
+
+read notify DESCRIBE_ERRORED
+
+connect await DESCRIBE_ERRORED
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .describe()
+                                   .topic("test")
+                                   .config("cleanup.policy")
+                                   .config("max.message.bytes")
+                                   .config("segment.bytes")
+                                   .config("segment.index.bytes")
+                                   .config("segment.ms")
+                                   .config("retention.bytes")
+                                   .config("retention.ms")
+                                   .config("delete.retention.ms")
+                                   .config("min.compaction.lag.ms")
+                                   .config("max.compaction.lag.ms")
+                                   .config("min.cleanable.dirty.ratio")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .topic("test")
+                                  .config("cleanup.policy")
+                                  .config("max.message.bytes")
+                                  .config("segment.bytes")
+                                  .config("segment.index.bytes")
+                                  .config("segment.ms")
+                                  .config("retention.bytes")
+                                  .config("retention.ms")
+                                  .config("delete.retention.ms")
+                                  .config("min.compaction.lag.ms")
+                                  .config("max.compaction.lag.ms")
+                                  .config("min.cleanable.dirty.ratio")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .describe()
+                                 .config("cleanup.policy", "delete")
+                                 .config("max.message.bytes", 1000012)
+                                 .config("segment.bytes", 1073741824)
+                                 .config("segment.index.bytes", 10485760)
+                                 .config("segment.ms", 604800000)
+                                 .config("retention.bytes", -1)
+                                 .config("retention.ms", 604800000)
+                                 .config("delete.retention.ms", 86400000)
+                                 .config("min.compaction.lag.ms", 0)
+                                 .config("max.compaction.lag.ms", 9223372036854775807)
+                                 .config("min.cleanable.dirty.ratio", 0.5)
+                                 .build()
+                             .build()}
+
+read notify RECEIVED_CONFIG
+
+connect await RECEIVED_CONFIG
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 1)
+                                 .build()
+                             .build()}
+
+read notify RECEIVED_META
+
+connect await RECEIVED_META
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -2)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .fetch()
+                                 .partition(0, 1, 1)
+                                 .build()
+                             .build()}
+read "Hello, world"

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.describe.error/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.describe.error/server.rpt
@@ -1,0 +1,169 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property deltaMillis 0L
+property newTimestamp ${kafka:timestamp() + deltaMillis}
+
+accept "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .topic("test")
+                                  .config("cleanup.policy")
+                                  .config("max.message.bytes")
+                                  .config("segment.bytes")
+                                  .config("segment.index.bytes")
+                                  .config("segment.ms")
+                                  .config("retention.bytes")
+                                  .config("retention.ms")
+                                  .config("delete.retention.ms")
+                                  .config("min.compaction.lag.ms")
+                                  .config("max.compaction.lag.ms")
+                                  .config("min.cleanable.dirty.ratio")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:reset.ext ${kafka:resetEx()
+                           .typeId(zilla:id("kafka"))
+                           .error(-1)
+                           .build()}
+read abort
+write aborted
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .topic("test")
+                                  .config("cleanup.policy")
+                                  .config("max.message.bytes")
+                                  .config("segment.bytes")
+                                  .config("segment.index.bytes")
+                                  .config("segment.ms")
+                                  .config("retention.bytes")
+                                  .config("retention.ms")
+                                  .config("delete.retention.ms")
+                                  .config("min.compaction.lag.ms")
+                                  .config("max.compaction.lag.ms")
+                                  .config("min.cleanable.dirty.ratio")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .describe()
+                                   .topic("test")
+                                   .config("cleanup.policy")
+                                   .config("max.message.bytes")
+                                   .config("segment.bytes")
+                                   .config("segment.index.bytes")
+                                   .config("segment.ms")
+                                   .config("retention.bytes")
+                                   .config("retention.ms")
+                                   .config("delete.retention.ms")
+                                   .config("min.compaction.lag.ms")
+                                   .config("max.compaction.lag.ms")
+                                   .config("min.cleanable.dirty.ratio")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .config("cleanup.policy", "delete")
+                                  .config("max.message.bytes", 1000012)
+                                  .config("segment.bytes", 1073741824)
+                                  .config("segment.index.bytes", 10485760)
+                                  .config("segment.ms", 604800000)
+                                  .config("retention.bytes", -1)
+                                  .config("retention.ms", 604800000)
+                                  .config("delete.retention.ms", 86400000)
+                                  .config("min.compaction.lag.ms", 0)
+                                  .config("max.compaction.lag.ms", 9223372036854775807)
+                                  .config("min.cleanable.dirty.ratio", 0.5)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 1)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, -2)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, 1, 1)
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .timestamp(newTimestamp)
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush
+write notify RECEIVED_MESSAGE

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.fetch.error/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.fetch.error/client.rpt
@@ -1,0 +1,161 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .describe()
+                                   .topic("test")
+                                   .config("cleanup.policy")
+                                   .config("max.message.bytes")
+                                   .config("segment.bytes")
+                                   .config("segment.index.bytes")
+                                   .config("segment.ms")
+                                   .config("retention.bytes")
+                                   .config("retention.ms")
+                                   .config("delete.retention.ms")
+                                   .config("min.compaction.lag.ms")
+                                   .config("max.compaction.lag.ms")
+                                   .config("min.cleanable.dirty.ratio")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .topic("test")
+                                  .config("cleanup.policy")
+                                  .config("max.message.bytes")
+                                  .config("segment.bytes")
+                                  .config("segment.index.bytes")
+                                  .config("segment.ms")
+                                  .config("retention.bytes")
+                                  .config("retention.ms")
+                                  .config("delete.retention.ms")
+                                  .config("min.compaction.lag.ms")
+                                  .config("max.compaction.lag.ms")
+                                  .config("min.cleanable.dirty.ratio")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .describe()
+                                 .config("cleanup.policy", "delete")
+                                 .config("max.message.bytes", 1000012)
+                                 .config("segment.bytes", 1073741824)
+                                 .config("segment.index.bytes", 10485760)
+                                 .config("segment.ms", 604800000)
+                                 .config("retention.bytes", -1)
+                                 .config("retention.ms", 604800000)
+                                 .config("delete.retention.ms", 86400000)
+                                 .config("min.compaction.lag.ms", 0)
+                                 .config("max.compaction.lag.ms", 9223372036854775807)
+                                 .config("min.cleanable.dirty.ratio", 0.5)
+                                 .build()
+                             .build()}
+
+read notify RECEIVED_CONFIG
+
+connect await RECEIVED_CONFIG
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 1)
+                                 .build()
+                             .build()}
+
+read notify RECEIVED_META
+
+connect await RECEIVED_META
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -2)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:reset.ext ${kafka:resetEx()
+                           .typeId(zilla:id("kafka"))
+                           .error(-1)
+                           .build()}
+write aborted
+read abort
+
+read notify FETCH_ERRORED
+
+connect await FETCH_ERRORED
+        "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -2)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .fetch()
+                                 .partition(0, 1, 1)
+                                 .build()
+                             .build()}
+read "Hello, world"

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.fetch.error/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/merged/unmerged.fetch.reconnect.after.fetch.error/server.rpt
@@ -1,0 +1,159 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property deltaMillis 0L
+property newTimestamp ${kafka:timestamp() + deltaMillis}
+
+accept "zilla://streams/app1"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .topic("test")
+                                  .config("cleanup.policy")
+                                  .config("max.message.bytes")
+                                  .config("segment.bytes")
+                                  .config("segment.index.bytes")
+                                  .config("segment.ms")
+                                  .config("retention.bytes")
+                                  .config("retention.ms")
+                                  .config("delete.retention.ms")
+                                  .config("min.compaction.lag.ms")
+                                  .config("max.compaction.lag.ms")
+                                  .config("min.cleanable.dirty.ratio")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .describe()
+                                   .topic("test")
+                                   .config("cleanup.policy")
+                                   .config("max.message.bytes")
+                                   .config("segment.bytes")
+                                   .config("segment.index.bytes")
+                                   .config("segment.ms")
+                                   .config("retention.bytes")
+                                   .config("retention.ms")
+                                   .config("delete.retention.ms")
+                                   .config("min.compaction.lag.ms")
+                                   .config("max.compaction.lag.ms")
+                                   .config("min.cleanable.dirty.ratio")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .describe()
+                                  .config("cleanup.policy", "delete")
+                                  .config("max.message.bytes", 1000012)
+                                  .config("segment.bytes", 1073741824)
+                                  .config("segment.index.bytes", 10485760)
+                                  .config("segment.ms", 604800000)
+                                  .config("retention.bytes", -1)
+                                  .config("retention.ms", 604800000)
+                                  .config("delete.retention.ms", 86400000)
+                                  .config("min.compaction.lag.ms", 0)
+                                  .config("max.compaction.lag.ms", 9223372036854775807)
+                                  .config("min.cleanable.dirty.ratio", 0.5)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 1)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, -2)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:reset.ext ${kafka:resetEx()
+                           .typeId(zilla:id("kafka"))
+                           .error(-1)
+                           .build()}
+read abort
+write aborted
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, -2)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, 1, 1)
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .timestamp(newTimestamp)
+                                  .partition(0, 1, 1)
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush
+write notify RECEIVED_MESSAGE

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MergedIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/MergedIT.java
@@ -510,6 +510,24 @@ public class MergedIT
 
     @Test
     @Specification({
+        "${app}/unmerged.fetch.reconnect.after.describe.error/client",
+        "${app}/unmerged.fetch.reconnect.after.describe.error/server"})
+    public void shouldReconnectUnmergedFetchAfterDescribeError() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/unmerged.fetch.reconnect.after.fetch.error/client",
+        "${app}/unmerged.fetch.reconnect.after.fetch.error/server"})
+    public void shouldReconnectUnmergedFetchAfterFetchError() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/unmerged.fetch.partition.offsets.latest/client",
         "${app}/unmerged.fetch.partition.offsets.latest/server"})
     public void shouldFetchUnmergedPartitionOffsetsLatest() throws Exception


### PR DESCRIPTION
## Description

Backport of #2129 (cherry-pick of develop commit e943a33c) to `support/1.x`.

`KafkaCacheClientFetchFactory` and `KafkaCacheServerFetchFactory` rejected a new fetch stream with `ERROR_NOT_LEADER_FOR_PARTITION` whenever the affinity/member leader id didn't match the fanout's current `leaderId` — including the case where the fanout had never resolved a leader at all yet (`leadersByPartitionId` returns its `missingValue()` sentinel before the first successful `meta` response). That meant a fetch stream racing ahead of the one-shot startup bootstrap for a partition was permanently rejected instead of being served once the real leader was known, since nothing ever retried the fetch.

Both factories now track leader-known state via `KafkaCacheRoute.LEADER_UNKNOWN`. The leader-mismatch checks only reject the stream when a leader was actually known and it disagrees — a genuinely unknown leader no longer short-circuits the stream. A real mismatch (e.g. partition reassignment) is still rejected exactly as before.

Added:
- `CacheFetchIT#shouldServeClientFetchThatRacesAheadOfLeader` plus `specs/binding-kafka.spec/.../fetch/partition.leader.unknown/{client,server}.rpt`
- `CacheBootstrapIT#shouldReconnectBootstrapAfterDescribeError` / `#shouldReconnectBootstrapAfterFetchError` plus matching `.rpt` scripts, confirming the one-shot startup bootstrap's internal describe/fetch streams recover via the existing fanout reconnect/backoff machinery after a transient broker failure.

### Backport adaptation

`support/1.x` pins an older `k3po` (3.4.0) that doesn't have `K3poRule#deferStartable` (added later, used on `develop` to avoid a fixed `Thread.sleep(500)` race guard in `CacheBootstrapIT`). Restored the original `Thread.sleep(500)` + `outerRule(k3po).around(engine)` ordering for this branch instead of bumping the k3po dependency.

Verified: `./mvnw clean verify -pl runtime/binding-kafka` and `./mvnw clean verify -pl specs/binding-kafka.spec` both green (172 tests in `binding-kafka`, matching the original PR's count).

Fixes #2116


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4kBqRRHskcArBkCWTjSJh)_