### PR TITLE
binding-mcp-http: add kind: client and require exit for kind: proxy

### DIFF
--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpBindingContext.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpBindingContext.java
@@ -38,7 +38,7 @@ final class McpHttpBindingContext implements BindingContext
     {
         BindingHandler handler = null;
 
-        if (binding.kind == KindConfig.PROXY)
+        if (binding.kind == KindConfig.PROXY || binding.kind == KindConfig.CLIENT)
         {
             factory.attach(binding);
             handler = factory;
@@ -51,7 +51,7 @@ final class McpHttpBindingContext implements BindingContext
     public void detach(
         BindingConfig binding)
     {
-        if (binding.kind == KindConfig.PROXY)
+        if (binding.kind == KindConfig.PROXY || binding.kind == KindConfig.CLIENT)
         {
             factory.detach(binding.id);
         }

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpConfiguration.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpConfiguration.java
@@ -32,6 +32,7 @@ public class McpHttpConfiguration extends Configuration
 
     public static final PropertyDef<SessionIdSupplier> MCP_HTTP_SESSION_ID;
     public static final IntPropertyDef MCP_HTTP_SESSION_ID_ATTEMPTS;
+    public static final PropertyDef<String> MCP_HTTP_CLIENT_EXIT;
 
     static
     {
@@ -40,6 +41,7 @@ public class McpHttpConfiguration extends Configuration
             McpHttpConfiguration::decodeSessionIdSupplier, McpHttpConfiguration::defaultSessionIdSupplier);
         MCP_HTTP_SESSION_ID_ATTEMPTS = config.property("session.id.attempts",
             McpHttpConfiguration::defaultSessionIdAttempts);
+        MCP_HTTP_CLIENT_EXIT = config.property("client.exit", "sys:http_client");
         MCP_HTTP_CONFIG = config;
     }
 
@@ -62,6 +64,11 @@ public class McpHttpConfiguration extends Configuration
     public int sessionIdAttempts()
     {
         return MCP_HTTP_SESSION_ID_ATTEMPTS.getAsInt(this);
+    }
+
+    public String clientExit()
+    {
+        return MCP_HTTP_CLIENT_EXIT.get(this);
     }
 
     @FunctionalInterface

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -55,7 +55,6 @@ public final class McpHttpBindingConfig
 {
     private static final String CREDENTIALS_TOKEN = "{credentials}";
     private static final String IDENTITY_TOKEN = "{identity}";
-    private static final String SYS_HTTP_CLIENT = "sys:http_client";
 
     public final long id;
     public final McpHttpOptionsConfig options;
@@ -79,7 +78,8 @@ public final class McpHttpBindingConfig
 
     public McpHttpBindingConfig(
         BindingConfig binding,
-        EngineContext context)
+        EngineContext context,
+        String clientExit)
     {
         this.id = binding.id;
         this.context = context;
@@ -88,8 +88,8 @@ public final class McpHttpBindingConfig
 
         if (binding.kind == KindConfig.CLIENT)
         {
-            final long httpClientId = resolveId.applyAsLong(SYS_HTTP_CLIENT);
-            binding.routes.forEach(route -> route.id = httpClientId);
+            final long clientExitId = resolveId.applyAsLong(clientExit);
+            binding.routes.forEach(route -> route.id = clientExitId);
         }
 
         this.routes = binding.routes.stream()

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfig.java
@@ -43,6 +43,7 @@ import io.aklivity.zilla.config.binding.mcp.http.McpHttpToolConfig;
 import io.aklivity.zilla.config.engine.BindingConfig;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.GuardedConfig;
+import io.aklivity.zilla.config.engine.KindConfig;
 import io.aklivity.zilla.config.engine.ModelConfig;
 import io.aklivity.zilla.config.engine.SchemaConfig;
 import io.aklivity.zilla.runtime.common.json.JsonSchema;
@@ -54,6 +55,7 @@ public final class McpHttpBindingConfig
 {
     private static final String CREDENTIALS_TOKEN = "{credentials}";
     private static final String IDENTITY_TOKEN = "{identity}";
+    private static final String SYS_HTTP_CLIENT = "sys:http_client";
 
     public final long id;
     public final McpHttpOptionsConfig options;
@@ -83,6 +85,13 @@ public final class McpHttpBindingConfig
         this.context = context;
         this.resolveId = binding.resolveId;
         this.options = (McpHttpOptionsConfig) binding.options;
+
+        if (binding.kind == KindConfig.CLIENT)
+        {
+            final long httpClientId = resolveId.applyAsLong(SYS_HTTP_CLIENT);
+            binding.routes.forEach(route -> route.id = httpClientId);
+        }
+
         this.routes = binding.routes.stream()
             .map(McpHttpRouteConfig::new)
             .collect(toList());

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpProxyFactory.java
@@ -169,6 +169,7 @@ public final class McpHttpProxyFactory implements BindingHandler
     private final Supplier<String> supplySessionId;
     private final int sessionIdAttempts;
     private final LongIntPredicate isLocalIndex;
+    private final String clientExit;
 
     public McpHttpProxyFactory(
         McpHttpConfiguration config,
@@ -192,12 +193,13 @@ public final class McpHttpProxyFactory implements BindingHandler
         this.supplySessionId = config.sessionIdSupplier();
         this.sessionIdAttempts = config.sessionIdAttempts();
         this.isLocalIndex = context::isLocalIndex;
+        this.clientExit = config.clientExit();
     }
 
     public void attach(
         BindingConfig binding)
     {
-        bindings.put(binding.id, new McpHttpBindingConfig(binding, context));
+        bindings.put(binding.id, new McpHttpBindingConfig(binding, context, clientExit));
     }
 
     public void detach(

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpConfigurationTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpConfigurationTest.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.binding.mcp.http.internal;
 
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfiguration.MCP_HTTP_CLIENT_EXIT;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfiguration.MCP_HTTP_SESSION_ID;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfiguration.MCP_HTTP_SESSION_ID_ATTEMPTS;
 import static org.junit.Assert.assertEquals;
@@ -32,12 +33,14 @@ public class McpHttpConfigurationTest
 {
     public static final String MCP_HTTP_SESSION_ID_NAME = "zilla.binding.mcp.http.session.id";
     public static final String MCP_HTTP_SESSION_ID_ATTEMPTS_NAME = "zilla.binding.mcp.http.session.id.attempts";
+    public static final String MCP_HTTP_CLIENT_EXIT_NAME = "zilla.binding.mcp.http.client.exit";
 
     @Test
     public void shouldVerifyConstants() throws Exception
     {
         assertEquals(MCP_HTTP_SESSION_ID.name(), MCP_HTTP_SESSION_ID_NAME);
         assertEquals(MCP_HTTP_SESSION_ID_ATTEMPTS.name(), MCP_HTTP_SESSION_ID_ATTEMPTS_NAME);
+        assertEquals(MCP_HTTP_CLIENT_EXIT.name(), MCP_HTTP_CLIENT_EXIT_NAME);
     }
 
     @Test
@@ -46,6 +49,24 @@ public class McpHttpConfigurationTest
         McpHttpConfiguration config = new McpHttpConfiguration();
 
         assertTrue(config.sessionIdAttempts() > 0);
+    }
+
+    @Test
+    public void shouldDefaultClientExitToSysHttpClient()
+    {
+        McpHttpConfiguration config = new McpHttpConfiguration();
+
+        assertEquals("sys:http_client", config.clientExit());
+    }
+
+    @Test
+    public void shouldOverrideClientExit()
+    {
+        Properties properties = new Properties();
+        properties.setProperty(MCP_HTTP_CLIENT_EXIT_NAME, "test:http0");
+        McpHttpConfiguration config = new McpHttpConfiguration(new Configuration(properties));
+
+        assertEquals("test:http0", config.clientExit());
     }
 
     @Test

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -75,7 +75,7 @@ public class McpHttpBindingConfigTest
             .kind(KindConfig.PROXY)
             .routes(routes)
             .build();
-        return new McpHttpBindingConfig(config, null);
+        return new McpHttpBindingConfig(config, null, "sys:http_client");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class McpHttpBindingConfigTest
     }
 
     @Test
-    public void shouldResolveClientRouteExitToSysHttpClient()
+    public void shouldResolveClientRouteExitToConfiguredDefault()
     {
         RouteConfig route = RouteConfig.builder()
             .order(0)
@@ -187,9 +187,34 @@ public class McpHttpBindingConfigTest
             .build();
         config.resolveId = name -> "sys:http_client".equals(name) ? 42L : 0L;
 
-        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null);
+        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null, "sys:http_client");
 
         assertThat(binding.routes.get(0).id, equalTo(42L));
+    }
+
+    @Test
+    public void shouldResolveClientRouteExitToConfiguredOverride()
+    {
+        RouteConfig route = RouteConfig.builder()
+            .order(0)
+            .with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
+            .exit("ignored")
+            .build();
+
+        BindingConfig config = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp_http")
+            .kind(KindConfig.CLIENT)
+            .routes(List.of(route))
+            .build();
+        config.resolveId = name -> "test:http0".equals(name) ? 24L : 0L;
+
+        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null, "test:http0");
+
+        assertThat(binding.routes.get(0).id, equalTo(24L));
     }
 
     @Test
@@ -213,7 +238,7 @@ public class McpHttpBindingConfigTest
             .build();
         config.resolveId = name -> "sys:http_client".equals(name) ? 42L : 0L;
 
-        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null);
+        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null, "sys:http_client");
 
         assertThat(binding.routes.get(0).id, equalTo(7L));
     }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.mcp.http.internal.config;
 import static io.aklivity.zilla.runtime.binding.mcp.http.internal.config.McpHttpBindingConfig.argPathValid;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -164,6 +165,57 @@ public class McpHttpBindingConfigTest
 
         assertThat(binding.resourceGuarded("order"), hasSize(2));
         assertThat(binding.resourceGuarded("other"), empty());
+    }
+
+    @Test
+    public void shouldResolveClientRouteExitToSysHttpClient()
+    {
+        RouteConfig route = RouteConfig.builder()
+            .order(0)
+            .with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
+            .exit("ignored")
+            .build();
+
+        BindingConfig config = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp_http")
+            .kind(KindConfig.CLIENT)
+            .routes(List.of(route))
+            .build();
+        config.resolveId = name -> "sys:http_client".equals(name) ? 42L : 0L;
+
+        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null);
+
+        assertThat(binding.routes.get(0).id, equalTo(42L));
+    }
+
+    @Test
+    public void shouldNotOverrideProxyRouteExit()
+    {
+        RouteConfig route = RouteConfig.builder()
+            .order(0)
+            .with(McpHttpWithConfig::builder)
+                .header(":path", "/items")
+                .build()
+            .exit("http0")
+            .build();
+        route.id = 7L;
+
+        BindingConfig config = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp_http")
+            .kind(KindConfig.PROXY)
+            .routes(List.of(route))
+            .build();
+        config.resolveId = name -> "sys:http_client".equals(name) ? 42L : 0L;
+
+        McpHttpBindingConfig binding = new McpHttpBindingConfig(config, null);
+
+        assertThat(binding.routes.get(0).id, equalTo(7L));
     }
 
     private static final String FLAT = "{\"type\":\"object\",\"properties\":{\"owner\":{\"type\":\"string\"}}}";

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpClientIT.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/stream/McpHttpClientIT.java
@@ -1,0 +1,680 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.http.internal.stream;
+
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfigurationTest.MCP_HTTP_CLIENT_EXIT_NAME;
+import static io.aklivity.zilla.runtime.binding.mcp.http.internal.McpHttpConfigurationTest.MCP_HTTP_SESSION_ID_NAME;
+import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import io.aklivity.k3po.runtime.junit.annotation.Specification;
+import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.test.EngineRule;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+
+public class McpHttpClientIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("mcp", "io/aklivity/zilla/specs/binding/mcp/http/streams/mcp")
+        .addScriptRoot("http", "io/aklivity/zilla/specs/binding/mcp/http/streams/http");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final EngineRule engine = new EngineRule()
+        .directory("target/zilla-itests")
+        .countersBufferCapacity(8192)
+        .configure(ENGINE_BUFFER_SLOT_CAPACITY, 8192)
+        .configure(MCP_HTTP_SESSION_ID_NAME, "%s::sessionId".formatted(McpHttpClientIT.class.getName()))
+        .configure(MCP_HTTP_CLIENT_EXIT_NAME, "http0")
+        .configurationRoot("io/aklivity/zilla/specs/binding/mcp/http/config")
+        .external("http0")
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(engine).around(k3po).around(timeout);
+
+    public static String sessionId()
+    {
+        return "session-1";
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/initialize/client"})
+    public void shouldInitialize() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/lifecycle.data/client"})
+    public void shouldConsumeLifecycleData() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/lifecycle.client.abort/client"})
+    public void shouldAbortLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/lifecycle.client.reset/client"})
+    public void shouldResetLifecycle() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.10k/client",
+        "${http}/create.pr.10k/server"})
+    public void shouldCallToolCreatePr10k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.100k/client",
+        "${http}/create.pr.100k/server"})
+    public void shouldCallToolCreatePr100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.fragmented/client",
+        "${http}/create.pr.fragmented/server"})
+    public void shouldCallToolCreatePrFragmented() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.widget/client",
+        "${http}/create.widget/server"})
+    public void shouldCallToolCreateWidgetWithNoPathParams() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.widget.fragmented/client",
+        "${http}/create.widget.fragmented/server"})
+    public void shouldCallToolCreateWidgetFragmentedWithNoPathParams() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.rich/client",
+        "${http}/create.pr.rich/server"})
+    public void shouldCallToolCreatePrWithStructuredArguments() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/read.order.10k/client",
+        "${http}/read.order.10k/server"})
+    public void shouldReadResourceOrder10k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/read.order.100k/client",
+        "${http}/read.order.100k/server"})
+    public void shouldReadResourceOrder100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr/client",
+        "${http}/create.pr/server"})
+    public void shouldCallToolCreatePr() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/comment.pr/client",
+        "${http}/comment.pr/server"})
+    public void shouldCallToolCommentPr() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.remap.yaml")
+    @Specification({
+        "${mcp}/create.pr.remap/client",
+        "${http}/create.pr/server"})
+    public void shouldCallToolWithBodyTemplate() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.remap.nested.yaml")
+    @Specification({
+        "${mcp}/create.pr.remap.nested/client",
+        "${http}/create.pr/server"})
+    public void shouldCallToolWithNestedBodyTemplate() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.yaml")
+    @Specification({
+        "${mcp}/tools.list/client"})
+    public void shouldListTools() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.annotations.yaml")
+    @Specification({
+        "${mcp}/tools.list.with.annotations/client"})
+    public void shouldListToolsWithAnnotations() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.yaml")
+    @Specification({
+        "${mcp}/tools.list.unknown.session/client"})
+    public void shouldRejectUnknownSession() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.yaml")
+    @Specification({
+        "${mcp}/resources.list/client"})
+    public void shouldListResources() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.yaml")
+    @Specification({
+        "${mcp}/resources.templates.list/client"})
+    public void shouldListResourcesTemplates() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.discovery.yaml")
+    @Specification({
+        "${mcp}/read.resource.unknown/client"})
+    public void shouldRejectResourceReadWhenUriUnmatched() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/read.order/client",
+        "${http}/read.order/server"})
+    public void shouldReadResourceOrder() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.code/client",
+        "${http}/search.code/server"})
+    public void shouldCallToolSearchCode() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.code.query.array/client",
+        "${http}/search.code.query.array/server"})
+    public void shouldCallToolSearchCodeWithArrayAndBooleanQuery() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.code.invalid/client"})
+    public void shouldRejectToolSearchCodeWhenArgumentsInvalid() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.items/client",
+        "${http}/search.items/server"})
+    public void shouldCallToolSearchItemsWithoutOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.items.with.limit/client",
+        "${http}/search.items.with.limit/server"})
+    public void shouldCallToolSearchItemsWithOptionalQueryParameter() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // a ~100KB tools/call response, streamed across many suspend/resume cycles; the leading total_count
+    // field is captured well before the large trailing items[].path value finishes streaming, proving
+    // tool.summary interpolation survives more than one window (see McpHttpResults)
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/search.code.100k/client",
+        "${http}/search.code.100k/server"})
+    public void shouldCallToolSearchCode100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // a ~100KB structuredContent.message value, also interpolated into tool.summary's content.text: proves
+    // the summary trailer (injected as more events once structuredContent's own value closes, see
+    // McpHttpToolResult) survives many suspend/resume cycles across the encode slot exactly like
+    // structuredContent's own streamed value does, not just when the destination has room left over
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/get.report.large/client",
+        "${http}/get.report.large/server"})
+    public void shouldCallToolGetReportWithLargeSummary() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // ping has no tool.summary configured: content[0].text falls back to the empty string
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/ping/client",
+        "${http}/ping/server"})
+    public void shouldCallToolPing() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // list_tags' output schema is array-rooted: structuredContent is the array itself, not an object
+    // wrapping it
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/list.tags/client",
+        "${http}/list.tags/server"})
+    public void shouldCallToolListTags() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // count_items' output schema is a bare scalar: structuredContent is the scalar itself, not an
+    // object/array wrapping it
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/count.items/client",
+        "${http}/count.items/server"})
+    public void shouldCallToolCountItems() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // a 12000-byte top-level argument value referenced by the route's :path template: proves
+    // McpHttpArguments captures a value spanning multiple decode windows correctly (see the
+    // mediating-transform rule / multi-window accumulation fix), not just short path arguments that
+    // always arrive in one window
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/echo.id.large/client",
+        "${http}/echo.id.large/server"})
+    public void shouldCallToolEchoIdWithLargeArgument() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.error/client",
+        "${http}/create.pr.error/server"})
+    public void shouldRejectToolCreatePr() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // a ~100KB non-2xx upstream error body, relayed back verbatim as escaped text; proves the error relay
+    // genuinely streams (windowed, no MAX_ERROR_BODY-style cap) rather than needing to fit one buffer
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.error.100k/client",
+        "${http}/create.pr.error.100k/server"})
+    public void shouldRejectToolCreatePr100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.aborted/client",
+        "${http}/create.pr.aborted/server"})
+    public void shouldAbortToolCreatePr() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.error.aborted/client",
+        "${http}/create.pr.error.aborted/server"})
+    public void shouldAbortToolCreatePrDuringErrorRelay() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.client.reset/client",
+        "${http}/create.pr.client.reset/server"})
+    public void shouldAbortUpstreamWhenReplyReset() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.reset/client",
+        "${http}/create.pr.reset/server"})
+    public void shouldAbortToolCreatePrWhenUpstreamResetsRequest() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.streaming.aborted/client",
+        "${http}/create.pr.streaming.aborted/server"})
+    public void shouldAbortToolCreatePrDuringResponseStreaming() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.guarded.yaml")
+    @Specification({
+        "${mcp}/create.pr/client",
+        "${http}/create.pr/server"})
+    public void shouldCallToolWhenAuthorized() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.guarded.yaml")
+    @Specification({
+        "${mcp}/search.code.forbidden/client"})
+    public void shouldRejectToolWhenUnauthorized() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/create.pr.forbidden.by.global.guard/client"})
+    public void shouldRejectToolWhenGlobalGuardOnlyLayerFails() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/tools.list.security.schemes.layered/client"})
+    public void shouldListToolsSecuritySchemesLayered() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/resources.list.security.schemes/client"})
+    public void shouldListResourcesSecuritySchemes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.credentials.yaml")
+    @Specification({
+        "${mcp}/create.pr/client",
+        "${http}/create.pr.credentials/server"})
+    public void shouldInjectCredentials() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.invalid/client"})
+    public void shouldRejectToolWhenArgumentsInvalid() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.malformed.request/client"})
+    public void shouldRejectToolWhenRequestMalformed() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/update.issue.invalid.input/client"})
+    public void shouldRejectToolWhenInputInvalid() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.unresolved.yaml")
+    @Specification({
+        "${mcp}/create.pr.unresolved/client"})
+    public void shouldRejectToolWhenExpressionUnresolved() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.unresolved.event.yaml")
+    @Specification({
+        "${mcp}/create.pr.unresolved/client"})
+    public void shouldEmitSchemaAccessorUnresolvedEvent() throws Exception
+    {
+        k3po.finish();
+    }
+
+    // reuses create.pr.unresolved's wire script against a route that mistakenly references
+    // ${params.owner} (a resource-uri capture) from a tool route instead of ${args.owner}: tool routes
+    // never have resource captures, so this always rejects, exercising the paramAccessors branch of
+    // McpHttpBindingConfig.unsatisfiedAccessors distinct from the argAccessors branch covered above
+    @Test
+    @Configuration("client.unresolved.params.yaml")
+    @Specification({
+        "${mcp}/create.pr.unresolved/client"})
+    public void shouldRejectToolWhenParamsExpressionUnresolved() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/create.pr.malformed/client",
+        "${http}/create.pr.malformed/server"})
+    public void shouldRejectToolWhenResponseInvalid() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/read.order.malformed/client",
+        "${http}/read.order.malformed/server"})
+    public void shouldRejectResourceWhenResponseInvalid() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/read.order.error/client",
+        "${http}/read.order.error/server"})
+    public void shouldAbortResourceReadWhenUpstreamStatusNotOk() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
+        "${mcp}/get.profile/client",
+        "${http}/get.profile/server"})
+    public void shouldCallToolGetProfileWithNoSummary() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.header.yaml")
+    @Specification({
+        "${mcp}/echo.header.present/client",
+        "${http}/echo.header.present/server"})
+    public void shouldIncludeHeaderWhenArgumentPresent() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.header.yaml")
+    @Specification({
+        "${mcp}/echo.header.absent/client",
+        "${http}/echo.header.absent/server"})
+    public void shouldOmitHeaderWhenArgumentAbsent() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.cookie.yaml")
+    @Specification({
+        "${mcp}/echo.cookie.both.present/client",
+        "${http}/echo.cookie.both.present/server"})
+    public void shouldAggregateCookiesWhenBothArgumentsPresent() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.cookie.yaml")
+    @Specification({
+        "${mcp}/echo.cookie.one.absent/client",
+        "${http}/echo.cookie.one.absent/server"})
+    public void shouldOmitOneCookieWhenOneArgumentAbsent() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.cookie.yaml")
+    @Specification({
+        "${mcp}/echo.cookie.all.absent/client",
+        "${http}/echo.cookie.all.absent/server"})
+    public void shouldOmitCookieHeaderWhenAllArgumentsAbsent() throws Exception
+    {
+        k3po.finish();
+    }
+}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.cookie.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.cookie.yaml
@@ -1,0 +1,76 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        echo_cookie_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+              }
+            }
+        echo_cookie_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "status": { "type": "string" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        echo_cookie:
+          description: >
+            Echo request, forwarding optional caller-supplied cookies a and b.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_cookie_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_cookie_result
+                    version: latest
+    routes:
+      - when:
+          - tool: echo_cookie
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /echo
+          cookies:
+            a: ${args.a}
+            b: ${args.b}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.credentials.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.credentials.yaml
@@ -1,0 +1,204 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+guards:
+  test0:
+    type: test
+    options:
+      credentials: ghp_secret
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      authorization:
+        test0:
+          credentials:
+            headers:
+              authorization: Bearer {credentials}
+              x-user-identity: "{identity}"
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: search_code
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.annotations.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.annotations.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: inline
+    options:
+      subjects:
+        get_item_params:
+          version: latest
+          schema: |
+            {"type":"object","properties":{"id":{"type":"string"}}}
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        get_item:
+          description: "Get an item"
+          summary: "Item retrieved"
+          schemas:
+            input:
+              model: json
+              catalog:
+                test0:
+                  - subject: get_item_params
+                    version: latest
+          annotations:
+            title: Get Item
+            readOnlyHint: true
+            destructiveHint: false
+            idempotentHint: true
+            openWorldHint: false
+    routes:
+      - when:
+          - tool: get_item
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.example.internal:443
+            ":path": /items/${args.id}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: inline
+    options:
+      subjects:
+        get_item_params:
+          version: latest
+          schema: |
+            {"type":"object","properties":{"id":{"type":"string"}}}
+        item_result:
+          version: latest
+          schema: |
+            {"type":"object","properties":{"id":{"type":"string"}}}
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        get_item:
+          description: "Get an item"
+          summary: "Item retrieved"
+          schemas:
+            input:
+              model: json
+              catalog:
+                test0:
+                  - subject: get_item_params
+                    version: latest
+      resources:
+        item:
+          uri: "item://{itemId}"
+          description: "An item resource"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                test0:
+                  - subject: item_result
+                    version: latest
+    routes:
+      - when:
+          - tool: get_item
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.example.internal:443
+            ":path": /items/${args.id}
+      - when:
+          - resource: item
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.example.internal:443
+            ":path": /items/${params.itemId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.exit.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.exit.invalid.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    exit: http0
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.layered.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.layered.yaml
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+guards:
+  test0:
+    type: test
+    options:
+      roles:
+        - pr:write
+  test1:
+    type: test
+    options:
+      roles:
+        - guest
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: Create a pull request
+          summary: "Created pull request"
+          schemas:
+            input:
+              model: test
+      resources:
+        settings:
+          uri: "config://settings"
+          description: Application settings
+          mimeType: application/json
+    routes:
+      - guarded:
+          test1:
+            - admin
+      - when:
+          - tool: create_pr
+        guarded:
+          test0:
+            - pr:write
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/acme/widget/pulls
+      - when:
+          - resource: settings
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.example.internal:443
+            ":path": /settings

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.yaml
@@ -1,0 +1,205 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+guards:
+  test0:
+    type: test
+    options:
+      roles:
+        - pr:write
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        guarded:
+          test0:
+            - pr:write
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: search_code
+        guarded:
+          test0:
+            - code:read
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.header.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.header.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        echo_header_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "requestId": { "type": "string" }
+              }
+            }
+        echo_header_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "status": { "type": "string" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        echo_header:
+          description: >
+            Echo request, forwarding an optional caller-supplied request id as a header.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_header_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_header_result
+                    version: latest
+    routes:
+      - when:
+          - tool: echo_header
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /echo
+            "x-request-id": ${args.requestId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.options.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.options.yaml
@@ -1,0 +1,48 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: Create a pull request
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: test
+              catalog:
+                catalog0:
+                  - subject: create_pr_params
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            model: test
+            catalog:
+              catalog0:
+                - subject: create_pr_body
+                  version: latest

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.nested.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.nested.yaml
@@ -1,0 +1,88 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "pr"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "pr": {
+                  "type": "object",
+                  "properties": {
+                    "branch": { "type": "string" },
+                    "target": { "type": "string" }
+                  }
+                }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            template:
+              title: ${args.title}
+              head: ${args.pr.branch}
+              base: ${args.pr.target}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "branch", "target"],
+              "properties": {
+                "owner":  { "type": "string" },
+                "repo":   { "type": "string" },
+                "title":  { "type": "string" },
+                "branch": { "type": "string" },
+                "target": { "type": "string" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            template:
+              title: ${args.title}
+              head: ${args.branch}
+              base: ${args.target}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.route.exit.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.route.exit.invalid.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    routes:
+      - when:
+          - tool: create_pr
+        exit: http0
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.event.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.event.yaml
@@ -1,0 +1,207 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+telemetry:
+  exporters:
+    exporter0:
+      type: test
+      options:
+        events:
+          - qname: engine:events
+            id: engine.started
+            name: ENGINE_STARTED
+            message: Engine Started.
+          - qname: test:app0
+            id: binding.mcp_http.schema.accessor.unresolved
+            name: BINDING_MCP_HTTP_SCHEMA_ACCESSOR_UNRESOLVED
+            message: Expression "args.ownerr" is unresolved against the schema for "create_pr".
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.ownerr}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: search_code
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.params.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.params.yaml
@@ -1,0 +1,198 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      # create_pr's :path mistakenly references ${params.owner} instead of ${args.owner}: tool routes never
+      # have resource-uri-captured params, so this accessor can never be satisfied — the request is rejected
+      # with a reset before any upstream connect, exercising the paramAccessors branch of
+      # McpHttpBindingConfig.unsatisfiedAccessors (distinct from the argAccessors branch proxy.unresolved.yaml
+      # already covers)
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${params.owner}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: search_code
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.yaml
@@ -1,0 +1,193 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.ownerr}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: search_code
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.yaml
@@ -1,0 +1,619 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  http_github0:
+    type: inline
+    options:
+      subjects:
+        create_pr_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "title", "head", "base"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_body:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["title", "head", "base"],
+              "properties": {
+                "title": { "type": "string" },
+                "head":  { "type": "string" },
+                "base":  { "type": "string" },
+                "body":  { "type": "string" },
+                "draft": { "type": "boolean" }
+              }
+            }
+        create_pr_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "number":   { "type": "integer" },
+                "html_url": { "type": "string" },
+                "state":    { "type": "string" },
+                "title":    { "type": "string" }
+              }
+            }
+        add_pr_comment_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["owner", "repo", "number", "message"],
+              "properties": {
+                "owner":   { "type": "string" },
+                "repo":    { "type": "string" },
+                "number":  { "type": "integer" },
+                "message": { "type": "string" }
+              }
+            }
+        add_pr_comment_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":   { "type": "integer" },
+                "body": { "type": "string" }
+              }
+            }
+        search_code_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":        { "type": "string" },
+                "per_page": { "type": "integer" },
+                "page":     { "type": "integer" },
+                "labels":   { "type": "array", "items": { "type": "string" } },
+                "archived": { "type": "boolean" }
+              }
+            }
+        search_code_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "total_count": { "type": "integer" },
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } }
+                  }
+                }
+              }
+            }
+        order_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "id":     { "type": "string" },
+                "status": { "type": "string" },
+                "total":  { "type": "number" }
+              }
+            }
+        search_items_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["q"],
+              "properties": {
+                "q":     { "type": "string" },
+                "limit": { "type": "integer" }
+              }
+            }
+        search_items_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "items": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+        report_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {}
+            }
+        report_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "message": { "type": "string" }
+              }
+            }
+        ping_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {}
+            }
+        ping_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "status": { "type": "string" }
+              }
+            }
+        list_tags_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {}
+            }
+        list_tags_result:
+          version: latest
+          schema: |
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+        count_items_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {}
+            }
+        count_items_result:
+          version: latest
+          schema: |
+            {
+              "type": "integer"
+            }
+        echo_id_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["id"],
+              "properties": {
+                "id": { "type": "string" }
+              }
+            }
+        echo_id_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "status": { "type": "string" }
+              }
+            }
+        profile_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {}
+            }
+        profile_result:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "user": {
+                  "type": "object",
+                  "properties": {
+                    "id":   { "type": "integer" },
+                    "name": { "type": "string" }
+                  }
+                },
+                "roles": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "active":  { "type": "boolean" },
+                "manager": { "type": ["string", "null"] }
+              }
+            }
+        update_issue_params:
+          version: latest
+          schema: |
+            {
+              "type": "object",
+              "required": ["state"],
+              "properties": {
+                "owner": { "type": "string" },
+                "repo":  { "type": "string" },
+                "state": { "type": "string" }
+              }
+            }
+bindings:
+  app0:
+    type: mcp_http
+    kind: client
+    options:
+      tools:
+        create_pr:
+          description: >
+            Create a pull request to merge one branch into another.
+            Use when proposing code changes for review.
+          summary: "Created pull request #${result.number}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_result
+                    version: latest
+        add_pr_comment:
+          description: >
+            Add a comment to a pull request.
+          summary: "Commented: ${result.body}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: add_pr_comment_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: add_pr_comment_result
+                    version: latest
+        create_widget:
+          description: >
+            Create a widget. A body-only tool with no path parameters,
+            covering the with.body request-shaping path independently of
+            any path-arg-driven readiness gate.
+          summary: "Created widget: ${result.name}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: create_pr_body
+                    version: latest
+        search_code:
+          description: >
+            Search for code across repositories using code search syntax.
+          summary: "Found ${result.total_count} matches"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_code_result
+                    version: latest
+        get_report:
+          description: >
+            Get a status report.
+          summary: "Report: ${result.message}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: report_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: report_result
+                    version: latest
+        ping:
+          description: >
+            Check service liveness.
+          summary: "Status: ${result.status}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: ping_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: ping_result
+                    version: latest
+        list_tags:
+          description: >
+            List repository tags.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: list_tags_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: list_tags_result
+                    version: latest
+        count_items:
+          description: >
+            Count items in the backlog.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: count_items_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: count_items_result
+                    version: latest
+        echo_id:
+          description: >
+            Echo the given identifier.
+          summary: "Echoed: ${result.status}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_id_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: echo_id_result
+                    version: latest
+        get_profile:
+          description: >
+            Get the caller's profile.
+          summary: "Profile for ${result.user.name}"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: profile_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: profile_result
+                    version: latest
+        search_items:
+          description: >
+            Search items, optionally limiting the number of results.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_items_params
+                    version: latest
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: search_items_result
+                    version: latest
+        update_issue:
+          description: >
+            Update an issue's state. Models a tool whose derived input schema
+            marks only the body arg as required, leaving path args (owner,
+            repo) present in properties but absent from required.
+          summary: "done"
+          schemas:
+            input:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: update_issue_params
+                    version: latest
+      resources:
+        order:
+          uri: "order://{orderId}"
+          description: "Customer order by identifier"
+          mimeType: application/json
+          schemas:
+            output:
+              model: json
+              catalog:
+                http_github0:
+                  - subject: order_result
+                    version: latest
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: create_widget
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /widgets
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: create_pr_body
+                  version: latest
+      - when:
+          - tool: add_pr_comment
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/issues/${args.number}/comments
+          body:
+            template:
+              body: "${args.message}"
+      - when:
+          - tool: search_code
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /search/code
+          query:
+            model: json
+            catalog:
+              http_github0:
+                - subject: search_code_params
+                  version: latest
+      - when:
+          - resource: order
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.orders.internal:443
+            ":path": /orders/${params.orderId}
+      - when:
+          - tool: get_report
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /report
+      - when:
+          - tool: ping
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /ping
+      - when:
+          - tool: list_tags
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /tags
+      - when:
+          - tool: count_items
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /count
+      - when:
+          - tool: echo_id
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /echo/${args.id}
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: echo_id_params
+                  version: latest
+      - when:
+          - tool: get_profile
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /profile
+      - when:
+          - tool: search_items
+        with:
+          headers:
+            ":method": GET
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /items?q=${args.q}&${?args.limit=limit}
+      - when:
+          - tool: update_issue
+        with:
+          headers:
+            ":method": PATCH
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/issues
+          body:
+            model: json
+            catalog:
+              http_github0:
+                - subject: update_issue_params
+                  version: latest

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.exit.required.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.exit.required.invalid.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+bindings:
+  app0:
+    type: mcp_http
+    kind: proxy
+    routes:
+      - when:
+          - tool: create_pr
+        with:
+          headers:
+            ":method": POST
+            ":scheme": https
+            ":authority": api.github.com:443
+            ":path": /repos/${args.owner}/${args.repo}/pulls

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
@@ -29,7 +29,7 @@
                     },
                     "kind":
                     {
-                        "enum": [ "proxy" ]
+                        "enum": [ "client", "proxy" ]
                     },
                     "vault": false,
                     "entry": false,
@@ -359,7 +359,58 @@
                             }
                         }
                     }
-                }
+                },
+                "oneOf":
+                [
+                    {
+                        "properties":
+                        {
+                            "kind":
+                            {
+                                "const": "proxy"
+                            }
+                        },
+                        "anyOf":
+                        [
+                            {
+                                "required": [ "exit" ]
+                            },
+                            {
+                                "properties":
+                                {
+                                    "routes":
+                                    {
+                                        "items":
+                                        {
+                                            "required": [ "exit" ]
+                                        }
+                                    }
+                                },
+                                "required": [ "routes" ]
+                            }
+                        ]
+                    },
+                    {
+                        "properties":
+                        {
+                            "kind":
+                            {
+                                "const": "client"
+                            },
+                            "exit": false,
+                            "routes":
+                            {
+                                "items":
+                                {
+                                    "properties":
+                                    {
+                                        "exit": false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
             }
         }
     }

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
@@ -368,27 +368,22 @@
                             "kind":
                             {
                                 "const": "proxy"
-                            }
-                        },
-                        "anyOf":
-                        [
-                            {
-                                "required": [ "exit" ]
                             },
+                            "routes":
                             {
-                                "properties":
+                                "items":
                                 {
-                                    "routes":
+                                    "if":
                                     {
-                                        "items":
-                                        {
-                                            "required": [ "exit" ]
-                                        }
+                                        "required": [ "with" ]
+                                    },
+                                    "then":
+                                    {
+                                        "required": [ "exit" ]
                                     }
-                                },
-                                "required": [ "routes" ]
+                                }
                             }
-                        ]
+                        }
                     },
                     {
                         "properties":

--- a/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/config/SchemaTest.java
+++ b/specs/binding-mcp-http.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/http/config/SchemaTest.java
@@ -123,4 +123,30 @@ public class SchemaTest
 
         assertThat(config, not(nullValue()));
     }
+
+    @Test
+    public void shouldValidateClientOptions()
+    {
+        JsonObject config = schema.validate("client.options.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectClientWithExit()
+    {
+        schema.validate("client.exit.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectClientRouteWithExit()
+    {
+        schema.validate("client.route.exit.invalid.yaml");
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectProxyWithoutExit()
+    {
+        schema.validate("proxy.exit.required.invalid.yaml");
+    }
 }


### PR DESCRIPTION
## Description

Adds a `kind: client` variant to `binding-mcp-http` that implicitly routes every request to the engine-provided `sys:http_client` binding — no operator-declared `exit` needed — mirroring the self-contained "real HTTP" pattern already used by `mcp_openapi`/`mcp_schema_registry`. Also fixes a schema gap where `kind: proxy` allowed `exit` to be omitted entirely, silently producing an unresolved (`0`) routing target at runtime.

### Runtime (`runtime/binding-mcp-http`)
- `McpHttpBindingConfig`: for `kind: client`, every route's `id` is overwritten to resolve to the configured client-exit target before routes are wrapped into `McpHttpRouteConfig` (which captures `id` at construction time).
- `McpHttpBindingContext`: `attach`/`detach` widened to accept both `PROXY` and `CLIENT` kinds, delegating to the same kind-agnostic `McpHttpProxyFactory` — mirroring `McpSchemaRegistryClientFactory`/`McpSchemaRegistryBindingContext`'s existing client+proxy dual-kind pattern.
- Added a `zilla.binding.mcp.http.client.exit` `Configuration` property (default `sys:http_client`), so the implicit client exit target is overridable for testing — mirroring `zilla.binding.mcp.openapi.http.client.exit` in `binding-mcp-openapi`.

### Schema (`specs/binding-mcp-http.spec`)
- `kind` enum widened to `["client", "proxy"]`.
- `kind: proxy` now requires `exit` on any route that also declares `with` (the routes that actually resolve to an upstream target) — correctly nested under `routes.items.if/then`, unlike `binding-tcp`'s vacuous `routes: {required: [exit]}` version, which doesn't constrain anything since `routes` is an array. Routes that only carry `guarded` (layering-only, no `with`) are unaffected, since they never resolve to a routed exit.
- `kind: client` disallows `exit` entirely, top-level and per-route (`exit: false`), since the exit is implicit.

### Tests (test-first)
- Unit tests in `McpHttpBindingConfigTest` covering the `kind: client` route-id resolution (default and overridden `client.exit`), and that `kind: proxy` routes are left untouched.
- `McpHttpConfigurationTest` covering the new `client.exit` property default and override.
- `SchemaTest` + new YAML fixtures for valid `kind: client` config and invalid combinations (client with exit, client route with exit, proxy route with `with` but no exit).
- Full `binding-mcp-http` k3po IT suite (62 tests) and spec `SchemaTest` (18 tests) verified green via `mvn verify`.

Fixes #2238


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKueUWZbnpZ6ABHUVn7xkV)_