### PR TITLE
fix(binding-openapi-asyncapi): remove inert asyncapi-side security instead of falling back to it

### DIFF
--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapter.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/OpenapiAsyncapiOptionsConfigAdapter.java
@@ -139,13 +139,6 @@ public final class OpenapiAsyncapiOptionsConfigAdapter implements OptionsConfigA
             }
             catalogObject.add(CATALOG_NAME, subjectObject);
 
-            if (asyncapiConfig.security != null && !asyncapiConfig.security.isEmpty())
-            {
-                final JsonObjectBuilder security = Json.createObjectBuilder();
-                asyncapiConfig.security.forEach(security::add);
-                catalogObject.add(SECURITY_NAME, security);
-            }
-
             if (asyncapiConfig.overlay != null)
             {
                 final JsonObjectBuilder overlaySchema = Json.createObjectBuilder();
@@ -276,15 +269,6 @@ public final class OpenapiAsyncapiOptionsConfigAdapter implements OptionsConfigA
                     }
 
                     catalog.build();
-                }
-
-                if (specObject.containsKey(SECURITY_NAME))
-                {
-                    final JsonObject securityObject = specObject.getJsonObject(SECURITY_NAME);
-                    for (String scheme : securityObject.keySet())
-                    {
-                        asyncapi.security(scheme, securityObject.getString(scheme));
-                    }
                 }
 
                 if (specObject.containsKey(OVERLAY_NAME))

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
@@ -44,6 +44,7 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.Openap
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaFilter;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaOperationEx;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSchemaConfig;
+import io.aklivity.zilla.runtime.common.asyncapi.security.AsyncapiGuardResolver;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiMessageView;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiOperationView;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiReplyView;
@@ -384,9 +385,9 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
                     OpenapiOperationView httpOp,
                     AsyncapiOperationView kafkaOp)
                 {
-                    if (allowed(schema, httpOp))
+                    if (allowed(schema, httpOp, kafkaOp))
                     {
-                        final GuardedResolution resolution = resolveGuarded(schema, httpOp);
+                        final GuardedResolution resolution = resolveGuarded(schema, httpOp, kafkaOp);
 
                         for (OpenapiServerView httpServer : httpOp.servers)
                         {
@@ -625,11 +626,34 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
 
                 private GuardedResolution resolveGuarded(
                     OpenapiSchemaConfig schema,
-                    OpenapiOperationView operation)
+                    OpenapiOperationView operation,
+                    AsyncapiOperationView kafkaOperation)
                 {
-                    return OpenapiGuardResolver.resolve(
+                    GuardedResolution resolution = OpenapiGuardResolver.resolve(
                         operation.id, schema.specLabel, operation.security, schema.security,
                         config.resolveId, config.supplyQName);
+
+                    if (operation.security == null && kafkaOperation != null)
+                    {
+                        resolution = resolveKafkaGuarded(kafkaOperation);
+                    }
+
+                    return resolution;
+                }
+
+                private GuardedResolution resolveKafkaGuarded(
+                    AsyncapiOperationView kafkaOperation)
+                {
+                    io.aklivity.zilla.runtime.common.asyncapi.security.GuardedResolution resolution =
+                        AsyncapiGuardResolver.resolve(
+                            kafkaOperation.name, mapping.with.specLabel, kafkaOperation.security, mapping.with.security,
+                            config.resolveId, config.supplyQName);
+
+                    return resolution.denied()
+                        ? GuardedResolution.denied(resolution.reason)
+                        : GuardedResolution.allowed(resolution.guarded.stream()
+                            .map(ref -> new GuardedRef(ref.qname, ref.roles))
+                            .toList());
                 }
 
                 private String guardQname(
@@ -640,9 +664,10 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
 
                 private boolean allowed(
                     OpenapiSchemaConfig schema,
-                    OpenapiOperationView operation)
+                    OpenapiOperationView operation,
+                    AsyncapiOperationView kafkaOperation)
                 {
-                    final GuardedResolution resolution = resolveGuarded(schema, operation);
+                    final GuardedResolution resolution = resolveGuarded(schema, operation, kafkaOperation);
                     final boolean allowed = !resolution.denied();
 
                     if (!allowed)

--- a/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
+++ b/runtime/binding-openapi-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGenerator.java
@@ -44,7 +44,6 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.Openap
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaFilter;
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.model.extensions.http.kafka.OpenapiHttpKafkaOperationEx;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSchemaConfig;
-import io.aklivity.zilla.runtime.common.asyncapi.security.AsyncapiGuardResolver;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiMessageView;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiOperationView;
 import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiReplyView;
@@ -385,9 +384,9 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
                     OpenapiOperationView httpOp,
                     AsyncapiOperationView kafkaOp)
                 {
-                    if (allowed(schema, httpOp, kafkaOp))
+                    if (allowed(schema, httpOp))
                     {
-                        final GuardedResolution resolution = resolveGuarded(schema, httpOp, kafkaOp);
+                        final GuardedResolution resolution = resolveGuarded(schema, httpOp);
 
                         for (OpenapiServerView httpServer : httpOp.servers)
                         {
@@ -626,34 +625,11 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
 
                 private GuardedResolution resolveGuarded(
                     OpenapiSchemaConfig schema,
-                    OpenapiOperationView operation,
-                    AsyncapiOperationView kafkaOperation)
+                    OpenapiOperationView operation)
                 {
-                    GuardedResolution resolution = OpenapiGuardResolver.resolve(
+                    return OpenapiGuardResolver.resolve(
                         operation.id, schema.specLabel, operation.security, schema.security,
                         config.resolveId, config.supplyQName);
-
-                    if (operation.security == null && kafkaOperation != null)
-                    {
-                        resolution = resolveKafkaGuarded(kafkaOperation);
-                    }
-
-                    return resolution;
-                }
-
-                private GuardedResolution resolveKafkaGuarded(
-                    AsyncapiOperationView kafkaOperation)
-                {
-                    io.aklivity.zilla.runtime.common.asyncapi.security.GuardedResolution resolution =
-                        AsyncapiGuardResolver.resolve(
-                            kafkaOperation.name, mapping.with.specLabel, kafkaOperation.security, mapping.with.security,
-                            config.resolveId, config.supplyQName);
-
-                    return resolution.denied()
-                        ? GuardedResolution.denied(resolution.reason)
-                        : GuardedResolution.allowed(resolution.guarded.stream()
-                            .map(ref -> new GuardedRef(ref.qname, ref.roles))
-                            .toList());
                 }
 
                 private String guardQname(
@@ -664,10 +640,9 @@ public final class OpenapiAsyncapiProxyGenerator extends OpenapiAsyncapiComposit
 
                 private boolean allowed(
                     OpenapiSchemaConfig schema,
-                    OpenapiOperationView operation,
-                    AsyncapiOperationView kafkaOperation)
+                    OpenapiOperationView operation)
                 {
-                    final GuardedResolution resolution = resolveGuarded(schema, operation, kafkaOperation);
+                    final GuardedResolution resolution = resolveGuarded(schema, operation);
                     final boolean allowed = !resolution.denied();
 
                     if (!allowed)

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGeneratorTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGeneratorTest.java
@@ -17,8 +17,10 @@ package io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.compo
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.PROXY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -47,6 +49,7 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.Openap
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiWithConfig;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiCatalogConfig;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSpecificationConfig;
+import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSpecificationConfigBuilder;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -95,6 +98,20 @@ public class OpenapiAsyncapiProxyGeneratorTest
                 },
                 "responses": { "200": { "description": "ok" } }
               }
+            },
+            "/kafka-guarded": {
+              "get": {
+                "operationId": "kafkaGuarded",
+                "x-zilla-http-kafka": { "filters": [ { "key": "{identity}" } ] },
+                "responses": { "200": { "description": "ok" } }
+              }
+            },
+            "/kafka-mixed": {
+              "get": {
+                "operationId": "kafkaMixed",
+                "x-zilla-http-kafka": { "filters": [ { "key": "{identity}" } ] },
+                "responses": { "200": { "description": "ok" } }
+              }
             }
           }
         }
@@ -109,7 +126,9 @@ public class OpenapiAsyncapiProxyGeneratorTest
           "channels": {
             "mapped": { "address": "mapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
             "unmapped": { "address": "unmapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
-            "produceMapped": { "address": "produceMapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } }
+            "produceMapped": { "address": "produceMapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
+            "kafkaGuarded": { "address": "kafkaGuarded", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
+            "kafkaMixed": { "address": "kafkaMixed", "messages": { "pet": { "$ref": "#/components/messages/pet" } } }
           },
           "operations": {
             "mapped": {
@@ -120,16 +139,36 @@ public class OpenapiAsyncapiProxyGeneratorTest
             "unmapped": {
               "action": "receive",
               "channel": { "$ref": "#/channels/unmapped" },
-              "messages": [ { "$ref": "#/channels/unmapped/messages/pet" } ]
+              "messages": [ { "$ref": "#/channels/unmapped/messages/pet" } ],
+              "security": [ { "$ref": "#/components/securitySchemes/kafkaAuth" } ]
             },
             "produceMapped": {
               "action": "send",
               "channel": { "$ref": "#/channels/produceMapped" },
               "messages": [ { "$ref": "#/channels/produceMapped/messages/pet" } ]
+            },
+            "kafkaGuarded": {
+              "action": "receive",
+              "channel": { "$ref": "#/channels/kafkaGuarded" },
+              "messages": [ { "$ref": "#/channels/kafkaGuarded/messages/pet" } ],
+              "security": [ { "$ref": "#/components/securitySchemes/kafkaAuth" } ]
+            },
+            "kafkaMixed": {
+              "action": "receive",
+              "channel": { "$ref": "#/channels/kafkaMixed" },
+              "messages": [ { "$ref": "#/channels/kafkaMixed/messages/pet" } ],
+              "security": [
+                { "$ref": "#/components/securitySchemes/kafkaAuth" },
+                { "$ref": "#/components/securitySchemes/kafkaAuthAlt" }
+              ]
             }
           },
           "components": {
-            "messages": { "pet": { "payload": { "type": "object" } } }
+            "messages": { "pet": { "payload": { "type": "object" } } },
+            "securitySchemes": {
+              "kafkaAuth": { "type": "http", "scheme": "bearer" },
+              "kafkaAuthAlt": { "type": "http", "scheme": "bearer" }
+            }
           }
         }
         """;
@@ -202,6 +241,7 @@ public class OpenapiAsyncapiProxyGeneratorTest
     case "catalog0" -> 1L;
     case "catalog1" -> 5L;
     case "guard0" -> 2L;
+    case "guard1" -> 4L;
     default -> 3L;
     };
 
@@ -213,6 +253,7 @@ public class OpenapiAsyncapiProxyGeneratorTest
         lenient().when(context.supplyTypeId(any())).thenReturn(9);
         lenient().when(context.supplyBindingId(any(), any())).thenReturn(42L);
         lenient().when(context.supplyQName(eq(2L))).thenReturn("guard0");
+        lenient().when(context.supplyQName(eq(4L))).thenReturn("guard1");
         lenient().when(openapiCatalog.resolve(eq("test"), eq("latest"))).thenReturn(7);
         lenient().when(openapiCatalog.resolve(anyInt())).thenReturn(OPENAPI_SPEC);
         lenient().when(asyncapiCatalog.resolve(eq("test"), eq("latest"))).thenReturn(8);
@@ -222,6 +263,22 @@ public class OpenapiAsyncapiProxyGeneratorTest
     private BindingConfig binding(
         Map<String, String> security)
     {
+        return binding(security, null);
+    }
+
+    private BindingConfig binding(
+        Map<String, String> openapiSecurity,
+        Map<String, String> asyncapiSecurity)
+    {
+        AsyncapiSpecificationConfigBuilder<AsyncapiSpecificationConfig> asyncapi = AsyncapiSpecificationConfig.builder()
+            .label("asyncapi-id")
+            .catalog(new AsyncapiCatalogConfig("catalog1", "test", "latest"));
+
+        if (asyncapiSecurity != null)
+        {
+            asyncapiSecurity.forEach(asyncapi::security);
+        }
+
         BindingConfig binding = BindingConfig.builder()
             .namespace("test")
             .name("composite0")
@@ -232,11 +289,8 @@ public class OpenapiAsyncapiProxyGeneratorTest
                     "openapi-id",
                     null,
                     List.of(new OpenapiCatalogConfig("catalog0", "test", "latest")),
-                    security)),
-                Set.of(AsyncapiSpecificationConfig.builder()
-                    .label("asyncapi-id")
-                    .catalog(new AsyncapiCatalogConfig("catalog1", "test", "latest"))
-                    .build()))))
+                    openapiSecurity)),
+                Set.of(asyncapi.build()))))
             .route()
                 .exit("asyncapi_client0")
                 .when(new OpenapiAsyncapiConditionConfig("openapi-id", null))
@@ -444,5 +498,45 @@ public class OpenapiAsyncapiProxyGeneratorTest
             .orElseThrow();
 
         assertThat(httpKafka.routes, empty());
+    }
+
+    @Test
+    public void shouldGuardUsingAsyncapiSecurityWhenOpenapiOperationDeclaresNone()
+    {
+        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
+            binding(null, Map.of("kafkaAuth", "guard0"))));
+
+        RouteConfig route = routeFor(composite, "/kafka-guarded");
+
+        assertThat(route.guarded, hasSize(1));
+        assertThat(route.guarded.get(0).name, equalTo("guard0"));
+    }
+
+    @Test
+    public void shouldNotFallBackToAsyncapiSecurityWhenOpenapiOperationDeclaresSecurity()
+    {
+        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
+            binding(Map.of("bearerAuth", "guard0"), Map.of("kafkaAuth", "guard0"))));
+
+        RouteConfig route = routeFor(composite, "/unmapped");
+
+        assertThat(route.guarded, empty());
+    }
+
+    @Test
+    public void shouldDenyWhenAsyncapiOperationRequiresMultipleDistinctGuards()
+    {
+        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
+            binding(null, Map.of("kafkaAuth", "guard0", "kafkaAuthAlt", "guard1"))));
+
+        BindingConfig httpKafka = composite.namespaces.get(0).bindings.stream()
+            .filter(b -> "http_kafka_proxy0".equals(b.name))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(httpKafka.routes.stream()
+            .anyMatch(r -> r.when.stream().anyMatch(c -> "/kafka-mixed".equals(((HttpKafkaConditionConfig) c).path))),
+            equalTo(false));
+        assertThat(generator.deniedOperations(), hasItem(containsString("multiple distinct guards")));
     }
 }

--- a/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGeneratorTest.java
+++ b/runtime/binding-openapi-asyncapi/src/test/java/io/aklivity/zilla/runtime/binding/openapi/asyncapi/internal/config/composite/OpenapiAsyncapiProxyGeneratorTest.java
@@ -17,10 +17,8 @@ package io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.compo
 import static io.aklivity.zilla.runtime.engine.config.KindConfig.PROXY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -49,7 +47,6 @@ import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.Openap
 import io.aklivity.zilla.runtime.binding.openapi.asyncapi.internal.config.OpenapiAsyncapiWithConfig;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiCatalogConfig;
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSpecificationConfig;
-import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiSpecificationConfigBuilder;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiCatalogConfig;
 import io.aklivity.zilla.runtime.common.openapi.config.OpenapiSpecificationConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -98,20 +95,6 @@ public class OpenapiAsyncapiProxyGeneratorTest
                 },
                 "responses": { "200": { "description": "ok" } }
               }
-            },
-            "/kafka-guarded": {
-              "get": {
-                "operationId": "kafkaGuarded",
-                "x-zilla-http-kafka": { "filters": [ { "key": "{identity}" } ] },
-                "responses": { "200": { "description": "ok" } }
-              }
-            },
-            "/kafka-mixed": {
-              "get": {
-                "operationId": "kafkaMixed",
-                "x-zilla-http-kafka": { "filters": [ { "key": "{identity}" } ] },
-                "responses": { "200": { "description": "ok" } }
-              }
             }
           }
         }
@@ -126,9 +109,7 @@ public class OpenapiAsyncapiProxyGeneratorTest
           "channels": {
             "mapped": { "address": "mapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
             "unmapped": { "address": "unmapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
-            "produceMapped": { "address": "produceMapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
-            "kafkaGuarded": { "address": "kafkaGuarded", "messages": { "pet": { "$ref": "#/components/messages/pet" } } },
-            "kafkaMixed": { "address": "kafkaMixed", "messages": { "pet": { "$ref": "#/components/messages/pet" } } }
+            "produceMapped": { "address": "produceMapped", "messages": { "pet": { "$ref": "#/components/messages/pet" } } }
           },
           "operations": {
             "mapped": {
@@ -139,36 +120,16 @@ public class OpenapiAsyncapiProxyGeneratorTest
             "unmapped": {
               "action": "receive",
               "channel": { "$ref": "#/channels/unmapped" },
-              "messages": [ { "$ref": "#/channels/unmapped/messages/pet" } ],
-              "security": [ { "$ref": "#/components/securitySchemes/kafkaAuth" } ]
+              "messages": [ { "$ref": "#/channels/unmapped/messages/pet" } ]
             },
             "produceMapped": {
               "action": "send",
               "channel": { "$ref": "#/channels/produceMapped" },
               "messages": [ { "$ref": "#/channels/produceMapped/messages/pet" } ]
-            },
-            "kafkaGuarded": {
-              "action": "receive",
-              "channel": { "$ref": "#/channels/kafkaGuarded" },
-              "messages": [ { "$ref": "#/channels/kafkaGuarded/messages/pet" } ],
-              "security": [ { "$ref": "#/components/securitySchemes/kafkaAuth" } ]
-            },
-            "kafkaMixed": {
-              "action": "receive",
-              "channel": { "$ref": "#/channels/kafkaMixed" },
-              "messages": [ { "$ref": "#/channels/kafkaMixed/messages/pet" } ],
-              "security": [
-                { "$ref": "#/components/securitySchemes/kafkaAuth" },
-                { "$ref": "#/components/securitySchemes/kafkaAuthAlt" }
-              ]
             }
           },
           "components": {
-            "messages": { "pet": { "payload": { "type": "object" } } },
-            "securitySchemes": {
-              "kafkaAuth": { "type": "http", "scheme": "bearer" },
-              "kafkaAuthAlt": { "type": "http", "scheme": "bearer" }
-            }
+            "messages": { "pet": { "payload": { "type": "object" } } }
           }
         }
         """;
@@ -241,7 +202,6 @@ public class OpenapiAsyncapiProxyGeneratorTest
     case "catalog0" -> 1L;
     case "catalog1" -> 5L;
     case "guard0" -> 2L;
-    case "guard1" -> 4L;
     default -> 3L;
     };
 
@@ -253,7 +213,6 @@ public class OpenapiAsyncapiProxyGeneratorTest
         lenient().when(context.supplyTypeId(any())).thenReturn(9);
         lenient().when(context.supplyBindingId(any(), any())).thenReturn(42L);
         lenient().when(context.supplyQName(eq(2L))).thenReturn("guard0");
-        lenient().when(context.supplyQName(eq(4L))).thenReturn("guard1");
         lenient().when(openapiCatalog.resolve(eq("test"), eq("latest"))).thenReturn(7);
         lenient().when(openapiCatalog.resolve(anyInt())).thenReturn(OPENAPI_SPEC);
         lenient().when(asyncapiCatalog.resolve(eq("test"), eq("latest"))).thenReturn(8);
@@ -263,22 +222,6 @@ public class OpenapiAsyncapiProxyGeneratorTest
     private BindingConfig binding(
         Map<String, String> security)
     {
-        return binding(security, null);
-    }
-
-    private BindingConfig binding(
-        Map<String, String> openapiSecurity,
-        Map<String, String> asyncapiSecurity)
-    {
-        AsyncapiSpecificationConfigBuilder<AsyncapiSpecificationConfig> asyncapi = AsyncapiSpecificationConfig.builder()
-            .label("asyncapi-id")
-            .catalog(new AsyncapiCatalogConfig("catalog1", "test", "latest"));
-
-        if (asyncapiSecurity != null)
-        {
-            asyncapiSecurity.forEach(asyncapi::security);
-        }
-
         BindingConfig binding = BindingConfig.builder()
             .namespace("test")
             .name("composite0")
@@ -289,8 +232,11 @@ public class OpenapiAsyncapiProxyGeneratorTest
                     "openapi-id",
                     null,
                     List.of(new OpenapiCatalogConfig("catalog0", "test", "latest")),
-                    openapiSecurity)),
-                Set.of(asyncapi.build()))))
+                    security)),
+                Set.of(AsyncapiSpecificationConfig.builder()
+                    .label("asyncapi-id")
+                    .catalog(new AsyncapiCatalogConfig("catalog1", "test", "latest"))
+                    .build()))))
             .route()
                 .exit("asyncapi_client0")
                 .when(new OpenapiAsyncapiConditionConfig("openapi-id", null))
@@ -501,42 +447,36 @@ public class OpenapiAsyncapiProxyGeneratorTest
     }
 
     @Test
-    public void shouldGuardUsingAsyncapiSecurityWhenOpenapiOperationDeclaresNone()
+    public void shouldIgnoreAsyncapiSideSecurity()
     {
-        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
-            binding(null, Map.of("kafkaAuth", "guard0"))));
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("composite0")
+            .type("openapi-asyncapi")
+            .kind(PROXY)
+            .options(new OpenapiAsyncapiOptionsConfig(new OpenapiAsyncapiSpecConfig(
+                Set.of(new OpenapiSpecificationConfig(
+                    "openapi-id",
+                    null,
+                    List.of(new OpenapiCatalogConfig("catalog0", "test", "latest")),
+                    null)),
+                Set.of(AsyncapiSpecificationConfig.builder()
+                    .label("asyncapi-id")
+                    .catalog(new AsyncapiCatalogConfig("catalog1", "test", "latest"))
+                    .security("kafkaAuth", "guard0")
+                    .build()))))
+            .route()
+                .exit("asyncapi_client0")
+                .when(new OpenapiAsyncapiConditionConfig("openapi-id", null))
+                .with(new OpenapiAsyncapiWithConfig("asyncapi-id", null, null))
+                .build()
+            .build();
+        binding.resolveId = resolveId;
 
-        RouteConfig route = routeFor(composite, "/kafka-guarded");
+        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context, binding));
 
-        assertThat(route.guarded, hasSize(1));
-        assertThat(route.guarded.get(0).name, equalTo("guard0"));
-    }
-
-    @Test
-    public void shouldNotFallBackToAsyncapiSecurityWhenOpenapiOperationDeclaresSecurity()
-    {
-        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
-            binding(Map.of("bearerAuth", "guard0"), Map.of("kafkaAuth", "guard0"))));
-
-        RouteConfig route = routeFor(composite, "/unmapped");
+        RouteConfig route = routeFor(composite, "/mapped");
 
         assertThat(route.guarded, empty());
-    }
-
-    @Test
-    public void shouldDenyWhenAsyncapiOperationRequiresMultipleDistinctGuards()
-    {
-        OpenapiAsyncapiCompositeConfig composite = generator.generate(new OpenapiAsyncapiBindingConfig(context,
-            binding(null, Map.of("kafkaAuth", "guard0", "kafkaAuthAlt", "guard1"))));
-
-        BindingConfig httpKafka = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "http_kafka_proxy0".equals(b.name))
-            .findFirst()
-            .orElseThrow();
-
-        assertThat(httpKafka.routes.stream()
-            .anyMatch(r -> r.when.stream().anyMatch(c -> "/kafka-mixed".equals(((HttpKafkaConditionConfig) c).path))),
-            equalTo(false));
-        assertThat(generator.deniedOperations(), hasItem(containsString("multiple distinct guards")));
     }
 }

--- a/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/schema/openapi.asyncapi.schema.patch.json
+++ b/specs/binding-openapi-asyncapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/openapi/asyncapi/schema/openapi.asyncapi.schema.patch.json
@@ -174,19 +174,6 @@
                                                             "additionalProperties": false
                                                         }
                                                     },
-                                                    "security":
-                                                    {
-                                                        "title": "Security",
-                                                        "type": "object",
-                                                        "patternProperties":
-                                                        {
-                                                            "^[a-zA-Z0-9_\\-]+$":
-                                                            {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "additionalProperties": false
-                                                    },
                                                     "overlay":
                                                     {
                                                         "title": "Overlay",


### PR DESCRIPTION
## Description

`options.specs.asyncapi[].security` (a scheme-name -> guard-name map) was fully parsed by `OpenapiAsyncapiOptionsConfigAdapter` and threaded into `AsyncapiSchemaConfig`, but `OpenapiAsyncapiProxyGenerator.resolveGuarded()` never consumed it — an operator could configure it, see it validate against the schema, and it would silently do nothing.

**Revision note:** this PR originally implemented a fallback (asyncapi-side security applied only when the openapi operation declared none). Further design discussion concluded that shape is a poor fit for a security control — which guard actually protects a route would depend on unrelated state in a *different* spec document (an unrelated edit to the openapi file could silently change what protects a Kafka operation, invisible to a reviewer of either file alone). The current commit instead removes asyncapi-side `security` support entirely.

The openapi side already provides complete, working, tested inbound authorization for this proxy's single HTTP ingress point — this is unrelated to the Kafka client's own connection credentials, which are configured separately (vault/SASL) on whatever binding the generated route's `exit` points to. Asyncapi-side `security` described the exact same access-control decision from a second source, so removing it loses no real capability while eliminating the redundancy and the "silently does nothing" trap that motivated #2133 in the first place.

- `OpenapiAsyncapiProxyGenerator` / `OpenapiAsyncapiOptionsConfigAdapter` no longer resolve or parse asyncapi-side `security`.
- Removed `security` from the asyncapi side of the JSON schema patch, so configuring it now produces a clear validation error instead of silently doing nothing.
- Added a regression test proving asyncapi-side `security` has no effect on route guard resolution, even when set directly on the config object (bypassing the schema).

True simultaneous enforcement of both an openapi-side and an asyncapi-side guard on one route was also considered and rejected for this PR's scope — it turns out to be blocked by a deeper limitation in how stream authorization works today (a stream carries exactly one guard-scoped session id, minted once by a single guard). That's now tracked separately in #2149 as its own cross-cutting engine design question.

Fixes #2133

## Test plan

- [x] `./mvnw -pl runtime/binding-openapi-asyncapi test` — all unit tests pass, including the new regression test in `OpenapiAsyncapiProxyGeneratorTest`
- [x] `./mvnw -pl runtime/binding-openapi-asyncapi checkstyle:check` — clean
- [x] `./mvnw -pl runtime/binding-openapi-asyncapi clean verify -Dit.test=OpenapiAsyncapiIT` — existing integration tests pass with no regressions
- [x] Confirmed the updated JSON schema patch is well-formed and `additionalProperties: false` still governs the asyncapi per-spec object after removing `security`
