### PR TITLE
fix(binding-mcp-kafka): echo partition/offset in reset_offsets output

### DIFF
--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -1075,8 +1075,11 @@ public class McpKafkaProxyFactory implements BindingHandler
                 .add("properties", Json.createObjectBuilder()
                     .add("group_id", Json.createObjectBuilder().add("type", "string"))
                     .add("topic", Json.createObjectBuilder().add("type", "string"))
+                    .add("partition", Json.createObjectBuilder().add("type", "integer"))
+                    .add("offset", Json.createObjectBuilder().add("type", "integer"))
                     .add("reset", Json.createObjectBuilder().add("type", "boolean")))
-                .add("required", Json.createArrayBuilder().add("group_id").add("topic").add("reset"))
+                .add("required", Json.createArrayBuilder()
+                    .add("group_id").add("topic").add("partition").add("offset").add("reset"))
                 .build();
             break;
         default:
@@ -6933,6 +6936,8 @@ public class McpKafkaProxyFactory implements BindingHandler
                     .writeStartObject("structuredContent")
                     .write("group_id", groupId)
                     .write("topic", topic)
+                    .write("partition", partition)
+                    .write("offset", offset)
                     .write("reset", success)
                     .writeEnd()
                     .writeStartArray("content")

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/client.rpt
@@ -56,7 +56,7 @@ connected
 
 write '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
-read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
+read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100,"reset":false},'
      '"content":[{"type":"text","text":"Group coordinator not found for my-group (error 15)"}],'
      '"isError":true}'
 read closed

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets.coordinator.not.found/server.rpt
@@ -56,7 +56,7 @@ read '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-top
 
 write flush
 
-write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
+write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100,"reset":false},'
       '"content":[{"type":"text","text":"Group coordinator not found for my-group (error 15)"}],'
       '"isError":true}'
 write flush

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/client.rpt
@@ -56,7 +56,7 @@ connected
 
 write '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100}}'
 
-read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
+read '{"structuredContent":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100,"reset":false},'
      '"content":[{"type":"text","text":"Consumer group my-group has active members (state Stable); cannot reset offsets"}],'
      '"isError":true}'
 read closed

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/reset.offsets/server.rpt
@@ -56,7 +56,7 @@ read '{"name":"reset_offsets","arguments":{"group_id":"my-group","topic":"my-top
 
 write flush
 
-write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","reset":false},'
+write '{"structuredContent":{"group_id":"my-group","topic":"my-topic","partition":0,"offset":100,"reset":false},'
       '"content":[{"type":"text","text":"Consumer group my-group has active members (state Stable); cannot reset offsets"}],'
       '"isError":true}'
 write flush

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/client.rpt
@@ -145,7 +145,8 @@ read  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":'
         '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
         '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
         '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
-        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group_id","topic","reset"]}}]}'
+        '"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"reset":{"type":"boolean"}},"required":["group_id","topic","partition","offset","reset"]}}]}'
 read closed
 
 write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list/server.rpt
@@ -145,7 +145,8 @@ write  '{"tools":[{"name":"produce","inputSchema":{"type":"object","properties":
         '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
         '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
         '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
-        '"topic":{"type":"string"},"reset":{"type":"boolean"}},"required":["group_id","topic","reset"]}}]}'
+        '"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"reset":{"type":"boolean"}},"required":["group_id","topic","partition","offset","reset"]}}]}'
 write flush
 
 write close


### PR DESCRIPTION
## Description

`reset_offsets` takes `group_id`, `topic`, `partition`, `offset` as input, but its output schema and `structuredContent` response only echoed back `group_id`, `topic`, `reset` — leaving the caller unable to confirm which partition/offset were actually set without an extra `describe_consumer_group` round trip.

Adds `partition` (integer, required) and `offset` (integer, required) to `reset_offsets`'s output schema and to the `structuredContent` written in the response, alongside the existing `group_id`/`topic`/`reset` fields.

Changes:
- `McpKafkaProxyFactory.java` — output schema (`buildConsumerGroupToolOutputSchema`) and `emitResult`'s `structuredContent` now include `partition`/`offset`
- `specs/binding-mcp-kafka.spec` — updated `tools.list`, `reset.offsets`, and `reset.offsets.coordinator.not.found` client/server `.rpt` fixtures to match

Verified locally: `McpKafkaClientIT` (including `shouldResetOffsetsCoordinatorNotFound`), the spec-level `McpIT` peer-to-peer script consistency check, and `checkstyle:check` all pass.

Fixes #2257


---
_Generated by [Claude Code](https://claude.ai/code/session_012az6o2pPmVmngqAMjM8dBW)_