### PR TITLE
fix(binding-mcp-kafka): shorten consume timeout once caught up to latest offset

### DIFF
--- a/runtime/AGENTS.md
+++ b/runtime/AGENTS.md
@@ -528,7 +528,7 @@ exists, the runtime-side work is:
    configuration is needed. Add a corresponding `XxxConfigurationTest` that
    calls `shouldVerifyConstants()` (verifying property name strings match the
    `PropertyDef` names) to satisfy class coverage requirements
-8. Write unit tests covering the stream state machine (see below)
+8. Write k3po IT scripts covering the stream state machine (see below)
 
 The Maven plugin generates flyweight classes during `generate-sources`. Run
 `./mvnw generate-sources -pl runtime/binding-<n>` to regenerate after `.idl`
@@ -542,14 +542,27 @@ project — see [../specs/AGENTS.md](../specs/AGENTS.md).
 ## Unit tests
 
 - Live in `src/test/java/` within each module
-- Cover the stream handler state machine exhaustively: every state transition,
-  every error path, every flow-control edge case
-- Use `mockito` for collaborators; never spin up a real engine instance
-- Target: 100% branch coverage on all `stream/` classes
+- Reserved for logic that does not involve a stream handler's frame lifecycle:
+  `XxxConfiguration` property parsing, condition/predicate matchers, config
+  adapters, generators, and other pure-Java helper classes
+- **Never test a stream handler's (`XxxServerFactory`, `XxxClientFactory`,
+  `XxxProxyFactory`, etc.) state machine with a mocked `EngineContext`,
+  `Signaler`, or `MessageConsumer`.** A mock only proves the mock returns
+  what it was told to return — it does not exercise the real engine's frame
+  dispatch, flow control, or buffer lifecycle, so a passing mocked test can
+  coexist with a binding that is actually broken end-to-end. Every state
+  transition, error path, and flow-control edge case for a stream handler
+  belongs in a k3po IT instead (see below), run against a live `EngineRule`
+  and verified via the wire protocol (or the application-level stream
+  protocol for cross-protocol proxies), not through mocked collaborators
 - Run with: `./mvnw test -pl runtime/binding-<n>`
 
-Spec-based integration tests (the source of truth for protocol behaviour) are
-described in [../specs/AGENTS.md](../specs/AGENTS.md).
+Stream handler state machines are covered exhaustively — every state
+transition, every error path, every flow-control edge case — by k3po-based
+integration tests (`*IT.java`) driven by `.rpt` scripts against a live engine.
+This is the source of truth for protocol behaviour and the only place stream
+handler coverage should be exercised; see [../specs/AGENTS.md](../specs/AGENTS.md)
+for script conventions and required coverage.
 
 ---
 

--- a/runtime/AGENTS.md
+++ b/runtime/AGENTS.md
@@ -562,7 +562,12 @@ transition, every error path, every flow-control edge case — by k3po-based
 integration tests (`*IT.java`) driven by `.rpt` scripts against a live engine.
 This is the source of truth for protocol behaviour and the only place stream
 handler coverage should be exercised; see [../specs/AGENTS.md](../specs/AGENTS.md)
-for script conventions and required coverage.
+for script conventions and required coverage. Every new scenario's scripts
+must be authored as a paired `client.rpt` / `server.rpt` — never a lone
+script — and must have a spec-level IT (`NetworkIT`/`ApplicationIT`, or the
+per-protocol equivalent for cross-protocol proxies) that runs the pair against
+each other to verify they are self-consistent, in addition to the binding IT
+that runs them against the live engine.
 
 ---
 

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -45,6 +45,7 @@ import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.transform.McpKafkaAr
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.transform.McpKafkaConsumeResult;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.Flyweight;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.KafkaKeyFW;
+import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.KafkaOffsetFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.OctetsFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.AbortFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.BeginFW;
@@ -99,6 +100,7 @@ public class McpKafkaProxyFactory implements BindingHandler
 
     private static final int CONSUME_TIMEOUT_SIGNAL_ID = 1;
     private static final long DEFAULT_CONSUME_TIMEOUT_MILLIS = 30_000L;
+    private static final long CONSUME_CAUGHT_UP_GRACE_MILLIS = 250L;
 
     private static final int KAFKA_ERROR_INVALID_RECORD = 87;
 
@@ -1387,6 +1389,8 @@ public class McpKafkaProxyFactory implements BindingHandler
         private boolean consumeIsError;
         private boolean consumeStarted;
         private long consumeTimeoutId = Signaler.NO_CANCEL_ID;
+        private long consumeDeadlineMillis;
+        private long consumeScheduledMillis;
 
         private KafkaProxy(
             McpProxy peer,
@@ -1524,6 +1528,7 @@ public class McpKafkaProxyFactory implements BindingHandler
                 }
                 else
                 {
+                    rescheduleConsumeTimeout(traceId, fetchDataEx);
                     pumpConsume(traceId);
                 }
             }
@@ -1676,6 +1681,33 @@ public class McpKafkaProxyFactory implements BindingHandler
             {
                 signaler.cancel(consumeTimeoutId);
                 consumeTimeoutId = Signaler.NO_CANCEL_ID;
+            }
+        }
+
+        private void scheduleConsumeTimeout(
+            long traceId,
+            long deadlineMillis)
+        {
+            cancelConsumeTimeout();
+            consumeTimeoutId = signaler.signalAt(deadlineMillis,
+                originId, resolvedId, kafkaInitialId, traceId, CONSUME_TIMEOUT_SIGNAL_ID, 0);
+            consumeScheduledMillis = deadlineMillis;
+        }
+
+        private void rescheduleConsumeTimeout(
+            long traceId,
+            KafkaMergedFetchDataExFW fetchDataEx)
+        {
+            final KafkaOffsetFW partition = fetchDataEx != null ? fetchDataEx.partition() : null;
+            final boolean caughtUp = partition != null && partition.latestOffset() >= 0 &&
+                partition.partitionOffset() + 1 >= partition.latestOffset();
+            final long deadlineMillis = caughtUp
+                ? Math.min(consumeDeadlineMillis, System.currentTimeMillis() + CONSUME_CAUGHT_UP_GRACE_MILLIS)
+                : consumeDeadlineMillis;
+
+            if (deadlineMillis != consumeScheduledMillis)
+            {
+                scheduleConsumeTimeout(traceId, deadlineMillis);
             }
         }
 
@@ -1853,8 +1885,8 @@ public class McpKafkaProxyFactory implements BindingHandler
                 }
                 applyConsumeStatus(traceId, status);
                 pumpConsume(traceId);
-                consumeTimeoutId = signaler.signalAt(System.currentTimeMillis() + consumeTimeoutMillis,
-                    originId, resolvedId, kafkaInitialId, traceId, CONSUME_TIMEOUT_SIGNAL_ID, 0);
+                consumeDeadlineMillis = System.currentTimeMillis() + consumeTimeoutMillis;
+                scheduleConsumeTimeout(traceId, consumeDeadlineMillis);
             }
         }
 

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
@@ -20,14 +20,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +49,6 @@ import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.BeginFW
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.DataFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.EndFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.KafkaBeginExFW;
-import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.KafkaDataExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpEndExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpOutcome;
@@ -89,7 +86,6 @@ public class McpKafkaProxyFactoryTest
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
     private final SignalFW.Builder signalRW = new SignalFW.Builder();
     private final McpBeginExFW.Builder mcpBeginExRW = new McpBeginExFW.Builder();
-    private final KafkaDataExFW.Builder kafkaDataExRW = new KafkaDataExFW.Builder();
 
     private final BeginFW beginRO = new BeginFW();
     private final DataFW dataRO = new DataFW();
@@ -349,42 +345,6 @@ public class McpKafkaProxyFactoryTest
             .budgetId(0L)
             .reserved(bytes.length)
             .payload(buffer, 0, bytes.length)
-            .build();
-
-        stream.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
-    }
-
-    private void dataWithRecord(
-        MessageConsumer stream,
-        long streamId,
-        String value,
-        long partitionOffset,
-        long latestOffset)
-    {
-        final byte[] bytes = value.getBytes(UTF_8);
-        final UnsafeBufferEx buffer = new UnsafeBufferEx(bytes);
-
-        final KafkaDataExFW kafkaDataEx = kafkaDataExRW
-            .wrap(extScratch, 0, extScratch.capacity())
-            .typeId(KAFKA_TYPE_ID)
-            .merged(m -> m.fetch(f -> f
-                .partition(p -> p.partitionId(0).partitionOffset(partitionOffset).latestOffset(latestOffset))))
-            .build();
-
-        final DataFW data = dataRW.wrap(scratch, 0, scratch.capacity())
-            .originId(ORIGIN_ID)
-            .routedId(ROUTE_ID)
-            .streamId(streamId)
-            .sequence(0)
-            .acknowledge(0)
-            .maximum(0)
-            .traceId(1L)
-            .authorization(AUTHORIZATION)
-            .flags(0x03)
-            .budgetId(0L)
-            .reserved(bytes.length)
-            .payload(buffer, 0, bytes.length)
-            .extension(kafkaDataEx.buffer(), kafkaDataEx.offset(), kafkaDataEx.sizeof())
             .build();
 
         stream.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
@@ -668,64 +628,6 @@ public class McpKafkaProxyFactoryTest
         assertEquals("{\"structuredContent\":{\"topic\":\"orders\",\"messages\":[],\"count\":0}," +
             "\"content\":[{\"type\":\"text\",\"text\":\"Consumed 0 messages from topic orders\"}],\"isError\":false}",
             result);
-    }
-
-    @Test
-    public void shouldShortenConsumeTimeoutOnceRecordReachesLatestOffset() throws Exception
-    {
-        factory.attach(newBinding("consume"));
-
-        final long before = System.currentTimeMillis();
-        final String body = "{\"name\":\"consume\",\"arguments\":{\"topic\":\"orders\"}}";
-        final MessageConsumer stream = beginToolsCall("consume", body.length(), 0L);
-
-        data(stream, INITIAL_ID, body);
-
-        final MessageConsumer kafkaSender = captureKafkaSender();
-        final long kafkaInitialId = supplyId.get() - 1L;
-        final long kafkaReplyId = kafkaInitialId | 0x01L;
-
-        // omitted limit defaults to 10, but only 1 record is currently available on the topic
-        dataWithRecord(kafkaSender, kafkaReplyId, "value-1", 0L, 1L);
-
-        final ArgumentCaptor<Long> deadlineCaptor = ArgumentCaptor.forClass(Long.class);
-        verify(signaler, times(2)).signalAt(deadlineCaptor.capture(), anyLong(), anyLong(),
-            eq(kafkaInitialId), anyLong(), anyInt(), anyInt());
-
-        final long initialDeadline = deadlineCaptor.getAllValues().get(0);
-        final long shortenedDeadline = deadlineCaptor.getAllValues().get(1);
-
-        // the original schedule waits close to the full 30s default consume timeout
-        assertTrue(initialDeadline - before >= 29_000L);
-        // once caught up to the latest known offset, the wait is cut down to a short grace period
-        assertTrue(shortenedDeadline - before < 5_000L);
-    }
-
-    @Test
-    public void shouldKeepFullConsumeTimeoutWhenRecordIsBehindLatestOffset() throws Exception
-    {
-        factory.attach(newBinding("consume"));
-
-        final long before = System.currentTimeMillis();
-        final String body = "{\"name\":\"consume\",\"arguments\":{\"topic\":\"orders\"}}";
-        final MessageConsumer stream = beginToolsCall("consume", body.length(), 0L);
-
-        data(stream, INITIAL_ID, body);
-
-        final MessageConsumer kafkaSender = captureKafkaSender();
-        final long kafkaInitialId = supplyId.get() - 1L;
-        final long kafkaReplyId = kafkaInitialId | 0x01L;
-
-        // still behind the latest known offset, so the full timeout must not be shortened
-        dataWithRecord(kafkaSender, kafkaReplyId, "value-1", 0L, 5L);
-
-        final ArgumentCaptor<Long> deadlineCaptor = ArgumentCaptor.forClass(Long.class);
-        verify(signaler, times(1)).signalAt(deadlineCaptor.capture(), anyLong(), anyLong(),
-            eq(kafkaInitialId), anyLong(), anyInt(), anyInt());
-
-        final long initialDeadline = deadlineCaptor.getValue();
-
-        assertTrue(initialDeadline - before >= 29_000L);
     }
 
     @Test

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
@@ -20,12 +20,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +51,7 @@ import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.BeginFW
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.DataFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.EndFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.KafkaBeginExFW;
+import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.KafkaDataExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpBeginExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpEndExFW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.types.stream.McpOutcome;
@@ -86,6 +89,7 @@ public class McpKafkaProxyFactoryTest
     private final ResetFW.Builder resetRW = new ResetFW.Builder();
     private final SignalFW.Builder signalRW = new SignalFW.Builder();
     private final McpBeginExFW.Builder mcpBeginExRW = new McpBeginExFW.Builder();
+    private final KafkaDataExFW.Builder kafkaDataExRW = new KafkaDataExFW.Builder();
 
     private final BeginFW beginRO = new BeginFW();
     private final DataFW dataRO = new DataFW();
@@ -345,6 +349,42 @@ public class McpKafkaProxyFactoryTest
             .budgetId(0L)
             .reserved(bytes.length)
             .payload(buffer, 0, bytes.length)
+            .build();
+
+        stream.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
+    }
+
+    private void dataWithRecord(
+        MessageConsumer stream,
+        long streamId,
+        String value,
+        long partitionOffset,
+        long latestOffset)
+    {
+        final byte[] bytes = value.getBytes(UTF_8);
+        final UnsafeBufferEx buffer = new UnsafeBufferEx(bytes);
+
+        final KafkaDataExFW kafkaDataEx = kafkaDataExRW
+            .wrap(extScratch, 0, extScratch.capacity())
+            .typeId(KAFKA_TYPE_ID)
+            .merged(m -> m.fetch(f -> f
+                .partition(p -> p.partitionId(0).partitionOffset(partitionOffset).latestOffset(latestOffset))))
+            .build();
+
+        final DataFW data = dataRW.wrap(scratch, 0, scratch.capacity())
+            .originId(ORIGIN_ID)
+            .routedId(ROUTE_ID)
+            .streamId(streamId)
+            .sequence(0)
+            .acknowledge(0)
+            .maximum(0)
+            .traceId(1L)
+            .authorization(AUTHORIZATION)
+            .flags(0x03)
+            .budgetId(0L)
+            .reserved(bytes.length)
+            .payload(buffer, 0, bytes.length)
+            .extension(kafkaDataEx.buffer(), kafkaDataEx.offset(), kafkaDataEx.sizeof())
             .build();
 
         stream.accept(data.typeId(), data.buffer(), data.offset(), data.sizeof());
@@ -628,6 +668,64 @@ public class McpKafkaProxyFactoryTest
         assertEquals("{\"structuredContent\":{\"topic\":\"orders\",\"messages\":[],\"count\":0}," +
             "\"content\":[{\"type\":\"text\",\"text\":\"Consumed 0 messages from topic orders\"}],\"isError\":false}",
             result);
+    }
+
+    @Test
+    public void shouldShortenConsumeTimeoutOnceRecordReachesLatestOffset() throws Exception
+    {
+        factory.attach(newBinding("consume"));
+
+        final long before = System.currentTimeMillis();
+        final String body = "{\"name\":\"consume\",\"arguments\":{\"topic\":\"orders\"}}";
+        final MessageConsumer stream = beginToolsCall("consume", body.length(), 0L);
+
+        data(stream, INITIAL_ID, body);
+
+        final MessageConsumer kafkaSender = captureKafkaSender();
+        final long kafkaInitialId = supplyId.get() - 1L;
+        final long kafkaReplyId = kafkaInitialId | 0x01L;
+
+        // omitted limit defaults to 10, but only 1 record is currently available on the topic
+        dataWithRecord(kafkaSender, kafkaReplyId, "value-1", 0L, 1L);
+
+        final ArgumentCaptor<Long> deadlineCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(signaler, times(2)).signalAt(deadlineCaptor.capture(), anyLong(), anyLong(),
+            eq(kafkaInitialId), anyLong(), anyInt(), anyInt());
+
+        final long initialDeadline = deadlineCaptor.getAllValues().get(0);
+        final long shortenedDeadline = deadlineCaptor.getAllValues().get(1);
+
+        // the original schedule waits close to the full 30s default consume timeout
+        assertTrue(initialDeadline - before >= 29_000L);
+        // once caught up to the latest known offset, the wait is cut down to a short grace period
+        assertTrue(shortenedDeadline - before < 5_000L);
+    }
+
+    @Test
+    public void shouldKeepFullConsumeTimeoutWhenRecordIsBehindLatestOffset() throws Exception
+    {
+        factory.attach(newBinding("consume"));
+
+        final long before = System.currentTimeMillis();
+        final String body = "{\"name\":\"consume\",\"arguments\":{\"topic\":\"orders\"}}";
+        final MessageConsumer stream = beginToolsCall("consume", body.length(), 0L);
+
+        data(stream, INITIAL_ID, body);
+
+        final MessageConsumer kafkaSender = captureKafkaSender();
+        final long kafkaInitialId = supplyId.get() - 1L;
+        final long kafkaReplyId = kafkaInitialId | 0x01L;
+
+        // still behind the latest known offset, so the full timeout must not be shortened
+        dataWithRecord(kafkaSender, kafkaReplyId, "value-1", 0L, 5L);
+
+        final ArgumentCaptor<Long> deadlineCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(signaler, times(1)).signalAt(deadlineCaptor.capture(), anyLong(), anyLong(),
+            eq(kafkaInitialId), anyLong(), anyInt(), anyInt());
+
+        final long initialDeadline = deadlineCaptor.getValue();
+
+        assertTrue(initialDeadline - before >= 29_000L);
     }
 
     @Test

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
@@ -112,6 +112,16 @@ public class McpKafkaProxyIT
     }
 
     @Test
+    @Configuration("proxy.consume.yaml")
+    @Specification({
+        "${mcp}/consume.without.limit/client",
+        "${kafka}/consume.without.limit/server"})
+    public void shouldConsumeWithoutLimit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.produce.yaml")
     @Specification({
         "${mcp}/reject.invalid.args/client"})

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -167,12 +167,30 @@ pointing at `streams/network/...` or `streams/application/...` and references
 scripts as `${net}/scenario/client` and `${net}/scenario/server` (or `${app}/`
 for application-layer scenarios).
 
+**Every scenario's scripts must always be authored as a `client.rpt` /
+`server.rpt` pair, never a single script.** A lone script cannot be verified
+for self-consistency and has no peer to run against — the pairing is what
+makes the peer-to-peer check below possible at all.
+
 Each scenario also has a corresponding test method in a `NetworkIT` or
 `ApplicationIT` class (in the spec project's `src/test/` tree) that runs
 `client.rpt` and `server.rpt` directly against each other — without Zilla —
 to verify that the two scripts are complementary and self-consistent. Every
 new scenario must have both a binding IT method (running against Zilla) and a
-`NetworkIT`/`ApplicationIT` method (running the scripts peer-to-peer).
+`NetworkIT`/`ApplicationIT` method (running the scripts peer-to-peer). This
+peer-to-peer verification is not optional — a scenario without it has never
+actually confirmed that its two scripts agree with each other, only that each
+independently passed against Zilla.
+
+Cross-protocol proxy specs (e.g. `binding-http-kafka.spec`,
+`binding-mcp-kafka.spec`) follow the same pairing and peer-to-peer-verification
+rule, but organise scripts per protocol instead of `network`/`application` —
+e.g. `streams/mcp/` and `streams/kafka/` — and name the peer-to-peer IT class
+after the protocol it verifies (`McpIT`, `KafkaIT`) rather than
+`NetworkIT`/`ApplicationIT`. Each such class pairs a protocol's own
+`client.rpt`/`server.rpt` against each other, independent of the engine and
+of the other protocol — see `binding-mcp-kafka.spec`'s `McpIT`/`KafkaIT` for
+the canonical example.
 
 IT test method names are derived from the scenario directory name by
 prepending `should` and converting `dot.separated.words` to `camelCase` — for

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/kafka/consume.without.limit/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/kafka/consume.without.limit/client.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                             .typeId(zilla:id("kafka"))
+                             .merged()
+                                 .capabilities("FETCH_ONLY")
+                                 .topic("orders")
+                                 .partition(-1, -2)
+                                 .build()
+                             .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .fetch()
+                               .partition(0, 0, 1)
+                               .progress(0, 1)
+                               .build()
+                           .build()}
+read "value-1"
+
+write close
+read closed

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/kafka/consume.without.limit/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/kafka/consume.without.limit/server.rpt
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("FETCH_ONLY")
+                                .topic("orders")
+                                .partition(-1, -2)
+                                .build()
+                            .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                               .fetch()
+                                .partition(0, 0, 1)
+                                .progress(0, 1)
+                                .build()
+                            .build()}
+write "value-1"
+write flush
+
+read closed
+write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/consume.without.limit/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/consume.without.limit/client.rpt
@@ -1,0 +1,90 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property authorization 0L
+
+connect "zilla://streams/mcp0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/mcp0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("session-1")
+                               .name("consume")
+                               .contentLength(49)
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"consume",'
+        '"arguments":'
+        '{'
+          '"topic":"orders"'
+        '}'
+      '}'
+
+read  '{'
+        '"structuredContent":'
+          '{'
+            '"topic":"orders",'
+            '"messages":'
+            '['
+              '{'
+                '"key":null,'
+                '"headers":[],'
+                '"value":"value-1"'
+              '}'
+            '],'
+            '"count":1'
+          '},'
+        '"content":'
+        '['
+          '{'
+            '"type":"text",'
+            '"text":"Consumed 1 messages from topic orders"'
+          '}'
+        '],'
+        '"isError":false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/consume.without.limit/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/consume.without.limit/server.rpt
@@ -1,0 +1,92 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/mcp0"
+property authorization 0L
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("session-1")
+                              .name("consume")
+                              .contentLength(49)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"consume",'
+        '"arguments":'
+        '{'
+          '"topic":"orders"'
+        '}'
+      '}'
+
+write flush
+
+write '{'
+        '"structuredContent":'
+          '{'
+            '"topic":"orders",'
+            '"messages":'
+            '['
+              '{'
+                '"key":null,'
+                '"headers":[],'
+                '"value":"value-1"'
+              '}'
+            '],'
+            '"count":1'
+          '},'
+        '"content":'
+        '['
+          '{'
+            '"type":"text",'
+            '"text":"Consumed 1 messages from topic orders"'
+          '}'
+        '],'
+        '"isError":false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/KafkaIT.java
+++ b/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/KafkaIT.java
@@ -92,6 +92,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/consume.without.limit/client",
+        "${kafka}/consume.without.limit/server"})
+    public void shouldConsumeWithoutLimit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/produce.args.fragmented/client",
         "${kafka}/produce.args.fragmented/server"})
     public void shouldProduceArgsFragmented() throws Exception

--- a/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
+++ b/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
@@ -92,6 +92,15 @@ public class McpIT
 
     @Test
     @Specification({
+        "${mcp}/consume.without.limit/client",
+        "${mcp}/consume.without.limit/server"})
+    public void shouldConsumeWithoutLimit() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/reject.invalid.args/client",
         "${mcp}/reject.invalid.args/server"})
     public void shouldRejectInvalidArgs() throws Exception


### PR DESCRIPTION
## Description

`kafka__consume` without an explicit `limit` defaults to waiting for 10 records or the full 30s consume timeout, whichever comes first. When a topic has fewer than 10 currently available records, the response was stuck waiting out the full 30s even though there is nothing more to fetch yet.

Each fetched Kafka record carries its partition's high-watermark offset (`latestOffset`) in `KafkaMergedFetchDataEx`. Once a record shows the fetch has caught up to that offset (`partitionOffset + 1 >= latestOffset`), the consume timeout is rescheduled to a short grace period instead of the original deadline, so the result returns shortly after the current backlog is drained. If a later record shows another partition is still behind, the full timeout is restored, so multi-partition topics with a genuine backlog aren't cut off early.

Also updates `runtime/AGENTS.md` and `specs/AGENTS.md`:
- Stream handler state machine behavior (every state transition, error path, flow-control edge case) must be covered by k3po ITs against a live engine, not by mocking `EngineContext`/`Signaler`/`MessageConsumer` — a mock only proves the mock does what it was told, not that the binding works end-to-end.
- Every spec scenario's scripts must be a paired `client.rpt`/`server.rpt`, with a spec-level IT (`NetworkIT`/`ApplicationIT`, or the per-protocol equivalent for cross-protocol proxies) verifying the pair against each other, in addition to the binding IT against the live engine.

Fixes #2217

## Test plan

- Added `McpKafkaProxyIT#shouldConsumeWithoutLimit`, an end-to-end k3po IT reproducing the reported symptom: omits both `limit` and the MCP-level `timeout` (so it exercises the real internal 30s default), and asserts the response returns quickly instead of waiting it out.
  - Verified against the pre-fix code first: fails with `TestTimedOut` (bounded by the test's 10s JUnit timeout), confirming it actually catches the regression.
  - Passes in ~0.6s with the fix.
- Added the paired peer-to-peer self-consistency scripts/tests per the spec convention: `mcp/consume.without.limit` + `kafka/consume.without.limit` `.rpt` pairs, and `McpIT#shouldConsumeWithoutLimit` / `KafkaIT#shouldConsumeWithoutLimit`.
- `./mvnw verify -pl runtime/binding-mcp-kafka`: 32 unit tests + 19 runtime ITs, all green, jacoco coverage checks pass.
- `./mvnw verify -pl specs/binding-mcp-kafka.spec`: spec-level ITs (including the new peer-to-peer pair) all green.
- `./mvnw checkstyle:check`: 0 violations.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRmpGbR3SBxUGwGqpibCMb)_