### PR TITLE
binding-mcp-openapi: add kind: proxy variant with operator-declared exit

### DIFF
--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactory.java
@@ -38,7 +38,7 @@ public final class McpKafkaClientFactory extends McpKafkaProxyFactory
         this.context = context;
         // cacheClientExit/clientExit default to null; tests override them to redirect the
         // synthesized composite's exit onto a statically-declared double, mirroring
-        // McpOpenapiConfiguration.MCP_OPENAPI_HTTP_CLIENT_EXIT
+        // McpHttpConfiguration.MCP_HTTP_CLIENT_EXIT
         this.generator = new McpKafkaClientGenerator(config.cacheClientExit(), config.clientExit());
         this.composites = new Long2ObjectHashMap<>();
     }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBinding.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBinding.java
@@ -40,14 +40,14 @@ public final class McpOpenapiBinding implements Binding
     public String originType(
         KindConfig kind)
     {
-        return kind == KindConfig.CLIENT ? TYPE : null;
+        return kind == KindConfig.CLIENT || kind == KindConfig.PROXY ? TYPE : null;
     }
 
     @Override
     public String routedType(
         KindConfig kind)
     {
-        return kind == KindConfig.CLIENT ? TYPE : null;
+        return kind == KindConfig.CLIENT || kind == KindConfig.PROXY ? TYPE : null;
     }
 
     @Override

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBindingContext.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBindingContext.java
@@ -38,7 +38,7 @@ final class McpOpenapiBindingContext implements BindingContext
     {
         BindingHandler handler = null;
 
-        if (binding.kind == KindConfig.CLIENT)
+        if (binding.kind == KindConfig.CLIENT || binding.kind == KindConfig.PROXY)
         {
             factory.attach(binding);
             handler = factory;
@@ -51,7 +51,7 @@ final class McpOpenapiBindingContext implements BindingContext
     public void detach(
         BindingConfig binding)
     {
-        if (binding.kind == KindConfig.CLIENT)
+        if (binding.kind == KindConfig.CLIENT || binding.kind == KindConfig.PROXY)
         {
             factory.detach(binding.id);
         }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiConfiguration.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiConfiguration.java
@@ -19,14 +19,12 @@ import io.aklivity.zilla.runtime.engine.Configuration;
 public class McpOpenapiConfiguration extends Configuration
 {
     public static final LongPropertyDef MCP_OPENAPI_COMPOSITE_ROUTE_ID;
-    public static final PropertyDef<String> MCP_OPENAPI_HTTP_CLIENT_EXIT;
     private static final ConfigurationDef MCP_OPENAPI_CONFIG;
 
     static
     {
         final ConfigurationDef config = new ConfigurationDef("zilla.binding.mcp.openapi");
         MCP_OPENAPI_COMPOSITE_ROUTE_ID = config.property("composite.route.id", -1L);
-        MCP_OPENAPI_HTTP_CLIENT_EXIT = config.property("http.client.exit", "sys:http_client");
         MCP_OPENAPI_CONFIG = config;
     }
 
@@ -44,10 +42,5 @@ public class McpOpenapiConfiguration extends Configuration
     public long compositeRouteId()
     {
         return MCP_OPENAPI_COMPOSITE_ROUTE_ID.getAsLong(this);
-    }
-
-    public String httpClientExit()
-    {
-        return MCP_OPENAPI_HTTP_CLIENT_EXIT.get(this);
     }
 }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/McpOpenapiBindingConfig.java
@@ -27,6 +27,7 @@ import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiOptionsConfig;
 import io.aklivity.zilla.config.engine.BindingConfig;
 import io.aklivity.zilla.config.engine.KindConfig;
 import io.aklivity.zilla.config.engine.NamespaceConfig;
+import io.aklivity.zilla.config.engine.RouteConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 
@@ -38,6 +39,7 @@ public final class McpOpenapiBindingConfig
     public final KindConfig kind;
     public final McpOpenapiOptionsConfig options;
     public final List<McpOpenapiRouteConfig> routes;
+    public final String exit;
 
     public final ToLongFunction<String> resolveId;
     public final LongFunction<CatalogHandler> supplyCatalog;
@@ -59,6 +61,12 @@ public final class McpOpenapiBindingConfig
         this.routes = binding.routes.stream()
             .map(McpOpenapiRouteConfig::new)
             .collect(toList());
+
+        final RouteConfig exitRoute = binding.routes.stream()
+            .filter(route -> route.exit != null)
+            .findFirst()
+            .orElse(null);
+        this.exit = exitRoute != null ? context.supplyQName(exitRoute.id) : null;
 
         this.resolveId = binding.resolveId;
         this.supplyBindingId = context::supplyBindingId;

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.composite;
 
+import static io.aklivity.zilla.config.engine.KindConfig.CLIENT;
 import static io.aklivity.zilla.config.engine.KindConfig.PROXY;
 import static org.agrona.LangUtil.rethrowUnchecked;
 
@@ -109,14 +110,11 @@ public final class McpOpenapiCompositeGenerator
     private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{([^}]+)\\}");
     private static final Pattern JSON_CONTENT_TYPE_PATTERN = Pattern.compile("^application/(?:.+\\+)?json$");
 
-    private final String httpClientExit;
     private final List<String> denied;
     private final Matcher jsonContentType;
 
-    public McpOpenapiCompositeGenerator(
-        String httpClientExit)
+    public McpOpenapiCompositeGenerator()
     {
-        this.httpClientExit = httpClientExit;
         this.denied = new ArrayList<>();
         this.jsonContentType = JSON_CONTENT_TYPE_PATTERN.matcher("");
     }
@@ -414,7 +412,7 @@ public final class McpOpenapiCompositeGenerator
         return namespace
             .binding(McpHttpBindingConfig::builder)
                 .name(BINDING_NAME)
-                .kind(PROXY)
+                .kind(binding.exit != null ? PROXY : CLIENT)
                 .options(mcpHttpOptions(binding, routed))
                 .inject(b -> injectRoutes(b, binding, routed))
                 .build();
@@ -575,8 +573,6 @@ public final class McpOpenapiCompositeGenerator
         McpOpenapiBindingConfig binding,
         List<RoutedOperation> routed)
     {
-        final String exit = binding.exit != null ? binding.exit : httpClientExit;
-
         for (RoutedOperation entry : routed)
         {
             final McpHttpConditionConfig when = McpHttpConditionConfig.builder()
@@ -588,7 +584,7 @@ public final class McpOpenapiCompositeGenerator
             mcpHttp.route()
                 .when(when)
                 .with(with)
-                .exit(exit)
+                .exit(binding.exit)
                 .inject(route -> injectGuarded(route, entry))
                 .build();
         }

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -14,8 +14,6 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.composite;
 
-import static io.aklivity.zilla.config.engine.KindConfig.CLIENT;
-import static io.aklivity.zilla.config.engine.KindConfig.PROXY;
 import static org.agrona.LangUtil.rethrowUnchecked;
 
 import java.io.StringReader;
@@ -412,7 +410,7 @@ public final class McpOpenapiCompositeGenerator
         return namespace
             .binding(McpHttpBindingConfig::builder)
                 .name(BINDING_NAME)
-                .kind(binding.exit != null ? PROXY : CLIENT)
+                .kind(binding.kind)
                 .options(mcpHttpOptions(binding, routed))
                 .inject(b -> injectRoutes(b, binding, routed))
                 .build();

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -416,7 +416,7 @@ public final class McpOpenapiCompositeGenerator
                 .name(BINDING_NAME)
                 .kind(PROXY)
                 .options(mcpHttpOptions(binding, routed))
-                .inject(b -> injectRoutes(b, routed))
+                .inject(b -> injectRoutes(b, binding, routed))
                 .build();
     }
 
@@ -571,9 +571,12 @@ public final class McpOpenapiCompositeGenerator
     }
 
     private <C> McpHttpBindingConfigBuilder<C> injectRoutes(
-        McpHttpBindingConfigBuilder<C> binding,
+        McpHttpBindingConfigBuilder<C> mcpHttp,
+        McpOpenapiBindingConfig binding,
         List<RoutedOperation> routed)
     {
+        final String exit = binding.exit != null ? binding.exit : httpClientExit;
+
         for (RoutedOperation entry : routed)
         {
             final McpHttpConditionConfig when = McpHttpConditionConfig.builder()
@@ -582,15 +585,15 @@ public final class McpOpenapiCompositeGenerator
                 .build();
             final McpHttpWithConfig with = withConfig(entry);
 
-            binding.route()
+            mcpHttp.route()
                 .when(when)
                 .with(with)
-                .exit(httpClientExit)
+                .exit(exit)
                 .inject(route -> injectGuarded(route, entry))
                 .build();
         }
 
-        return binding;
+        return mcpHttp;
     }
 
     private <C> McpHttpRouteConfigBuilder<C> injectGuarded(

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientFactory.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientFactory.java
@@ -82,7 +82,7 @@ public final class McpOpenapiClientFactory implements BindingHandler
         this.supplyInitialId = context::supplyInitialId;
         this.supplyReplyId = context::supplyReplyId;
         this.bindings = new Long2ObjectHashMap<>();
-        this.generator = new McpOpenapiCompositeGenerator(config.httpClientExit());
+        this.generator = new McpOpenapiCompositeGenerator();
         this.event = new McpOpenapiEventContext(context);
         this.compositeRouteId = config.compositeRouteId();
     }

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiConfigurationTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiConfigurationTest.java
@@ -15,7 +15,6 @@
 package io.aklivity.zilla.runtime.binding.mcp.openapi.internal;
 
 import static io.aklivity.zilla.runtime.binding.mcp.openapi.internal.McpOpenapiConfiguration.MCP_OPENAPI_COMPOSITE_ROUTE_ID;
-import static io.aklivity.zilla.runtime.binding.mcp.openapi.internal.McpOpenapiConfiguration.MCP_OPENAPI_HTTP_CLIENT_EXIT;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -23,12 +22,10 @@ import org.junit.Test;
 public class McpOpenapiConfigurationTest
 {
     public static final String MCP_OPENAPI_COMPOSITE_ROUTE_ID_NAME = "zilla.binding.mcp.openapi.composite.route.id";
-    public static final String MCP_OPENAPI_HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.openapi.http.client.exit";
 
     @Test
     public void shouldVerifyConstants() throws Exception
     {
         assertEquals(MCP_OPENAPI_COMPOSITE_ROUTE_ID.name(), MCP_OPENAPI_COMPOSITE_ROUTE_ID_NAME);
-        assertEquals(MCP_OPENAPI_HTTP_CLIENT_EXIT.name(), MCP_OPENAPI_HTTP_CLIENT_EXIT_NAME);
     }
 }

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -406,7 +406,7 @@ public class McpOpenapiCompositeGeneratorTest
     @Mock
     private CatalogHandler catalog;
 
-    private final McpOpenapiCompositeGenerator generator = new McpOpenapiCompositeGenerator("sys:http_client");
+    private final McpOpenapiCompositeGenerator generator = new McpOpenapiCompositeGenerator();
 
     private final ToLongFunction<String> resolveId = name -> switch (name)
     {
@@ -482,7 +482,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         assertThat(mcpHttp, notNullValue());
         assertThat(mcpHttp.type, equalTo("mcp_http"));
-        assertThat(mcpHttp.kind, equalTo(PROXY));
+        assertThat(mcpHttp.kind, equalTo(CLIENT));
 
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
         assertThat(mcpHttpOptions.tools, notNullValue());
@@ -497,7 +497,7 @@ public class McpOpenapiCompositeGeneratorTest
         assertThat(mcpHttpOptions.resources, notNullValue());
         assertThat(mcpHttpOptions.resources.get(0).uri, equalTo("/repos/{owner}/{repo}"));
 
-        assertThat(mcpHttp.routes.get(0).exit, equalTo("sys:http_client"));
+        assertThat(mcpHttp.routes.get(0).exit, nullValue());
 
         McpHttpWithConfig toolWith = mcpHttp.routes.stream()
             .map(r -> (McpHttpWithConfig) r.with)
@@ -521,7 +521,7 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
-    public void shouldOverrideHttpClientExitFromBindingLevelExit()
+    public void shouldGenerateProxyKindMcpHttpFromBindingLevelExit()
     {
         lenient().when(context.supplyQName(eq(9L))).thenReturn("test:schema_registry0");
 
@@ -568,6 +568,7 @@ public class McpOpenapiCompositeGeneratorTest
             .orElse(null);
 
         assertThat(mcpHttp, notNullValue());
+        assertThat(mcpHttp.kind, equalTo(PROXY));
         assertThat(mcpHttp.routes, hasSize(1));
         assertThat(mcpHttp.routes.get(0).exit, equalTo("test:schema_registry0"));
     }

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -521,7 +521,7 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
-    public void shouldGenerateProxyKindMcpHttpFromBindingLevelExit()
+    public void shouldGenerateProxyKindMcpHttpFromProxyKindExit()
     {
         lenient().when(context.supplyQName(eq(9L))).thenReturn("test:schema_registry0");
 
@@ -529,7 +529,7 @@ public class McpOpenapiCompositeGeneratorTest
             .namespace("test")
             .name("mcp_openapi0")
             .type("mcp_openapi")
-            .kind(CLIENT)
+            .kind(PROXY)
             .exit("schema_registry0")
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -521,6 +521,58 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
+    public void shouldOverrideHttpClientExitFromBindingLevelExit()
+    {
+        lenient().when(context.supplyQName(eq(9L))).thenReturn("test:schema_registry0");
+
+        BindingConfig binding = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("mcp_openapi0")
+            .type("mcp_openapi")
+            .kind(CLIENT)
+            .exit("schema_registry0")
+            .options(McpOpenapiOptionsConfig.builder()
+                .spec()
+                    .label("openapi_github0")
+                    .server("https://api.github.com")
+                    .catalog()
+                        .name("catalog0")
+                        .subject("rest-api")
+                        .version("latest")
+                        .build()
+                    .build()
+                .build())
+            .route()
+                .when(McpOpenapiConditionConfig.builder()
+                    .tool("create_pr")
+                    .build())
+                .with(McpOpenapiWithConfig.builder()
+                    .spec("openapi_github0")
+                    .operation("pulls/create")
+                    .build())
+                .build()
+            .build();
+        binding.resolveId = resolveId;
+        binding.routes.stream()
+            .filter(route -> "schema_registry0".equals(route.exit))
+            .findFirst()
+            .orElseThrow()
+            .id = 9L;
+
+        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
+
+        NamespaceConfig namespace = composite.namespaces.get(0);
+        BindingConfig mcpHttp = namespace.bindings.stream()
+            .filter(b -> "mcp_http0".equals(b.name))
+            .findFirst()
+            .orElse(null);
+
+        assertThat(mcpHttp, notNullValue());
+        assertThat(mcpHttp.routes, hasSize(1));
+        assertThat(mcpHttp.routes.get(0).exit, equalTo("test:schema_registry0"));
+    }
+
+    @Test
     public void shouldForwardAuthorizationToMcpHttp()
     {
         BindingConfig binding = GenericBindingConfig.builder()

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientIT.java
@@ -31,7 +31,7 @@ import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 
 public class McpOpenapiClientIT
 {
-    private static final String HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.openapi.http.client.exit";
+    private static final String HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.http.client.exit";
     private static final String SESSION_ID_NAME = "zilla.binding.mcp.http.session.id";
 
     private final K3poRule k3po = new K3poRule()

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiProxyIT.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiProxyIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.openapi.internal.stream;
+
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.test.EngineRule;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+
+public class McpOpenapiProxyIT
+{
+    private static final String SESSION_ID_NAME = "zilla.binding.mcp.http.session.id";
+
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("mcp", "io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp")
+        .addScriptRoot("http", "io/aklivity/zilla/specs/binding/mcp/openapi/streams/http");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final EngineRule engine = new EngineRule()
+        .directory("target/zilla-itests")
+        .countersBufferCapacity(8192)
+        .configure(ENGINE_BUFFER_SLOT_CAPACITY, 8192)
+        .configure(SESSION_ID_NAME, "%s::sessionId".formatted(McpOpenapiProxyIT.class.getName()))
+        .configurationRoot("io/aklivity/zilla/specs/binding/mcp/openapi/config")
+        .external("http0")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
+
+    public static String sessionId()
+    {
+        return "session-1";
+    }
+
+    @Test
+    @Configuration("kind.proxy.yaml")
+    @Specification({
+        "${mcp}/create.pr/client",
+        "${http}/create.pr/server"})
+    public void shouldCallToolCreatePr() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("kind.proxy.yaml")
+    @Specification({
+        "${mcp}/read.order/client",
+        "${http}/read.order/server"})
+    public void shouldReadResourceOrder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("kind.proxy.yaml")
+    @Specification({
+        "${mcp}/tools.list/client"})
+    public void shouldListTools() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("kind.proxy.yaml")
+    @Specification({
+        "${mcp}/resources.list/client"})
+    public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/stream/McpSchemaRegistryClientIT.java
+++ b/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/stream/McpSchemaRegistryClientIT.java
@@ -30,7 +30,7 @@ import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 
 public class McpSchemaRegistryClientIT
 {
-    private static final String HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.openapi.http.client.exit";
+    private static final String HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.http.client.exit";
     private static final String SESSION_ID_NAME = "zilla.binding.mcp.http.session.id";
 
     private final K3poRule k3po = new K3poRule()

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/exit.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/exit.invalid.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: client
+    exit: http0

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.invalid.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          spec: github
+          operation: create_pr

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.route.exit.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.route.exit.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          spec: github
+          operation: create_pr
+        exit: http0

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.yaml
@@ -1,0 +1,128 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  catalog0:
+    type: inline
+    options:
+      subjects:
+        github:
+          version: latest
+          schema: |
+            {
+              "openapi": "3.1.0",
+              "info": { "title": "GitHub", "version": "1.0.0" },
+              "servers": [ { "url": "https://api.github.com" } ],
+              "paths": {
+                "/repos/{owner}/{repo}/pulls": {
+                  "post": {
+                    "operationId": "create_pr",
+                    "summary": "Create a pull request",
+                    "parameters": [
+                      { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+                      { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } }
+                    ],
+                    "requestBody": {
+                      "required": true,
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "type": "object",
+                            "required": [ "title", "head", "base" ],
+                            "properties": {
+                              "title": { "type": "string" },
+                              "head": { "type": "string" },
+                              "base": { "type": "string" },
+                              "body": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "responses": {
+                      "201": {
+                        "description": "created",
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "type": "object",
+                              "properties": {
+                                "number": { "type": "integer" },
+                                "html_url": { "type": "string" },
+                                "state": { "type": "string" },
+                                "title": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "/orders/{orderId}": {
+                  "get": {
+                    "operationId": "read_order",
+                    "summary": "Read an order",
+                    "parameters": [
+                      { "name": "orderId", "in": "path", "required": true, "schema": { "type": "string" } }
+                    ],
+                    "responses": {
+                      "200": {
+                        "description": "ok",
+                        "content": {
+                          "application/json": {
+                            "schema": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "string" },
+                                "status": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_openapi
+    kind: proxy
+    exit: http0
+    options:
+      specs:
+        github:
+          catalog:
+            catalog0:
+              subject: github
+              version: latest
+      tools:
+        create_pr:
+          description: Create a pull request to merge one branch into another.
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          spec: github
+          operation: create_pr
+      - when:
+          - resource: read_order
+        with:
+          spec: github
+          operation: read_order

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -474,12 +474,16 @@
                                 {
                                     "routes":
                                     {
-                                        "contains":
+                                        "items":
                                         {
-                                            "required":
-                                            [
-                                                "exit"
-                                            ]
+                                            "if":
+                                            {
+                                                "required": [ "with" ]
+                                            },
+                                            "then":
+                                            {
+                                                "required": [ "exit" ]
+                                            }
                                         }
                                     }
                                 },

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -29,7 +29,7 @@
                     },
                     "kind":
                     {
-                        "enum": [ "client" ]
+                        "enum": [ "client", "proxy" ]
                     },
                     "vault": false,
                     "entry": false,
@@ -381,6 +381,11 @@
                                             "items": { "title": "Role", "type": "string" }
                                         }
                                     }
+                                },
+                                "exit":
+                                {
+                                    "title": "Exit",
+                                    "type": "string"
                                 }
                             },
                             "required": [ "with" ],
@@ -425,7 +430,67 @@
                         }
                     }
                 },
-                "required": [ "routes" ]
+                "required": [ "routes" ],
+                "oneOf":
+                [
+                    {
+                        "properties":
+                        {
+                            "kind":
+                            {
+                                "const": "client"
+                            },
+                            "exit": false,
+                            "routes":
+                            {
+                                "items":
+                                {
+                                    "properties":
+                                    {
+                                        "exit": false
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "properties":
+                        {
+                            "kind":
+                            {
+                                "const": "proxy"
+                            }
+                        },
+                        "anyOf":
+                        [
+                            {
+                                "required":
+                                [
+                                    "exit"
+                                ]
+                            },
+                            {
+                                "properties":
+                                {
+                                    "routes":
+                                    {
+                                        "contains":
+                                        {
+                                            "required":
+                                            [
+                                                "exit"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required":
+                                [
+                                    "routes"
+                                ]
+                            }
+                        ]
+                    }
+                ]
             }
         }
     }

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
@@ -49,6 +49,26 @@ public class SchemaTest
         schema.validate("proxy.kind.invalid.yaml");
     }
 
+    @Test
+    public void shouldValidateProxyKind()
+    {
+        JsonObject config = schema.validate("kind.proxy.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyKindWithoutExit()
+    {
+        schema.validate("kind.proxy.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectClientKindWithExit()
+    {
+        schema.validate("exit.invalid.yaml");
+    }
+
     @Test(expected = JsonException.class)
     public void shouldRejectUnknownOption()
     {

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
@@ -57,6 +57,14 @@ public class SchemaTest
         assertThat(config, not(nullValue()));
     }
 
+    @Test
+    public void shouldValidateProxyKindWithRouteExit()
+    {
+        JsonObject config = schema.validate("kind.proxy.route.exit.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
     @Test(expected = JsonException.class)
     public void shouldRejectProxyKindWithoutExit()
     {


### PR DESCRIPTION
## Description

`mcp_openapi` previously supported only `kind: client`, with the generated `mcp_http0` route's `exit` always sourced from the JVM-wide `zilla.binding.mcp.openapi.http.client.exit` Configuration property. This adds a `kind: proxy` variant that lets the operator declare `exit` directly on the binding (top-level or per-route), so the generated composite can terminate at an operator-provided binding instead of the configured default — the same split `binding-mcp-schema-registry` got in #2068/#2231.

Rebased onto latest `develop` (post #2241, #2243, #2244), which landed `binding-mcp-http`'s own `kind: client` (#2243, #2238). That unlocked a cleaner design than originally planned: `mcp_openapi` no longer needs its own `zilla.binding.mcp.openapi.http.client.exit` default for the generated `mcp_http0` — it now propagates its own `kind` directly onto `mcp_http0` (`client` → `client`, `proxy` → `proxy` with the resolved `exit` stamped per route), relying entirely on `mcp_http`'s own `zilla.binding.mcp.http.client.exit` default (`sys:http_client`) for the client case. The mcp-openapi-level property is removed as redundant.

`client` (no `exit` anywhere) and `proxy` (`exit` required) now have a precisely-specified meaning enforced by the schema, so `McpOpenapiCompositeGenerator` trusts `binding.kind` directly (`.kind(binding.kind)`) rather than deriving the generated kind from exit presence — every caller of `McpOpenapiBindingConfig` lives in this codebase, so a caller that ever set kind/exit inconsistently would simply fail to route correctly and get caught by tests, rather than needing to be defended against here.

### Changes

- `specs/binding-mcp-openapi.spec`: schema patch widens `kind` to `["client", "proxy"]`. `client` keeps disallowing `exit` (top-level and per-route); `proxy` requires `exit` either top-level or per-route — the per-route branch mirrors `binding-mcp-http`'s own `if: {required: [with]} then: {required: [exit]}` shape (and the corrected, non-vacuous form of `binding-tcp`'s pattern from #2241) rather than `binding-tcp`'s original array-level `"required"`, which is a no-op since `required` only constrains object instances. New fixtures (`kind.proxy.yaml`, `kind.proxy.invalid.yaml`, `kind.proxy.route.exit.yaml`, `exit.invalid.yaml`) plus `SchemaTest` coverage for the valid/invalid combinations.
- `runtime/binding-mcp-openapi`:
  - `McpOpenapiBindingConfig` resolves a binding-level `exit` from the first route with a non-null `exit`, using that route's already-resolved `route.id` (set generically by `EngineManager` for every route before any binding-specific code runs) rather than re-resolving the raw `route.exit` string a second time.
  - `McpOpenapiCompositeGenerator` generates `mcp_http0` with the same `kind` as the outer `mcp_openapi` binding, stamping the resolved `exit` on every route when one exists.
  - `McpOpenapiBinding`/`McpOpenapiBindingContext` widen their `kind == CLIENT` gates to also accept `PROXY` — without this, `kind: proxy` bindings never reach `attach()` at all and every stream aborts immediately, mirroring `McpSchemaRegistryBinding`/`McpSchemaRegistryBindingContext`'s existing client+proxy dual-kind pattern from #2231.
- `McpOpenapiClientIT`/`McpSchemaRegistryClientIT`: switch their exit override from the removed `zilla.binding.mcp.openapi.http.client.exit` to `zilla.binding.mcp.http.client.exit` (now owned by `binding-mcp-http`), since there's no longer an mcp-openapi-level exit for `kind: client` to override.
- New `McpOpenapiProxyIT` reuses the existing `mcp`/`http` `.rpt` scripts already exercised by `McpOpenapiClientIT`, driven by a `kind: proxy` + `exit:` fixture — analogous to `McpSchemaRegistryProxyIT`.

`options.specs.*.server` is untouched — it stays available for both kinds, since it shapes per-spec HTTP headers independently of which binding receives the stream.

**Follow-up for `binding-mcp-schema-registry`** (once #2104/#2231 lands and picks this up): its own composite generator currently hardcodes `.kind(CLIENT)` on the intermediate `mcp_openapi0` it generates, regardless of its own kind. It should instead propagate its own kind the same way this PR does — `.kind(schemaRegistryBinding.kind)` with `.exit(schemaRegistryBinding.exit)` stamped on the generated route(s) — rather than hardcoding `CLIENT` while separately threading `exit` through, which is exactly the kind/exit inconsistency this PR moved away from tolerating.

Verified locally: `./mvnw verify` is green for `specs/binding-mcp-openapi.spec`, `runtime/binding-mcp-openapi`, and `runtime/binding-mcp-schema-registry`, including checkstyle, license checks, JaCoCo coverage, and all ITs.

Fixes #2237