### PR TITLE
fix(binding-mcp-kafka): rename reset_offsets group field to group_id

### DIFF
--- a/examples/mcp.proxy/README.md
+++ b/examples/mcp.proxy/README.md
@@ -709,7 +709,7 @@ members (`DescribeGroups`), then commits directly:
 ```bash
 docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
     -e CALL_TOOL=kafka__reset_offsets \
-    -e CALL_ARGS='{"group":"orders-analytics","topic":"orders","partition":0,"offset":0}' \
+    -e CALL_ARGS='{"group_id":"orders-analytics","topic":"orders","partition":0,"offset":0}' \
     tools-list-client
 ```
 

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -850,11 +850,11 @@ public class McpKafkaProxyFactory implements BindingHandler
             schema = Json.createObjectBuilder()
                 .add("type", "object")
                 .add("properties", Json.createObjectBuilder()
-                    .add("group", Json.createObjectBuilder().add("type", "string"))
+                    .add("group_id", Json.createObjectBuilder().add("type", "string"))
                     .add("topic", Json.createObjectBuilder().add("type", "string"))
                     .add("partition", Json.createObjectBuilder().add("type", "integer"))
                     .add("offset", Json.createObjectBuilder().add("type", "integer")))
-                .add("required", Json.createArrayBuilder().add("group").add("topic").add("partition").add("offset"))
+                .add("required", Json.createArrayBuilder().add("group_id").add("topic").add("partition").add("offset"))
                 .build();
             break;
         default:
@@ -1073,10 +1073,10 @@ public class McpKafkaProxyFactory implements BindingHandler
             schema = Json.createObjectBuilder()
                 .add("type", "object")
                 .add("properties", Json.createObjectBuilder()
-                    .add("group", Json.createObjectBuilder().add("type", "string"))
+                    .add("group_id", Json.createObjectBuilder().add("type", "string"))
                     .add("topic", Json.createObjectBuilder().add("type", "string"))
                     .add("reset", Json.createObjectBuilder().add("type", "boolean")))
-                .add("required", Json.createArrayBuilder().add("group").add("topic").add("reset"))
+                .add("required", Json.createArrayBuilder().add("group_id").add("topic").add("reset"))
                 .build();
             break;
         default:
@@ -2150,12 +2150,12 @@ public class McpKafkaProxyFactory implements BindingHandler
         private void completeResetOffsetsArgs(
             long traceId)
         {
-            final String group = capturedArgs.get("arguments.group");
+            final String groupId = capturedArgs.get("arguments.group_id");
             final String topic = capturedArgs.get("arguments.topic");
             final int partition = parseInt(capturedArgs.get("arguments.partition"), -1);
             final long offset = parseLong(capturedArgs.get("arguments.offset"), -1L);
 
-            if (group != null && topic != null && partition >= 0 && offset >= 0)
+            if (groupId != null && topic != null && partition >= 0 && offset >= 0)
             {
                 final McpKafkaRouteConfig route = binding.resolve(authorization, tool, null);
                 if (route != null)
@@ -2163,7 +2163,7 @@ public class McpKafkaProxyFactory implements BindingHandler
                     resolvedId = route.id;
 
                     final KafkaApiResetOffsetsClient client = new KafkaApiResetOffsetsClient(
-                        this, originId, resolvedId, affinity, authorization, group, topic, partition, offset);
+                        this, originId, resolvedId, affinity, authorization, groupId, topic, partition, offset);
                     client.doKafkaBegin(traceId);
                     kafka = client;
                 }
@@ -6452,7 +6452,7 @@ public class McpKafkaProxyFactory implements BindingHandler
         private final long resolvedId;
         private final long affinity;
         private final long authorization;
-        private final String group;
+        private final String groupId;
         private final String topic;
         private final int partition;
         private final long offset;
@@ -6485,7 +6485,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             long resolvedId,
             long affinity,
             long authorization,
-            String group,
+            String groupId,
             String topic,
             int partition,
             long offset)
@@ -6495,12 +6495,12 @@ public class McpKafkaProxyFactory implements BindingHandler
             this.resolvedId = resolvedId;
             this.affinity = affinity;
             this.authorization = authorization;
-            this.group = group;
+            this.groupId = groupId;
             this.topic = topic;
             this.partition = partition;
             this.offset = offset;
-            this.describeGroupsSource = new SingleGroupSource(group);
-            this.findCoordinatorRequestLength = KafkaFindCoordinatorRequest.sizeof(group, FIND_COORDINATOR_API_VERSION);
+            this.describeGroupsSource = new SingleGroupSource(groupId);
+            this.findCoordinatorRequestLength = KafkaFindCoordinatorRequest.sizeof(groupId, FIND_COORDINATOR_API_VERSION);
             this.describeGroupsRequestLength =
                 KafkaDescribeGroupsRequest.sizeof(describeGroupsSource, DESCRIBE_GROUPS_API_VERSION);
             this.stage = STAGE_FIND_COORDINATOR;
@@ -6654,7 +6654,7 @@ public class McpKafkaProxyFactory implements BindingHandler
 
             if (response.error() != 0)
             {
-                emitResult(traceId, false, "Group coordinator not found for " + group + " (error " + response.error() + ")");
+                emitResult(traceId, false, "Group coordinator not found for " + groupId + " (error " + response.error() + ")");
             }
             else
             {
@@ -6688,12 +6688,12 @@ public class McpKafkaProxyFactory implements BindingHandler
 
             if (groupError != 0)
             {
-                emitResult(traceId, false, "Failed to describe consumer group " + group + " (error " + groupError + ")");
+                emitResult(traceId, false, "Failed to describe consumer group " + groupId + " (error " + groupError + ")");
             }
             else if (!RESETTABLE_GROUP_STATES.contains(groupState))
             {
                 emitResult(traceId, false,
-                    "Consumer group " + group + " has active members (state " + groupState + "); cannot reset offsets");
+                    "Consumer group " + groupId + " has active members (state " + groupState + "); cannot reset offsets");
             }
             else
             {
@@ -6736,7 +6736,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             final KafkaBeginExFW kafkaBeginEx = kafkaBeginExRW.wrap(extBuffer, 0, extBuffer.capacity())
                 .typeId(kafkaTypeId)
                 .offsetCommit(o -> o
-                    .groupId(group)
+                    .groupId(groupId)
                     .memberId("")
                     .instanceId("")
                     .host(coordinatorHost)
@@ -6817,7 +6817,7 @@ public class McpKafkaProxyFactory implements BindingHandler
                 final MutableDirectBufferEx slot = encodePool.buffer(encodeSlot);
                 final boolean fits = findCoordinatorRequestLength <= slot.capacity();
                 findCoordinatorRequestGenerator.wrap(slot, 0, slot.capacity());
-                final boolean built = fits && findCoordinatorRequestGenerator.generate(group);
+                final boolean built = fits && findCoordinatorRequestGenerator.generate(groupId);
 
                 if (built)
                 {
@@ -6901,7 +6901,7 @@ public class McpKafkaProxyFactory implements BindingHandler
                     : null;
                 final int error = kafkaResetEx != null ? kafkaResetEx.error() : 0;
 
-                emitResult(traceId, false, "Failed to reset offset for group " + group + " (error " + error + ")");
+                emitResult(traceId, false, "Failed to reset offset for group " + groupId + " (error " + error + ")");
             }
             else
             {
@@ -6926,12 +6926,12 @@ public class McpKafkaProxyFactory implements BindingHandler
                 apiResultGenerator.wrap(encodeBuffer, 0, encodeBuffer.capacity());
 
                 final String text = success
-                    ? "Reset offset for group " + group + " topic " + topic + " partition " + partition + " to " + offset
+                    ? "Reset offset for group " + groupId + " topic " + topic + " partition " + partition + " to " + offset
                     : failureMessage;
 
                 apiResultGenerator.writeStartObject()
                     .writeStartObject("structuredContent")
-                    .write("group", group)
+                    .write("group_id", groupId)
                     .write("topic", topic)
                     .write("reset", success)
                     .writeEnd()

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaArguments.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/transform/McpKafkaArguments.java
@@ -26,8 +26,8 @@ import io.aklivity.zilla.runtime.common.json.JsonSource;
  * Terminal {@link JsonSink} that captures the fixed set of scalar tool-call argument fields
  * mcp-kafka's flat-argument tools accept ({@code produce}/{@code consume}: {@code arguments.topic},
  * {@code arguments.key}, {@code arguments.value}, {@code arguments.partition},
- * {@code arguments.offset}, {@code arguments.limit}; {@code describe_consumer_group}:
- * {@code arguments.group_id}; {@code reset_offsets}: {@code arguments.group}) as the request body
+ * {@code arguments.offset}, {@code arguments.limit}; {@code describe_consumer_group},
+ * {@code reset_offsets}: {@code arguments.group_id}) as the request body
  * streams in, without buffering the whole body first. There is no downstream stage -- captured
  * values are read back from {@code captured} once the pipeline reports {@link Status#COMPLETED}
  * -- so every event is observed here and never forwarded.
@@ -42,8 +42,7 @@ public final class McpKafkaArguments implements JsonSink
         "arguments.partition",
         "arguments.offset",
         "arguments.limit",
-        "arguments.group_id",
-        "arguments.group"
+        "arguments.group_id"
     };
 
     private final Map<String, String> captured;

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/client.rpt
@@ -48,15 +48,15 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("reset_offsets")
-                               .contentLength(103)
+                               .contentLength(106)
                                .build()
                            .build()}
 
 connected
 
-write '{"name":"reset_offsets","arguments":{"group":"my-group","topic":"my-topic","partition":0,"offset":100}}'
+write '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
-read '{"structuredContent":{"group":"my-group","topic":"my-topic","reset":false},'
+read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
      '"content":[{"type":"text","text":"Group coordinator not found for my-group (error 15)"}],'
      '"isError":true}'
 read closed

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/server.rpt
@@ -46,17 +46,17 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("reset_offsets")
-                              .contentLength(103)
+                              .contentLength(106)
                               .build()
                           .build()}
 
 connected
 
-read '{"name":"reset_offsets","arguments":{"group":"my-group","topic":"my-topic","partition":0,"offset":100}}'
+read '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
 write flush
 
-write '{"structuredContent":{"group":"my-group","topic":"my-topic","reset":false},'
+write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
       '"content":[{"type":"text","text":"Group coordinator not found for my-group (error 15)"}],'
       '"isError":true}'
 write flush

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/client.rpt
@@ -48,15 +48,15 @@ write zilla:begin.ext ${mcp:beginEx()
                            .toolsCall()
                                .sessionId("session-1")
                                .name("reset_offsets")
-                               .contentLength(103)
+                               .contentLength(106)
                                .build()
                            .build()}
 
 connected
 
-write '{"name":"reset_offsets","arguments":{"group":"my-group","topic":"my-topic","partition":0,"offset":100}}'
+write '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
-read '{"structuredContent":{"group":"my-group","topic":"my-topic","reset":false},'
+read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
      '"content":[{"type":"text","text":"Consumer group my-group has active members (state Stable); cannot reset offsets"}],'
      '"isError":true}'
 read closed

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/server.rpt
@@ -46,17 +46,17 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                           .toolsCall()
                               .sessionId("session-1")
                               .name("reset_offsets")
-                              .contentLength(103)
+                              .contentLength(106)
                               .build()
                           .build()}
 
 connected
 
-read '{"name":"reset_offsets","arguments":{"group":"my-group","topic":"my-topic","partition":0,"offset":100}}'
+read '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
 write flush
 
-write '{"structuredContent":{"group":"my-group","topic":"my-topic","reset":false},'
+write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
       '"content":[{"type":"text","text":"Consumer group my-group has active members (state Stable); cannot reset offsets"}],'
       '"isError":true}'
 write flush

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
@@ -142,10 +142,10 @@ read  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":'
         '"required":["member_id","client_id"]}}},"required":["group_id","state","members"]},'
         '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
         '{"name":"reset_offsets","inputSchema":{"type":"object","properties":'
-        '{"group":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
-        '"offset":{"type":"integer"}},"required":["group","topic","partition","offset"]},'
-        '"outputSchema":{"type":"object","properties":{"group":{"type":"string"},'
-        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group","topic","reset"]}}]}'
+        '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group_id","topic","reset"]}}]}'
 read closed
 
 write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
@@ -142,10 +142,10 @@ write  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":
         '"required":["member_id","client_id"]}}},"required":["group_id","state","members"]},'
         '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
         '{"name":"reset_offsets","inputSchema":{"type":"object","properties":'
-        '{"group":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
-        '"offset":{"type":"integer"}},"required":["group","topic","partition","offset"]},'
-        '"outputSchema":{"type":"object","properties":{"group":{"type":"string"},'
-        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group","topic","reset"]}}]}'
+        '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group_id","topic","reset"]}}]}'
 write flush
 
 write close


### PR DESCRIPTION
## Description

`reset_offsets` (added in #2232) took a bare `group` field to identify the consumer group, while `describe_consumer_group` (same PR) used `group_id` for the identical concept. This renames `reset_offsets`' `group` field to `group_id` throughout — input schema, output schema, argument capture, and result payload — so it matches `describe_consumer_group`'s input, `list_consumer_groups`' output (`groups[].group_id`), and the binding's general naming convention.

Updated the `tools.list`, `reset.offsets`, and `reset.offsets.coordinator.not.found` k3po spec scripts (both mcp-side client/server pairs) and the `mcp.proxy` example README to match. No behavior change beyond the field rename.

Fixes #2248

## Test plan

- [x] `./mvnw -pl runtime/binding-mcp-kafka clean verify` — unit tests, checkstyle, all k3po ITs, JaCoCo coverage all pass
- [x] `./mvnw -pl specs/binding-mcp-kafka.spec clean verify -Dit.test=McpIT` — peer-to-peer client/server script verification passes, including the updated `reset_offsets` and `tools.list` scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01W7YzrxCGD8qUtpwW2vzw1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7YzrxCGD8qUtpwW2vzw1H)_