### PR TITLE
fix(common-asyncapi): parse channel-level servers scoping and missing server fields

### DIFF
--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServer.java
@@ -17,14 +17,19 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 import java.util.List;
 import java.util.Map;
 
-public class AsyncapiServer
+public class AsyncapiServer extends AbstractAsyncapiResolvable
 {
     public String host;
     public String url;
     public String pathname;
+    public String title;
+    public String summary;
+    public String description;
     public String protocol;
+    public String protocolVersion;
     public List<AsyncapiSecurityScheme> security;
     public Map<String, AsyncapiServerVariable> variables;
+    public List<AsyncapiTag> tags;
     public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/resolver/AsyncapiResolver.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/resolver/AsyncapiResolver.java
@@ -31,6 +31,7 @@ public final class AsyncapiResolver
     public final AsyncapiMessageTraitResolver messageTraits;
     public final AsyncapiServerVariableResolver serverVariables;
     public final AsyncapiCorrelationIdResolver correlationIds;
+    public final AsyncapiServerResolver servers;
 
     private final Set<String> unresolved;
 
@@ -47,6 +48,7 @@ public final class AsyncapiResolver
         this.messageTraits = new AsyncapiMessageTraitResolver(model, unresolved);
         this.serverVariables = new AsyncapiServerVariableResolver(model, unresolved);
         this.correlationIds = new AsyncapiCorrelationIdResolver(model, unresolved);
+        this.servers = new AsyncapiServerResolver(model, unresolved);
     }
 
     public Collection<String> unresolvedRefs()

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/resolver/AsyncapiServerResolver.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/resolver/AsyncapiServerResolver.java
@@ -12,18 +12,20 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.common.asyncapi.model;
+package io.aklivity.zilla.runtime.common.asyncapi.model.resolver;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
-public class AsyncapiChannel extends AbstractAsyncapiResolvable
+import io.aklivity.zilla.runtime.common.asyncapi.model.Asyncapi;
+import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiServer;
+
+public final class AsyncapiServerResolver extends AbstractAsyncapiResolver<AsyncapiServer>
 {
-    public String address;
-    public LinkedHashMap<String, AsyncapiMessage> messages;
-    public LinkedHashMap<String, AsyncapiParameter> parameters;
-    public List<AsyncapiServer> servers;
-
-    public Map<String, Object> extensions;
+    public AsyncapiServerResolver(
+        Asyncapi model,
+        Set<String> unresolved)
+    {
+        super(model.servers, Pattern.compile("#/servers/(.+)"), unresolved);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiChannelView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiChannelView.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiChannel;
@@ -29,6 +30,7 @@ public final class AsyncapiChannelView
     public final String address;
     public final List<AsyncapiMessageView> messages;
     public final List<AsyncapiParameterView> parameters;
+    public final List<AsyncapiServerView> servers;
 
     private final Map<String, Object> extensions;
 
@@ -57,17 +59,20 @@ public final class AsyncapiChannelView
 
     AsyncapiChannelView(
         AsyncapiResolver resolver,
+        List<AsyncapiServerView> specServers,
         AsyncapiChannel model)
     {
-        this(resolver, resolver.channels.resolveRef(model.ref), model);
+        this(resolver, specServers, resolver.channels.resolveRef(model.ref), model);
     }
 
     AsyncapiChannelView(
         AsyncapiResolver resolver,
+        List<AsyncapiServerView> specServers,
         String name,
         AsyncapiChannel model)
     {
         final AsyncapiChannel resolved = resolver.channels.resolve(model);
+        final List<AsyncapiServerView> allServers = specServers != null ? specServers : List.of();
 
         this.name = requireNonNull(name);
         this.address = resolved.address;
@@ -81,6 +86,17 @@ public final class AsyncapiChannelView
                 .map(e -> new AsyncapiParameterView(this, resolver, e.getKey(), e.getValue()))
                 .toList()
             : null;
+        if (resolved.servers != null)
+        {
+            resolved.servers.forEach(resolver.servers::resolve);
+        }
+        this.servers = resolved.servers != null && !resolved.servers.isEmpty()
+            ? resolved.servers.stream()
+                .map(s -> resolver.servers.resolveRef(s.ref))
+                .filter(Objects::nonNull)
+                .flatMap(n -> allServers.stream().filter(s -> n.equals(s.name)))
+                .toList()
+            : allServers;
         this.extensions = resolved.extensions;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiOperationView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiOperationView.java
@@ -33,6 +33,7 @@ public final class AsyncapiOperationView
     public final List<AsyncapiMessageView> messages;
     public final List<AsyncapiSecuritySchemeView> security;
     public final List<String> tags;
+    public final List<AsyncapiServerView> servers;
 
     private final Map<String, Object> bindings;
     private final Map<String, Object> extensions;
@@ -84,11 +85,11 @@ public final class AsyncapiOperationView
         this.bindings = resolved.bindings;
         this.extensions = resolved.extensions;
         this.channel = resolved.channel != null
-                ? new AsyncapiChannelView(resolver, resolved.channel)
+                ? new AsyncapiChannelView(resolver, specification.servers, resolved.channel)
                 : null;
         this.action = resolved.action;
         this.reply = resolved.reply != null
-                ? new AsyncapiReplyView(resolver, resolved.reply)
+                ? new AsyncapiReplyView(resolver, specification.servers, resolved.reply)
                 : null;
         this.messages = resolved.messages != null
             ? resolved.messages.stream()
@@ -105,5 +106,6 @@ public final class AsyncapiOperationView
                     .map(tag -> tag.name)
                     .toList()
                 : null;
+        this.servers = channel != null ? channel.servers : specification.servers;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiReplyView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiReplyView.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.view;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,13 +43,14 @@ public class AsyncapiReplyView
 
     AsyncapiReplyView(
         AsyncapiResolver resolver,
+        List<AsyncapiServerView> specServers,
         AsyncapiReply model)
     {
         this.address = model.address != null
                 ? model.address.location
                 : null;
         this.channel = model.channel != null
-            ? new AsyncapiChannelView(resolver, model.channel)
+            ? new AsyncapiChannelView(resolver, specServers, model.channel)
             : null;
         this.extensions = model.extensions;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiServerView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiServerView.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -40,7 +41,12 @@ public final class AsyncapiServerView
     public final int port;
     public final String pathname;
     public final String literalPathname;
+    public final String title;
+    public final String summary;
+    public final String description;
     public final String protocol;
+    public final String protocolVersion;
+    public final List<String> tags;
 
     private final Map<String, Object> bindings;
     private final Map<String, Object> extensions;
@@ -124,7 +130,16 @@ public final class AsyncapiServerView
             ? pathnameMatcher.resolve(null)
             : null;
 
+        this.title = model.title;
+        this.summary = model.summary;
+        this.description = model.description;
         this.protocol = model.protocol;
+        this.protocolVersion = model.protocolVersion;
+        this.tags = model.tags != null
+            ? model.tags.stream()
+                .map(tag -> tag.name)
+                .toList()
+            : null;
         this.bindings = model.bindings;
         this.extensions = model.extensions;
     }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiView.java
@@ -127,7 +127,7 @@ public final class AsyncapiView
 
         this.channels = asyncapi.channels != null
             ? asyncapi.channels.entrySet().stream()
-                .map(e -> new AsyncapiChannelView(resolver, e.getKey(), e.getValue()))
+                .map(e -> new AsyncapiChannelView(resolver, this.servers, e.getKey(), e.getValue()))
                 .collect(toMap(c -> c.name, identity()))
             : null;
 

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiViewTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiViewTest.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.common.asyncapi.view;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -233,5 +234,129 @@ public class AsyncapiViewTest
         AsyncapiView view = AsyncapiView.of(model);
 
         assertThat(view, is(not(nullValue())));
+    }
+
+    @Test
+    public void shouldScopeChannelToDeclaredServerSubset() throws Exception
+    {
+        Asyncapi model = new AsyncapiParser().parse("""
+            asyncapi: 3.0.0
+            info:
+              title: Test API
+              version: 0.1.0
+            servers:
+              production:
+                host: 'prod.example.com:9092'
+                protocol: kafka
+              staging:
+                host: 'staging.example.com:9092'
+                protocol: kafka
+            operations:
+              doSend:
+                action: send
+                channel:
+                  $ref: '#/channels/output'
+            channels:
+              output:
+                servers:
+                  - $ref: '#/servers/production'
+                messages:
+                  note:
+                    $ref: '#/components/messages/note'
+            components:
+              messages:
+                note:
+                  payload:
+                    $ref: '#/components/schemas/note.payload'
+              schemas:
+                note.payload:
+                  schema:
+                    type: string
+            """);
+
+        AsyncapiServerConfig config = AsyncapiServerConfig.builder().build();
+        AsyncapiView view = AsyncapiView.of(model, List.of(config));
+
+        AsyncapiChannelView channel = view.channels.get("output");
+        assertThat(channel.servers, hasSize(1));
+        assertThat(channel.servers.get(0).name, is("production"));
+
+        AsyncapiOperationView operation = view.operations.get("doSend");
+        assertThat(operation.servers, hasSize(1));
+        assertThat(operation.servers.get(0).name, is("production"));
+    }
+
+    @Test
+    public void shouldMakeChannelAvailableOnAllServersWhenServersAbsent() throws Exception
+    {
+        Asyncapi model = new AsyncapiParser().parse("""
+            asyncapi: 3.0.0
+            info:
+              title: Test API
+              version: 0.1.0
+            servers:
+              production:
+                host: 'prod.example.com:9092'
+                protocol: kafka
+              staging:
+                host: 'staging.example.com:9092'
+                protocol: kafka
+            operations:
+              doSend:
+                action: send
+                channel:
+                  $ref: '#/channels/output'
+            channels:
+              output:
+                messages:
+                  note:
+                    $ref: '#/components/messages/note'
+            components:
+              messages:
+                note:
+                  payload:
+                    $ref: '#/components/schemas/note.payload'
+              schemas:
+                note.payload:
+                  schema:
+                    type: string
+            """);
+
+        AsyncapiServerConfig config = AsyncapiServerConfig.builder().build();
+        AsyncapiView view = AsyncapiView.of(model, List.of(config));
+
+        AsyncapiChannelView channel = view.channels.get("output");
+        assertThat(channel.servers, hasSize(2));
+    }
+
+    @Test
+    public void shouldParseServerMetadataFields() throws Exception
+    {
+        Asyncapi model = new AsyncapiParser().parse("""
+            asyncapi: 3.0.0
+            info:
+              title: Test API
+              version: 0.1.0
+            servers:
+              production:
+                host: 'prod.example.com:9092'
+                protocol: kafka
+                protocolVersion: '3.2'
+                title: Production Kafka
+                summary: The production broker
+                description: Production Kafka broker.
+                tags:
+                  - name: 'env:production'
+            """);
+
+        AsyncapiServerConfig config = AsyncapiServerConfig.builder().build();
+        AsyncapiView view = AsyncapiView.of(model, List.of(config));
+        AsyncapiServerView server = view.servers.get(0);
+
+        assertThat(server.protocolVersion, is("3.2"));
+        assertThat(server.title, is("Production Kafka"));
+        assertThat(server.summary, is("The production broker"));
+        assertThat(server.description, is("Production Kafka broker."));
+        assertThat(server.tags, is(List.of("env:production")));
     }
 }


### PR DESCRIPTION
## Description

AsyncAPI 3.0's Channel Object supports an optional `servers` property — an array of `$ref`s into the document's top-level `servers` map, scoping a channel to a subset of the declared servers. Zilla's bundled JSON Schema already validates this property, but `AsyncapiChannel` (the deserialization target) had no field to receive it, so it was silently dropped and every channel/operation was treated as available on every server.

This change:

- Adds the missing `servers` field to `AsyncapiChannel`.
- Adds a new `AsyncapiServerResolver` (resolving `#/servers/(.+)` refs), wired into `AsyncapiResolver` alongside the existing channel/message/schema resolvers, including unresolved-ref tracking for malformed docs.
- Threads a resolved `List<AsyncapiServerView>` through `AsyncapiChannelView` and `AsyncapiOperationView` — a channel scoped to a server subset now returns only those servers; an unscoped channel falls back to every declared server, per the spec's stated semantics ("If absent or empty then this channel must be available on all servers").
- Adds `protocolVersion`, `title`, `summary`, `description`, `tags` to `AsyncapiServer` — fields the schema already allows and existing spec fixtures (`client.http.yaml`, `client.kafka.yaml`) already set, but were previously discarded for lack of a model field. Threaded through to `AsyncapiServerView`.
- Adds unit tests covering channel server-subset scoping, the all-servers fallback, and the new server metadata fields.

**Out of scope (left for a follow-up):** wiring this into `binding-asyncapi`'s `when.servers[]` route condition / `AsyncapiServerFactory`'s routing logic. That mechanism is currently a coarse per-spec filter, and making it genuinely per-operation needs its own design discussion to avoid the class of bug PR #2145 fixed on the OpenAPI side.

Fixes #2150


---
_Generated by [Claude Code](https://claude.ai/code/session_01XuXPFNyEeKmiRcmbGM3Yjq)_