### PR TITLE
docs(agents): fix flyweight-maven-plugin location in repo layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ runtime/                     # Core engine and all bindings
   ...
 specs/                       # Integration test specifications (IT)
 incubator/                   # Bindings under active development
-maven-plugin/                # Code generator for flyweight types
+build/flyweight-maven-plugin/ # Code generator for flyweight types (local peer module, not a remote artifact)
 ```
 
 ---
@@ -101,8 +101,10 @@ without properly saying goodbye", event-assertion mismatches) is a symptom of
 this same root cause, not a real bug — before spending time diagnosing a
 crash from an `*IT` run, confirm it was launched with `verify`.
 
-The Maven plugin in `maven-plugin/` generates flyweight Java classes from `.idl`
-files. Always run a full build after modifying any `.idl` file.
+The Maven plugin in `build/flyweight-maven-plugin/` generates flyweight Java
+classes from `.idl` files. Always run a full build after modifying any `.idl`
+file. It is a peer reactor module, not a published remote artifact — it comes
+from this same checkout, not from a Maven registry.
 
 ---
 


### PR DESCRIPTION
## Summary
- `AGENTS.md`'s repository layout section pointed to a top-level `maven-plugin/` directory for the flyweight codegen plugin, but that directory doesn't exist in this repo — the plugin actually lives at `build/flyweight-maven-plugin/`
- Also clarifies that it's a peer reactor module resolved from this same checkout, not a published remote Maven artifact, since the wrong path led directly to an agent concluding (incorrectly) that the plugin required network/registry credentials to resolve

## Test plan
- Docs-only change; no build/test impact
- Verified no other `maven-plugin/` path references remain in the repo's markdown docs

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0157qpppRcorMgMSxTddQV9a

---
_Generated by [Claude Code](https://claude.ai/code/session_0157qpppRcorMgMSxTddQV9a)_