### PR TITLE
ci(release): pin gitflow-changelog to v0, not the WIP branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,12 @@ jobs:
       uses: actions/cache@v5
       with:
         path: .gitflow-changelog-cache.json
-        key: gitflow-changelog-dev-${{ github.repository }}
+        key: gitflow-changelog-v0-${{ github.repository }}
 
     - name: Generate CHANGELOG on release branch
       id: changelog
       continue-on-error: true
-      uses: aklivity/gitflow-changelog@claude/gitflow-changelog-impl-b2b3tl
+      uses: aklivity/gitflow-changelog@v0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -377,12 +377,12 @@ jobs:
       uses: actions/cache@v5
       with:
         path: .gitflow-changelog-cache.json
-        key: gitflow-changelog-dev-${{ github.repository }}
+        key: gitflow-changelog-v0-${{ github.repository }}
 
     - name: Generate CHANGELOG on base branch
       id: changelog
       continue-on-error: true
-      uses: aklivity/gitflow-changelog@claude/gitflow-changelog-impl-b2b3tl
+      uses: aklivity/gitflow-changelog@v0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

`aklivity/gitflow-changelog@v0.1.0` is released, and its `dist/` is no longer committed on its own branches — only at tagged releases ([aklivity/gitflow-changelog#1](https://github.com/aklivity/gitflow-changelog/pull/1)). That means `@claude/gitflow-changelog-impl-b2b3tl` (used since the trial in #2165/#2166) no longer resolves to a working action.

Switches both `develop` CHANGELOG steps to `@v0` (the moving major-version tag, following the `actions/checkout`/`actions/setup-node` convention), and renames the cache key from the trial's `gitflow-changelog-dev-*` to `gitflow-changelog-v0-*` — cold-starting the real cache now that this is production usage, not a trial.

Fixes # (issue)

## Test plan

- [ ] Next release run confirms `@v0` resolves correctly and the CHANGELOG generates as it did during the trial runs


---
_Generated by [Claude Code](https://claude.ai/code/session_0145r8t5N827hoExeFhZE489)_