### PR TITLE
fix(binding-mcp): set content-type on deferred JSON-RPC error responses

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -1836,6 +1836,7 @@ public final class McpServerFactory implements McpStreamFactory
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                    .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .inject(this::injectAltSvc)
                     .build(),
                     id, error.code(), error.message().asString());
@@ -2421,6 +2422,7 @@ public final class McpServerFactory implements McpStreamFactory
                 httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                    .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .inject(this::injectAltSvc)
                     .build(),
                 -32700,
@@ -2435,6 +2437,7 @@ public final class McpServerFactory implements McpStreamFactory
                 httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(httpTypeId)
                     .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                    .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
                     .inject(this::injectAltSvc)
                     .build(),
                 -32600,

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/client.rpt
@@ -94,6 +94,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "200")
+                           .header("content-type", "application/json")
                            .build()}
 
 read '{"jsonrpc":"2.0","id":2,"error":{"code":-32700,"message":"Parse error"}}'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.array/server.rpt
@@ -91,6 +91,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "200")
+                            .header("content-type", "application/json")
                             .build()}
 write flush
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/client.rpt
@@ -94,6 +94,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "200")
+                           .header("content-type", "application/json")
                            .build()}
 
 read '{"jsonrpc":"2.0","id":2,"error":{"code":-32700,"message":"Parse error"}}'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.params.before.method/server.rpt
@@ -91,6 +91,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "200")
+                            .header("content-type", "application/json")
                             .build()}
 write flush
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/client.rpt
@@ -94,6 +94,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "200")
+                           .header("content-type", "application/json")
                            .build()}
 
 read '{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"Invalid request"}}'

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.tools.call.without.content.length/server.rpt
@@ -91,6 +91,7 @@ read closed
 write zilla:begin.ext ${http:beginEx()
                             .typeId(zilla:id("http"))
                             .header(":status", "200")
+                            .header("content-type", "application/json")
                             .build()}
 write flush
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.reject.error/client.rpt
@@ -96,6 +96,7 @@ write close
 read zilla:begin.ext ${http:matchBeginEx()
                            .typeId(zilla:id("http"))
                            .header(":status", "200")
+                           .header("content-type", "application/json")
                            .build()}
 
 read '{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"unresolved expression: args.ownerr"}}'


### PR DESCRIPTION
## Description

A user reported that `kafka__produce` (an mcp-kafka tool) worked fine from a raw CLI test client but failed from MCP Inspector's UI with:

```
MCP error -32099: Streamable HTTP error: Unexpected content type: null
```

Tracing the response path in `runtime/binding-mcp/.../McpServerFactory.java` found three places that build the HTTP `BEGIN` frame for a JSON-RPC error response but never set the `content-type` header, unlike every other response path in the class:

- `doNetRejectError` — fires when an app-side stream (e.g. the `mcp_kafka` proxy) resets with a `McpResetExFW.KIND_ERROR` extension, i.e. a tool-call failure surfaced after the request was routed. This is the path a failing `kafka__produce`/`kafka__consume` call hits.
- `onDecodeParseError` — JSON-RPC `-32700 Parse error`.
- `onDecodeInvalidRequest` — JSON-RPC `-32600 Invalid request`.

MCP Streamable HTTP clients that validate the response `Content-Type` (e.g. MCP Inspector) reject these responses outright since no header is present, even though a valid JSON body follows — matching the reported symptom. A client that doesn't check the header (the CLI test) sees the JSON fine, which is why the same request behaved differently across clients.

Fixes are minimal: add the missing `content-type: application/json` header at each of the three sites.

Per the repo's test-first discipline, the existing spec scripts covering these paths (`tools.call.reject.error`, `reject.request.params.before.method`, `reject.request.params.array`, `reject.tools.call.without.content.length`) were first extended to assert `content-type: application/json` on the reject response, confirmed to fail against the old code, then the implementation was fixed to make them pass.

## Test plan

- [x] Extended the 4 affected spec scripts with a `content-type` header assertion; confirmed `McpServerIT` failed for the right reason before the fix
- [x] Applied the fix; confirmed the same tests pass
- [x] `./mvnw clean verify -pl runtime/binding-mcp` — 173 unit tests + 271 integration tests pass, checkstyle clean, JaCoCo coverage met

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0193i2YdyGh3tt1PBTDH9KGo)_