### PR TITLE
fix(engine): LabelManager.lookupLabel tolerates invalid/unregistered label ids

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/LabelManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/LabelManager.java
@@ -38,6 +38,8 @@ import org.agrona.LangUtil;
 
 public final class LabelManager
 {
+    private static final String UNKNOWN_LABEL = "unknown";
+
     private final List<String> labels;
     private final Map<String, Integer> labelIds;
     private final Path labelsPath;
@@ -69,7 +71,7 @@ public final class LabelManager
             checkSnapshot();
         }
 
-        return labels.get(labelId - 1);
+        return labelId >= 1 && labelId <= labels.size() ? labels.get(labelId - 1) : UNKNOWN_LABEL;
     }
 
     private int nextLabelId(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/LabelManagerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/LabelManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2024 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import io.aklivity.zilla.runtime.engine.namespace.NamespacedId;
+
+public class LabelManagerTest
+{
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void shouldRoundTripLabel() throws Exception
+    {
+        LabelManager labels = new LabelManager(folder.getRoot().toPath());
+
+        int labelId = labels.supplyLabelId("test");
+
+        assertThat(labels.lookupLabel(labelId), equalTo("test"));
+    }
+
+    @Test
+    public void shouldNotThrowForNoNamespaceIdSentinel() throws Exception
+    {
+        LabelManager labels = new LabelManager(folder.getRoot().toPath());
+
+        String label = labels.lookupLabel(NamespacedId.NO_NAMESPACE_ID);
+
+        assertThat(label, not(equalTo("test")));
+    }
+
+    @Test
+    public void shouldNotThrowForZeroLabelId() throws Exception
+    {
+        LabelManager labels = new LabelManager(folder.getRoot().toPath());
+        labels.supplyLabelId("test");
+
+        assertThat(labels.lookupLabel(0), not(equalTo("test")));
+    }
+
+    @Test
+    public void shouldNotThrowForUnregisteredLabelId() throws Exception
+    {
+        LabelManager labels = new LabelManager(folder.getRoot().toPath());
+        labels.supplyLabelId("test");
+
+        assertThat(labels.lookupLabel(999), not(equalTo("test")));
+    }
+}


### PR DESCRIPTION
## Closing — this was a workaround, not a fix

`LabelManager.lookupLabel()` throwing on an invalid label id is correct behavior; the actual bug was that `guard-aws-cognito` was ever producing an invalid id in the first place (see `aklivity/zilla-plus#938`). Making the engine's label registry silently tolerate bad input treats a symptom (a crash on read) instead of the cause (bad data on write), and would have hidden any future caller's mistake behind a silent "unknown" label instead of a loud, correct failure.

Verified directly: with `guard-aws-cognito`'s `guardId` fix in place and **no** change to this file, a new IT (`AwsCognitoGuardIT.shouldEmitDiscoveryFailedEventWithGuardIdAtAttach`, using a real `type: test` exporter that round-trips the event through the real `EngineContext.supplyQName()`/`LabelManager`) passes cleanly against the unmodified, unpatched engine. Temporarily reverting the guardId fix to reproduce the original `0L` reproduces the exact original crash (`IndexOutOfBoundsException: Index -1 out of bounds for length 18`) against this same unpatched `LabelManager` — confirming the write-side fix alone is sufficient and this read-side tolerance change is unnecessary.

Closing without merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_011LfmguC5M5mwdLJ64Dxruk)_