### PR TITLE
feat(ci): add merge-report workflow

### DIFF
--- a/.github/workflows/merge-report.yml
+++ b/.github/workflows/merge-report.yml
@@ -1,0 +1,35 @@
+name: Merge Report
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  merge-report:
+    name: Merge Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch every branch
+        run: git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Cache gitflow-changelog events
+        uses: actions/cache@v6
+        with:
+          path: .gitflow-changelog-cache.json
+          key: gitflow-changelog-v3-${{ github.repository }}-${{ github.run_id }}
+          restore-keys: |
+            gitflow-changelog-v3-${{ github.repository }}-
+
+      - name: Merge report
+        uses: aklivity/gitflow-changelog/merge-report@v0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adds a `Merge Report` workflow (`.github/workflows/merge-report.yml`) that sweeps `develop` and every `support/N.x` branch for commits that landed on one branch but have no equivalent patch content on another that should have it — catching a fix on `support/1.x` that never made it to `develop`, which becomes a regression for a customer upgrading past `1.x`.

Uses [`aklivity/gitflow-changelog/merge-report@v0`](https://github.com/aklivity/gitflow-changelog), already in production use on `zilla-plus`. `mainline-branch`/`support-branch-pattern` aren't set explicitly — the tool's defaults (`develop`, `^support/(\d+)\.x$`) already match this repo's actual branches, and the existing `.gitflow-changelog.yml` only needs `tag-pattern` for the changelog use case.

`workflow_dispatch` only for now, no `schedule` trigger — same rollout order used on `zilla-plus`: validate manually first, add a schedule once the false-positive filtering (`exclude-paths`, `exclude-message-patterns`, `.gitflow-changelog-merge-ignore.yml`) has been calibrated against this repo's real history.

Reuses the same `gitflow-changelog-v3-${{ github.repository }}-*` cache key `release.yml` already populates, so this makes no additional GitHub API calls when that cache is warm.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6qDXDS9YjjXMVa7yRCqt2)_