### PR TITLE
docs(examples): update http.kafka.oneway.oauthbearer to use inline guard

### DIFF
--- a/examples/http.kafka.oneway.oauthbearer/etc/zilla.yaml
+++ b/examples/http.kafka.oneway.oauthbearer/etc/zilla.yaml
@@ -2,7 +2,7 @@
 name: example
 guards:
   authn_kafka:
-    type: identity
+    type: inline
     options:
       credentials: ${{env.KAFKA_SASL_TOKEN}}
 bindings:


### PR DESCRIPTION
## Description

`guard-identity` was renamed to `guard-inline` in #2182 / #2195. `type: identity` still resolves via the backwards-compatible alias added in that PR, but the `http.kafka.oneway.oauthbearer` example was the only example in the repo still configured with the old type name — update it to `type: inline` so examples demonstrate the current primary type.

No functional change; the guard's `credentials`-passthrough behavior is identical either way.

## Test plan

- [x] Confirmed no other `examples/` config in the repo references `type: identity` (only this one)
- [x] `type: inline` is the renamed guard's primary type (validated against the schema in #2195); no other changes needed to this example


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeEyCoZoGvqWfCVovcHdzT)_