### PR TITLE
fix(binding-http): prevent ReDoS in Basic auth format regex

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfig.java
@@ -56,7 +56,7 @@ import io.aklivity.zilla.runtime.engine.model.ValidatorHandler;
 public final class HttpBindingConfig
 {
     private static final Pattern BASIC_FORMAT_PATTERN =
-        Pattern.compile("^\\s*Basic\\s+(?<format>(:?[^\\\\{]*\\{[^}]+}[^\\\\{]*)+)$");
+        Pattern.compile("^\\s*Basic\\s+(?<format>[^\\\\{]*+(?:\\{[^}]++}[^\\\\{]*+)++)$");
     private static final Function<Function<String, String>, String> DEFAULT_CREDENTIALS = f -> null;
     private static final SortedSet<HttpVersion> DEFAULT_VERSIONS = new TreeSet<>(allOf(HttpVersion.class));
     private static final HttpAccessControlConfig DEFAULT_ACCESS_CONTROL =

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfigTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.binding.http.internal.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class HttpBindingConfigTest
+{
+    private static final int ADVERSARIAL_GROUP_COUNT = 10_000;
+    private static final long LINEAR_TIME_BUDGET_MILLIS = 1000L;
+
+    private final Pattern basicFormatPattern = basicFormatPattern();
+
+    @Test
+    public void shouldMatchUsernamePasswordFormat()
+    {
+        Matcher matcher = basicFormatPattern.matcher("Basic {username}:{password}");
+
+        assertTrue(matcher.matches());
+        assertEquals("{username}:{password}", matcher.group("format"));
+    }
+
+    @Test
+    public void shouldNotMatchWithoutBasicPrefix()
+    {
+        Matcher matcher = basicFormatPattern.matcher("{username}:{password}");
+
+        assertFalse(matcher.matches());
+    }
+
+    @Test
+    public void shouldNotHangOnManyBraceGroups()
+    {
+        String adversarial = adversarialInput(ADVERSARIAL_GROUP_COUNT);
+
+        long start = System.nanoTime();
+        boolean matched = basicFormatPattern.matcher(adversarial).matches();
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000L;
+
+        assertFalse(matched);
+        assertTrue("expected linear-time match, took " + elapsedMillis + "ms", elapsedMillis < LINEAR_TIME_BUDGET_MILLIS);
+    }
+
+    private static String adversarialInput(
+        int groupCount)
+    {
+        StringBuilder adversarial = new StringBuilder("Basic {|}");
+        for (int i = 0; i < groupCount; i++)
+        {
+            adversarial.append(":{|}");
+        }
+        adversarial.append('\\');
+        return adversarial.toString();
+    }
+
+    private static Pattern basicFormatPattern()
+    {
+        Pattern pattern;
+        try
+        {
+            Field field = HttpBindingConfig.class.getDeclaredField("BASIC_FORMAT_PATTERN");
+            field.setAccessible(true);
+            pattern = (Pattern) field.get(null);
+        }
+        catch (ReflectiveOperationException ex)
+        {
+            throw new IllegalStateException(ex);
+        }
+        return pattern;
+    }
+}


### PR DESCRIPTION
## Description

Backport of #2184 to `support/1.x`.

`HttpBindingConfig.BASIC_FORMAT_PATTERN` used greedy quantifiers with an ambiguous split between adjacent `{...}` group repetitions, so on a rejected input Java's backtracking regex engine could explore exponentially many parses of the string (CodeQL `java/redos`). `support/1.x` carries the identical vulnerable pattern.

Rewrote the quantifiers as possessive (`*+`, `++`) so a mismatch fails immediately instead of backtracking. This resolves the CodeQL alert while matching the exact same set of strings as before — verified with a standalone harness that the original pattern already hung past ~800 repetitions of a `:{|}` group, while the fixed pattern resolves 100,000 repetitions in ~23ms, and that legitimate patterns like `Basic {username}:{password}` still match identically.

Added `HttpBindingConfigTest` (the `internal/config` package previously had no unit tests) covering:
- a valid `Basic {username}:{password}` match
- rejection of input missing the `Basic` prefix
- a regression test asserting the adversarial input resolves in under 1 second

## Test plan

- [x] `./mvnw test -pl runtime/binding-http -Dtest=HttpBindingConfigTest`
- [x] `./mvnw test -pl runtime/binding-http` (full unit test suite)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb4yHqFwomzdaZbPTCg3nT)_