### PR TITLE
refactor(binding-kafka): rename remaining api Response classes with Kafka prefix

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponse.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponse.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
  * returns a fixed default for any field its wire version does not carry, rather than changing shape.
  * </p>
  */
-public interface CreateTopicsResponse
+public interface KafkaCreateTopicsResponse
 {
     enum Kind
     {

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponseV7FW.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponseV7FW.java
@@ -30,10 +30,10 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 /**
  * Hand-crafted (not {@code .idl}-generated) CreateTopics v7 response cursor. Delegates the actual
  * byte decoding to the generated {@code protocol.idl} wire types, adding the version-tolerant
- * {@link CreateTopicsResponse} view on top - a fixed-default-on-read behavior the flyweight
+ * {@link KafkaCreateTopicsResponse} view on top - a fixed-default-on-read behavior the flyweight
  * generator cannot produce, since generated builders only default missing fields on write.
  */
-public final class CreateTopicsResponseV7FW implements CreateTopicsResponse
+public final class KafkaCreateTopicsResponseV7FW implements KafkaCreateTopicsResponse
 {
     private static final int FIELD_SIZE_THROTTLE_TIME_MILLIS = 4;
 
@@ -81,7 +81,7 @@ public final class CreateTopicsResponseV7FW implements CreateTopicsResponse
      * Wraps a complete CreateTopics v7 response body: tagged fields, throttle time, and topic count,
      * followed by the topics themselves.
      */
-    public CreateTopicsResponseV7FW wrap(
+    public KafkaCreateTopicsResponseV7FW wrap(
         DirectBufferEx buffer,
         int offset,
         int limit)
@@ -105,7 +105,7 @@ public final class CreateTopicsResponseV7FW implements CreateTopicsResponse
      * the throttle time and topic count itself (e.g. via a generated header flyweight covering a wider
      * response envelope, such as one that also carries a correlation id).
      */
-    public CreateTopicsResponseV7FW wrapTopics(
+    public KafkaCreateTopicsResponseV7FW wrapTopics(
         DirectBufferEx buffer,
         int offset,
         int limit,

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponse.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponse.java
@@ -23,11 +23,11 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
  * The caller drives the cursor: {@code while (hasNext()) { Topic topic = next(); ... }}. Accessors
  * are valid only until the next {@link #next()} call. A version-specific implementation (e.g. a v6
  * wire decoder) returns a fixed default for any field its wire version does not carry, rather than
- * changing shape. Unlike {@link CreateTopicsResponse}, DeleteTopics has exactly one result shape per
+ * changing shape. Unlike {@link KafkaCreateTopicsResponse}, DeleteTopics has exactly one result shape per
  * entry, so there is no {@code Kind} discriminator.
  * </p>
  */
-public interface DeleteTopicsResponse
+public interface KafkaDeleteTopicsResponse
 {
     int throttleTimeMillis();
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponseV6FW.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponseV6FW.java
@@ -28,10 +28,10 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 /**
  * Hand-crafted (not {@code .idl}-generated) DeleteTopics v6 response cursor. Delegates the actual
  * byte decoding to the generated {@code protocol.idl} wire types, adding the version-tolerant
- * {@link DeleteTopicsResponse} view on top - a fixed-default-on-read behavior the flyweight
+ * {@link KafkaDeleteTopicsResponse} view on top - a fixed-default-on-read behavior the flyweight
  * generator cannot produce, since generated builders only default missing fields on write.
  */
-public final class DeleteTopicsResponseV6FW implements DeleteTopicsResponse
+public final class KafkaDeleteTopicsResponseV6FW implements KafkaDeleteTopicsResponse
 {
     private static final int FIELD_SIZE_THROTTLE_TIME_MILLIS = 4;
 
@@ -63,7 +63,7 @@ public final class DeleteTopicsResponseV6FW implements DeleteTopicsResponse
      * Wraps a complete DeleteTopics v6 response body: tagged fields, throttle time, and topic count,
      * followed by the topics themselves.
      */
-    public DeleteTopicsResponseV6FW wrap(
+    public KafkaDeleteTopicsResponseV6FW wrap(
         DirectBufferEx buffer,
         int offset,
         int limit)
@@ -87,7 +87,7 @@ public final class DeleteTopicsResponseV6FW implements DeleteTopicsResponse
      * the throttle time and topic count itself (e.g. via a generated header flyweight covering a wider
      * response envelope, such as one that also carries a correlation id).
      */
-    public DeleteTopicsResponseV6FW wrapTopics(
+    public KafkaDeleteTopicsResponseV6FW wrapTopics(
         DirectBufferEx buffer,
         int offset,
         int limit,

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
@@ -30,9 +30,9 @@ import org.agrona.collections.LongLongConsumer;
 
 import io.aklivity.zilla.config.binding.kafka.KafkaSaslConfig;
 import io.aklivity.zilla.config.binding.kafka.KafkaServerConfig;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Kind;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Topic;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponseV7FW;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Kind;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Topic;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponseV7FW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.KafkaBinding;
 import io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguration;
 import io.aklivity.zilla.runtime.binding.kafka.internal.config.KafkaBindingConfig;
@@ -129,7 +129,7 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
     private final ConfigResponseFW configResponseRO = new ConfigResponseFW();
     private final TopicResponsePart2FW topicResponsePart2RO = new TopicResponsePart2FW();
     private final CreateTopicsResponsePart2FW createTopicsResponsePart2RO = new CreateTopicsResponsePart2FW();
-    private final CreateTopicsResponseV7FW createTopicsResponseV7RO = new CreateTopicsResponseV7FW();
+    private final KafkaCreateTopicsResponseV7FW createTopicsResponseV7RO = new KafkaCreateTopicsResponseV7FW();
 
     private final KafkaCreateTopicsClientDecoder decodeSaslHandshakeResponse = this::decodeSaslHandshakeResponse;
     private final KafkaCreateTopicsClientDecoder decodeSaslHandshake = this::decodeSaslHandshake;
@@ -791,7 +791,7 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
             {
                 state = KafkaState.openingReply(state);
 
-                final CreateTopicsResponseV7FW response =
+                final KafkaCreateTopicsResponseV7FW response =
                     createTopicsResponseV7RO.wrapTopics(buffer, topicsOffset, topicsLimit, throttle, topicCount);
 
                 doBegin(application, originId, routedId, replyId, replySeq, replyAck, replyMax,
@@ -811,7 +811,7 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
 
         private void encodeTopics(
             Array32FW.Builder<KafkaCreateTopicStatusFW.Builder, KafkaCreateTopicStatusFW> topics,
-            CreateTopicsResponseV7FW response)
+            KafkaCreateTopicsResponseV7FW response)
         {
             while (response.hasNext())
             {

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponseV7FWTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaCreateTopicsResponseV7FWTest.java
@@ -21,13 +21,15 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.binding.kafka.api.DeleteTopicsResponse.Topic;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Config;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Kind;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Topic;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
-public class DeleteTopicsResponseV6FWTest
+public class KafkaCreateTopicsResponseV7FWTest
 {
-    // body bytes only, as verified against the real KafkaClientDeleteTopicsFactory v6 wire decoder input
+    // body bytes only, as verified against the real KafkaClientCreateTopicsFactory v7 wire decoder input
     // (the response header's correlationId is decoded separately and excluded here)
     private static final byte[] BODY = new byte[]
     {
@@ -38,11 +40,23 @@ public class DeleteTopicsResponseV6FWTest
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00,
         0x00,
+        0x00, 0x00, 0x00, 0x01,
+        0x00, 0x01,
+        0x02,
+        0x0f, 'c', 'l', 'e', 'a', 'n', 'u', 'p', '.', 'p', 'o', 'l', 'i', 'c', 'y',
+        0x07, 'd', 'e', 'l', 'e', 't', 'e',
+        0x00,
+        0x01,
         0x00,
         0x00,
+        0x00,
+        0x0a, 's', 'n', 'a', 'p', 's', 'h', 'o', 't', 's',
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x03,
-        0x10, 't', 'o', 'p', 'i', 'c', ' ', 'n', 'o', 't', ' ', 'f', 'o', 'u', 'n', 'd',
+        0x00, 0x00,
+        0x00,
+        0x00, 0x00, 0x00, 0x01,
+        0x00, 0x01,
+        0x01,
         0x00,
         0x00
     };
@@ -56,9 +70,9 @@ public class DeleteTopicsResponseV6FWTest
     }
 
     @Test
-    public void shouldDecodeDeleteTopicsV6Response()
+    public void shouldDecodeCreateTopicsV7Response()
     {
-        DeleteTopicsResponseV6FW response = new DeleteTopicsResponseV6FW();
+        KafkaCreateTopicsResponseV7FW response = new KafkaCreateTopicsResponseV7FW();
 
         DirectBufferEx buffer = new UnsafeBufferEx(BODY);
         response.wrap(buffer, 0, buffer.capacity());
@@ -67,20 +81,36 @@ public class DeleteTopicsResponseV6FWTest
         assertEquals(2, response.topicCount());
 
         assertTrue(response.hasNext());
-        Topic events = response.next();
+        assertEquals(Kind.TOPIC, response.next());
+
+        Topic events = response.topic();
         assertEquals("events", asString(events.buffer(), events.nameOffset(), events.nameLength()));
         assertEquals(0L, events.topicIdMostSigBits());
         assertEquals(0L, events.topicIdLeastSigBits());
         assertEquals(0, events.error());
         assertEquals(-1, events.messageLength());
+        assertEquals(1, events.numPartitions());
+        assertEquals(1, events.replicationFactor());
+        assertEquals(1, events.configCount());
 
         assertTrue(response.hasNext());
-        Topic missing = response.next();
-        assertEquals(-1, missing.nameLength());
-        assertEquals(0L, missing.topicIdMostSigBits());
-        assertEquals(0L, missing.topicIdLeastSigBits());
-        assertEquals(3, missing.error());
-        assertEquals("topic not found", asString(missing.buffer(), missing.messageOffset(), missing.messageLength()));
+        assertEquals(Kind.CONFIG, response.next());
+
+        Config cleanupPolicy = response.config();
+        assertEquals("cleanup.policy", asString(cleanupPolicy.buffer(), cleanupPolicy.nameOffset(), cleanupPolicy.nameLength()));
+        assertEquals("delete", asString(cleanupPolicy.buffer(), cleanupPolicy.valueOffset(), cleanupPolicy.valueLength()));
+        assertFalse(cleanupPolicy.readOnly());
+        assertEquals(1, cleanupPolicy.configSource());
+        assertFalse(cleanupPolicy.isSensitive());
+
+        assertTrue(response.hasNext());
+        assertEquals(Kind.TOPIC, response.next());
+
+        Topic snapshots = response.topic();
+        assertEquals("snapshots", asString(snapshots.buffer(), snapshots.nameOffset(), snapshots.nameLength()));
+        assertEquals(1, snapshots.numPartitions());
+        assertEquals(1, snapshots.replicationFactor());
+        assertEquals(0, snapshots.configCount());
 
         assertFalse(response.hasNext());
         assertEquals(BODY.length, response.limit());

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponseV6FWTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/api/KafkaDeleteTopicsResponseV6FWTest.java
@@ -21,15 +21,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Config;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Kind;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Topic;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDeleteTopicsResponse.Topic;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
-public class CreateTopicsResponseV7FWTest
+public class KafkaDeleteTopicsResponseV6FWTest
 {
-    // body bytes only, as verified against the real KafkaClientCreateTopicsFactory v7 wire decoder input
+    // body bytes only, as verified against the real KafkaClientDeleteTopicsFactory v6 wire decoder input
     // (the response header's correlationId is decoded separately and excluded here)
     private static final byte[] BODY = new byte[]
     {
@@ -40,23 +38,11 @@ public class CreateTopicsResponseV7FWTest
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00,
         0x00,
-        0x00, 0x00, 0x00, 0x01,
-        0x00, 0x01,
-        0x02,
-        0x0f, 'c', 'l', 'e', 'a', 'n', 'u', 'p', '.', 'p', 'o', 'l', 'i', 'c', 'y',
-        0x07, 'd', 'e', 'l', 'e', 't', 'e',
-        0x00,
-        0x01,
         0x00,
         0x00,
-        0x00,
-        0x0a, 's', 'n', 'a', 'p', 's', 'h', 'o', 't', 's',
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00,
-        0x00,
-        0x00, 0x00, 0x00, 0x01,
-        0x00, 0x01,
-        0x01,
+        0x00, 0x03,
+        0x10, 't', 'o', 'p', 'i', 'c', ' ', 'n', 'o', 't', ' ', 'f', 'o', 'u', 'n', 'd',
         0x00,
         0x00
     };
@@ -70,9 +56,9 @@ public class CreateTopicsResponseV7FWTest
     }
 
     @Test
-    public void shouldDecodeCreateTopicsV7Response()
+    public void shouldDecodeDeleteTopicsV6Response()
     {
-        CreateTopicsResponseV7FW response = new CreateTopicsResponseV7FW();
+        KafkaDeleteTopicsResponseV6FW response = new KafkaDeleteTopicsResponseV6FW();
 
         DirectBufferEx buffer = new UnsafeBufferEx(BODY);
         response.wrap(buffer, 0, buffer.capacity());
@@ -81,36 +67,20 @@ public class CreateTopicsResponseV7FWTest
         assertEquals(2, response.topicCount());
 
         assertTrue(response.hasNext());
-        assertEquals(Kind.TOPIC, response.next());
-
-        Topic events = response.topic();
+        Topic events = response.next();
         assertEquals("events", asString(events.buffer(), events.nameOffset(), events.nameLength()));
         assertEquals(0L, events.topicIdMostSigBits());
         assertEquals(0L, events.topicIdLeastSigBits());
         assertEquals(0, events.error());
         assertEquals(-1, events.messageLength());
-        assertEquals(1, events.numPartitions());
-        assertEquals(1, events.replicationFactor());
-        assertEquals(1, events.configCount());
 
         assertTrue(response.hasNext());
-        assertEquals(Kind.CONFIG, response.next());
-
-        Config cleanupPolicy = response.config();
-        assertEquals("cleanup.policy", asString(cleanupPolicy.buffer(), cleanupPolicy.nameOffset(), cleanupPolicy.nameLength()));
-        assertEquals("delete", asString(cleanupPolicy.buffer(), cleanupPolicy.valueOffset(), cleanupPolicy.valueLength()));
-        assertFalse(cleanupPolicy.readOnly());
-        assertEquals(1, cleanupPolicy.configSource());
-        assertFalse(cleanupPolicy.isSensitive());
-
-        assertTrue(response.hasNext());
-        assertEquals(Kind.TOPIC, response.next());
-
-        Topic snapshots = response.topic();
-        assertEquals("snapshots", asString(snapshots.buffer(), snapshots.nameOffset(), snapshots.nameLength()));
-        assertEquals(1, snapshots.numPartitions());
-        assertEquals(1, snapshots.replicationFactor());
-        assertEquals(0, snapshots.configCount());
+        Topic missing = response.next();
+        assertEquals(-1, missing.nameLength());
+        assertEquals(0L, missing.topicIdMostSigBits());
+        assertEquals(0L, missing.topicIdLeastSigBits());
+        assertEquals(3, missing.error());
+        assertEquals("topic not found", asString(missing.buffer(), missing.messageOffset(), missing.messageLength()));
 
         assertFalse(response.hasNext());
         assertEquals(BODY.length, response.limit());

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -40,13 +40,13 @@ import jakarta.json.JsonObjectBuilder;
 import org.agrona.collections.Long2ObjectHashMap;
 
 import io.aklivity.zilla.config.engine.BindingConfig;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Kind;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponse.Topic;
-import io.aklivity.zilla.runtime.binding.kafka.api.CreateTopicsResponseV7FW;
-import io.aklivity.zilla.runtime.binding.kafka.api.DeleteTopicsResponse;
-import io.aklivity.zilla.runtime.binding.kafka.api.DeleteTopicsResponseV6FW;
 import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsRequest;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Kind;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponse.Topic;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaCreateTopicsResponseV7FW;
 import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDeleteTopicsRequest;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDeleteTopicsResponse;
+import io.aklivity.zilla.runtime.binding.kafka.api.KafkaDeleteTopicsResponseV6FW;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.McpKafkaConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.config.McpKafkaBindingConfig;
 import io.aklivity.zilla.runtime.binding.mcp.kafka.internal.config.McpKafkaRouteConfig;
@@ -182,8 +182,8 @@ public class McpKafkaProxyFactory implements BindingHandler
     private final KafkaCreateTopicsRequest.Generator createTopicsRequestGenerator;
     private final KafkaDeleteTopicsRequest.Generator deleteTopicsRequestGenerator;
     private final JsonGeneratorEx apiResultGenerator;
-    private final CreateTopicsResponseV7FW createTopicsResponseRO;
-    private final DeleteTopicsResponseV6FW deleteTopicsResponseRO;
+    private final KafkaCreateTopicsResponseV7FW createTopicsResponseRO;
+    private final KafkaDeleteTopicsResponseV6FW deleteTopicsResponseRO;
     private final int createTopicsRequestTimeoutMs;
 
     protected final Long2ObjectHashMap<McpKafkaBindingConfig> bindings;
@@ -209,8 +209,8 @@ public class McpKafkaProxyFactory implements BindingHandler
         this.createTopicsRequestGenerator = new KafkaCreateTopicsRequest.Generator();
         this.deleteTopicsRequestGenerator = new KafkaDeleteTopicsRequest.Generator();
         this.apiResultGenerator = JsonEx.createGenerator();
-        this.createTopicsResponseRO = new CreateTopicsResponseV7FW();
-        this.deleteTopicsResponseRO = new DeleteTopicsResponseV6FW();
+        this.createTopicsResponseRO = new KafkaCreateTopicsResponseV7FW();
+        this.deleteTopicsResponseRO = new KafkaDeleteTopicsResponseV6FW();
         this.createTopicsRequestTimeoutMs = (int) config.requestTimeout().toMillis();
     }
 
@@ -2471,7 +2471,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             long traceId)
         {
             final MutableDirectBufferEx slot = decodePool.buffer(decodeSlot);
-            final CreateTopicsResponseV7FW response = createTopicsResponseRO.wrap(slot, 0, responseLength);
+            final KafkaCreateTopicsResponseV7FW response = createTopicsResponseRO.wrap(slot, 0, responseLength);
 
             final int encodeSlot = encodePool.acquire(kafkaReplyId);
             if (encodeSlot == NO_SLOT)
@@ -2878,7 +2878,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             long traceId)
         {
             final MutableDirectBufferEx slot = decodePool.buffer(decodeSlot);
-            final DeleteTopicsResponseV6FW response = deleteTopicsResponseRO.wrap(slot, 0, responseLength);
+            final KafkaDeleteTopicsResponseV6FW response = deleteTopicsResponseRO.wrap(slot, 0, responseLength);
 
             final int encodeSlot = encodePool.acquire(kafkaReplyId);
             if (encodeSlot == NO_SLOT)
@@ -2900,7 +2900,7 @@ public class McpKafkaProxyFactory implements BindingHandler
 
                 while (response.hasNext())
                 {
-                    final DeleteTopicsResponse.Topic topic = response.next();
+                    final KafkaDeleteTopicsResponse.Topic topic = response.next();
                     final String name = topic.buffer().getStringWithoutLengthUtf8(topic.nameOffset(), topic.nameLength());
                     final short error = topic.error();
 


### PR DESCRIPTION
## Description

`runtime/binding-kafka`'s `api` package mixes `Kafka*`-prefixed classes (e.g. `KafkaCreateTopicsRequest`) with a few that lack the prefix. This PR renames the remaining four to match:

- `CreateTopicsResponse` → `KafkaCreateTopicsResponse`
- `CreateTopicsResponseV7FW` → `KafkaCreateTopicsResponseV7FW`
- `DeleteTopicsResponse` → `KafkaDeleteTopicsResponse`
- `DeleteTopicsResponseV6FW` → `KafkaDeleteTopicsResponseV6FW`

Every class in `runtime/binding-kafka/src/main/java/.../api/` now begins with `Kafka`.

Mechanical rename only, no behavior change. Updates the two consumers of these types:
- `KafkaClientCreateTopicsFactory` (binding-kafka)
- `McpKafkaProxyFactory` (binding-mcp-kafka)

along with their matching test files (`*ResponseV7FWTest`, `*ResponseV6FWTest`) and internal javadoc cross-references between the renamed classes.

Not touched: the unrelated, separately-generated `internal.types.codec.create_topics.CreateTopicsResponseFW`/`CreateTopicsResponsePart2FW` (and the `delete_topics` equivalents) — these come from `.idl` struct definitions in a different package and are out of scope.

## Test plan

- `./mvnw checkstyle:check -pl runtime/binding-kafka,runtime/binding-mcp-kafka` — 0 violations
- `./mvnw clean verify -pl runtime/binding-kafka,runtime/binding-mcp-kafka` — full unit + k3po IT suite green (binding-kafka: 392 tests; binding-mcp-kafka: 32 unit + 23 IT), including the JaCoCo coverage gate

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_018y5rq93rvSxyPB81tGLu9Q)_