### PR TITLE
Add AsyncAPI channel-binding SPI, writer, and typed document builders

### DIFF
--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiFragment.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiFragment.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.config;
+
+import java.io.StringReader;
+
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+
+import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiDeserializers;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
+public final class AsyncapiFragment
+{
+    private AsyncapiFragment()
+    {
+    }
+
+    public static Object parse(
+        String content)
+    {
+        JsonValue value;
+        try (JsonReader reader = YamlJson.createReader(new StringReader(content)))
+        {
+            value = reader.readValue();
+        }
+
+        return AsyncapiDeserializers.toPlainValue(value);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
@@ -107,6 +107,7 @@ public class AsyncapiParser
             Jsonb jsonb = JsonbBuilder.newBuilder()
                     .withConfig(new JsonbConfig()
                         .withDeserializers(deserializers.toArray(JsonbDeserializer[]::new)))
+                    .withProvider(provider)
                     .build();
 
             asyncapi = jsonb.fromJson(asyncapiObject.toString(), Asyncapi.class);

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParser.java
@@ -52,18 +52,20 @@ public class AsyncapiParser
     private final Map<String, Class<?>> operationBindingTypes;
     private final Map<String, Class<?>> messageBindingTypes;
     private final Map<String, Class<?>> serverBindingTypes;
+    private final Map<String, Class<?>> channelBindingTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
 
     public AsyncapiParser()
     {
-        this(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
+        this(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
     }
 
     AsyncapiParser(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
@@ -74,6 +76,7 @@ public class AsyncapiParser
         this.operationBindingTypes = operationBindingTypes;
         this.messageBindingTypes = messageBindingTypes;
         this.serverBindingTypes = serverBindingTypes;
+        this.channelBindingTypes = channelBindingTypes;
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
     }
@@ -99,7 +102,8 @@ public class AsyncapiParser
             }
 
             List<JsonbDeserializer<?>> deserializers = AsyncapiDeserializers.all(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes);
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes);
             Jsonb jsonb = JsonbBuilder.newBuilder()
                     .withConfig(new JsonbConfig()
                         .withDeserializers(deserializers.toArray(JsonbDeserializer[]::new)))

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserFactory.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiParserFactory.java
@@ -22,6 +22,7 @@ public final class AsyncapiParserFactory
     private final Map<String, Class<?>> operationBindingTypes;
     private final Map<String, Class<?>> messageBindingTypes;
     private final Map<String, Class<?>> serverBindingTypes;
+    private final Map<String, Class<?>> channelBindingTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
 
@@ -30,6 +31,7 @@ public final class AsyncapiParserFactory
         this.operationBindingTypes = new LinkedHashMap<>();
         this.messageBindingTypes = new LinkedHashMap<>();
         this.serverBindingTypes = new LinkedHashMap<>();
+        this.channelBindingTypes = new LinkedHashMap<>();
         this.extensionTypes = new LinkedHashMap<>();
         this.prefixExtensionTypes = new LinkedHashMap<>();
     }
@@ -58,6 +60,14 @@ public final class AsyncapiParserFactory
         return this;
     }
 
+    public <T> AsyncapiParserFactory withChannelBinding(
+        String name,
+        Class<T> type)
+    {
+        channelBindingTypes.put(name, type);
+        return this;
+    }
+
     public AsyncapiParserFactory withExtension(
         AsyncapiExtension extension)
     {
@@ -72,6 +82,7 @@ public final class AsyncapiParserFactory
     public AsyncapiParser createParser()
     {
         return new AsyncapiParser(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes);
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
@@ -18,7 +18,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Map;
 
-import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
@@ -43,6 +42,7 @@ public class AsyncapiWriter
     {
         this.jsonb = JsonbBuilder.newBuilder()
             .withConfig(new JsonbConfig().withNullValues(false))
+            .withProvider(YamlJson.provider())
             .build();
     }
 
@@ -75,7 +75,7 @@ public class AsyncapiWriter
 
         if (value instanceof JsonObject object)
         {
-            JsonObjectBuilder builder = Json.createObjectBuilder();
+            JsonObjectBuilder builder = YamlJson.provider().createObjectBuilder();
 
             for (Map.Entry<String, JsonValue> entry : object.entrySet())
             {
@@ -96,7 +96,7 @@ public class AsyncapiWriter
         }
         else if (value instanceof JsonArray array)
         {
-            JsonArrayBuilder builder = Json.createArrayBuilder();
+            JsonArrayBuilder builder = YamlJson.provider().createArrayBuilder();
 
             for (JsonValue element : array)
             {

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
@@ -16,9 +16,15 @@ package io.aklivity.zilla.runtime.common.asyncapi.config;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Map;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
 import jakarta.json.JsonWriter;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -29,6 +35,8 @@ import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public class AsyncapiWriter
 {
+    private static final String EXTENSIONS_FIELD = "extensions";
+
     private final Jsonb jsonb;
 
     public AsyncapiWriter()
@@ -49,12 +57,55 @@ public class AsyncapiWriter
             object = reader.readObject();
         }
 
+        JsonObject flattened = (JsonObject) flattenExtensions(object);
+
         StringWriter writer = new StringWriter();
         try (JsonWriter yaml = YamlJson.createWriter(writer))
         {
-            yaml.writeObject(object);
+            yaml.writeObject(flattened);
         }
 
         return writer.toString();
+    }
+
+    private static JsonValue flattenExtensions(
+        JsonValue value)
+    {
+        JsonValue result = value;
+
+        if (value instanceof JsonObject object)
+        {
+            JsonObjectBuilder builder = Json.createObjectBuilder();
+
+            for (Map.Entry<String, JsonValue> entry : object.entrySet())
+            {
+                if (EXTENSIONS_FIELD.equals(entry.getKey()) && entry.getValue() instanceof JsonObject extensions)
+                {
+                    for (Map.Entry<String, JsonValue> extension : extensions.entrySet())
+                    {
+                        builder.add(extension.getKey(), flattenExtensions(extension.getValue()));
+                    }
+                }
+                else
+                {
+                    builder.add(entry.getKey(), flattenExtensions(entry.getValue()));
+                }
+            }
+
+            result = builder.build();
+        }
+        else if (value instanceof JsonArray array)
+        {
+            JsonArrayBuilder builder = Json.createArrayBuilder();
+
+            for (JsonValue element : array)
+            {
+                builder.add(flattenExtensions(element));
+            }
+
+            result = builder.build();
+        }
+
+        return result;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.config;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonWriter;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+import io.aklivity.zilla.runtime.common.asyncapi.model.Asyncapi;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
+
+public class AsyncapiWriter
+{
+    private final Jsonb jsonb;
+
+    public AsyncapiWriter()
+    {
+        this.jsonb = JsonbBuilder.newBuilder()
+            .withConfig(new JsonbConfig().withNullValues(false))
+            .build();
+    }
+
+    public String write(
+        Asyncapi asyncapi)
+    {
+        String json = jsonb.toJson(asyncapi);
+
+        JsonObject object;
+        try (JsonReader reader = YamlJson.createReader(new StringReader(json)))
+        {
+            object = reader.readObject();
+        }
+
+        StringWriter writer = new StringWriter();
+        try (JsonWriter yaml = YamlJson.createWriter(writer))
+        {
+            yaml.writeObject(object);
+        }
+
+        return writer.toString();
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AbstractAsyncapiResolvableBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AbstractAsyncapiResolvableBuilder.java
@@ -14,22 +14,16 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
-import java.util.function.Function;
-
-public class AsyncapiInfo
+public abstract class AbstractAsyncapiResolvableBuilder<T, B extends AbstractAsyncapiResolvableBuilder<T, B>>
+    extends AsyncapiModelBuilder<T, B>
 {
-    public String title;
-    public String version;
-    public String description;
+    protected String ref;
 
-    public static AsyncapiInfoBuilder<AsyncapiInfo> builder()
+    @SuppressWarnings("unchecked")
+    public B ref(
+        String ref)
     {
-        return new AsyncapiInfoBuilder<>(AsyncapiInfo.class::cast);
-    }
-
-    public static <T> AsyncapiInfoBuilder<T> builder(
-        Function<AsyncapiInfo, T> mapper)
-    {
-        return new AsyncapiInfoBuilder<>(mapper);
+        this.ref = ref;
+        return (B) this;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/Asyncapi.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/Asyncapi.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public class Asyncapi
 {
@@ -27,4 +28,15 @@ public class Asyncapi
     public String defaultContentType;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiBuilder<Asyncapi> builder()
+    {
+        return new AsyncapiBuilder<>(Asyncapi.class::cast);
+    }
+
+    public static <T> AsyncapiBuilder<T> builder(
+        Function<Asyncapi, T> mapper)
+    {
+        return new AsyncapiBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiBuilder.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiBuilder<T> extends AsyncapiModelBuilder<T, AsyncapiBuilder<T>>
+{
+    private final Function<Asyncapi, T> mapper;
+
+    private String asyncapi;
+    private AsyncapiInfo info;
+    private Map<String, AsyncapiServer> servers;
+    private Map<String, AsyncapiChannel> channels;
+    private Map<String, AsyncapiOperation> operations;
+    private AsyncapiComponents components;
+
+    AsyncapiBuilder(
+        Function<Asyncapi, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiBuilder<T>>) getClass();
+    }
+
+    public AsyncapiBuilder<T> asyncapi(
+        String asyncapi)
+    {
+        this.asyncapi = asyncapi;
+        return this;
+    }
+
+    public AsyncapiInfoBuilder<AsyncapiBuilder<T>> info()
+    {
+        return AsyncapiInfo.builder(this::info);
+    }
+
+    public AsyncapiBuilder<T> info(
+        AsyncapiInfo info)
+    {
+        this.info = info;
+        return this;
+    }
+
+    public AsyncapiServerBuilder<AsyncapiBuilder<T>> server(
+        String name)
+    {
+        return AsyncapiServer.builder(server -> server(name, server));
+    }
+
+    public AsyncapiBuilder<T> server(
+        String name,
+        AsyncapiServer server)
+    {
+        if (servers == null)
+        {
+            servers = new LinkedHashMap<>();
+        }
+        servers.put(name, server);
+        return this;
+    }
+
+    public AsyncapiBuilder<T> servers(
+        Map<String, AsyncapiServer> servers)
+    {
+        this.servers = servers;
+        return this;
+    }
+
+    public AsyncapiChannelBuilder<AsyncapiBuilder<T>> channel(
+        String name)
+    {
+        return AsyncapiChannel.builder(channel -> channel(name, channel));
+    }
+
+    public AsyncapiBuilder<T> channel(
+        String name,
+        AsyncapiChannel channel)
+    {
+        if (channels == null)
+        {
+            channels = new LinkedHashMap<>();
+        }
+        channels.put(name, channel);
+        return this;
+    }
+
+    public AsyncapiBuilder<T> channels(
+        Map<String, AsyncapiChannel> channels)
+    {
+        this.channels = channels;
+        return this;
+    }
+
+    public AsyncapiOperationBuilder<AsyncapiBuilder<T>> operation(
+        String name)
+    {
+        return AsyncapiOperation.builder(operation -> operation(name, operation));
+    }
+
+    public AsyncapiBuilder<T> operation(
+        String name,
+        AsyncapiOperation operation)
+    {
+        if (operations == null)
+        {
+            operations = new LinkedHashMap<>();
+        }
+        operations.put(name, operation);
+        return this;
+    }
+
+    public AsyncapiBuilder<T> operations(
+        Map<String, AsyncapiOperation> operations)
+    {
+        this.operations = operations;
+        return this;
+    }
+
+    public AsyncapiComponentsBuilder<AsyncapiBuilder<T>> components()
+    {
+        return AsyncapiComponents.builder(this::components);
+    }
+
+    public AsyncapiBuilder<T> components(
+        AsyncapiComponents components)
+    {
+        this.components = components;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        Asyncapi asyncapiDoc = new Asyncapi();
+        asyncapiDoc.asyncapi = asyncapi;
+        asyncapiDoc.info = info;
+        asyncapiDoc.servers = servers;
+        asyncapiDoc.channels = channels;
+        asyncapiDoc.operations = operations;
+        asyncapiDoc.components = components;
+        return mapper.apply(asyncapiDoc);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannel.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannel.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class AsyncapiChannel extends AbstractAsyncapiResolvable
 {
@@ -27,4 +28,15 @@ public class AsyncapiChannel extends AbstractAsyncapiResolvable
     public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiChannelBuilder<AsyncapiChannel> builder()
+    {
+        return new AsyncapiChannelBuilder<>(AsyncapiChannel.class::cast);
+    }
+
+    public static <T> AsyncapiChannelBuilder<T> builder(
+        Function<AsyncapiChannel, T> mapper)
+    {
+        return new AsyncapiChannelBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannel.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannel.java
@@ -24,6 +24,7 @@ public class AsyncapiChannel extends AbstractAsyncapiResolvable
     public LinkedHashMap<String, AsyncapiMessage> messages;
     public LinkedHashMap<String, AsyncapiParameter> parameters;
     public List<AsyncapiServer> servers;
+    public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiChannelBuilder<T> extends AbstractAsyncapiResolvableBuilder<T, AsyncapiChannelBuilder<T>>
+{
+    private final Function<AsyncapiChannel, T> mapper;
+
+    private String address;
+    private LinkedHashMap<String, AsyncapiMessage> messages;
+    private Map<String, Object> bindings;
+    private Map<String, Object> extensions;
+
+    AsyncapiChannelBuilder(
+        Function<AsyncapiChannel, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiChannelBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiChannelBuilder<T>>) getClass();
+    }
+
+    public AsyncapiChannelBuilder<T> address(
+        String address)
+    {
+        this.address = address;
+        return this;
+    }
+
+    public AsyncapiMessageBuilder<AsyncapiChannelBuilder<T>> message(
+        String name)
+    {
+        return AsyncapiMessage.builder(message -> message(name, message));
+    }
+
+    public AsyncapiChannelBuilder<T> message(
+        String name,
+        AsyncapiMessage message)
+    {
+        if (messages == null)
+        {
+            messages = new LinkedHashMap<>();
+        }
+        messages.put(name, message);
+        return this;
+    }
+
+    public AsyncapiChannelBuilder<T> messages(
+        LinkedHashMap<String, AsyncapiMessage> messages)
+    {
+        this.messages = messages;
+        return this;
+    }
+
+    public AsyncapiChannelBuilder<T> bindings(
+        Map<String, Object> bindings)
+    {
+        this.bindings = bindings;
+        return this;
+    }
+
+    public AsyncapiChannelBuilder<T> extensions(
+        Map<String, Object> extensions)
+    {
+        this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiChannel channel = new AsyncapiChannel();
+        channel.ref = ref;
+        channel.address = address;
+        channel.messages = messages;
+        channel.bindings = bindings;
+        channel.extensions = extensions;
+        return mapper.apply(channel);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiChannelDeserializer.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
 
 public final class AsyncapiChannelDeserializer implements JsonbDeserializer<AsyncapiChannel>
 {
+    private final Map<String, Class<?>> channelBindingTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes;
     private final Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes;
     private final Supplier<Jsonb> plain;
@@ -36,14 +37,16 @@ public final class AsyncapiChannelDeserializer implements JsonbDeserializer<Asyn
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
+        this.channelBindingTypes = channelBindingTypes;
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiChannelDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiChannelDeserializer.class);
     }
 
     @Override
@@ -54,6 +57,8 @@ public final class AsyncapiChannelDeserializer implements JsonbDeserializer<Asyn
     {
         JsonObject object = parser.getObject();
         AsyncapiChannel model = plain.get().fromJson(object.toString(), AsyncapiChannel.class);
+
+        model.bindings = AsyncapiDeserializers.bindings(object, channelBindingTypes, plain.get());
         model.extensions = AsyncapiDeserializers.extensions(
             object, AsyncapiExtension.Scope.CHANNEL, extensionTypes, prefixExtensionTypes, plain);
 

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponents.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponents.java
@@ -15,6 +15,7 @@
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public class AsyncapiComponents
 {
@@ -26,4 +27,15 @@ public class AsyncapiComponents
     public Map<String, AsyncapiServerVariable> serverVariables;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiComponentsBuilder<AsyncapiComponents> builder()
+    {
+        return new AsyncapiComponentsBuilder<>(AsyncapiComponents.class::cast);
+    }
+
+    public static <T> AsyncapiComponentsBuilder<T> builder(
+        Function<AsyncapiComponents, T> mapper)
+    {
+        return new AsyncapiComponentsBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiComponentsBuilder<T> extends AsyncapiModelBuilder<T, AsyncapiComponentsBuilder<T>>
+{
+    private final Function<AsyncapiComponents, T> mapper;
+
+    private Map<String, AsyncapiMessage> messages;
+    private Map<String, AsyncapiSchemaItem> schemas;
+    private Map<String, Object> extensions;
+
+    AsyncapiComponentsBuilder(
+        Function<AsyncapiComponents, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiComponentsBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiComponentsBuilder<T>>) getClass();
+    }
+
+    public AsyncapiMessageBuilder<AsyncapiComponentsBuilder<T>> message(
+        String name)
+    {
+        return AsyncapiMessage.builder(message -> message(name, message));
+    }
+
+    public AsyncapiComponentsBuilder<T> message(
+        String name,
+        AsyncapiMessage message)
+    {
+        if (messages == null)
+        {
+            messages = new LinkedHashMap<>();
+        }
+        messages.put(name, message);
+        return this;
+    }
+
+    public AsyncapiComponentsBuilder<T> messages(
+        Map<String, AsyncapiMessage> messages)
+    {
+        this.messages = messages;
+        return this;
+    }
+
+    public AsyncapiMultiFormatSchemaBuilder<AsyncapiComponentsBuilder<T>> schema(
+        String name)
+    {
+        return AsyncapiMultiFormatSchema.builder(schema -> schema(name, schema));
+    }
+
+    public AsyncapiComponentsBuilder<T> schema(
+        String name,
+        AsyncapiSchemaItem schema)
+    {
+        if (schemas == null)
+        {
+            schemas = new LinkedHashMap<>();
+        }
+        schemas.put(name, schema);
+        return this;
+    }
+
+    public AsyncapiComponentsBuilder<T> schemas(
+        Map<String, AsyncapiSchemaItem> schemas)
+    {
+        this.schemas = schemas;
+        return this;
+    }
+
+    public AsyncapiComponentsBuilder<T> extensions(
+        Map<String, Object> extensions)
+    {
+        this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiComponents components = new AsyncapiComponents();
+        components.messages = messages;
+        components.schemas = schemas;
+        components.extensions = extensions;
+        return mapper.apply(components);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiComponentsDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiComponentsDeserializer implements JsonbDeserializer<A
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiComponentsDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiComponentsDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiCorrelationIdDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiCorrelationIdDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiCorrelationIdDeserializer implements JsonbDeserialize
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiCorrelationIdDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiCorrelationIdDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiDeserializer implements JsonbDeserializer<Asyncapi>
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
@@ -16,15 +16,18 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import static java.util.Collections.emptyMap;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -32,6 +35,7 @@ import jakarta.json.bind.JsonbConfig;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 
 import io.aklivity.zilla.runtime.common.asyncapi.config.AsyncapiExtension;
+import io.aklivity.zilla.runtime.common.yaml.json.YamlJson;
 
 public final class AsyncapiDeserializers
 {
@@ -119,6 +123,7 @@ public final class AsyncapiDeserializers
                         .toArray(JsonbDeserializer[]::new);
                 cache[0] = JsonbBuilder.newBuilder()
                     .withConfig(new JsonbConfig().withDeserializers(others))
+                    .withProvider(YamlJson.provider())
                     .build();
             }
             return cache[0];
@@ -144,7 +149,10 @@ public final class AsyncapiDeserializers
                     {
                         bindings = new LinkedHashMap<>();
                     }
-                    bindings.put(entry.getKey(), plain.fromJson(entry.getValue().toString(), bindingType));
+                    Object binding = Map.class.equals(bindingType)
+                        ? toPlainValue(entry.getValue())
+                        : plain.fromJson(entry.getValue().toString(), bindingType);
+                    bindings.put(entry.getKey(), binding);
                 }
             }
         }
@@ -175,7 +183,10 @@ public final class AsyncapiDeserializers
                     {
                         extensions = new LinkedHashMap<>();
                     }
-                    extensions.put(name, plain.get().fromJson(object.get(name).toString(), extensionType));
+                    Object extension = Map.class.equals(extensionType)
+                        ? toPlainValue(object.get(name))
+                        : plain.get().fromJson(object.get(name).toString(), extensionType);
+                    extensions.put(name, extension);
                 }
             }
         }
@@ -192,7 +203,7 @@ public final class AsyncapiDeserializers
                 {
                     if (aggregate == null)
                     {
-                        aggregate = Json.createObjectBuilder();
+                        aggregate = YamlJson.provider().createObjectBuilder();
                     }
                     aggregate.add(name.substring(prefix.length()), object.get(name));
                 }
@@ -204,11 +215,80 @@ public final class AsyncapiDeserializers
                 {
                     extensions = new LinkedHashMap<>();
                 }
-                extensions.put(registeredName,
-                    plain.get().fromJson(aggregate.build().toString(), prefixExtensionType.getValue()));
+                JsonObject aggregated = aggregate.build();
+                Class<?> prefixExtensionClass = prefixExtensionType.getValue();
+                Object extension = Map.class.equals(prefixExtensionClass)
+                    ? toPlainValue(aggregated)
+                    : plain.get().fromJson(aggregated.toString(), prefixExtensionClass);
+                extensions.put(registeredName, extension);
             }
         }
 
         return extensions;
+    }
+
+    public static Object toPlainValue(
+        JsonValue value)
+    {
+        Object result;
+
+        switch (value.getValueType())
+        {
+        case OBJECT:
+            Map<String, Object> object = new LinkedHashMap<>();
+            for (Map.Entry<String, JsonValue> entry : value.asJsonObject().entrySet())
+            {
+                object.put(entry.getKey(), toPlainValue(entry.getValue()));
+            }
+            result = object;
+            break;
+        case ARRAY:
+            List<Object> array = new ArrayList<>();
+            for (JsonValue element : (JsonArray) value)
+            {
+                array.add(toPlainValue(element));
+            }
+            result = array;
+            break;
+        case STRING:
+            result = ((JsonString) value).getString();
+            break;
+        case NUMBER:
+            result = toPlainNumber((JsonNumber) value);
+            break;
+        case TRUE:
+            result = Boolean.TRUE;
+            break;
+        case FALSE:
+            result = Boolean.FALSE;
+            break;
+        case NULL:
+        default:
+            result = null;
+            break;
+        }
+
+        return result;
+    }
+
+    private static Object toPlainNumber(
+        JsonNumber number)
+    {
+        Object result;
+
+        if (!number.isIntegral())
+        {
+            result = number.doubleValue();
+        }
+        else if (number.bigIntegerValue().bitLength() < 32)
+        {
+            result = number.intValue();
+        }
+        else
+        {
+            result = number.longValue();
+        }
+
+        return result;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiDeserializers.java
@@ -43,46 +43,63 @@ public final class AsyncapiDeserializers
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         return List.of(
             new AsyncapiDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiServerDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiServerVariableDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiChannelDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiOperationDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiMessageDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiTraitDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiParameterDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiComponentsDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiSchemaDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiMultiFormatSchemaDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiSchemaItemDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiSecuritySchemeDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiCorrelationIdDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes),
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes),
             new AsyncapiReplyDeserializer(
-                operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes));
+                operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                prefixExtensionTypes));
     }
 
     static Supplier<Jsonb> plain(
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes,
         Class<?>... excludes)
@@ -95,7 +112,8 @@ public final class AsyncapiDeserializers
             if (cache[0] == null)
             {
                 JsonbDeserializer<?>[] others = all(
-                    operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes)
+                    operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+                    prefixExtensionTypes)
                         .stream()
                         .filter(deserializer -> !excluded.contains(deserializer.getClass()))
                         .toArray(JsonbDeserializer[]::new);

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiInfo.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiInfo.java
@@ -14,17 +14,9 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
-import java.util.Map;
-
-public class Asyncapi
+public class AsyncapiInfo
 {
-    public String asyncapi;
-    public AsyncapiInfo info;
-    public Map<String, AsyncapiServer> servers;
-    public Map<String, AsyncapiChannel> channels;
-    public Map<String, AsyncapiOperation> operations;
-    public AsyncapiComponents components;
-    public String defaultContentType;
-
-    public Map<String, Object> extensions;
+    public String title;
+    public String version;
+    public String description;
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiInfoBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiInfoBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.function.Function;
+
+public final class AsyncapiInfoBuilder<T> extends AsyncapiModelBuilder<T, AsyncapiInfoBuilder<T>>
+{
+    private final Function<AsyncapiInfo, T> mapper;
+
+    private String title;
+    private String version;
+    private String description;
+
+    AsyncapiInfoBuilder(
+        Function<AsyncapiInfo, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiInfoBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiInfoBuilder<T>>) getClass();
+    }
+
+    public AsyncapiInfoBuilder<T> title(
+        String title)
+    {
+        this.title = title;
+        return this;
+    }
+
+    public AsyncapiInfoBuilder<T> version(
+        String version)
+    {
+        this.version = version;
+        return this;
+    }
+
+    public AsyncapiInfoBuilder<T> description(
+        String description)
+    {
+        this.description = description;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiInfo info = new AsyncapiInfo();
+        info.title = title;
+        info.version = version;
+        info.description = description;
+        return mapper.apply(info);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessage.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessage.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class AsyncapiMessage extends AbstractAsyncapiResolvable
 {
@@ -27,4 +28,15 @@ public class AsyncapiMessage extends AbstractAsyncapiResolvable
     public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiMessageBuilder<AsyncapiMessage> builder()
+    {
+        return new AsyncapiMessageBuilder<>(AsyncapiMessage.class::cast);
+    }
+
+    public static <T> AsyncapiMessageBuilder<T> builder(
+        Function<AsyncapiMessage, T> mapper)
+    {
+        return new AsyncapiMessageBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiMessageBuilder<T> extends AbstractAsyncapiResolvableBuilder<T, AsyncapiMessageBuilder<T>>
+{
+    private final Function<AsyncapiMessage, T> mapper;
+
+    private String contentType;
+    private AsyncapiSchemaItem payload;
+    private Map<String, Object> bindings;
+    private Map<String, Object> extensions;
+
+    AsyncapiMessageBuilder(
+        Function<AsyncapiMessage, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiMessageBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiMessageBuilder<T>>) getClass();
+    }
+
+    public AsyncapiMessageBuilder<T> contentType(
+        String contentType)
+    {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public AsyncapiMultiFormatSchemaBuilder<AsyncapiMessageBuilder<T>> payload()
+    {
+        return AsyncapiMultiFormatSchema.builder(this::payload);
+    }
+
+    public AsyncapiMessageBuilder<T> payload(
+        AsyncapiSchemaItem payload)
+    {
+        this.payload = payload;
+        return this;
+    }
+
+    public AsyncapiMessageBuilder<T> bindings(
+        Map<String, Object> bindings)
+    {
+        this.bindings = bindings;
+        return this;
+    }
+
+    public AsyncapiMessageBuilder<T> extensions(
+        Map<String, Object> extensions)
+    {
+        this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiMessage message = new AsyncapiMessage();
+        message.ref = ref;
+        message.contentType = contentType;
+        message.payload = payload;
+        message.bindings = bindings;
+        message.extensions = extensions;
+        return mapper.apply(message);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMessageDeserializer.java
@@ -37,6 +37,7 @@ public final class AsyncapiMessageDeserializer implements JsonbDeserializer<Asyn
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
@@ -44,8 +45,8 @@ public final class AsyncapiMessageDeserializer implements JsonbDeserializer<Asyn
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiMessageDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiMessageDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiModelBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiModelBuilder.java
@@ -16,20 +16,15 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.function.Function;
 
-public class AsyncapiInfo
+public abstract class AsyncapiModelBuilder<T, B extends AsyncapiModelBuilder<T, B>>
 {
-    public String title;
-    public String version;
-    public String description;
+    protected abstract Class<B> thisType();
 
-    public static AsyncapiInfoBuilder<AsyncapiInfo> builder()
+    public final <R> R inject(
+        Function<B, R> visitor)
     {
-        return new AsyncapiInfoBuilder<>(AsyncapiInfo.class::cast);
+        return visitor.apply(thisType().cast(this));
     }
 
-    public static <T> AsyncapiInfoBuilder<T> builder(
-        Function<AsyncapiInfo, T> mapper)
-    {
-        return new AsyncapiInfoBuilder<>(mapper);
-    }
+    public abstract T build();
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchema.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchema.java
@@ -14,8 +14,21 @@
  */
 package io.aklivity.zilla.runtime.common.asyncapi.model;
 
+import java.util.function.Function;
+
 public class AsyncapiMultiFormatSchema extends AsyncapiSchemaItem
 {
     public String schemaFormat;
     public Object schema;
+
+    public static AsyncapiMultiFormatSchemaBuilder<AsyncapiMultiFormatSchema> builder()
+    {
+        return new AsyncapiMultiFormatSchemaBuilder<>(AsyncapiMultiFormatSchema.class::cast);
+    }
+
+    public static <T> AsyncapiMultiFormatSchemaBuilder<T> builder(
+        Function<AsyncapiMultiFormatSchema, T> mapper)
+    {
+        return new AsyncapiMultiFormatSchemaBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.function.Function;
+
+public final class AsyncapiMultiFormatSchemaBuilder<T>
+    extends AbstractAsyncapiResolvableBuilder<T, AsyncapiMultiFormatSchemaBuilder<T>>
+{
+    private final Function<AsyncapiMultiFormatSchema, T> mapper;
+
+    private String schemaFormat;
+    private Object schema;
+
+    AsyncapiMultiFormatSchemaBuilder(
+        Function<AsyncapiMultiFormatSchema, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiMultiFormatSchemaBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiMultiFormatSchemaBuilder<T>>) getClass();
+    }
+
+    public AsyncapiMultiFormatSchemaBuilder<T> schemaFormat(
+        String schemaFormat)
+    {
+        this.schemaFormat = schemaFormat;
+        return this;
+    }
+
+    public AsyncapiMultiFormatSchemaBuilder<T> schema(
+        Object schema)
+    {
+        this.schema = schema;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiMultiFormatSchema schema = new AsyncapiMultiFormatSchema();
+        schema.ref = ref;
+        schema.schemaFormat = schemaFormat;
+        schema.schema = this.schema;
+        return mapper.apply(schema);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiMultiFormatSchemaDeserializer implements JsonbDeseria
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiMultiFormatSchemaDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiMultiFormatSchemaDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiMultiFormatSchemaDeserializer.java
@@ -63,6 +63,10 @@ public final class AsyncapiMultiFormatSchemaDeserializer implements JsonbDeseria
         Supplier<Jsonb> plain)
     {
         AsyncapiMultiFormatSchema model = plain.get().fromJson(object.toString(), AsyncapiMultiFormatSchema.class);
+        if (object.containsKey("schema"))
+        {
+            model.schema = AsyncapiDeserializers.toPlainValue(object.get("schema"));
+        }
         model.extensions = AsyncapiDeserializers.extensions(
             object, AsyncapiExtension.Scope.SCHEMA, extensionTypes, prefixExtensionTypes, plain);
 

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperation.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperation.java
@@ -21,6 +21,9 @@ public class AsyncapiOperation extends AbstractAsyncapiResolvable
 {
     public AsyncapiChannel channel;
     public String action;
+    public String title;
+    public String summary;
+    public String description;
     public AsyncapiReply reply;
     public List<AsyncapiMessage> messages;
     public List<AsyncapiSecurityScheme> security;

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperation.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperation.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class AsyncapiOperation extends AbstractAsyncapiResolvable
 {
@@ -31,4 +32,15 @@ public class AsyncapiOperation extends AbstractAsyncapiResolvable
     public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiOperationBuilder<AsyncapiOperation> builder()
+    {
+        return new AsyncapiOperationBuilder<>(AsyncapiOperation.class::cast);
+    }
+
+    public static <T> AsyncapiOperationBuilder<T> builder(
+        Function<AsyncapiOperation, T> mapper)
+    {
+        return new AsyncapiOperationBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiOperationBuilder<T> extends AbstractAsyncapiResolvableBuilder<T, AsyncapiOperationBuilder<T>>
+{
+    private final Function<AsyncapiOperation, T> mapper;
+
+    private AsyncapiChannel channel;
+    private String action;
+    private String summary;
+    private Map<String, Object> bindings;
+    private Map<String, Object> extensions;
+
+    AsyncapiOperationBuilder(
+        Function<AsyncapiOperation, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiOperationBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiOperationBuilder<T>>) getClass();
+    }
+
+    public AsyncapiChannelBuilder<AsyncapiOperationBuilder<T>> channel()
+    {
+        return AsyncapiChannel.builder(this::channel);
+    }
+
+    public AsyncapiOperationBuilder<T> channel(
+        AsyncapiChannel channel)
+    {
+        this.channel = channel;
+        return this;
+    }
+
+    public AsyncapiOperationBuilder<T> action(
+        String action)
+    {
+        this.action = action;
+        return this;
+    }
+
+    public AsyncapiOperationBuilder<T> summary(
+        String summary)
+    {
+        this.summary = summary;
+        return this;
+    }
+
+    public AsyncapiOperationBuilder<T> bindings(
+        Map<String, Object> bindings)
+    {
+        this.bindings = bindings;
+        return this;
+    }
+
+    public AsyncapiOperationBuilder<T> extensions(
+        Map<String, Object> extensions)
+    {
+        this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiOperation operation = new AsyncapiOperation();
+        operation.ref = ref;
+        operation.channel = channel;
+        operation.action = action;
+        operation.summary = summary;
+        operation.bindings = bindings;
+        operation.extensions = extensions;
+        return mapper.apply(operation);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiOperationDeserializer.java
@@ -37,6 +37,7 @@ public final class AsyncapiOperationDeserializer implements JsonbDeserializer<As
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
@@ -44,8 +45,8 @@ public final class AsyncapiOperationDeserializer implements JsonbDeserializer<As
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiOperationDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiOperationDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiParameterDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiParameterDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiParameterDeserializer implements JsonbDeserializer<As
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiParameterDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiParameterDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiReplyDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiReplyDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiReplyDeserializer implements JsonbDeserializer<Asynca
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiReplyDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiReplyDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaDeserializer.java
@@ -38,14 +38,15 @@ public final class AsyncapiSchemaDeserializer implements JsonbDeserializer<Async
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiSchemaDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiSchemaDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaItemDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSchemaItemDeserializer.java
@@ -36,14 +36,16 @@ public final class AsyncapiSchemaItemDeserializer implements JsonbDeserializer<A
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiSchemaItemDeserializer.class, AsyncapiSchemaDeserializer.class, AsyncapiMultiFormatSchemaDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiSchemaItemDeserializer.class, AsyncapiSchemaDeserializer.class,
+            AsyncapiMultiFormatSchemaDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiSecuritySchemeDeserializer implements JsonbDeserializ
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiSecuritySchemeDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiSecuritySchemeDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiSecuritySchemeDeserializer.java
@@ -55,6 +55,10 @@ public final class AsyncapiSecuritySchemeDeserializer implements JsonbDeserializ
     {
         JsonObject object = parser.getObject();
         AsyncapiSecurityScheme model = plain.get().fromJson(object.toString(), AsyncapiSecurityScheme.class);
+        if (object.containsKey("flows"))
+        {
+            model.flows = AsyncapiDeserializers.toPlainValue(object.get("flows"));
+        }
         model.extensions = AsyncapiDeserializers.extensions(
             object, AsyncapiExtension.Scope.SECURITY_SCHEME, extensionTypes, prefixExtensionTypes, plain);
 

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServer.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.asyncapi.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public class AsyncapiServer extends AbstractAsyncapiResolvable
 {
@@ -33,4 +34,15 @@ public class AsyncapiServer extends AbstractAsyncapiResolvable
     public Map<String, Object> bindings;
 
     public Map<String, Object> extensions;
+
+    public static AsyncapiServerBuilder<AsyncapiServer> builder()
+    {
+        return new AsyncapiServerBuilder<>(AsyncapiServer.class::cast);
+    }
+
+    public static <T> AsyncapiServerBuilder<T> builder(
+        Function<AsyncapiServer, T> mapper)
+    {
+        return new AsyncapiServerBuilder<>(mapper);
+    }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerBuilder.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public final class AsyncapiServerBuilder<T> extends AbstractAsyncapiResolvableBuilder<T, AsyncapiServerBuilder<T>>
+{
+    private final Function<AsyncapiServer, T> mapper;
+
+    private String host;
+    private String protocol;
+    private Map<String, Object> bindings;
+    private Map<String, Object> extensions;
+
+    AsyncapiServerBuilder(
+        Function<AsyncapiServer, T> mapper)
+    {
+        this.mapper = mapper;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Class<AsyncapiServerBuilder<T>> thisType()
+    {
+        return (Class<AsyncapiServerBuilder<T>>) getClass();
+    }
+
+    public AsyncapiServerBuilder<T> host(
+        String host)
+    {
+        this.host = host;
+        return this;
+    }
+
+    public AsyncapiServerBuilder<T> protocol(
+        String protocol)
+    {
+        this.protocol = protocol;
+        return this;
+    }
+
+    public AsyncapiServerBuilder<T> bindings(
+        Map<String, Object> bindings)
+    {
+        this.bindings = bindings;
+        return this;
+    }
+
+    public AsyncapiServerBuilder<T> extensions(
+        Map<String, Object> extensions)
+    {
+        this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public T build()
+    {
+        AsyncapiServer server = new AsyncapiServer();
+        server.ref = ref;
+        server.host = host;
+        server.protocol = protocol;
+        server.bindings = bindings;
+        server.extensions = extensions;
+        return mapper.apply(server);
+    }
+}

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerDeserializer.java
@@ -37,6 +37,7 @@ public final class AsyncapiServerDeserializer implements JsonbDeserializer<Async
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
@@ -44,8 +45,8 @@ public final class AsyncapiServerDeserializer implements JsonbDeserializer<Async
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiServerDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiServerDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerVariableDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiServerVariableDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiServerVariableDeserializer implements JsonbDeserializ
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiServerVariableDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiServerVariableDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTraitDeserializer.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiTraitDeserializer.java
@@ -36,14 +36,15 @@ public final class AsyncapiTraitDeserializer implements JsonbDeserializer<Asynca
         Map<String, Class<?>> operationBindingTypes,
         Map<String, Class<?>> messageBindingTypes,
         Map<String, Class<?>> serverBindingTypes,
+        Map<String, Class<?>> channelBindingTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> extensionTypes,
         Map<AsyncapiExtension.Scope, Map<String, Class<?>>> prefixExtensionTypes)
     {
         this.extensionTypes = extensionTypes;
         this.prefixExtensionTypes = prefixExtensionTypes;
         this.plain = AsyncapiDeserializers.plain(
-            operationBindingTypes, messageBindingTypes, serverBindingTypes, extensionTypes, prefixExtensionTypes,
-            AsyncapiTraitDeserializer.class);
+            operationBindingTypes, messageBindingTypes, serverBindingTypes, channelBindingTypes, extensionTypes,
+            prefixExtensionTypes, AsyncapiTraitDeserializer.class);
     }
 
     @Override

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiChannelView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiChannelView.java
@@ -32,6 +32,7 @@ public final class AsyncapiChannelView
     public final List<AsyncapiParameterView> parameters;
     public final List<AsyncapiServerView> servers;
 
+    private final Map<String, Object> bindings;
     private final Map<String, Object> extensions;
 
     public boolean hasMessages()
@@ -42,6 +43,19 @@ public final class AsyncapiChannelView
     public boolean hasParameters()
     {
         return parameters != null && !parameters.isEmpty();
+    }
+
+    public boolean hasBinding(
+        String name)
+    {
+        return bindings != null && bindings.containsKey(name);
+    }
+
+    public <T> Optional<T> binding(
+        String name,
+        Class<T> type)
+    {
+        return Optional.ofNullable(bindings != null ? type.cast(bindings.get(name)) : null);
     }
 
     public boolean hasExtension(
@@ -97,6 +111,7 @@ public final class AsyncapiChannelView
                 .flatMap(n -> allServers.stream().filter(s -> n.equals(s.name)))
                 .toList()
             : allServers;
+        this.bindings = resolved.bindings;
         this.extensions = resolved.extensions;
     }
 }

--- a/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiSchemaView.java
+++ b/runtime/common-asyncapi/src/main/java/io/aklivity/zilla/runtime/common/asyncapi/view/AsyncapiSchemaView.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.asyncapi.view;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,7 +61,8 @@ public final class AsyncapiSchemaView extends AsyncapiSchemaItemView
             : null;
         this.properties = resolved.properties != null
             ? resolved.properties.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> new AsyncapiSchemaView(resolver, e.getValue())))
+                .collect(toMap(Map.Entry::getKey, e -> new AsyncapiSchemaView(resolver, e.getValue()),
+                    (l, r) -> l, LinkedHashMap::new))
             : null;
         this.required = resolved.required;
         this.format = resolved.format;

--- a/runtime/common-asyncapi/src/main/resources/io/aklivity/zilla/runtime/common/asyncapi/config/schema/asyncapi.3.0.1.schema.json
+++ b/runtime/common-asyncapi/src/main/resources/io/aklivity/zilla/runtime/common/asyncapi/config/schema/asyncapi.3.0.1.schema.json
@@ -1244,6 +1244,7 @@
           "properties": {
             "bindingVersion": {
               "enum": [
+                "0.5.0",
                 "0.4.0",
                 "0.3.0"
               ]
@@ -1260,7 +1261,22 @@
                 }
               },
               "then": {
-                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/server.json"
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "bindingVersion"
+                ],
+                "properties": {
+                  "bindingVersion": {
+                    "const": "0.5.0"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/server.json"
               }
             },
             {
@@ -1949,6 +1965,42 @@
         }
       },
       "default": true
+    },
+    "http://asyncapi.com/bindings/kafka/0.5.0/server.json": {
+      "$id": "http://asyncapi.com/bindings/kafka/0.5.0/server.json",
+      "title": "Server Schema",
+      "description": "This object contains server connection information to a Kafka broker. This object contains additional information not possible to represent within the core AsyncAPI specification.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+      },
+      "properties": {
+        "schemaRegistryUrl": {
+          "type": "string",
+          "description": "API URL for the Schema Registry used when producing Kafka messages (if a Schema Registry was used)."
+        },
+        "schemaRegistryVendor": {
+          "type": "string",
+          "description": "The vendor of the Schema Registry and Kafka serdes library that should be used."
+        },
+        "bindingVersion": {
+          "type": "string",
+          "enum": [
+            "0.5.0"
+          ],
+          "description": "The version of this binding."
+        }
+      },
+      "examples": [
+        {
+          "schemaRegistryUrl": "https://my-schema-registry.com",
+          "schemaRegistryVendor": "confluent",
+          "bindingVersion": "0.5.0"
+        }
+      ]
     },
     "http://asyncapi.com/bindings/kafka/0.4.0/server.json": {
       "$id": "http://asyncapi.com/bindings/kafka/0.4.0/server.json",
@@ -3705,6 +3757,7 @@
           "properties": {
             "bindingVersion": {
               "enum": [
+                "0.5.0",
                 "0.4.0",
                 "0.3.0"
               ]
@@ -3721,7 +3774,22 @@
                 }
               },
               "then": {
-                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/message.json"
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "bindingVersion"
+                ],
+                "properties": {
+                  "bindingVersion": {
+                    "const": "0.5.0"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/message.json"
               }
             },
             {
@@ -4114,6 +4182,75 @@
           },
           "responseTopic": "application/responses",
           "bindingVersion": "0.2.0"
+        }
+      ]
+    },
+    "http://asyncapi.com/bindings/kafka/0.5.0/message.json": {
+      "$id": "http://asyncapi.com/bindings/kafka/0.5.0/message.json",
+      "title": "Message Schema",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+      },
+      "properties": {
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/Reference.json"
+            },
+            {
+              "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json"
+            }
+          ],
+          "description": "The message key."
+        },
+        "schemaIdLocation": {
+          "type": "string",
+          "description": "If a Schema Registry is used when performing this operation, tells where the id of schema is stored.",
+          "enum": [
+            "header",
+            "payload"
+          ]
+        },
+        "schemaIdPayloadEncoding": {
+          "type": "string",
+          "description": "Number of bytes or vendor specific values when schema id is encoded in payload."
+        },
+        "schemaLookupStrategy": {
+          "type": "string",
+          "description": "Freeform string for any naming strategy class to use. Clients should default to the vendor default if not supplied."
+        },
+        "bindingVersion": {
+          "type": "string",
+          "enum": [
+            "0.5.0"
+          ],
+          "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+        }
+      },
+      "examples": [
+        {
+          "key": {
+            "type": "string",
+            "enum": [
+              "myKey"
+            ]
+          },
+          "schemaIdLocation": "payload",
+          "schemaIdPayloadEncoding": "apicurio-new",
+          "schemaLookupStrategy": "TopicIdStrategy",
+          "bindingVersion": "0.5.0"
+        },
+        {
+          "key": {
+            "$ref": "path/to/user-create.avsc#/UserCreate"
+          },
+          "schemaIdLocation": "payload",
+          "schemaIdPayloadEncoding": "4",
+          "bindingVersion": "0.5.0"
         }
       ]
     },
@@ -4788,6 +4925,7 @@
           "properties": {
             "bindingVersion": {
               "enum": [
+                "0.5.0",
                 "0.4.0",
                 "0.3.0"
               ]
@@ -4804,7 +4942,22 @@
                 }
               },
               "then": {
-                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/channel.json"
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "bindingVersion"
+                ],
+                "properties": {
+                  "bindingVersion": {
+                    "const": "0.5.0"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json"
               }
             },
             {
@@ -5320,6 +5473,103 @@
             "vhost": "/"
           },
           "bindingVersion": "0.3.0"
+        }
+      ]
+    },
+    "http://asyncapi.com/bindings/kafka/0.5.0/channel.json": {
+      "$id": "http://asyncapi.com/bindings/kafka/0.5.0/channel.json",
+      "title": "Channel Schema",
+      "description": "This object contains information about the channel representation in Kafka.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+      },
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "Kafka topic name if different from channel name."
+        },
+        "partitions": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of partitions configured on this topic."
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of replicas configured on this topic."
+        },
+        "topicConfiguration": {
+          "description": "Topic configuration properties that are relevant for the API.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cleanup.policy": {
+              "description": "The [`cleanup.policy`](https://kafka.apache.org/documentation/#topicconfigs_cleanup.policy) configuration option.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "compact",
+                  "delete"
+                ]
+              }
+            },
+            "retention.ms": {
+              "description": "The [`retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_retention.ms) configuration option.",
+              "type": "integer",
+              "minimum": -1
+            },
+            "retention.bytes": {
+              "description": "The [`retention.bytes`](https://kafka.apache.org/documentation/#topicconfigs_retention.bytes) configuration option.",
+              "type": "integer",
+              "minimum": -1
+            },
+            "delete.retention.ms": {
+              "description": "The [`delete.retention.ms`](https://kafka.apache.org/documentation/#topicconfigs_delete.retention.ms) configuration option.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "max.message.bytes": {
+              "description": "The [`max.message.bytes`](https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes) configuration option.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "confluent.key.schema.validation": {
+              "description": "It shows whether the schema validation for the message key is enabled. Vendor specific config.",
+              "type": "boolean"
+            },
+            "confluent.key.subject.name.strategy": {
+              "description": "The name of the schema lookup strategy for the message key. Vendor specific config.",
+              "type": "string"
+            },
+            "confluent.value.schema.validation": {
+              "description": "It shows whether the schema validation for the message value is enabled. Vendor specific config.",
+              "type": "boolean"
+            },
+            "confluent.value.subject.name.strategy": {
+              "description": "The name of the schema lookup strategy for the message value. Vendor specific config.",
+              "type": "string"
+            }
+          }
+        },
+        "bindingVersion": {
+          "type": "string",
+          "enum": [
+            "0.5.0"
+          ],
+          "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+        }
+      },
+      "examples": [
+        {
+          "topic": "my-specific-topic",
+          "partitions": 20,
+          "replicas": 3,
+          "bindingVersion": "0.5.0"
         }
       ]
     },
@@ -6741,6 +6991,7 @@
           "properties": {
             "bindingVersion": {
               "enum": [
+                "0.5.0",
                 "0.4.0",
                 "0.3.0"
               ]
@@ -6757,7 +7008,22 @@
                 }
               },
               "then": {
-                "$ref": "http://asyncapi.com/bindings/kafka/0.4.0/operation.json"
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "bindingVersion"
+                ],
+                "properties": {
+                  "bindingVersion": {
+                    "const": "0.5.0"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json"
               }
             },
             {
@@ -7283,6 +7549,52 @@
           "retain": true,
           "messageExpiryInterval": 60,
           "bindingVersion": "0.2.0"
+        }
+      ]
+    },
+    "http://asyncapi.com/bindings/kafka/0.5.0/operation.json": {
+      "$id": "http://asyncapi.com/bindings/kafka/0.5.0/operation.json",
+      "title": "Operation Schema",
+      "description": "This object contains information about the operation representation in Kafka.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-[\\w\\d\\.\\x2d_]+$": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/specificationExtension.json"
+        }
+      },
+      "properties": {
+        "groupId": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+          "description": "Id of the consumer group."
+        },
+        "clientId": {
+          "$ref": "http://asyncapi.com/definitions/3.0.0/schema.json",
+          "description": "Id of the consumer inside a consumer group."
+        },
+        "bindingVersion": {
+          "type": "string",
+          "enum": [
+            "0.5.0"
+          ],
+          "description": "The version of this binding. If omitted, 'latest' MUST be assumed."
+        }
+      },
+      "examples": [
+        {
+          "groupId": {
+            "type": "string",
+            "enum": [
+              "myGroupId"
+            ]
+          },
+          "clientId": {
+            "type": "string",
+            "enum": [
+              "myClientId"
+            ]
+          },
+          "bindingVersion": "0.5.0"
         }
       ]
     },

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiFragmentTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiFragmentTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class AsyncapiFragmentTest
+{
+    @Test
+    public void shouldParseObjectPreservingKeyOrder()
+    {
+        String json = "{\"type\":\"object\",\"description\":\"Order event\"," +
+            "\"properties\":{\"id\":{\"type\":\"string\"},\"timestamp\":{\"type\":\"integer\"}," +
+            "\"amount\":{\"type\":\"number\"}}}";
+
+        Object parsed = AsyncapiFragment.parse(json);
+
+        assertTrue(parsed instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> object = (Map<String, Object>) parsed;
+        assertEquals(List.of("type", "description", "properties"), List.copyOf(object.keySet()));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) object.get("properties");
+        assertEquals(List.of("id", "timestamp", "amount"), List.copyOf(properties.keySet()));
+    }
+
+    @Test
+    public void shouldParseArray()
+    {
+        Object parsed = AsyncapiFragment.parse("[\"delete\",\"compact\"]");
+
+        assertEquals(List.of("delete", "compact"), parsed);
+    }
+
+    @Test
+    public void shouldParsePrimitives()
+    {
+        assertEquals("hello", AsyncapiFragment.parse("\"hello\""));
+        assertEquals(42, AsyncapiFragment.parse("42"));
+        assertEquals(Boolean.TRUE, AsyncapiFragment.parse("true"));
+    }
+
+    @Test
+    public void shouldRoundTripNestedMapUnchanged()
+    {
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("a", 1);
+        nested.put("b", 2);
+
+        Object parsed = AsyncapiFragment.parse("{\"a\":1,\"b\":2}");
+
+        assertEquals(nested, parsed);
+    }
+}

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriterTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriterTest.java
@@ -36,6 +36,11 @@ public class AsyncapiWriterTest
         public String key;
     }
 
+    public static final class SampleExtension
+    {
+        public String key;
+    }
+
     @Test
     public void shouldRoundTripAsyncapiVersionAndInfo()
     {
@@ -111,5 +116,42 @@ public class AsyncapiWriterTest
 
         assertEquals(1, reparsed.channels.size());
         assertEquals("events", reparsed.channels.get("events").address);
+    }
+
+    @Test
+    public void shouldFlattenExtensionsToSiblingXKeysNotWrapperField()
+    {
+        Asyncapi asyncapi = new Asyncapi();
+        asyncapi.asyncapi = "3.0.0";
+        asyncapi.info = new AsyncapiInfo();
+        asyncapi.info.title = "Test API";
+        asyncapi.info.version = "1.0.0";
+
+        Map<String, Object> extensionValue = new LinkedHashMap<>();
+        extensionValue.put("key", "server-value");
+
+        AsyncapiServer server = new AsyncapiServer();
+        server.host = "localhost:9092";
+        server.protocol = "kafka";
+        server.extensions = new LinkedHashMap<>();
+        server.extensions.put("x-zilla-sample", extensionValue);
+
+        asyncapi.servers = new LinkedHashMap<>();
+        asyncapi.servers.put("local", server);
+
+        String yaml = new AsyncapiWriter().write(asyncapi);
+
+        assertTrue(yaml.contains("x-zilla-sample"));
+        assertTrue(!yaml.contains("extensions:"));
+
+        AsyncapiParser parser = new AsyncapiParserFactory()
+            .withExtension(AsyncapiExtension.of(AsyncapiExtension.Scope.SERVER, "x-zilla-sample", SampleExtension.class))
+            .createParser();
+        Asyncapi reparsed = parser.parse(yaml);
+        AsyncapiView view = AsyncapiView.of(reparsed);
+        AsyncapiServerView reparsedServer = view.servers.get(0);
+
+        assertTrue(reparsedServer.hasExtension("x-zilla-sample"));
+        assertEquals("server-value", reparsedServer.extension("x-zilla-sample", SampleExtension.class).get().key);
     }
 }

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriterTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/config/AsyncapiWriterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.asyncapi.model.Asyncapi;
+import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiChannel;
+import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiInfo;
+import io.aklivity.zilla.runtime.common.asyncapi.model.AsyncapiServer;
+import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiServerView;
+import io.aklivity.zilla.runtime.common.asyncapi.view.AsyncapiView;
+
+public class AsyncapiWriterTest
+{
+    public static final class SampleBinding
+    {
+        public String key;
+    }
+
+    @Test
+    public void shouldRoundTripAsyncapiVersionAndInfo()
+    {
+        Asyncapi asyncapi = new Asyncapi();
+        asyncapi.asyncapi = "3.0.0";
+        asyncapi.info = new AsyncapiInfo();
+        asyncapi.info.title = "Test API";
+        asyncapi.info.version = "1.0.0";
+        asyncapi.info.description = "A test API";
+
+        String yaml = new AsyncapiWriter().write(asyncapi);
+
+        Asyncapi reparsed = new AsyncapiParser().parse(yaml);
+
+        assertEquals("3.0.0", reparsed.asyncapi);
+        assertEquals("Test API", reparsed.info.title);
+        assertEquals("1.0.0", reparsed.info.version);
+        assertEquals("A test API", reparsed.info.description);
+    }
+
+    @Test
+    public void shouldWriteGenericMapBindingWithoutBespokeClass()
+    {
+        Asyncapi asyncapi = new Asyncapi();
+        asyncapi.asyncapi = "3.0.0";
+        asyncapi.info = new AsyncapiInfo();
+        asyncapi.info.title = "Test API";
+        asyncapi.info.version = "1.0.0";
+
+        Map<String, Object> serverBinding = new LinkedHashMap<>();
+        serverBinding.put("key", "server-value");
+
+        AsyncapiServer server = new AsyncapiServer();
+        server.host = "localhost:9092";
+        server.protocol = "kafka";
+        server.bindings = new LinkedHashMap<>();
+        server.bindings.put("x-zilla-sample", serverBinding);
+
+        asyncapi.servers = new LinkedHashMap<>();
+        asyncapi.servers.put("local", server);
+
+        String yaml = new AsyncapiWriter().write(asyncapi);
+
+        AsyncapiParser parser = new AsyncapiParserFactory()
+            .withServerBinding("x-zilla-sample", SampleBinding.class)
+            .createParser();
+        Asyncapi reparsed = parser.parse(yaml);
+        AsyncapiView view = AsyncapiView.of(reparsed);
+        AsyncapiServerView reparsedServer = view.servers.get(0);
+
+        assertTrue(reparsedServer.hasBinding("x-zilla-sample"));
+        assertEquals("server-value", reparsedServer.binding("x-zilla-sample", SampleBinding.class).get().key);
+    }
+
+    @Test
+    public void shouldRoundTripChannelsAndOperations()
+    {
+        Asyncapi asyncapi = new Asyncapi();
+        asyncapi.asyncapi = "3.0.0";
+        asyncapi.info = new AsyncapiInfo();
+        asyncapi.info.title = "Test API";
+        asyncapi.info.version = "1.0.0";
+
+        AsyncapiChannel channel = new AsyncapiChannel();
+        channel.address = "events";
+
+        asyncapi.channels = new LinkedHashMap<>();
+        asyncapi.channels.put("events", channel);
+
+        String yaml = new AsyncapiWriter().write(asyncapi);
+
+        Asyncapi reparsed = new AsyncapiParser().parse(yaml);
+
+        assertEquals(1, reparsed.channels.size());
+        assertEquals("events", reparsed.channels.get("events").address);
+    }
+}

--- a/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiBuilderTest.java
+++ b/runtime/common-asyncapi/src/test/java/io/aklivity/zilla/runtime/common/asyncapi/model/AsyncapiBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.asyncapi.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class AsyncapiBuilderTest
+{
+    @Test
+    public void shouldBuildFullDocument()
+    {
+        Asyncapi asyncapi = Asyncapi.builder()
+            .asyncapi("3.0.0")
+            .info()
+                .title("Test API")
+                .version("0.1.0")
+                .description("A test API")
+                .build()
+            .server("prod")
+                .host("kafka.example.com:9092")
+                .protocol("kafka")
+                .bindings(Map.of("kafka", Map.of()))
+                .build()
+            .channel("customer.events")
+                .address("customer.events")
+                .message("CustomerEvent")
+                    .contentType("application/json")
+                    .payload()
+                        .ref("#/components/schemas/CustomerEvent")
+                        .build()
+                    .build()
+                .build()
+            .operation("receiveCustomerEvents")
+                .action("receive")
+                .channel()
+                    .ref("#/channels/customer.events")
+                    .build()
+                .build()
+            .components()
+                .message("CustomerEvent")
+                    .contentType("application/json")
+                    .build()
+                .schema("CustomerEvent")
+                    .schemaFormat("application/schema+json;version=draft-07")
+                    .schema(Map.of("type", "object"))
+                    .build()
+                .build()
+            .build();
+
+        assertThat(asyncapi.asyncapi, equalTo("3.0.0"));
+        assertThat(asyncapi.info.title, equalTo("Test API"));
+        assertThat(asyncapi.info.version, equalTo("0.1.0"));
+        assertThat(asyncapi.info.description, equalTo("A test API"));
+
+        AsyncapiServer server = asyncapi.servers.get("prod");
+        assertThat(server.host, equalTo("kafka.example.com:9092"));
+        assertThat(server.protocol, equalTo("kafka"));
+
+        AsyncapiChannel channel = asyncapi.channels.get("customer.events");
+        assertThat(channel.address, equalTo("customer.events"));
+        AsyncapiMessage channelMessage = channel.messages.get("CustomerEvent");
+        assertThat(channelMessage.contentType, equalTo("application/json"));
+        assertThat(((AsyncapiMultiFormatSchema) channelMessage.payload).ref,
+            equalTo("#/components/schemas/CustomerEvent"));
+
+        AsyncapiOperation operation = asyncapi.operations.get("receiveCustomerEvents");
+        assertThat(operation.action, equalTo("receive"));
+        assertThat(operation.channel.ref, equalTo("#/channels/customer.events"));
+
+        AsyncapiMessage componentMessage = asyncapi.components.messages.get("CustomerEvent");
+        assertThat(componentMessage.contentType, equalTo("application/json"));
+        AsyncapiMultiFormatSchema schema = (AsyncapiMultiFormatSchema) asyncapi.components.schemas.get("CustomerEvent");
+        assertThat(schema.schemaFormat, equalTo("application/schema+json;version=draft-07"));
+        assertThat(schema.schema, equalTo(Map.of("type", "object")));
+    }
+
+    @Test
+    public void shouldBuildViaMapper()
+    {
+        Asyncapi asyncapi = Asyncapi.builder(Asyncapi.class::cast)
+            .asyncapi("3.0.0")
+            .build();
+
+        assertThat(asyncapi.asyncapi, equalTo("3.0.0"));
+        assertThat(asyncapi.info, nullValue());
+    }
+}


### PR DESCRIPTION
## Summary

Extends `common-asyncapi` in three connected pieces, driven by zilla-platform's need to both read AsyncAPI 3.0 specs (with Kafka channel bindings) and programmatically generate them:

- Kafka channel-binding SPI + `asyncapi.3.0.1.schema.json` support for kafka bindings 0.5.0 (`cd3b22f67a`)
- `AsyncapiWriter` to serialize the `Asyncapi` model back to YAML/JSON text, with insertion-order preservation and vendor-extension flattening to sibling `x-*` keys (`52b2da6a35`, `2393cdcacf`), plus an explicit `JsonProvider` pin so `Jsonb` instances stop resolving nondeterministically off classpath order (`aadcbdfcc4`)
- Typed builders for the AsyncAPI document model (`Asyncapi`, `AsyncapiInfo`, `AsyncapiServer`, `AsyncapiChannel`, `AsyncapiOperation`, `AsyncapiComponents`, `AsyncapiMessage`, `AsyncapiMultiFormatSchema`) so consumers building a doc don't have to hand-assemble every node via `new X(); x.field = y;` (`5910e17444`)

The builders follow the existing `ConfigBuilder<T,B>` idiom from `config/*.conf` (e.g. `OtlpEndpointConfigBuilder`) — CRTP self-type, nested builders composed via a parent setter method-reference, keyed variants for the `Map<String,X>` fields adapting the list-append pattern (`NamespaceConfigBuilder.binding()`) to map-insert-by-name. The CRTP base is kept local to `common-asyncapi` rather than depending on `config/engine.conf`, avoiding a new `runtime`→`config` cross-group dependency that nothing else in the reactor has today.

Scoped to the 8 model classes actually exercised by a real write path (zilla-platform's Kafka-metadata-to-AsyncAPI generator) — no builders added for classes never manually constructed (parameters, security schemes, correlation ids, traits, replies, tags); same pattern extends cleanly if that changes.

## Test plan

- [x] `./mvnw -pl runtime/common-asyncapi -am test` — all green, including new `AsyncapiBuilderTest`, `AsyncapiWriterTest`, `AsyncapiFragmentTest`
- [x] `./mvnw -pl runtime/common-asyncapi -am install -DskipTests` — installs cleanly
- [x] Downstream consumer (zilla-platform's `KafkaAsyncapiGenerator`) refactored onto the new builders; its golden-fixture tests pass with zero output diffs, confirming the builders are behavior-preserving vs hand construction