### PR TITLE
test(binding-mcp-kafka): add IT coverage for tools/list

### DIFF
--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
@@ -188,6 +188,15 @@ public class McpKafkaProxyIT
         k3po.finish();
     }
 
+    @Test
+    @Configuration("proxy.produce.yaml")
+    @Specification({
+        "${mcp}/tools.list/client"})
+    public void shouldListTools() throws Exception
+    {
+        k3po.finish();
+    }
+
     public static String sessionId()
     {
         return "session-1";

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property authorization 0L
+
+connect "zilla://streams/mcp0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/mcp0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"value":{"type":"string"},"key":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","value"]}},'
+        '{"name":"consume","inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"limit":{"type":"integer"}},"required":["topic"]}}]}'
+read closed
+
+write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
@@ -1,0 +1,65 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/mcp0"
+property authorization 0L
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"value":{"type":"string"},"key":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","value"]}},'
+        '{"name":"consume","inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"limit":{"type":"integer"}},"required":["topic"]}}]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
+++ b/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
@@ -161,4 +161,13 @@ public class McpIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${mcp}/tools.list/client",
+        "${mcp}/tools.list/server"})
+    public void shouldListTools() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
## Description

The `mcp_kafka` proxy binding's `McpKafkaProxyFactory` already dispatches on `KIND_TOOLS_LIST` via a dedicated `McpToolsListProxy`, replying with a static `produce`/`consume` tool list, but this path had no spec scripts or IT coverage at all.

This PR adds:

- `specs/binding-mcp-kafka.spec/.../streams/mcp/tools.list/{client,server}.rpt` — asserts the exact compact-JSON payload (`{"tools":[{"name":"produce",...},{"name":"consume",...}]}`) that `McpKafkaProxyFactory` emits for a `tools/list` request.
- `McpIT#shouldListTools` in `specs/binding-mcp-kafka.spec` — runs the client/server scripts peer-to-peer for self-consistency.
- `McpKafkaProxyIT#shouldListTools` in `runtime/binding-mcp-kafka` — runs the client script against a live engine instance.

No production code changes — this is test-only, adding coverage for existing (previously untested) behavior.

Verified locally:
- `McpIT` (15 tests) and `KafkaIT` (9 tests) in `specs/binding-mcp-kafka.spec` — all pass
- Full `runtime/binding-mcp-kafka` verify (15 IT + 38 unit tests) — all pass
- `checkstyle:check` — clean

Fixes # (none — no tracking issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QzKDrmzxbShspSgMAFnTee)_