### PR TITLE
ci(release): trial aklivity/gitflow-changelog on develop's release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,45 +113,22 @@ jobs:
       run: |
         ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ inputs.version }}
 
-    - name: Generate CHANGELOG on release branch (attempt 1)
-      id: changelog-1
-      continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+    - name: Cache gitflow-changelog events
+      uses: actions/cache@v5
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        path: .gitflow-changelog-cache.json
+        key: gitflow-changelog-dev-${{ github.repository }}
 
-    - name: Generate CHANGELOG on release branch (attempt 2)
-      id: changelog-2
-      if: steps.changelog-1.outcome == 'failure'
+    - name: Generate CHANGELOG on release branch
+      id: changelog
       continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Generate CHANGELOG on release branch (attempt 3)
-      id: changelog-3
-      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure'
-      continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      uses: aklivity/gitflow-changelog@claude/gitflow-changelog-impl-b2b3tl
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Warn if CHANGELOG generation failed on release branch
-      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure' && steps.changelog-3.outcome == 'failure'
-      run: echo "::warning::CHANGELOG generation failed after 3 attempts; release/${{ inputs.version }} will carry the previous CHANGELOG.md unchanged."
-
-    - name: Fix CHANGELOG issue attribution on release branch
-      id: fix-changelog-issues-release
-      continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        REPO="${{ github.repository }}"
-        ruby .github/scripts/fix_changelog_issue_attribution.rb CHANGELOG.md "${REPO%%/*}" "${REPO##*/}" . HEAD
-
-    - name: Warn if CHANGELOG issue-attribution fix failed on release branch
-      if: steps.fix-changelog-issues-release.outcome == 'failure'
-      run: echo "::warning::CHANGELOG issue-attribution correction failed on release/${{ inputs.version }}; issue listings may misattribute issues closed by fixes that haven't shipped on this line yet (github_changelog_generator buckets issues by close date, not by ancestry)."
+      if: steps.changelog.outcome == 'failure'
+      run: echo "::warning::CHANGELOG generation failed on release/${{ inputs.version }}; release/${{ inputs.version }} will carry the previous CHANGELOG.md unchanged."
 
     - name: Commit POM versions and CHANGELOG on release branch
       run: git commit -a -m "Prepare release ${{ inputs.version }}"
@@ -396,45 +373,22 @@ jobs:
         git fetch origin ${{ github.ref_name }}
         git checkout ${{ github.ref_name }}
 
-    - name: Generate CHANGELOG on base branch (attempt 1)
-      id: changelog-1
-      continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+    - name: Cache gitflow-changelog events
+      uses: actions/cache@v5
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        path: .gitflow-changelog-cache.json
+        key: gitflow-changelog-dev-${{ github.repository }}
 
-    - name: Generate CHANGELOG on base branch (attempt 2)
-      id: changelog-2
-      if: steps.changelog-1.outcome == 'failure'
+    - name: Generate CHANGELOG on base branch
+      id: changelog
       continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Generate CHANGELOG on base branch (attempt 3)
-      id: changelog-3
-      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure'
-      continue-on-error: true
-      uses: janheinrichmerker/action-github-changelog-generator@v2.4
+      uses: aklivity/gitflow-changelog@claude/gitflow-changelog-impl-b2b3tl
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Warn if CHANGELOG generation failed on base branch
-      if: steps.changelog-1.outcome == 'failure' && steps.changelog-2.outcome == 'failure' && steps.changelog-3.outcome == 'failure'
-      run: echo "::warning::CHANGELOG generation failed after 3 attempts; ${{ github.ref_name }} was not updated. The release itself (tag, merge) already completed successfully — rerun CHANGELOG generation manually or it will catch up next release."
-
-    - name: Fix CHANGELOG issue attribution on base branch
-      id: fix-changelog-issues-base
-      continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        REPO="${{ github.repository }}"
-        ruby .github/scripts/fix_changelog_issue_attribution.rb CHANGELOG.md "${REPO%%/*}" "${REPO##*/}" . HEAD
-
-    - name: Warn if CHANGELOG issue-attribution fix failed on base branch
-      if: steps.fix-changelog-issues-base.outcome == 'failure'
-      run: echo "::warning::CHANGELOG issue-attribution correction failed on ${{ github.ref_name }}; issue listings may misattribute issues closed by fixes that haven't shipped on this line yet (github_changelog_generator buckets issues by close date, not by ancestry)."
+      if: steps.changelog.outcome == 'failure'
+      run: echo "::warning::CHANGELOG generation failed on ${{ github.ref_name }}; the release itself (tag, merge) already completed successfully — rerun CHANGELOG generation manually or it will catch up next release."
 
     - name: Commit and push CHANGELOG on base branch (if needed)
       run: |


### PR DESCRIPTION
## Description

Replaces the CHANGELOG-generation steps in `develop`'s copy of `release.yml` (in both the `prepare` job, on the release branch, and the `finalize` job, on the base branch after `git flow release finish`) with a single call to [`aklivity/gitflow-changelog`](https://github.com/aklivity/gitflow-changelog).

`aklivity/gitflow-changelog` replaces `github_changelog_generator` (three retry attempts) plus the `.github/scripts/fix_changelog_issue_attribution.rb` post-processing fixup (six steps total, at each of the two call sites) with a single step. Instead of bucketing issues by closed-at date and PRs by an unreliable timeline `commit_id`, it places every entry by asking git which tag actually contains its commit — the same ancestry-based approach the Ruby fixup script used, built in from the start rather than patched on after.

This PR points the action at `aklivity/gitflow-changelog@claude/gitflow-changelog-impl-b2b3tl` (its WIP branch, not yet tagged `v1`) so we can validate it against a real release (`2.0.0-alpha-24`) before doing the full migration. The Ruby fixup script is left in the repo, unused, so this is a one-line revert if the trial turns up a problem. The cache key (`gitflow-changelog-dev-...`) is also scoped separately from the eventual production key so this trial can't leave stale/incompatible cache data behind for the real migration.

Only `develop`'s copy of `release.yml` is touched here — `support/1.x` has its own separate copy and is out of scope for this trial.

Fixes # (issue)

## Test plan

- [ ] Trigger a real `2.0.0-alpha-24` release from `develop` via `workflow_dispatch` and confirm `CHANGELOG.md` on both `release/2.0.0-alpha-24` and `develop` is generated correctly
- [ ] Confirm the release itself (tag, deploy, merge) is unaffected if the CHANGELOG step fails (`continue-on-error` + warning, matching prior behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_0145r8t5N827hoExeFhZE489)_