### PR TITLE
build(binding-http): fix stale copyright year in license header

### DIFF
--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfigTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpBindingConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Aklivity Inc.
+ * Copyright 2021-2026 Aklivity Inc.
  *
  * Aklivity licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
## Description

`./mvnw verify` currently fails on `develop` at `binding-http`'s `license:check` because `HttpBindingConfigTest.java` (added by #2184, the Basic-auth ReDoS fix) still carries a `Copyright 2021-2024 Aklivity Inc.` header, while the project's copyright-year bump (#2183) expects `2021-2026` on all files. This blocks the full reactor build for anyone building `develop` from a clean checkout.

Fix is a one-line header update to match the rest of the codebase.

## Test plan

- [x] `./mvnw license:check -pl runtime/binding-http` passes
- [x] `./mvnw clean verify -pl runtime/binding-http` — 394 tests pass, checkstyle/license/JaCoCo coverage all green


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeEyCoZoGvqWfCVovcHdzT)_