### PR TITLE
feat(binding-mcp): disambiguate colliding tool titles across toolkits

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -25,6 +25,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpFlu
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.LongFunction;
@@ -296,6 +297,7 @@ public final class McpProxyCacheHydrater
         private final HandlerImpl handler;
         private final int kind;
         private final List<String> prefixes;
+        private final Map<String, String> toolkitsByPrefix;
         private final List<McpListRouteSink> sinks;
 
         private int pending;
@@ -308,6 +310,7 @@ public final class McpProxyCacheHydrater
             this.handler = handler;
             this.kind = kind;
             this.prefixes = new ArrayList<>();
+            this.toolkitsByPrefix = new HashMap<>();
             this.sinks = new ArrayList<>();
         }
 
@@ -358,7 +361,9 @@ public final class McpProxyCacheHydrater
 
             for (McpRoutePrefix route : routes)
             {
-                prefixes.add(route.prefix().asString());
+                final String prefix = route.prefix().asString();
+                prefixes.add(prefix);
+                toolkitsByPrefix.put(prefix, route.route().toolkit());
             }
 
             if (routes.isEmpty())
@@ -411,6 +416,10 @@ public final class McpProxyCacheHydrater
             }
             else
             {
+                if (kind == KIND_TOOLS_LIST)
+                {
+                    listCache.disambiguateTitles(toolkitsByPrefix);
+                }
                 final McpProxyListFactory listFactory = listFactories.get(kind);
                 listCache.putAssembled(listFactory.hydrationPrelude(), listFactory.hydrationClose(),
                     prefixes, k -> terminal(failedAny));

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpProxyCache.java
@@ -479,6 +479,12 @@ public final class McpProxyCache
             fragments.put(prefix, items);
         }
 
+        public void disambiguateTitles(
+            Map<String, String> toolkitsByPrefix)
+        {
+            McpToolTitleDisambiguator.disambiguate(fragments, toolkitsByPrefix);
+        }
+
         public boolean fragmentsAbsent(
             List<String> orderedPrefixes)
         {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguator.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguator.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonWriter;
+
+// each hydrated route's tools/list fragment already carries its toolkit__-prefixed name (see
+// McpProxyListFactory), but an optional "title" is a free-text, unprefixed display label -- two
+// toolkits can legitimately expose tools with the same everyday-language title. Disambiguation is
+// collision-only: a title is only rewritten when the SAME title is shared by tools from two or more
+// distinct toolkits. A route with no toolkit configured has no identifier to disambiguate with, so
+// its items never contribute to collision detection and are never themselves rewritten -- a title
+// shared with only one other toolkit-identified route (or with a toolkit-less route) is left alone.
+// This runs once per cache hydration cycle (not on the request hot path), so the jakarta.json object
+// model is used freely, mirroring McpProxyCacheHydrater's own per-item JSON rewrites (nameFirst,
+// injectToolScopes).
+final class McpToolTitleDisambiguator
+{
+    private static final String TITLE = "title";
+
+    private McpToolTitleDisambiguator()
+    {
+    }
+
+    static void disambiguate(
+        Map<String, String> fragmentsByPrefix,
+        Map<String, String> toolkitsByPrefix)
+    {
+        final Map<String, List<JsonObject>> itemsByPrefix = new LinkedHashMap<>();
+        final Map<String, Set<String>> toolkitsByTitle = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> fragment : fragmentsByPrefix.entrySet())
+        {
+            final String prefix = fragment.getKey();
+            final String items = fragment.getValue();
+            if (items == null || items.isEmpty())
+            {
+                continue;
+            }
+
+            final List<JsonObject> parsed = parseItems(items);
+            itemsByPrefix.put(prefix, parsed);
+
+            final String toolkit = toolkitsByPrefix.get(prefix);
+            if (toolkit != null)
+            {
+                for (JsonObject item : parsed)
+                {
+                    final String title = item.getString(TITLE, null);
+                    if (title != null)
+                    {
+                        toolkitsByTitle.computeIfAbsent(title, t -> new LinkedHashSet<>()).add(toolkit);
+                    }
+                }
+            }
+        }
+
+        final Set<String> collidingTitles = new HashSet<>();
+        for (Map.Entry<String, Set<String>> entry : toolkitsByTitle.entrySet())
+        {
+            if (entry.getValue().size() > 1)
+            {
+                collidingTitles.add(entry.getKey());
+            }
+        }
+
+        if (!collidingTitles.isEmpty())
+        {
+            for (Map.Entry<String, List<JsonObject>> entry : itemsByPrefix.entrySet())
+            {
+                final String prefix = entry.getKey();
+                final String toolkit = toolkitsByPrefix.get(prefix);
+                final String rewritten = toolkit != null
+                    ? rewriteItems(entry.getValue(), collidingTitles, toolkit)
+                    : null;
+                if (rewritten != null)
+                {
+                    fragmentsByPrefix.put(prefix, rewritten);
+                }
+            }
+        }
+    }
+
+    private static String rewriteItems(
+        List<JsonObject> items,
+        Set<String> collidingTitles,
+        String toolkit)
+    {
+        boolean changed = false;
+        final List<JsonObject> rewritten = new ArrayList<>(items.size());
+
+        for (JsonObject item : items)
+        {
+            final String title = item.getString(TITLE, null);
+            if (title != null && collidingTitles.contains(title))
+            {
+                rewritten.add(withDisambiguatedTitle(item, title, toolkit));
+                changed = true;
+            }
+            else
+            {
+                rewritten.add(item);
+            }
+        }
+
+        return changed ? writeItems(rewritten) : null;
+    }
+
+    private static JsonObject withDisambiguatedTitle(
+        JsonObject item,
+        String title,
+        String toolkit)
+    {
+        final String disambiguated = title + " (" + toolkit + ")";
+        final JsonObjectBuilder builder = Json.createObjectBuilder();
+        for (Map.Entry<String, JsonValue> field : item.entrySet())
+        {
+            builder.add(field.getKey(), TITLE.equals(field.getKey()) ? Json.createValue(disambiguated) : field.getValue());
+        }
+        return builder.build();
+    }
+
+    private static List<JsonObject> parseItems(
+        String items)
+    {
+        final List<JsonObject> result = new ArrayList<>();
+        try (JsonReader reader = Json.createReader(new StringReader("[" + items + "]")))
+        {
+            for (JsonValue item : reader.readArray())
+            {
+                result.add((JsonObject) item);
+            }
+        }
+        catch (JsonException | ClassCastException ex)
+        {
+            result.clear();
+        }
+        return result;
+    }
+
+    private static String writeItems(
+        List<JsonObject> items)
+    {
+        final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+        items.forEach(arrayBuilder::add);
+
+        final StringWriter writer = new StringWriter();
+        try (JsonWriter jsonWriter = Json.createWriter(writer))
+        {
+            jsonWriter.writeArray(arrayBuilder.build());
+        }
+        final String written = writer.toString();
+        return written.substring(1, written.length() - 1);
+    }
+}

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -133,6 +133,17 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.toolkit.multi.yaml")
+    @Specification({
+        "${app}/cache.hydrate.toolkit.multi.title.collision/server",
+        "${app}/cache.hydrate.toolkit.multi.title.collision/client" })
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldHydrateToolkitMultiDisambiguatingCollidingTitles() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.seeded.toolkit.multi.yaml")
     @Specification({
         "${app}/lifecycle.elicit.cached/client",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguatorTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.binding.mcp.internal.stream.cache;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class McpToolTitleDisambiguatorTest
+{
+    @Test
+    public void shouldLeaveTitlesUnchangedWhenNoCollision()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__get_time\",\"title\":\"Get Time\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}", fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__get_time\",\"title\":\"Get Time\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldDisambiguateTitlesCollidingAcrossToolkits()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"bluesky__send_message\",\"title\":\"Send Message (bluesky)\"}", fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message (quartz)\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldOnlyRewriteItemsWithCollidingTitleWithinAFragment()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__",
+            "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}," +
+            "{\"name\":\"bluesky__get_time\",\"title\":\"Get Time\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals(
+            "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message (bluesky)\"}," +
+            "{\"name\":\"bluesky__get_time\",\"title\":\"Get Time\"}",
+            fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message (quartz)\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldNotDisambiguateTitleCollidingOnlyWithinSameToolkit()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__",
+            "{\"name\":\"bluesky__send_message_a\",\"title\":\"Send Message\"}," +
+            "{\"name\":\"bluesky__send_message_b\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals(
+            "{\"name\":\"bluesky__send_message_a\",\"title\":\"Send Message\"}," +
+            "{\"name\":\"bluesky__send_message_b\",\"title\":\"Send Message\"}",
+            fragments.get("bluesky__"));
+    }
+
+    @Test
+    public void shouldLeaveTitlesUnchangedWhenOnlyOneRouteHasAToolkit()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("", "{\"name\":\"send_message\",\"title\":\"Send Message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = new LinkedHashMap<>();
+        toolkits.put("", null);
+        toolkits.put("quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"send_message\",\"title\":\"Send Message\"}", fragments.get(""));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldLeaveUnprefixedRouteTitleUnchangedWhileDisambiguatingToolkitCollision()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("", "{\"name\":\"send_message\",\"title\":\"Send Message\"}");
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = new LinkedHashMap<>();
+        toolkits.put("", null);
+        toolkits.put("bluesky__", "bluesky");
+        toolkits.put("quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"send_message\",\"title\":\"Send Message\"}", fragments.get(""));
+        assertEquals("{\"name\":\"bluesky__send_message\",\"title\":\"Send Message (bluesky)\"}", fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message (quartz)\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldLeaveItemsWithoutTitleUnchanged()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"bluesky__send_message\"}", fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}", fragments.get("quartz__"));
+    }
+}

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/client.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("agent-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("agent-1")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"bluesky__send_message","title":"Send Message (bluesky)"}'
+          ','
+          '{"name":"bluesky__get_time","title":"Get Time"}'
+          ','
+          '{"name":"quartz__send_message","title":"Send Message (quartz)"}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/server.rpt
@@ -1,0 +1,98 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1a")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1a")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":[{"name":"send_message","title":"Send Message"},{"name":"get_time","title":"Get Time"}]}'
+write flush
+
+write close
+
+read closed
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1a")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1a")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":[{"name":"send_message","title":"Send Message"}]}'
+write flush
+
+write close
+
+read closed


### PR DESCRIPTION
## Description

The `mcp` proxy binding namespaces proxied tool **names** with a `toolkit__` prefix so names never collide across aggregated toolkits. An optional tool `title`, however, is a free-text, unprefixed display label — MCP clients typically render it in place of the raw name — so two toolkits exposing a similarly-titled tool (e.g. "Send Message") reintroduce the exact duplicate-display problem the name prefix was meant to solve.

This adds **collision-only** title disambiguation, scoped to the tools cache path (`options.cache.tools`) only — the plain streaming proxy (no cache configured) decodes and forwards one JSON object at a time without ever holding the full tool list, so true cross-toolkit collision detection isn't feasible there without buffering, and is out of scope for this change.

Once per cache hydration cycle (not on the request hot path):
- A tool's `title` is rewritten to `"<title> (<toolkit>)"` only when that exact title is shared by tools from **two or more distinct toolkits**, using the same toolkit identifier already used for the `toolkit__` name prefix.
- Non-colliding titles, tools without a title, and routes with no toolkit configured (which have no identifier to disambiguate with) are left unchanged.

Implementation is a new pure-JSON-transform utility, `McpToolTitleDisambiguator`, invoked from `McpProxyCacheHydrater` once all routes for `KIND_TOOLS_LIST` have settled, before the fragments are assembled into the cached response — mirroring the existing per-item JSON rewrites (`nameFirst`, `injectToolScopes`) already done there.

## Testing

- New unit tests (`McpToolTitleDisambiguatorTest`) cover the collision logic directly: no collision, collision across two toolkits, same title within one toolkit only (not a collision), routes with no toolkit, and items without a title.
- New k3po spec scenario `cache.hydrate.toolkit.multi.title.collision` + `McpProxyCacheIT#shouldHydrateToolkitMultiDisambiguatingCollidingTitles` exercise the full hydration path against a live engine with two toolkits, one colliding title and one non-colliding title.
- `./mvnw clean verify -pl runtime/binding-mcp` passes in full (161 unit tests, 285 integration tests, checkstyle, license headers, JaCoCo coverage).

Fixes #2260


---
_Generated by [Claude Code](https://claude.ai/code/session_01GigP5EY5KusjbJASWMhm7k)_