### PR TITLE
feat(guard-inline): support format-based splitting of identity and credentials

### DIFF
--- a/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandler.java
+++ b/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandler.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.agrona.collections.Long2ObjectHashMap;
 
@@ -32,6 +34,7 @@ public class InlineGuardHandler implements GuardHandler
     private final Long2ObjectHashMap<InlineSessionStore> sessionStoresByContextId;
     private final String identity;
     private final String credentials;
+    private final Matcher formatMatcher;
 
     public InlineGuardHandler(
         LongSupplier supplyAuthorizedId,
@@ -42,6 +45,9 @@ public class InlineGuardHandler implements GuardHandler
         this.sessionStoresByContextId = new Long2ObjectHashMap<>();
         this.identity = options != null ? options.identity : null;
         this.credentials = options != null ? options.credentials : null;
+        this.formatMatcher = options != null && options.format != null
+            ? Pattern.compile(toFormatPattern(options.format)).matcher("")
+            : null;
     }
 
     @Override
@@ -51,8 +57,25 @@ public class InlineGuardHandler implements GuardHandler
         long contextId,
         String credentials)
     {
+        String identityPart = credentials;
+        String credentialsPart = credentials;
+
+        if (formatMatcher != null)
+        {
+            if (formatMatcher.reset(credentials).matches())
+            {
+                identityPart = formatMatcher.group("identity");
+                credentialsPart = formatMatcher.group("credentials");
+            }
+            else
+            {
+                credentialsPart = this.credentials;
+            }
+        }
+
         InlineSessionStore sessionStore = supplySessionStore(contextId);
-        InlineSession session = sessionStore.supplySession(credentials);
+        InlineSession session = sessionStore.supplySession(identityPart);
+        session.credentials = credentialsPart;
         session.traceId = traceId;
         session.bindingId = bindingId;
 
@@ -101,7 +124,7 @@ public class InlineGuardHandler implements GuardHandler
         long sessionId)
     {
         InlineSession session = sessionsById.get(sessionId);
-        return session != null ? session.identity : credentials;
+        return session != null ? session.credentials : credentials;
     }
 
     @Override
@@ -130,6 +153,16 @@ public class InlineGuardHandler implements GuardHandler
         long contextId)
     {
         return sessionStoresByContextId.computeIfAbsent(contextId, InlineSessionStore::new);
+    }
+
+    private static String toFormatPattern(
+        String format)
+    {
+        String pattern = format
+            .replaceAll("([\\\\.^$|?*+()\\[\\]])", "\\\\$1")
+            .replace("{identity}", "(?<identity>[^\\s]+)")
+            .replace("{credentials}", "(?<credentials>[^\\s]+)");
+        return "^" + pattern + "$";
     }
 
     boolean verify(
@@ -205,6 +238,7 @@ public class InlineGuardHandler implements GuardHandler
         private final String identity;
         private final Consumer<InlineSession> unshare;
 
+        private String credentials;
         private long traceId;
         private long bindingId;
 

--- a/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfig.java
+++ b/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfig.java
@@ -20,12 +20,15 @@ public final class InlineOptionsConfig extends OptionsConfig
 {
     public final String identity;
     public final String credentials;
+    public final String format;
 
     public InlineOptionsConfig(
         String identity,
-        String credentials)
+        String credentials,
+        String format)
     {
         this.identity = identity;
         this.credentials = credentials;
+        this.format = format;
     }
 }

--- a/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfigAdapter.java
+++ b/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfigAdapter.java
@@ -29,6 +29,7 @@ public final class InlineOptionsConfigAdapter implements OptionsConfigAdapterSpi
 {
     private static final String IDENTITY_NAME = "identity";
     private static final String CREDENTIALS_NAME = "credentials";
+    private static final String FORMAT_NAME = "format";
 
     @Override
     public String type()
@@ -66,6 +67,11 @@ public final class InlineOptionsConfigAdapter implements OptionsConfigAdapterSpi
             object.add(CREDENTIALS_NAME, inlineOptions.credentials);
         }
 
+        if (inlineOptions.format != null)
+        {
+            object.add(FORMAT_NAME, inlineOptions.format);
+        }
+
         return object.build();
     }
 
@@ -81,6 +87,10 @@ public final class InlineOptionsConfigAdapter implements OptionsConfigAdapterSpi
             ? object.getString(CREDENTIALS_NAME)
             : null;
 
-        return new InlineOptionsConfig(identity, credentials);
+        String format = object.containsKey(FORMAT_NAME)
+            ? object.getString(FORMAT_NAME)
+            : null;
+
+        return new InlineOptionsConfig(identity, credentials, format);
     }
 }

--- a/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandlerTest.java
+++ b/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandlerTest.java
@@ -16,10 +16,15 @@ package io.aklivity.zilla.runtime.guard.inline.internal;
 
 import static java.util.Collections.emptyList;
 import static java.util.List.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import io.aklivity.zilla.runtime.guard.inline.internal.config.InlineOptionsConfig;
 
 public class InlineGuardHandlerTest
 {
@@ -34,5 +39,52 @@ public class InlineGuardHandlerTest
         assertTrue(handler.verify(sessionId, emptyList()));
         assertFalse(handler.verify(sessionId, of("admin")));
         assertFalse(handler.verify(0L, emptyList()));
+    }
+
+    @Test
+    public void shouldSplitIdentityAndCredentialsWhenFormatConfigured()
+    {
+        InlineOptionsConfig options = new InlineOptionsConfig(null, null, "{identity}:{credentials}");
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+
+        long sessionId = handler.reauthorize(0L, 0L, 0L, "alice:secret");
+
+        assertThat(handler.identity(sessionId), equalTo("alice"));
+        assertThat(handler.credentials(sessionId), equalTo("secret"));
+    }
+
+    @Test
+    public void shouldFallBackToWholeValueAsIdentityWhenFormatConfiguredButInputDoesNotMatch()
+    {
+        InlineOptionsConfig options = new InlineOptionsConfig(null, "default-credentials", "{identity}:{credentials}");
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+
+        long sessionId = handler.reauthorize(0L, 0L, 0L, "malformed-input-without-separator");
+
+        assertThat(handler.identity(sessionId), equalTo("malformed-input-without-separator"));
+        assertThat(handler.credentials(sessionId), equalTo("default-credentials"));
+    }
+
+    @Test
+    public void shouldFallBackToNullCredentialsWhenFormatConfiguredButInputDoesNotMatchAndNoStaticDefault()
+    {
+        InlineOptionsConfig options = new InlineOptionsConfig(null, null, "{identity}:{credentials}");
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+
+        long sessionId = handler.reauthorize(0L, 0L, 0L, "malformed-input-without-separator");
+
+        assertThat(handler.identity(sessionId), equalTo("malformed-input-without-separator"));
+        assertThat(handler.credentials(sessionId), nullValue());
+    }
+
+    @Test
+    public void shouldReturnSameValueForIdentityAndCredentialsWhenFormatNotConfigured()
+    {
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null);
+
+        long sessionId = handler.reauthorize(0L, 0L, 0L, "alice:secret");
+
+        assertThat(handler.identity(sessionId), equalTo("alice:secret"));
+        assertThat(handler.credentials(sessionId), equalTo("alice:secret"));
     }
 }

--- a/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineIT.java
+++ b/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineIT.java
@@ -31,6 +31,7 @@ import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+import io.aklivity.zilla.runtime.guard.inline.internal.config.InlineOptionsConfig;
 
 public class InlineIT
 {
@@ -73,6 +74,21 @@ public class InlineIT
         assertThat(guard.expiresAt(sessionId), equalTo(Long.MAX_VALUE));
         assertThat(guard.expiringAt(sessionId), equalTo(Long.MAX_VALUE));
         assertThat(guard.credentials(sessionId), equalTo(token));
+
+        guard.deauthorize(sessionId);
+    }
+
+    @Test
+    public void shouldSplitIdentityAndCredentialsWhenFormatConfigured() throws Exception
+    {
+        InlineOptionsConfig options = new InlineOptionsConfig(null, null, "{identity}:{credentials}");
+        InlineGuardHandler guard = new InlineGuardHandler(new MutableLong(1L)::getAndIncrement, options);
+
+        long sessionId = guard.reauthorize(0L, 0L, 101L, "alice:secret");
+
+        assertThat(sessionId, not(equalTo(0L)));
+        assertThat(guard.identity(sessionId), equalTo("alice"));
+        assertThat(guard.credentials(sessionId), equalTo("secret"));
 
         guard.deauthorize(sessionId);
     }

--- a/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfigAdapterTest.java
+++ b/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/config/InlineOptionsConfigAdapterTest.java
@@ -68,7 +68,7 @@ public class InlineOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptionsWithCredentials()
     {
-        InlineOptionsConfig options = new InlineOptionsConfig(null, "token");
+        InlineOptionsConfig options = new InlineOptionsConfig(null, "token", null);
 
         String yaml = jsonb.toJson(options);
 
@@ -79,7 +79,7 @@ public class InlineOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptionsWithIdentity()
     {
-        InlineOptionsConfig options = new InlineOptionsConfig("alice", null);
+        InlineOptionsConfig options = new InlineOptionsConfig("alice", null, null);
 
         String yaml = jsonb.toJson(options);
 
@@ -90,11 +90,33 @@ public class InlineOptionsConfigAdapterTest
     @Test
     public void shouldWriteOptionsWithNullFields()
     {
-        InlineOptionsConfig options = new InlineOptionsConfig(null, null);
+        InlineOptionsConfig options = new InlineOptionsConfig(null, null, null);
 
         String yaml = jsonb.toJson(options);
 
         assertThat(yaml, not(nullValue()));
         assertThat(yaml, equalTo("{}\n"));
+    }
+
+    @Test
+    public void shouldReadOptionsWithFormat()
+    {
+        String yaml = "format: \"{identity}:{credentials}\"";
+
+        InlineOptionsConfig options = jsonb.fromJson(yaml, InlineOptionsConfig.class);
+
+        assertThat(options, not(nullValue()));
+        assertThat(options.format, equalTo("{identity}:{credentials}"));
+    }
+
+    @Test
+    public void shouldWriteOptionsWithFormat()
+    {
+        InlineOptionsConfig options = new InlineOptionsConfig(null, null, "{identity}:{credentials}");
+
+        String yaml = jsonb.toJson(options);
+
+        assertThat(yaml, not(nullValue()));
+        assertThat(yaml, equalTo("format: \"{identity}:{credentials}\"\n"));
     }
 }

--- a/specs/guard-inline.spec/src/main/scripts/io/aklivity/zilla/specs/guard/inline/schema/inline.schema.patch.json
+++ b/specs/guard-inline.spec/src/main/scripts/io/aklivity/zilla/specs/guard/inline/schema/inline.schema.patch.json
@@ -46,6 +46,11 @@
                             {
                                 "title": "Credentials",
                                 "type": "string"
+                            },
+                            "format":
+                            {
+                                "title": "Format",
+                                "type": "string"
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
## Description

`guard-inline`'s `reauthorize()` currently treats the entire input as one atomic value — `identity()` and `credentials()` are aliased to the same session field, so there's no way to recover two independent parts from a compound credential.

Adds an optional `format` string option (e.g. `"{identity}:{credentials}"`), mirroring `guard-api-keys`' existing `format` field. When configured, `reauthorize()` compiles it into a regex and splits the incoming string into two independently-stored session values, returned separately by `identity()`/`credentials()`. Without `format`, behavior is unchanged — the whole input remains the identity, and `credentials()` returning that same value is correct for the single-part case (nothing to split).

```yaml
guards:
  passthrough0:
    type: inline
    options:
      format: "{identity}:{credentials}"
```

This lets any client binding consume `{identity}` + `{credentials}` together (e.g. `binding-kafka`'s plain/scram mechanism: `username: "{identity}"`, `password: "{credentials}"`) or `{credentials}` alone, uniformly, regardless of which guard is behind it.

## Test plan

- `InlineGuardHandlerTest`: 5/5 passing, including new coverage for the format-configured split (matching input, non-matching fallback) and the no-format backward-compat path.
- `InlineOptionsConfigAdapterTest`: 7/7 passing, including round-trip coverage for the new `format` field.
- `InlineGuardTest`: 3/3, `InlineGuardFactoryTest`: 1/1 — unaffected, still green.
- `./mvnw test -pl runtime/guard-inline` — 16 tests total, 0 failures, 0 errors.

Fixes #2201

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfdZXUbAuFm2nediVssqoM)_