### PR TITLE
fix(binding-tcp): enforce per-route exit requirement for kind: server

### DIFF
--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.empty.invalid.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.empty.invalid.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+    net0:
+        type: tcp
+        kind: server
+        options:
+            host: 0.0.0.0
+            port: 12345
+        routes: []

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.exit.missing.invalid.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.exit.missing.invalid.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+    net0:
+        type: tcp
+        kind: server
+        options:
+            host: 0.0.0.0
+            port: 12345
+        routes:
+            - when:
+                  - port: 12345

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.exit.yaml
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/config/server.routes.exit.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+    net0:
+        type: tcp
+        kind: server
+        options:
+            host: 0.0.0.0
+            port: 12345
+        routes:
+            - when:
+                  - port: 12345
+              exit: app0

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/schema/tcp.schema.patch.json
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/schema/tcp.schema.patch.json
@@ -129,10 +129,13 @@
                                 {
                                     "routes":
                                     {
-                                        "required":
-                                        [
-                                            "exit"
-                                        ]
+                                        "items":
+                                        {
+                                            "required":
+                                            [
+                                                "exit"
+                                            ]
+                                        }
                                     }
                                 },
                                 "required":

--- a/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/schema/tcp.schema.patch.json
+++ b/specs/binding-tcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/tcp/schema/tcp.schema.patch.json
@@ -129,6 +129,7 @@
                                 {
                                     "routes":
                                     {
+                                        "minItems": 1,
                                         "items":
                                         {
                                             "required":

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -135,5 +136,19 @@ public class SchemaTest
         JsonObject config = schema.validate("client.ports.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateServerRoutesExit()
+    {
+        JsonObject config = schema.validate("server.routes.exit.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectServerRoutesExitMissing()
+    {
+        schema.validate("server.routes.exit.missing.invalid.yaml");
     }
 }

--- a/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
+++ b/specs/binding-tcp.spec/src/test/java/io/aklivity/zilla/specs/binding/tcp/config/SchemaTest.java
@@ -151,4 +151,10 @@ public class SchemaTest
     {
         schema.validate("server.routes.exit.missing.invalid.yaml");
     }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectServerRoutesEmpty()
+    {
+        schema.validate("server.routes.empty.invalid.yaml");
+    }
 }


### PR DESCRIPTION
## Description

`binding-tcp`'s schema patch requires `kind: server` to declare `exit` either top-level or per-route, via an `anyOf` with two branches. The per-route branch checked `"routes": { "required": ["exit"] }`, but per JSON Schema semantics `required` only constrains object instances — `routes` is a `type: array`, so the check was vacuously true against any array and never actually inspected route contents.

Net effect: a `kind: server` binding with `routes:` and no `exit` anywhere (top-level or per-route) passed schema validation, when it should be rejected. Such a route resolves to `route.id = 0` at engine-attach time (`EngineManager.NameResolver.resolve` returns `0L` for a `null` name), silently breaking routing instead of failing at startup with a clear error.

Fix: wrap the per-route check in `items` so it actually reaches each route object: `"routes": { "items": { "required": ["exit"] } }`.

Added `SchemaTest` fixtures:
- `server.routes.exit.yaml` — routes with per-route `exit`, no top-level `exit` — confirms the intended valid case still passes.
- `server.routes.exit.missing.invalid.yaml` — routes with no `exit` anywhere — confirms it is now rejected. Verified this test fails for the right reason against the pre-fix schema.

Fixes #2239

## Test plan

- [x] `./mvnw -pl specs/binding-tcp.spec test -Dtest=SchemaTest` — all 15 cases pass
- [x] Confirmed the new negative test fails against the pre-fix schema (reverted the schema change locally, re-ran, saw the expected `JsonException` was not thrown)
- [x] `./mvnw -pl specs/binding-tcp.spec license:check checkstyle:check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZSeQpusk33eebeZGi9Mnz)_