### PR TITLE
fix(binding-tls): consolidate mutual/trustcacerts defaulting to runtime, after vault resolution

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfig.java
@@ -29,7 +29,7 @@ public final class TlsOptionsConfig extends OptionsConfig
     public final List<String> alpn;
     public final TlsMutualConfig mutual;
     public final List<String> signers;
-    public final boolean trustcacerts;
+    public final Boolean trustcacerts;
 
     public static TlsOptionsConfigBuilder<TlsOptionsConfig> builder()
     {
@@ -50,7 +50,7 @@ public final class TlsOptionsConfig extends OptionsConfig
         List<String> alpn,
         TlsMutualConfig mutual,
         List<String> signers,
-        boolean trustcacerts)
+        Boolean trustcacerts)
     {
         this.version = version;
         this.keys = keys;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/config/TlsOptionsConfigBuilder.java
@@ -15,8 +15,6 @@
  */
 package io.aklivity.zilla.runtime.binding.tls.config;
 
-import static io.aklivity.zilla.runtime.binding.tls.config.TlsMutualConfig.REQUIRED;
-
 import java.util.List;
 import java.util.function.Function;
 
@@ -108,8 +106,6 @@ public final class TlsOptionsConfigBuilder<T> extends ConfigBuilder<T, TlsOption
     @Override
     public T build()
     {
-        final TlsMutualConfig mutual = this.mutual == null && this.trust != null ? REQUIRED : this.mutual;
-        final boolean trustcacerts = this.trustcacerts == null ? this.trust == null : this.trustcacerts;
         return mapper.apply(new TlsOptionsConfig(version, keys, trust, sni, alpn, mutual, signers, trustcacerts));
     }
 }

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfig.java
@@ -28,7 +28,6 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.ExtendedSSLSession;
@@ -75,6 +74,7 @@ public final class TlsBindingConfig
 
     private boolean clientHttpsIdentification;
     private boolean clientServerNameIndication;
+    private TlsMutualConfig mutualDefault;
 
     public TlsBindingConfig(
         BindingConfig binding)
@@ -98,9 +98,18 @@ public final class TlsBindingConfig
         KeyManagerFactory keys = nothingConfigured
             ? newKeysWildcard(vault)
             : newKeys(config, vault, options.keys, options.signers);
+
+        boolean trustcacerts = kind == KindConfig.CLIENT && Boolean.TRUE.equals(options.trustcacerts);
         TrustManagerFactory trust = nothingConfigured
-            ? newTrustWildcard(config, vault, options.trustcacerts && kind == KindConfig.CLIENT)
-            : newTrust(config, vault, options.trust, options.trustcacerts && kind == KindConfig.CLIENT);
+            ? newTrustWildcard(config, vault, trustcacerts)
+            : newTrust(config, vault, options.trust, trustcacerts);
+
+        if (trust == null && kind == KindConfig.CLIENT && !trustcacerts)
+        {
+            trust = newTrustCacertsOnly(config);
+        }
+
+        this.mutualDefault = trust != null ? TlsMutualConfig.REQUIRED : TlsMutualConfig.NONE;
 
         try
         {
@@ -304,7 +313,7 @@ public final class TlsBindingConfig
             engine = context.createSSLEngine();
             engine.setUseClientMode(false);
 
-            TlsMutualConfig mutual = Optional.ofNullable(options != null ? options.mutual : null).orElse(TlsMutualConfig.NONE);
+            TlsMutualConfig mutual = options.mutual != null ? options.mutual : mutualDefault;
 
             switch (mutual)
             {
@@ -481,11 +490,9 @@ public final class TlsBindingConfig
             {
                 trust = vault.initTrust(trustNames, cacerts);
             }
-            else if (cacerts != null)
+            else
             {
-                TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                factory.init(cacerts);
-                trust = factory;
+                trust = newTrustFromCacerts(cacerts);
             }
         }
         catch (Exception ex)
@@ -536,16 +543,46 @@ public final class TlsBindingConfig
             {
                 trust = vault.initTrust(cacerts);
             }
-            else if (cacerts != null)
+            else
             {
-                TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                factory.init(cacerts);
-                trust = factory;
+                trust = newTrustFromCacerts(cacerts);
             }
         }
         catch (Exception ex)
         {
             LangUtil.rethrowUnchecked(ex);
+        }
+
+        return trust;
+    }
+
+    private TrustManagerFactory newTrustCacertsOnly(
+        TlsConfiguration config)
+    {
+        TrustManagerFactory trust = null;
+
+        try
+        {
+            trust = newTrustFromCacerts(Trusted.cacerts(config));
+        }
+        catch (Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+
+        return trust;
+    }
+
+    private TrustManagerFactory newTrustFromCacerts(
+        KeyStore cacerts)
+        throws Exception
+    {
+        TrustManagerFactory trust = null;
+
+        if (cacerts != null)
+        {
+            trust = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trust.init(cacerts);
         }
 
         return trust;

--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapter.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsOptionsConfigAdapter.java
@@ -15,7 +15,6 @@
  */
 package io.aklivity.zilla.runtime.binding.tls.internal.config;
 
-import static io.aklivity.zilla.runtime.binding.tls.config.TlsMutualConfig.REQUIRED;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
@@ -86,8 +85,7 @@ public final class TlsOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
             object.add(TRUST_NAME, trust);
         }
 
-        if (tlsOptions.trust != null && tlsOptions.trustcacerts ||
-            tlsOptions.trust == null && !tlsOptions.trustcacerts)
+        if (tlsOptions.trustcacerts != null)
         {
             object.add(TRUSTCACERTS_NAME, tlsOptions.trustcacerts);
         }
@@ -106,8 +104,7 @@ public final class TlsOptionsConfigAdapter implements OptionsConfigAdapterSpi, J
             object.add(ALPN_NAME, alpn);
         }
 
-        if (tlsOptions.mutual != null &&
-            (tlsOptions.trust == null || tlsOptions.mutual != REQUIRED))
+        if (tlsOptions.mutual != null)
         {
             String mutual = tlsOptions.mutual.name().toLowerCase();
             object.add(MUTUAL_NAME, mutual);

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfigTest.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/config/TlsBindingConfigTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.binding.tls.internal.config;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.SecureRandom;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.binding.tls.config.TlsMutualConfig;
+import io.aklivity.zilla.runtime.binding.tls.config.TlsOptionsConfig;
+import io.aklivity.zilla.runtime.binding.tls.internal.TlsConfiguration;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.config.BindingConfig;
+import io.aklivity.zilla.runtime.engine.config.KindConfig;
+import io.aklivity.zilla.runtime.engine.vault.VaultHandler;
+
+public class TlsBindingConfigTest
+{
+    private final TlsConfiguration config = new TlsConfiguration(new Configuration());
+    private final SecureRandom random = new SecureRandom();
+
+    private static TlsBindingConfig binding(
+        KindConfig kind,
+        TlsOptionsConfig options)
+    {
+        BindingConfig binding = BindingConfig.builder()
+            .namespace("test")
+            .name("tls0")
+            .type("tls")
+            .kind(kind)
+            .options(options)
+            .build();
+
+        return new TlsBindingConfig(binding);
+    }
+
+    private static TrustManagerFactory mockTrust()
+    {
+        return mock(TrustManagerFactory.class);
+    }
+
+    @Test
+    public void shouldDefaultMutualToRequiredWhenExplicitTrustResolvesViaVault()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(eq(asList("serverca")), isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("serverca"))
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.SERVER, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(true));
+        assertThat(engine.getWantClientAuth(), equalTo(false));
+    }
+
+    @Test
+    public void shouldDefaultMutualToRequiredWhenWildcardTrustResolvesViaVault()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder().build();
+        TlsBindingConfig binding = binding(KindConfig.SERVER, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(true));
+        assertThat(engine.getWantClientAuth(), equalTo(false));
+    }
+
+    @Test
+    public void shouldDefaultMutualToNoneWhenNoTrustResolves()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder().build();
+        TlsBindingConfig binding = binding(KindConfig.SERVER, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(false));
+        assertThat(engine.getWantClientAuth(), equalTo(false));
+    }
+
+    @Test
+    public void shouldHonorExplicitMutualOverDefaultWhenTrustResolves()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(eq(asList("serverca")), isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("serverca"))
+            .mutual(TlsMutualConfig.NONE)
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.SERVER, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(false));
+        assertThat(engine.getWantClientAuth(), equalTo(false));
+    }
+
+    @Test
+    public void shouldNotMergeCacertsWhenClientWildcardTrustResolvesViaVault()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder().build();
+        TlsBindingConfig binding = binding(KindConfig.CLIENT, options);
+
+        binding.init(config, null, vault, random);
+
+        verify(vault).initTrust(isNull());
+    }
+
+    @Test
+    public void shouldNotMergeCacertsWhenClientExplicitTrustResolvesViaVault()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(eq(asList("pinnedca")), isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("pinnedca"))
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.CLIENT, options);
+
+        binding.init(config, null, vault, random);
+
+        verify(vault).initTrust(eq(asList("pinnedca")), isNull());
+    }
+
+    @Test
+    public void shouldFallBackToCacertsWhenClientWildcardVaultResolvesNothing()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder().build();
+        TlsBindingConfig binding = binding(KindConfig.CLIENT, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(true));
+    }
+
+    @Test
+    public void shouldFallBackToCacertsWhenClientExplicitTrustVaultResolvesNothing()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("missingca"))
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.CLIENT, options);
+
+        binding.init(config, null, vault, random);
+
+        SSLEngine engine = binding.newServerEngine(0L, 0);
+        assertThat(engine.getNeedClientAuth(), equalTo(true));
+    }
+
+    @Test
+    public void shouldMergeCacertsUpfrontWhenClientTrustcacertsExplicitlyTrue()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(notNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trustcacerts(true)
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.CLIENT, options);
+
+        binding.init(config, null, vault, random);
+
+        verify(vault).initTrust(notNull());
+    }
+
+    @Test
+    public void shouldNotApplyTrustcacertsForServerKind()
+    {
+        VaultHandler vault = mock(VaultHandler.class);
+        when(vault.initTrust(anyList(), isNull())).thenReturn(mockTrust());
+
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("serverca"))
+            .trustcacerts(true)
+            .build();
+        TlsBindingConfig binding = binding(KindConfig.SERVER, options);
+
+        binding.init(config, null, vault, random);
+
+        verify(vault).initTrust(eq(asList("serverca")), isNull());
+    }
+
+    @Test
+    public void shouldLeaveMutualAndTrustcacertsUnsetAfterBuildWithNoExplicitConfig()
+    {
+        TlsOptionsConfig options = TlsOptionsConfig.builder().build();
+
+        assertThat(options.mutual, nullValue());
+        assertThat(options.trustcacerts, nullValue());
+    }
+
+    @Test
+    public void shouldPreserveExplicitOptionsAfterBuild()
+    {
+        TlsOptionsConfig options = TlsOptionsConfig.builder()
+            .trust(asList("serverca"))
+            .mutual(TlsMutualConfig.REQUESTED)
+            .trustcacerts(false)
+            .build();
+
+        assertThat(options.mutual, equalTo(TlsMutualConfig.REQUESTED));
+        assertThat(options.trustcacerts, not(nullValue()));
+        assertThat(options.trustcacerts, equalTo(false));
+    }
+}


### PR DESCRIPTION
## Description

`TlsOptionsConfigBuilder.build()` computed `mutual`/`trustcacerts` defaults at config-parse time, based only on whether an explicit `trust:` alias list was given — before the vault is ever consulted. This was wrong for the no-refs (vault-wildcard) case added in #2114/#1576: a `tls` binding with no explicit `trust:` list, backed by a vault that resolves real trust material via wildcard, silently never required a client certificate. For `kind: client`, `trustcacerts` also defaulted to `true` in the no-refs case, unconditionally merging system CA trust on top of a vault's pinned trust store.

This PR consolidates both defaults into a single runtime decision in `TlsBindingConfig`, made from the *actual resolved* trust material (`TrustManagerFactory` non-null), applied uniformly whether trust came from an explicit `trust: [...]` list or wildcard vault resolution:

- `mutual` now defaults to `REQUIRED` iff trust material actually resolved, decided in `newServerEngine` — the single remaining place the default is chosen (previously computed both at build-time in the options builder *and* independently defaulted to `NONE` in `newServerEngine`).
- `trustcacerts` (only meaningful for `kind: client`) now defaults to `false`. Trust is resolved from the vault *without* cacerts first; only if the vault has nothing to offer does it fall back to `Trusted.cacerts(config)` alone (never merged on top of vault-provided trust). Explicit `trustcacerts: true` is unchanged — cacerts is still computed and merged upfront.
- `TlsOptionsConfigBuilder.build()` no longer defaults these fields — `mutual`/`trustcacerts` (`trustcacerts` is now `Boolean`, not `boolean`) stay `null` unless explicitly configured.
- `TlsOptionsConfigAdapter`'s JSON read/write updated accordingly (the write-suppression logic that hid the old computed default is no longer needed).

Added `TlsBindingConfigTest` (12 unit tests, Mockito-mocked `VaultHandler`) covering both defaulting bugs for explicit-refs and wildcard cases, the explicit-override case, and confirming `trustcacerts` has no effect for `kind: server`.

### Backwards compatibility

- Existing YAML configs that rely on the documented default (`trust: [...]` with no explicit `mutual:` → `REQUIRED`) behave identically — verified by the existing k3po specs (`server.mutual.yaml`, `server.mutual.requested.yaml`, `client.cacerts.yaml`, etc.) via `ServerIT`/`ClientIT`, all passing.
- The no-refs/wildcard scenario intentionally changes behavior — that's the bug being fixed: `mutual` now correctly defaults to `REQUIRED` when the vault resolves real trust via wildcard (previously silently stayed `NONE`), and `kind: client` no longer silently widens a pinned vault trust store with system CA trust when `trustcacerts` isn't set.
- `TlsOptionsConfig.trustcacerts` changes from `boolean` to `Boolean`. All internal reads are null-checked; searched the rest of the monorepo (`binding-openapi`, `binding-asyncapi`, `zilla-plus`) for any other production code reading this field and found none — only test code that always sets it explicitly.

Full `mvn clean verify` on `runtime/binding-tls` passes: unit tests, checkstyle, and all k3po integration tests (`ServerIT`, `ClientIT`, `ProxyIT`, `BridgeIT`, `*FragmentedIT`).

Fixes #2157


---
_Generated by [Claude Code](https://claude.ai/code/session_01We3DWbSeqAyeoFmEUdQA5r)_