### PR TITLE
feat(docker-image): put /opt/zilla on PATH

### DIFF
--- a/cloud/docker-image/src/main/docker/Dockerfile
+++ b/cloud/docker-image/src/main/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN ./zpmw clean --keep-image
 FROM ubuntu:jammy-20260627
 
 ENV ZILLA_VERSION ${project.version}
+ENV PATH="/opt/zilla:${PATH}"
 
 COPY --from=build /.zpm /opt/zilla/.zpm
 COPY --from=build /zilla /opt/zilla/zilla

--- a/cloud/docker-image/src/main/docker/alpine.Dockerfile
+++ b/cloud/docker-image/src/main/docker/alpine.Dockerfile
@@ -30,6 +30,7 @@ RUN ./zpmw clean --keep-image
 FROM alpine:3.24.1
 
 ENV ZILLA_VERSION ${project.version}
+ENV PATH="/opt/zilla:${PATH}"
 
 COPY --from=build /.zpm /opt/zilla/.zpm
 COPY --from=build /zilla /opt/zilla/zilla


### PR DESCRIPTION
## Description

The Docker image installs the launcher at `/opt/zilla/zilla` and the `ENTRYPOINT` already hardcodes that full path, so `docker run <image> <command>` works fine. But `/opt/zilla` isn't on `PATH`, so anything that runs a command *inside* an already-running container — `docker exec <container> zilla logs`, a healthcheck `test:`, an interactive shell for debugging — has to spell out the full path `/opt/zilla/zilla` instead of the bare `zilla`.

Adds `ENV PATH="/opt/zilla:${PATH}"` to both `cloud/docker-image/src/main/docker/Dockerfile` and `alpine.Dockerfile`, right alongside the existing `ENV ZILLA_VERSION` line. This is purely additive — `ENTRYPOINT` already uses the full path, so `docker run` behavior is unchanged; it only adds a new capability for `docker exec`/interactive use.

Fixes #2153

### Testing

- `./mvnw clean install -pl cloud/docker-image -am` builds both image variants successfully.
- Verified against the locally built image: `docker exec <container> zilla help` now works without the full path, producing the same output as `/opt/zilla/zilla help`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015gEjFBcrpmGxgfvigBdCSa)_