### PR TITLE
fix(examples/mcp.proxy): give Karapace-backed test.sh calls the same retry budget as Kafka calls

### DIFF
--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -513,7 +513,7 @@ call_list_subjects() {
       tools-list-client 2>&1)
   echo "$LIST_SUBJECTS_OUT" | grep -q "$SR_SUBJECT"
 }
-retry_until 5 3 call_list_subjects
+retry_until 10 3 call_list_subjects
 echo "LIST_SUBJECTS_OUT=$LIST_SUBJECTS_OUT"
 if echo "$LIST_SUBJECTS_OUT" | grep -q "$SR_SUBJECT"; then
   echo "✅ kafka_sr__list_subjects saw the registered subject in real Karapace state"
@@ -531,7 +531,7 @@ call_describe_subject() {
       tools-list-client 2>&1)
   echo "$DESCRIBE_SUBJECT_OUT" | grep -q '\[1\]'
 }
-retry_until 5 3 call_describe_subject
+retry_until 10 3 call_describe_subject
 echo "DESCRIBE_SUBJECT_OUT=$DESCRIBE_SUBJECT_OUT"
 if echo "$DESCRIBE_SUBJECT_OUT" | grep -q '\[1\]'; then
   echo "✅ kafka_sr__describe_subject listed version 1 of the registered subject"
@@ -553,7 +553,7 @@ call_get_schema() {
       tools-list-client 2>&1)
   echo "$GET_SCHEMA_OUT" | grep -q 'Retrieved schema id 1, version 1'
 }
-retry_until 5 3 call_get_schema
+retry_until 10 3 call_get_schema
 echo "GET_SCHEMA_OUT=$GET_SCHEMA_OUT"
 if echo "$GET_SCHEMA_OUT" | grep -q 'Retrieved schema id 1, version 1'; then
   echo "✅ kafka_sr__get_schema read the schema back with both result fields interpolated"
@@ -576,7 +576,7 @@ call_set_compatibility() {
       tools-list-client 2>&1)
   echo "$SET_COMPAT_OUT" | grep -q 'Compatibility level set to FULL'
 }
-retry_until 5 3 call_set_compatibility
+retry_until 10 3 call_set_compatibility
 echo "SET_COMPAT_OUT=$SET_COMPAT_OUT"
 if echo "$SET_COMPAT_OUT" | grep -q 'Compatibility level set to FULL'; then
   echo "✅ kafka_sr__set_compatibility set a compatibility level on the registered subject"
@@ -594,7 +594,7 @@ call_get_compatibility() {
       tools-list-client 2>&1)
   echo "$GET_COMPAT_OUT" | grep -q 'Compatibility level is FULL'
 }
-retry_until 5 3 call_get_compatibility
+retry_until 10 3 call_get_compatibility
 echo "GET_COMPAT_OUT=$GET_COMPAT_OUT"
 if echo "$GET_COMPAT_OUT" | grep -q 'Compatibility level is FULL'; then
   echo "✅ kafka_sr__get_compatibility read back the level set above"
@@ -615,7 +615,7 @@ call_check_compatibility() {
       tools-list-client 2>&1)
   echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'
 }
-retry_until 5 3 call_check_compatibility
+retry_until 10 3 call_check_compatibility
 echo "CHECK_COMPAT_OUT=$CHECK_COMPAT_OUT"
 if echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'; then
   echo "✅ kafka_sr__check_compatibility reported the identical schema as compatible"


### PR DESCRIPTION
## Description

`testing (mcp.proxy)` has been intermittently failing on `develop` (confirmed on the most recent `develop` CI run, independent of any open PR — see run [30478308810](https://github.com/aklivity/zilla/actions/runs/30478308810/job/90671449633)) on Karapace-backed `kafka_sr__*` tool calls in `examples/mcp.proxy/.github/test.sh`.

Root cause: `call_register_schema` and every real-Kafka-broker call (`call_kafka_produce`/`consume`/etc.) already use `retry_until 10 3` (30s budget) because they were recognized as needing extra time against real infrastructure under CI load. But the other six Karapace-backed calls — `call_list_subjects`, `call_describe_subject`, `call_get_schema`, `call_set_compatibility`, `call_get_compatibility`, `call_check_compatibility` — were left at `retry_until 5 3` (15s), the same short budget used for calls against purely local/mocked services that don't need it.

Karapace is exactly as much "real infrastructure" as the Kafka broker, so it needs the same retry budget. This asymmetry explains two independently observed failures:
- `develop`'s own CI (run above): `kafka_sr__get_compatibility` exhausted 5 retries.
- PR #2211's CI run: `kafka_sr__describe_subject` exhausted 5 retries (see [job](https://github.com/aklivity/zilla/actions/runs/30568894377/job/90966764948)), even though `register_schema`/`list_subjects` immediately before it succeeded.

Different specific call each time, same failure shape (`[client] connected...` with no result text after 5×3s of retries), same six under-budgeted calls — consistent with generic CI resource pressure against Karapace rather than a logic bug in any one tool.

## Fix

Bump the six under-budgeted `retry_until 5 3` calls to `retry_until 10 3`, matching the budget `register_schema` and the Kafka calls already use. Purely mechanical — six one-line changes, no other test.sh logic touched.

## Test plan

- [x] `sh -n examples/mcp.proxy/.github/test.sh` — syntax valid
- [x] Confirmed via GitHub Actions job logs (linked above) that this failure predates and is unrelated to any in-flight PR
- [x] Confirm `testing (mcp.proxy)` passes green on this PR's own CI run


---
_Generated by [Claude Code](https://claude.ai/code/session_01ShEikNDTdSoYi5i5JqVDxN)_