### PR TITLE
fix(binding-mcp): MCP spec-compliance fixes (method-not-found, protocolVersion negotiation)

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -1020,7 +1020,7 @@ public final class McpServerFactory implements McpStreamFactory
                     server.decodedRequest = server::onDecodeNotifyCancelled;
                     break;
                 default:
-                    server.onDecodeParseError(traceId, authorization);
+                    server.onDecodeMethodNotFound(traceId, authorization);
                     server.decoder = decodeIgnore;
                     break decode;
                 }
@@ -2442,6 +2442,21 @@ public final class McpServerFactory implements McpStreamFactory
                     .build(),
                 -32600,
                 "Invalid request");
+        }
+
+        private void onDecodeMethodNotFound(
+            long traceId,
+            long authorization)
+        {
+            doEncodeResponseError(traceId, authorization,
+                httpBeginExRW.wrap(codecBuffer, 0, codecBuffer.capacity())
+                    .typeId(httpTypeId)
+                    .headersItem(h -> h.name(HTTP_HEADER_STATUS).value(STATUS_200))
+                    .headersItem(h -> h.name(HTTP_HEADER_CONTENT_TYPE).value(CONTENT_TYPE_JSON))
+                    .inject(this::injectAltSvc)
+                    .build(),
+                -32601,
+                "Method not found");
         }
 
         private void onAppChallenge(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -25,6 +25,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -95,6 +96,7 @@ import io.aklivity.zilla.runtime.engine.util.function.LongIntToLongFunction;
 public final class McpServerFactory implements McpStreamFactory
 {
     private static final String MCP_PROTOCOL_VERSION = "2025-11-25";
+    private static final Set<String> SUPPORTED_PROTOCOL_VERSIONS = Set.of("2025-06-18", MCP_PROTOCOL_VERSION);
 
     private static final String HTTP_TYPE_NAME = "http";
     private static final String MCP_TYPE_NAME = "mcp";
@@ -2128,7 +2130,7 @@ public final class McpServerFactory implements McpStreamFactory
                 .inject(this::injectAltSvc)
                 .build());
             final String negotiatedVersion = decodedProtocolVersion != null &&
-                decodedProtocolVersion.compareTo(MCP_PROTOCOL_VERSION) <= 0
+                SUPPORTED_PROTOCOL_VERSIONS.contains(decodedProtocolVersion)
                     ? decodedProtocolVersion
                     : MCP_PROTOCOL_VERSION;
             String8FW payload = new String8FW(INITIALIZE_RESPONSE_PROTOCOL_PREFIX + negotiatedVersion +

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -715,7 +715,8 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
-        "${net}/reject.request.method.unknown/client"})
+        "${net}/reject.request.method.unknown/client",
+        "${app}/reject.request.method.unknown/server"})
     public void shouldRejectRequestMethodUnknown() throws Exception
     {
         k3po.finish();

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -715,6 +715,15 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/reject.request.method.unknown/client"})
+    public void shouldRejectRequestMethodUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/lifecycle.events.keepalive/client",
         "${app}/lifecycle.events.keepalive/server"})
     @Configure(name = MCP_SSE_KEEPALIVE_INTERVAL_NAME, value = "PT0.5S")

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -105,6 +105,16 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/lifecycle.initialize.version.unsupported/client",
+        "${app}/lifecycle.initialize/server"})
+    public void shouldInitializeLifecycleWithUnsupportedVersionFallback() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/lifecycle.initialize.reject.bearer/client",
         "${app}/lifecycle.initialize.reject.bearer/server"})
     public void shouldRejectLifecycleInitializeWithBearerChallenge() throws Exception

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.unknown/client.rpt
@@ -1,0 +1,33 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/reject.request.method.unknown/server.rpt
@@ -1,0 +1,36 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version.unsupported/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version.unsupported/client.rpt
@@ -1,0 +1,70 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2024-11-05")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .headerMissing("alt-svc")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+read notify LIFECYCLE_INITIALIZING
+
+connect await LIFECYCLE_INITIALIZING
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version.unsupported/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.version.unsupported/server.rpt
@@ -1,0 +1,72 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2024-11-05")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.unknown/client.rpt
@@ -1,0 +1,102 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+read notify LIFECYCLE_INITIALIZING
+
+connect await LIFECYCLE_INITIALIZING
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+write close
+
+read closed
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":2,"method":"tools/unknown","params":{}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"Method not found"}}'
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/reject.request.method.unknown/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":2,"method":"tools/unknown","params":{}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"Method not found"}}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -182,6 +182,15 @@ public class ApplicationIT
 
     @Test
     @Specification({
+        "${app}/reject.request.method.unknown/client",
+        "${app}/reject.request.method.unknown/server"})
+    public void shouldRejectRequestMethodUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/tools.call.10k/client",
         "${app}/tools.call.10k/server"})
     public void shouldCallToolWith10kParams() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -227,6 +227,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/reject.request.method.unknown/client",
+        "${net}/reject.request.method.unknown/server"})
+    public void shouldRejectRequestMethodUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/reject.tools.call.without.content.length/client",
         "${net}/reject.tools.call.without.content.length/server"})
     public void shouldRejectToolsCallWithoutContentLength() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -83,6 +83,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.initialize.version.unsupported/client",
+        "${net}/lifecycle.initialize.version.unsupported/server"})
+    public void shouldInitializeLifecycleWithUnsupportedVersionFallback() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/lifecycle.initialize.reject.bearer/client",
         "${net}/lifecycle.initialize.reject.bearer/server"})
     public void shouldRejectLifecycleInitializeOnUpstreamBearerChallenge() throws Exception


### PR DESCRIPTION
## Description

Two spec-compliance fixes to `binding-mcp`'s `mcp kind: server` (Streamable HTTP transport), found during an audit against the MCP specification and the `modelcontextprotocol/conformance` test suite:

1. **`fix(binding-mcp): return Method not found for unrecognized JSON-RPC methods`** — an unrecognized top-level JSON-RPC `method` was answered with `-32700` ("Parse error"); per JSON-RPC 2.0 / MCP that case is `-32601` ("Method not found"). Adds `onDecodeMethodNotFound`, wired into the method-dispatch default case. New `reject.request.method.unknown` spec scenario (network `client.rpt`/`server.rpt` pair, plus the application-side lifecycle-accept pair a full `initialize` handshake requires), wired into `NetworkIT`, `ApplicationIT`, and the runtime `McpServerIT`.

2. **`fix(binding-mcp): negotiate protocolVersion against a supported-version allow-list`** — `initialize` echoed back any client-requested `protocolVersion` that sorted lexicographically at or before the server's own version, rather than checking whether Zilla actually supports it. Dated MCP versions are ISO date strings, so this happened to preserve ordering for real values, but it also meant an unvalidated/unsupported older version (e.g. `2024-11-05`, which predates the Streamable HTTP transport this binding exclusively implements) would be accepted and echoed back verbatim instead of falling back to the server's own version. Replaced the comparison with an explicit allow-list (`2025-06-18`, `2025-11-25`, matching existing spec coverage), falling back to the server's own version otherwise. New `lifecycle.initialize.version.unsupported` spec scenario exercises the fallback path.

Both fixes follow this repo's test-first discipline: each new spec scenario was confirmed to fail for the right reason against the pre-fix code, then pass after the fix.

## Test plan

- [x] `./mvnw clean verify -pl specs/binding-mcp.spec,runtime/binding-mcp` — 273 integration tests + 151 unit tests, all passing
- [x] `./mvnw checkstyle:check license:check -pl runtime/binding-mcp,specs/binding-mcp.spec` — clean
- [x] Each new scenario confirmed RED against pre-fix code, GREEN after the fix
- [x] Rebased onto latest `develop` (including `724ccb8b0`, which also touches JSON-RPC error-response content-type handling) with a clean regression run


---
_Generated by [Claude Code](https://claude.ai/code/session_01FfEsAy87naXVt1Q63nkHKe)_