### PR TITLE
fix(manager): preserve uses clauses from real modules merged into the zpm delegate

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -620,6 +620,24 @@ public final class ZpmInstall extends ZpmCommand
         providesMatcher.appendTail(cleanedModuleInfo);
         moduleInfoContents = cleanedModuleInfo.toString();
 
+        // preserve `uses` declarations already authored by any real (non-automatic) module folded into
+        // this delegate -- jdeps only derives `uses` here from provides/services pairs it can resolve
+        // within this module, so a merged module's own ServiceLoader consumption of a service this
+        // delegate does not itself provide (for example slf4j-api's `uses org.slf4j.spi.SLF4JServiceProvider`,
+        // satisfied by a separate, non-merged provider module) would otherwise be silently dropped
+        Set<String> mergedUses = new LinkedHashSet<>(uses);
+        for (Path path : delegate.paths)
+        {
+            ModuleFinder.of(path).findAll().stream()
+                .map(ModuleReference::descriptor)
+                .filter(descriptor -> !descriptor.isAutomatic())
+                .flatMap(descriptor -> descriptor.uses().stream())
+                .map(service -> String.format("    uses %s;", service))
+                .forEach(mergedUses::add);
+        }
+        uses.clear();
+        uses.addAll(mergedUses);
+
         if (!uses.isEmpty())
         {
             int lastBraceIndex = moduleInfoContents.lastIndexOf('}');

--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -620,11 +620,6 @@ public final class ZpmInstall extends ZpmCommand
         providesMatcher.appendTail(cleanedModuleInfo);
         moduleInfoContents = cleanedModuleInfo.toString();
 
-        // preserve `uses` declarations already authored by any real (non-automatic) module folded into
-        // this delegate -- jdeps only derives `uses` here from provides/services pairs it can resolve
-        // within this module, so a merged module's own ServiceLoader consumption of a service this
-        // delegate does not itself provide (for example slf4j-api's `uses org.slf4j.spi.SLF4JServiceProvider`,
-        // satisfied by a separate, non-merged provider module) would otherwise be silently dropped
         Set<String> mergedUses = new LinkedHashSet<>(uses);
         for (Path path : delegate.paths)
         {

--- a/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
+++ b/manager/src/test/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstallTest.java
@@ -19,10 +19,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.File;
 import java.io.InputStream;
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -150,5 +154,35 @@ public class ZpmInstallTest
         listModules.waitFor();
 
         assertThat(modules, containsString("jdk.incubator.vector"));
+    }
+
+    @Test
+    public void shouldPreserveUsesClauseWhenMergingModuleIntoDelegate() throws Exception
+    {
+        Path configDir = Paths.get(getClass().getResource("/conf/install-delegate-uses/zpm.json").toURI()).getParent();
+
+        String[] args =
+        {
+            "install",
+            "--config-directory", configDir.toString(),
+            "--lock-directory", "target/test-locks/install-delegate-uses",
+            "--output-directory", "target/zpm-delegate-uses",
+            "--launcher-directory", "target",
+            "--exclude-remote-repositories",
+            "--silent"
+        };
+
+        Cli<Runnable> parser = new Cli<>(ZpmCli.class);
+        Runnable install = parser.parse(args);
+
+        install.run();
+
+        Path delegateJar = Paths.get("target/zpm-delegate-uses/modules/io.aklivity.zilla.manager.delegate.jar");
+        assertThat(delegateJar.toFile(), anExistingFile());
+
+        ModuleReference reference = ModuleFinder.of(delegateJar).findAll().iterator().next();
+        ModuleDescriptor descriptor = reference.descriptor();
+
+        assertThat(descriptor.uses(), hasItem("org.slf4j.spi.SLF4JServiceProvider"));
     }
 }

--- a/manager/src/test/resources/conf/install-delegate-uses/zpm.json
+++ b/manager/src/test/resources/conf/install-delegate-uses/zpm.json
@@ -1,0 +1,19 @@
+{
+  "repositories":
+  [
+    "https://maven.packages.aklivity.io/",
+    "https://repo1.maven.org/maven2/"
+  ],
+
+  "imports":
+  [
+    "io.aklivity.zilla:runtime:${project.version}"
+  ],
+
+  "dependencies":
+  [
+    "io.aklivity.zilla:engine",
+    "org.bitbucket.b_c:jose4j:0.9.6",
+    "org.slf4j:slf4j-api:2.0.17"
+  ]
+}


### PR DESCRIPTION
## Description

`zpm install` folds every automatic (non-modular) dependency into a synthetic `io.aklivity.zilla.manager.delegate` module, and recursively drags in any of that dependency's own dependencies too — including real, correctly-modularized ones. `ZpmInstall.generateDelegate()` derives the delegate's `uses` clauses only from `provides ... with ...;` pairs it can resolve within the delegate itself. `jdeps --generate-module-info` (the fallback path used whenever a dependency tree has unresolved optional artifacts, which is the common case) never proactively detects arbitrary `ServiceLoader.load()` call sites, so it emits zero bare `uses` clauses on its own.

The practical effect: when a real module with its own authored `uses` declaration (e.g. `org.slf4j`, whose module descriptor already declares `uses org.slf4j.spi.SLF4JServiceProvider`) gets merged into the delegate via this recursive process, that declaration is silently dropped. Any code from that module that calls `ServiceLoader.load()` for the first time then throws an uncaught `ServiceConfigurationError`, which crashes the whole engine (any configured `ErrorHandler` sees this as a fatal condition and shuts down).

This surfaced while investigating a crash in a downstream zilla-plus component (`guard-aws-cognito`, which bundles `jose4j` — itself depending on `slf4j-api`) that killed the entire engine the first time a real JWT reached signature verification.

### Fix

Preserve the `uses` declarations of every real (non-automatic) module folded into the delegate — read via `ModuleFinder.of(path).findAll()` over each constituent artifact path already tracked on the delegate `ZpmModule`, filtered to non-automatic descriptors, unioned with whatever `uses` clauses were already derived from `provides` matching.

### Verification

- New regression test `ZpmInstallTest.shouldPreserveUsesClauseWhenMergingModuleIntoDelegate`: runs a real `zpm install` against a fixture depending on `jose4j` + `slf4j-api` (the exact shape that triggers the bug), then asserts the generated delegate module's `ModuleDescriptor.uses()` contains `org.slf4j.spi.SLF4JServiceProvider`. Confirmed failing (`was empty`) against the pre-fix code, passing after.
- Rebuilt the full zilla-plus runtime image (via `zpmw install`) with this patched `manager` jar, confirmed via jlink's own module-link diagnostics that `org.slf4j.simple provides org.slf4j.spi.SLF4JServiceProvider` is now `used by io.aklivity.zilla.manager.delegate` (previously `not used by any observable module`), and confirmed the downstream `guard-aws-cognito` crash no longer reproduces against a real Kafka client end-to-end.


---
_Generated by [Claude Code](https://claude.ai/code/session_011LfmguC5M5mwdLJ64Dxruk)_