### PR TITLE
build(deps): ignore yasson 3.x on support/1.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
       versions: [ "62" ]
     - dependency-name: "org.slf4j:slf4j-*"
       versions: [ "2.x" ]
+    - dependency-name: "org.eclipse:yasson"
+      versions: [ "3.x" ]
   schedule:
     interval: daily
 - package-ecosystem: docker


### PR DESCRIPTION
## Description

Dependabot opened #2097 bumping `org.eclipse:yasson` from 2.0.3 to 3.0.4 on `support/1.x`. CI failed: yasson 3.0.4 implements the JSON-B 3.0 API, but `support/1.x` still pins `jakarta.json.bind-api` at 2.0.0, causing `NoClassDefFoundError: Could not initialize class org.eclipse.yasson.internal.AnnotationIntrospector` across most of the engine test suite.

Bumping `jakarta.json.bind-api` alone isn't sufficient either — it surfaces a further regression in `EngineConfigReader` (reuses/`reset()`s a shared `Reader` across namespace documents; yasson 3.0.4 now closes the reader after each `Jsonb.fromJson` call), and yasson 3.0.4 pulls in `org.eclipse.parsson` transitively where 2.0.3 didn't, which collides with the `org.leadpony.joy` `JsonProvider` `runtime/engine` relies on for YAML-flavored config parsing (and leaves `manager` with no `JsonProvider` at all if excluded uniformly).

`develop` already carries this upgrade, along with the accompanying `jakarta.json.bind-api` bump, an `EngineConfigReader` fix, and a `common-json`-provides-`JsonProvider` change that resolved the same provider collision (#2084). That's a deliberate multi-file migration — not something `support/1.x` should take piecemeal through a routine dependency bump.

Closed #2097 without merging and added `org.eclipse:yasson` (versions `3.x`) to Dependabot's ignore list, scoped to the `support/1.x`-targeted `maven` block only. `develop`'s Dependabot block is untouched, so it keeps receiving normal yasson updates.

## Changes

- `.github/dependabot.yml`: add an `org.eclipse:yasson` / `3.x` ignore rule to the `support/1.x` maven `updates` entry

## Testing

Configuration-only change (Dependabot ignore rule); no build/test impact. Root-caused the original CI failure by reproducing it in an isolated worktree of the `support/1.x` dependabot branch and bisecting the fix (`jakarta.json.bind-api` bump + `EngineConfigReader` fix got engine tests to 331/332 green), then verified via `dependency:tree` that a uniform parsson exclusion (mirroring `develop`'s fix) would leave `manager` without any `JsonProvider`, before concluding a partial backport was the wrong call for a support branch.

https://claude.ai/code/session_016WCtH7mWa6tc6GLbJnZxyh