### PR TITLE
refactor(binding-mcp,binding-mcp-kafka,binding-mcp-openapi,binding-mcp-schema-registry): unify route condition naming

### DIFF
--- a/config/binding-mcp-kafka.conf/NOTICE
+++ b/config/binding-mcp-kafka.conf/NOTICE
@@ -15,7 +15,9 @@ This project includes:
   JSON-B API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   zilla::config::binding-kafka.conf under Aklivity Community License Agreement
   zilla::config::engine.conf under Aklivity Community License Agreement
+  zilla::runtime::common-agrona under The Apache Software License, Version 2.0
   zilla::runtime::common-feature under The Apache Software License, Version 2.0
+  zilla::runtime::common-json under Aklivity Community License Agreement
   zilla::runtime::common-lang under Aklivity Community License Agreement
 
 

--- a/config/binding-mcp-kafka.conf/pom.xml
+++ b/config/binding-mcp-kafka.conf/pom.xml
@@ -62,7 +62,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>common-json</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaConditionConfig.java
+++ b/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaConditionConfig.java
@@ -21,7 +21,7 @@ import io.aklivity.zilla.config.engine.ConditionConfig;
 
 public final class McpKafkaConditionConfig extends ConditionConfig
 {
-    public final String tool;
+    public final List<String> tool;
     public final String resource;
     public final List<String> topics;
 
@@ -37,7 +37,7 @@ public final class McpKafkaConditionConfig extends ConditionConfig
     }
 
     McpKafkaConditionConfig(
-        String tool,
+        List<String> tool,
         String resource,
         List<String> topics)
     {

--- a/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaConditionConfigBuilder.java
+++ b/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaConditionConfigBuilder.java
@@ -24,7 +24,7 @@ public final class McpKafkaConditionConfigBuilder<T> extends ConfigBuilder<T, Mc
 {
     private final Function<ConditionConfig, T> mapper;
 
-    private String tool;
+    private List<String> tool;
     private String resource;
     private List<String> topics;
 
@@ -42,7 +42,7 @@ public final class McpKafkaConditionConfigBuilder<T> extends ConfigBuilder<T, Mc
     }
 
     public McpKafkaConditionConfigBuilder<T> tool(
-        String tool)
+        List<String> tool)
     {
         this.tool = tool;
         return this;

--- a/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaConditionConfigAdapter.java
+++ b/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaConditionConfigAdapter.java
@@ -27,6 +27,7 @@ import jakarta.json.bind.adapter.JsonbAdapter;
 
 import io.aklivity.zilla.config.binding.mcp.kafka.McpKafkaConditionConfig;
 import io.aklivity.zilla.config.engine.ConditionConfig;
+import io.aklivity.zilla.runtime.common.json.JsonStrings;
 
 public final class McpKafkaConditionConfigAdapter implements JsonbAdapter<ConditionConfig, JsonObject>
 {
@@ -42,10 +43,7 @@ public final class McpKafkaConditionConfigAdapter implements JsonbAdapter<Condit
 
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        if (mcpKafkaCondition.tool != null)
-        {
-            object.add(TOOL_NAME, mcpKafkaCondition.tool);
-        }
+        JsonStrings.addStringOrArray(object, TOOL_NAME, mcpKafkaCondition.tool);
 
         if (mcpKafkaCondition.resource != null)
         {
@@ -66,10 +64,6 @@ public final class McpKafkaConditionConfigAdapter implements JsonbAdapter<Condit
     public ConditionConfig adaptFromJson(
         JsonObject object)
     {
-        String tool = object.containsKey(TOOL_NAME)
-            ? object.getString(TOOL_NAME)
-            : null;
-
         String resource = object.containsKey(RESOURCE_NAME)
             ? object.getString(RESOURCE_NAME)
             : null;
@@ -82,7 +76,7 @@ public final class McpKafkaConditionConfigAdapter implements JsonbAdapter<Condit
             : null;
 
         return McpKafkaConditionConfig.builder()
-            .tool(tool)
+            .tool(JsonStrings.asStringOrArray(object, TOOL_NAME))
             .resource(resource)
             .topics(topics)
             .build();

--- a/config/binding-mcp-kafka.conf/src/main/moditect/module-info.java
+++ b/config/binding-mcp-kafka.conf/src/main/moditect/module-info.java
@@ -17,6 +17,7 @@ module io.aklivity.zilla.config.binding.mcp.kafka
     requires jakarta.json;
     requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
+    requires io.aklivity.zilla.runtime.common.json;
     requires transitive io.aklivity.zilla.config.binding.kafka;
 
     exports io.aklivity.zilla.config.binding.mcp.kafka;

--- a/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaBindingConfigBuilderTest.java
+++ b/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaBindingConfigBuilderTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
+import java.util.List;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.config.binding.mcp.kafka.internal.McpKafkaBindingInfo;
@@ -43,7 +45,7 @@ public class McpKafkaBindingConfigBuilderTest
                 .build()
             .route()
                 .when()
-                    .tool("test")
+                    .tool(List.of("test"))
                     .build()
                 .build()
             .build();
@@ -65,6 +67,6 @@ public class McpKafkaBindingConfigBuilderTest
 
         ConditionConfig condition = route.when.get(0);
         assertThat(condition, instanceOf(McpKafkaConditionConfig.class));
-        assertThat(((McpKafkaConditionConfig) condition).tool, equalTo("test"));
+        assertThat(((McpKafkaConditionConfig) condition).tool, equalTo(List.of("test")));
     }
 }

--- a/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaConditionConfigAdapterTest.java
+++ b/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaConditionConfigAdapterTest.java
@@ -55,7 +55,7 @@ public class McpKafkaConditionConfigAdapterTest
         McpKafkaConditionConfig condition = jsonb.fromJson(text, McpKafkaConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
-        assertThat(condition.tool, equalTo("produce"));
+        assertThat(condition.tool, contains("produce"));
         assertThat(condition.resource, equalTo("orders"));
         assertThat(condition.topics, contains("orders", "shipments"));
     }
@@ -64,7 +64,7 @@ public class McpKafkaConditionConfigAdapterTest
     public void shouldWriteCondition()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .resource("orders")
             .topics(asList("orders", "shipments"))
             .build();
@@ -73,5 +73,29 @@ public class McpKafkaConditionConfigAdapterTest
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo("{\"tool\":\"produce\",\"resource\":\"orders\",\"topics\":[\"orders\",\"shipments\"]}"));
+    }
+
+    @Test
+    public void shouldReadToolArray()
+    {
+        String text = "{\"tool\": [\"produce\", \"consume\"]}";
+
+        McpKafkaConditionConfig condition = jsonb.fromJson(text, McpKafkaConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.tool, contains("produce", "consume"));
+    }
+
+    @Test
+    public void shouldWriteToolArray()
+    {
+        McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
+            .tool(asList("produce", "consume"))
+            .build();
+
+        String text = jsonb.toJson(condition);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"tool\":[\"produce\",\"consume\"]}"));
     }
 }

--- a/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiConditionConfig.java
+++ b/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiConditionConfig.java
@@ -14,7 +14,6 @@
  */
 package io.aklivity.zilla.config.binding.mcp.openapi;
 
-import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.ConditionConfig;
@@ -23,7 +22,6 @@ public final class McpOpenapiConditionConfig extends ConditionConfig
 {
     public final String tool;
     public final String resource;
-    public final List<String> capability;
 
     public static McpOpenapiConditionConfigBuilder<McpOpenapiConditionConfig> builder()
     {
@@ -38,11 +36,9 @@ public final class McpOpenapiConditionConfig extends ConditionConfig
 
     McpOpenapiConditionConfig(
         String tool,
-        String resource,
-        List<String> capability)
+        String resource)
     {
         this.tool = tool;
         this.resource = resource;
-        this.capability = capability;
     }
 }

--- a/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiConditionConfigBuilder.java
+++ b/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiConditionConfigBuilder.java
@@ -14,7 +14,6 @@
  */
 package io.aklivity.zilla.config.binding.mcp.openapi;
 
-import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.ConditionConfig;
@@ -26,7 +25,6 @@ public final class McpOpenapiConditionConfigBuilder<T> extends ConfigBuilder<T, 
 
     private String tool;
     private String resource;
-    private List<String> capability;
 
     McpOpenapiConditionConfigBuilder(
         Function<ConditionConfig, T> mapper)
@@ -55,16 +53,9 @@ public final class McpOpenapiConditionConfigBuilder<T> extends ConfigBuilder<T, 
         return this;
     }
 
-    public McpOpenapiConditionConfigBuilder<T> capability(
-        List<String> capability)
-    {
-        this.capability = capability;
-        return this;
-    }
-
     @Override
     public T build()
     {
-        return mapper.apply(new McpOpenapiConditionConfig(tool, resource, capability));
+        return mapper.apply(new McpOpenapiConditionConfig(tool, resource));
     }
 }

--- a/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiConditionConfigAdapter.java
+++ b/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiConditionConfigAdapter.java
@@ -14,15 +14,9 @@
  */
 package io.aklivity.zilla.config.binding.mcp.openapi.internal;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
-
 import jakarta.json.Json;
-import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonString;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
 import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiConditionConfig;
@@ -32,7 +26,6 @@ public final class McpOpenapiConditionConfigAdapter implements JsonbAdapter<Cond
 {
     private static final String TOOL_NAME = "tool";
     private static final String RESOURCE_NAME = "resource";
-    private static final String CAPABILITY_NAME = "capability";
 
     @Override
     public JsonObject adaptToJson(
@@ -52,13 +45,6 @@ public final class McpOpenapiConditionConfigAdapter implements JsonbAdapter<Cond
             object.add(RESOURCE_NAME, mcpOpenapiCondition.resource);
         }
 
-        if (mcpOpenapiCondition.capability != null)
-        {
-            JsonArrayBuilder array = Json.createArrayBuilder();
-            mcpOpenapiCondition.capability.forEach(array::add);
-            object.add(CAPABILITY_NAME, array);
-        }
-
         return object.build();
     }
 
@@ -74,17 +60,9 @@ public final class McpOpenapiConditionConfigAdapter implements JsonbAdapter<Cond
             ? object.getString(RESOURCE_NAME)
             : null;
 
-        List<String> capability = object.containsKey(CAPABILITY_NAME)
-            ? object.getJsonArray(CAPABILITY_NAME).stream()
-                .map(JsonString.class::cast)
-                .map(JsonString::getString)
-                .collect(toList())
-            : null;
-
         return McpOpenapiConditionConfig.builder()
             .tool(tool)
             .resource(resource)
-            .capability(capability)
             .build();
     }
 }

--- a/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiConditionConfigAdapterTest.java
+++ b/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiConditionConfigAdapterTest.java
@@ -14,9 +14,7 @@
  */
 package io.aklivity.zilla.config.binding.mcp.openapi.internal;
 
-import static java.util.List.of;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -55,7 +53,6 @@ public class McpOpenapiConditionConfigAdapterTest
         assertThat(condition, not(nullValue()));
         assertThat(condition.tool, equalTo("create_pr"));
         assertThat(condition.resource, nullValue());
-        assertThat(condition.capability, nullValue());
     }
 
     @Test
@@ -71,20 +68,6 @@ public class McpOpenapiConditionConfigAdapterTest
         assertThat(condition, not(nullValue()));
         assertThat(condition.tool, nullValue());
         assertThat(condition.resource, equalTo("repo://{owner}/{repo}"));
-    }
-
-    @Test
-    public void shouldReadConditionWithCapability()
-    {
-        String text =
-                "{" +
-                    "\"capability\": [\"fetch\", \"subscribe\"]" +
-                "}";
-
-        McpOpenapiConditionConfig condition = jsonb.fromJson(text, McpOpenapiConditionConfig.class);
-
-        assertThat(condition, not(nullValue()));
-        assertThat(condition.capability, contains("fetch", "subscribe"));
     }
 
     @Test
@@ -111,18 +94,5 @@ public class McpOpenapiConditionConfigAdapterTest
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo("{\"resource\":\"repo://{owner}/{repo}\"}"));
-    }
-
-    @Test
-    public void shouldWriteConditionWithCapability()
-    {
-        McpOpenapiConditionConfig condition = McpOpenapiConditionConfig.builder()
-            .capability(of("fetch", "subscribe"))
-            .build();
-
-        String text = jsonb.toJson(condition);
-
-        assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"capability\":[\"fetch\",\"subscribe\"]}"));
     }
 }

--- a/config/binding-mcp-schema-registry.conf/NOTICE
+++ b/config/binding-mcp-schema-registry.conf/NOTICE
@@ -14,7 +14,9 @@ This project includes:
   Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   JSON-B API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   zilla::config::engine.conf under Aklivity Community License Agreement
+  zilla::runtime::common-agrona under The Apache Software License, Version 2.0
   zilla::runtime::common-feature under The Apache Software License, Version 2.0
+  zilla::runtime::common-json under Aklivity Community License Agreement
   zilla::runtime::common-lang under Aklivity Community License Agreement
   zilla::runtime::common-yaml under Aklivity Community License Agreement
 

--- a/config/binding-mcp-schema-registry.conf/pom.xml
+++ b/config/binding-mcp-schema-registry.conf/pom.xml
@@ -57,7 +57,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>common-json</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryConditionConfig.java
+++ b/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryConditionConfig.java
@@ -14,13 +14,14 @@
  */
 package io.aklivity.zilla.config.binding.mcp.schema.registry;
 
+import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.ConditionConfig;
 
 public final class McpSchemaRegistryConditionConfig extends ConditionConfig
 {
-    public final String tool;
+    public final List<String> tool;
 
     public static McpSchemaRegistryConditionConfigBuilder<McpSchemaRegistryConditionConfig> builder()
     {
@@ -34,7 +35,7 @@ public final class McpSchemaRegistryConditionConfig extends ConditionConfig
     }
 
     McpSchemaRegistryConditionConfig(
-        String tool)
+        List<String> tool)
     {
         this.tool = tool;
     }

--- a/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryConditionConfigBuilder.java
+++ b/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryConditionConfigBuilder.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.config.binding.mcp.schema.registry;
 
+import java.util.List;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.ConditionConfig;
@@ -24,7 +25,7 @@ public final class McpSchemaRegistryConditionConfigBuilder<T> extends
 {
     private final Function<ConditionConfig, T> mapper;
 
-    private String tool;
+    private List<String> tool;
 
     McpSchemaRegistryConditionConfigBuilder(
         Function<ConditionConfig, T> mapper)
@@ -40,7 +41,7 @@ public final class McpSchemaRegistryConditionConfigBuilder<T> extends
     }
 
     public McpSchemaRegistryConditionConfigBuilder<T> tool(
-        String tool)
+        List<String> tool)
     {
         this.tool = tool;
         return this;

--- a/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryConditionConfigAdapter.java
+++ b/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryConditionConfigAdapter.java
@@ -21,6 +21,7 @@ import jakarta.json.bind.adapter.JsonbAdapter;
 
 import io.aklivity.zilla.config.binding.mcp.schema.registry.McpSchemaRegistryConditionConfig;
 import io.aklivity.zilla.config.engine.ConditionConfig;
+import io.aklivity.zilla.runtime.common.json.JsonStrings;
 
 public final class McpSchemaRegistryConditionConfigAdapter implements JsonbAdapter<ConditionConfig, JsonObject>
 {
@@ -34,10 +35,7 @@ public final class McpSchemaRegistryConditionConfigAdapter implements JsonbAdapt
 
         JsonObjectBuilder object = Json.createObjectBuilder();
 
-        if (schemaRegistryCondition.tool != null)
-        {
-            object.add(TOOL_NAME, schemaRegistryCondition.tool);
-        }
+        JsonStrings.addStringOrArray(object, TOOL_NAME, schemaRegistryCondition.tool);
 
         return object.build();
     }
@@ -46,12 +44,8 @@ public final class McpSchemaRegistryConditionConfigAdapter implements JsonbAdapt
     public ConditionConfig adaptFromJson(
         JsonObject object)
     {
-        String tool = object.containsKey(TOOL_NAME)
-            ? object.getString(TOOL_NAME)
-            : null;
-
         return McpSchemaRegistryConditionConfig.builder()
-            .tool(tool)
+            .tool(JsonStrings.asStringOrArray(object, TOOL_NAME))
             .build();
     }
 }

--- a/config/binding-mcp-schema-registry.conf/src/main/moditect/module-info.java
+++ b/config/binding-mcp-schema-registry.conf/src/main/moditect/module-info.java
@@ -17,6 +17,7 @@ module io.aklivity.zilla.config.binding.mcp.schema.registry
     requires jakarta.json;
     requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
+    requires io.aklivity.zilla.runtime.common.json;
 
     exports io.aklivity.zilla.config.binding.mcp.schema.registry;
 

--- a/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryBindingConfigBuilderTest.java
+++ b/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryBindingConfigBuilderTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
+import java.util.List;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.config.binding.mcp.schema.registry.internal.McpSchemaRegistryBindingInfo;
@@ -40,7 +42,7 @@ public class McpSchemaRegistryBindingConfigBuilderTest
                 .build()
             .route()
                 .when()
-                    .tool("test")
+                    .tool(List.of("test"))
                     .build()
                 .build()
             .build();
@@ -60,6 +62,6 @@ public class McpSchemaRegistryBindingConfigBuilderTest
 
         ConditionConfig condition = route.when.get(0);
         assertThat(condition, instanceOf(McpSchemaRegistryConditionConfig.class));
-        assertThat(((McpSchemaRegistryConditionConfig) condition).tool, equalTo("test"));
+        assertThat(((McpSchemaRegistryConditionConfig) condition).tool, equalTo(List.of("test")));
     }
 }

--- a/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryConditionConfigAdapterTest.java
+++ b/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryConditionConfigAdapterTest.java
@@ -14,7 +14,9 @@
  */
 package io.aklivity.zilla.config.binding.mcp.schema.registry.internal;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -51,19 +53,43 @@ public class McpSchemaRegistryConditionConfigAdapterTest
         McpSchemaRegistryConditionConfig condition = jsonb.fromJson(text, McpSchemaRegistryConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
-        assertThat(condition.tool, equalTo("list_subjects"));
+        assertThat(condition.tool, contains("list_subjects"));
     }
 
     @Test
     public void shouldWriteCondition()
     {
         McpSchemaRegistryConditionConfig condition = McpSchemaRegistryConditionConfig.builder()
-            .tool("list_subjects")
+            .tool(asList("list_subjects"))
             .build();
 
         String text = jsonb.toJson(condition);
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo("{\"tool\":\"list_subjects\"}"));
+    }
+
+    @Test
+    public void shouldReadToolArray()
+    {
+        String text = "{\"tool\": [\"list_subjects\", \"get_schema\"]}";
+
+        McpSchemaRegistryConditionConfig condition = jsonb.fromJson(text, McpSchemaRegistryConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.tool, contains("list_subjects", "get_schema"));
+    }
+
+    @Test
+    public void shouldWriteToolArray()
+    {
+        McpSchemaRegistryConditionConfig condition = McpSchemaRegistryConditionConfig.builder()
+            .tool(asList("list_subjects", "get_schema"))
+            .build();
+
+        String text = jsonb.toJson(condition);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"tool\":[\"list_subjects\",\"get_schema\"]}"));
     }
 }

--- a/config/binding-mcp.conf/NOTICE
+++ b/config/binding-mcp.conf/NOTICE
@@ -14,7 +14,9 @@ This project includes:
   Jakarta JSON Processing API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   JSON-B API under Eclipse Public License 2.0 or GNU General Public License, version 2 with the GNU Classpath Exception
   zilla::config::engine.conf under Aklivity Community License Agreement
+  zilla::runtime::common-agrona under The Apache Software License, Version 2.0
   zilla::runtime::common-feature under The Apache Software License, Version 2.0
+  zilla::runtime::common-json under Aklivity Community License Agreement
   zilla::runtime::common-lang under Aklivity Community License Agreement
   zilla::runtime::common-yaml under Aklivity Community License Agreement
 

--- a/config/binding-mcp.conf/pom.xml
+++ b/config/binding-mcp.conf/pom.xml
@@ -57,7 +57,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>common-json</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpConditionConfig.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpConditionConfig.java
@@ -22,20 +22,20 @@ import io.aklivity.zilla.config.engine.ConditionConfig;
 public final class McpConditionConfig extends ConditionConfig
 {
     public final String toolkit;
-    public final List<String> tools;
-    public final List<String> prompts;
-    public final List<String> resources;
+    public final List<String> tool;
+    public final List<String> prompt;
+    public final List<String> resource;
 
     McpConditionConfig(
         String toolkit,
-        List<String> tools,
-        List<String> prompts,
-        List<String> resources)
+        List<String> tool,
+        List<String> prompt,
+        List<String> resource)
     {
         this.toolkit = toolkit;
-        this.tools = tools;
-        this.prompts = prompts;
-        this.resources = resources;
+        this.tool = tool;
+        this.prompt = prompt;
+        this.resource = resource;
     }
 
     public static McpConditionConfigBuilder<McpConditionConfig> builder()

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpConditionConfigBuilder.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/McpConditionConfigBuilder.java
@@ -25,9 +25,9 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
     private final Function<ConditionConfig, T> mapper;
 
     private String toolkit;
-    private List<String> tools;
-    private List<String> prompts;
-    private List<String> resources;
+    private List<String> tool;
+    private List<String> prompt;
+    private List<String> resource;
 
     public McpConditionConfigBuilder(
         Function<ConditionConfig, T> mapper)
@@ -42,24 +42,24 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
         return this;
     }
 
-    public McpConditionConfigBuilder<T> tools(
-        List<String> tools)
+    public McpConditionConfigBuilder<T> tool(
+        List<String> tool)
     {
-        this.tools = tools;
+        this.tool = tool;
         return this;
     }
 
-    public McpConditionConfigBuilder<T> prompts(
-        List<String> prompts)
+    public McpConditionConfigBuilder<T> prompt(
+        List<String> prompt)
     {
-        this.prompts = prompts;
+        this.prompt = prompt;
         return this;
     }
 
-    public McpConditionConfigBuilder<T> resources(
-        List<String> resources)
+    public McpConditionConfigBuilder<T> resource(
+        List<String> resource)
     {
-        this.resources = resources;
+        this.resource = resource;
         return this;
     }
 
@@ -73,6 +73,6 @@ public final class McpConditionConfigBuilder<T> extends ConfigBuilder<T, McpCond
     @Override
     public T build()
     {
-        return mapper.apply(new McpConditionConfig(toolkit, tools, prompts, resources));
+        return mapper.apply(new McpConditionConfig(toolkit, tool, prompt, resource));
     }
 }

--- a/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/internal/McpConditionConfigAdapter.java
+++ b/config/binding-mcp.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/internal/McpConditionConfigAdapter.java
@@ -14,27 +14,21 @@
  */
 package io.aklivity.zilla.config.binding.mcp.internal;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
-
 import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonString;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
 import io.aklivity.zilla.config.binding.mcp.McpConditionConfig;
 import io.aklivity.zilla.config.engine.ConditionConfig;
+import io.aklivity.zilla.runtime.common.json.JsonStrings;
 
 public final class McpConditionConfigAdapter implements JsonbAdapter<ConditionConfig, JsonObject>
 {
     private static final String TOOLKIT_NAME = "toolkit";
-    private static final String TOOLS_NAME = "tools";
-    private static final String PROMPTS_NAME = "prompts";
-    private static final String RESOURCES_NAME = "resources";
+    private static final String TOOL_NAME = "tool";
+    private static final String PROMPT_NAME = "prompt";
+    private static final String RESOURCE_NAME = "resource";
 
     @Override
     public JsonObject adaptToJson(
@@ -49,26 +43,9 @@ public final class McpConditionConfigAdapter implements JsonbAdapter<ConditionCo
             object.add(TOOLKIT_NAME, mcpCondition.toolkit);
         }
 
-        if (mcpCondition.tools != null)
-        {
-            JsonArrayBuilder array = Json.createArrayBuilder();
-            mcpCondition.tools.forEach(array::add);
-            object.add(TOOLS_NAME, array);
-        }
-
-        if (mcpCondition.prompts != null)
-        {
-            JsonArrayBuilder array = Json.createArrayBuilder();
-            mcpCondition.prompts.forEach(array::add);
-            object.add(PROMPTS_NAME, array);
-        }
-
-        if (mcpCondition.resources != null)
-        {
-            JsonArrayBuilder array = Json.createArrayBuilder();
-            mcpCondition.resources.forEach(array::add);
-            object.add(RESOURCES_NAME, array);
-        }
+        JsonStrings.addStringOrArray(object, TOOL_NAME, mcpCondition.tool);
+        JsonStrings.addStringOrArray(object, PROMPT_NAME, mcpCondition.prompt);
+        JsonStrings.addStringOrArray(object, RESOURCE_NAME, mcpCondition.resource);
 
         return object.build();
     }
@@ -83,25 +60,9 @@ public final class McpConditionConfigAdapter implements JsonbAdapter<ConditionCo
 
         return McpConditionConfig.builder()
             .toolkit(toolkit)
-            .tools(asStringList(object, TOOLS_NAME))
-            .prompts(asStringList(object, PROMPTS_NAME))
-            .resources(asStringList(object, RESOURCES_NAME))
+            .tool(JsonStrings.asStringOrArray(object, TOOL_NAME))
+            .prompt(JsonStrings.asStringOrArray(object, PROMPT_NAME))
+            .resource(JsonStrings.asStringOrArray(object, RESOURCE_NAME))
             .build();
-    }
-
-    private static List<String> asStringList(
-        JsonObject object,
-        String name)
-    {
-        List<String> result = null;
-        if (object.containsKey(name))
-        {
-            JsonArray array = object.getJsonArray(name);
-            result = array.stream()
-                .map(JsonString.class::cast)
-                .map(JsonString::getString)
-                .collect(toList());
-        }
-        return result;
     }
 }

--- a/config/binding-mcp.conf/src/main/moditect/module-info.java
+++ b/config/binding-mcp.conf/src/main/moditect/module-info.java
@@ -17,6 +17,7 @@ module io.aklivity.zilla.config.binding.mcp
     requires jakarta.json;
     requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
+    requires io.aklivity.zilla.runtime.common.json;
 
     exports io.aklivity.zilla.config.binding.mcp;
 

--- a/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpBindingConfigBuilderTest.java
+++ b/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/McpBindingConfigBuilderTest.java
@@ -43,7 +43,7 @@ public class McpBindingConfigBuilderTest
                 .build()
             .route()
                 .when()
-                    .tools(List.of("test"))
+                    .tool(List.of("test"))
                     .build()
                 .with()
                     .cache()
@@ -68,7 +68,7 @@ public class McpBindingConfigBuilderTest
 
         ConditionConfig condition = route.when.get(0);
         assertThat(condition, instanceOf(McpConditionConfig.class));
-        assertThat(((McpConditionConfig) condition).tools, equalTo(List.of("test")));
+        assertThat(((McpConditionConfig) condition).tool, equalTo(List.of("test")));
 
         WithConfig with = route.with;
         assertThat(with, instanceOf(McpWithConfig.class));

--- a/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/internal/McpConditionConfigAdapterTest.java
+++ b/config/binding-mcp.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/internal/McpConditionConfigAdapterTest.java
@@ -53,9 +53,9 @@ public class McpConditionConfigAdapterTest
 
         assertThat(condition, not(nullValue()));
         assertThat(condition.toolkit, equalTo("github"));
-        assertThat(condition.tools, nullValue());
-        assertThat(condition.prompts, nullValue());
-        assertThat(condition.resources, nullValue());
+        assertThat(condition.tool, nullValue());
+        assertThat(condition.prompt, nullValue());
+        assertThat(condition.resource, nullValue());
     }
 
     @Test
@@ -75,15 +75,15 @@ public class McpConditionConfigAdapterTest
     public void shouldReadFilterCondition()
     {
         String text = "{\"toolkit\":\"github\"," +
-            "\"tools\":[\"create_*\",\"get_*\"],\"resources\":[\"repo://*\"]}";
+            "\"tool\":[\"create_*\",\"get_*\"],\"resource\":[\"repo://*\"]}";
 
         McpConditionConfig condition = jsonb.fromJson(text, McpConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
         assertThat(condition.toolkit, equalTo("github"));
-        assertThat(condition.tools, contains("create_*", "get_*"));
-        assertThat(condition.resources, contains("repo://*"));
-        assertThat(condition.prompts, nullValue());
+        assertThat(condition.tool, contains("create_*", "get_*"));
+        assertThat(condition.resource, contains("repo://*"));
+        assertThat(condition.prompt, nullValue());
     }
 
     @Test
@@ -91,28 +91,28 @@ public class McpConditionConfigAdapterTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
                 .toolkit("github")
-                .tools(asList("create_*", "get_*"))
-                .resources(asList("repo://*"))
+                .tool(asList("create_*", "get_*"))
+                .resource(asList("repo://*"))
                 .build();
 
         String text = jsonb.toJson(condition);
 
         assertThat(text, not(nullValue()));
         assertThat(text, equalTo("{\"toolkit\":\"github\"," +
-            "\"tools\":[\"create_*\",\"get_*\"],\"resources\":[\"repo://*\"]}"));
+            "\"tool\":[\"create_*\",\"get_*\"],\"resource\":\"repo://*\"}"));
     }
 
     @Test
     public void shouldReadEmptyFilterCondition()
     {
-        String text = "{\"toolkit\":\"slack\",\"tools\":[]}";
+        String text = "{\"toolkit\":\"slack\",\"tool\":[]}";
 
         McpConditionConfig condition = jsonb.fromJson(text, McpConditionConfig.class);
 
         assertThat(condition, not(nullValue()));
-        assertThat(condition.tools, empty());
-        assertThat(condition.prompts, nullValue());
-        assertThat(condition.resources, nullValue());
+        assertThat(condition.tool, empty());
+        assertThat(condition.prompt, nullValue());
+        assertThat(condition.resource, nullValue());
     }
 
     @Test
@@ -120,12 +120,59 @@ public class McpConditionConfigAdapterTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
                 .toolkit("slack")
-                .tools(emptyList())
+                .tool(emptyList())
                 .build();
 
         String text = jsonb.toJson(condition);
 
         assertThat(text, not(nullValue()));
-        assertThat(text, equalTo("{\"toolkit\":\"slack\",\"tools\":[]}"));
+        assertThat(text, equalTo("{\"toolkit\":\"slack\",\"tool\":[]}"));
+    }
+
+    @Test
+    public void shouldReadBareStringShorthandForSingleTool()
+    {
+        String text = "{\"toolkit\":\"github\",\"tool\":\"get_weather\"}";
+
+        McpConditionConfig condition = jsonb.fromJson(text, McpConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.tool, contains("get_weather"));
+    }
+
+    @Test
+    public void shouldWriteSingleToolAsBareStringShorthand()
+    {
+        McpConditionConfig condition = McpConditionConfig.builder()
+                .toolkit("github")
+                .tool(asList("get_weather"))
+                .build();
+
+        String text = jsonb.toJson(condition);
+
+        assertThat(text, not(nullValue()));
+        assertThat(text, equalTo("{\"toolkit\":\"github\",\"tool\":\"get_weather\"}"));
+    }
+
+    @Test
+    public void shouldReadBareStringShorthandForSinglePrompt()
+    {
+        String text = "{\"toolkit\":\"github\",\"prompt\":\"summarize\"}";
+
+        McpConditionConfig condition = jsonb.fromJson(text, McpConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.prompt, contains("summarize"));
+    }
+
+    @Test
+    public void shouldReadBareStringShorthandForSingleResource()
+    {
+        String text = "{\"toolkit\":\"github\",\"resource\":\"repo://acme/widgets\"}";
+
+        McpConditionConfig condition = jsonb.fromJson(text, McpConditionConfig.class);
+
+        assertThat(condition, not(nullValue()));
+        assertThat(condition.resource, contains("repo://acme/widgets"));
     }
 }

--- a/examples/mcp.proxy/etc/zilla.yaml
+++ b/examples/mcp.proxy/etc/zilla.yaml
@@ -371,7 +371,7 @@ bindings:
       - exit: south_mcp_client_urlelicit
         when:
           - toolkit: urlelicit
-            tools: ["*"]
+            tool: ["*"]
         guarded:
           authn_jwt:
             - urlelicit:authorize

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaConditionMatcher.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaConditionMatcher.java
@@ -16,81 +16,31 @@ package io.aklivity.zilla.runtime.binding.mcp.kafka.internal.config;
 
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import io.aklivity.zilla.config.binding.mcp.kafka.McpKafkaConditionConfig;
+import io.aklivity.zilla.runtime.common.lang.Matchers;
 
 final class McpKafkaConditionMatcher
 {
-    private final String tool;
+    private final List<Pattern> tool;
     private final List<Pattern> topics;
 
     McpKafkaConditionMatcher(
         McpKafkaConditionConfig condition)
     {
-        this.tool = condition.tool;
-        this.topics = compile(condition.topics);
+        this.tool = Matchers.globAll(condition.tool);
+        this.topics = Matchers.globAll(condition.topics);
     }
 
     boolean matchesTool(
         String tool)
     {
-        return this.tool == null || this.tool.equals(tool);
+        return Matchers.admits(this.tool, tool);
     }
 
     boolean matchesTopic(
         String topic)
     {
-        return topic == null || admits(topics, topic);
-    }
-
-    private static boolean admits(
-        List<Pattern> allow,
-        String name)
-    {
-        boolean result = allow == null;
-
-        if (!result)
-        {
-            for (Pattern pattern : allow)
-            {
-                if (pattern.matcher(name).matches())
-                {
-                    result = true;
-                    break;
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static List<Pattern> compile(
-        List<String> globs)
-    {
-        return globs == null
-            ? null
-            : globs.stream()
-                .map(McpKafkaConditionMatcher::compile)
-                .collect(Collectors.toList());
-    }
-
-    private static Pattern compile(
-        String glob)
-    {
-        final StringBuilder regex = new StringBuilder();
-        final String[] literals = glob.split("\\*", -1);
-        for (int index = 0; index < literals.length; index++)
-        {
-            if (index > 0)
-            {
-                regex.append(".*");
-            }
-            if (!literals[index].isEmpty())
-            {
-                regex.append(Pattern.quote(literals[index]));
-            }
-        }
-        return Pattern.compile(regex.toString());
+        return topic == null || Matchers.admits(topics, topic);
     }
 }

--- a/runtime/binding-mcp-kafka/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp-kafka/src/main/moditect/module-info.java
@@ -16,6 +16,7 @@ module io.aklivity.zilla.runtime.binding.mcp.kafka
 {
     requires io.aklivity.zilla.runtime.binding.kafka;
     requires io.aklivity.zilla.runtime.common.json;
+    requires io.aklivity.zilla.runtime.common.lang;
     requires io.aklivity.zilla.runtime.engine;
     requires io.aklivity.zilla.config.binding.mcp.kafka;
     requires io.aklivity.zilla.config.binding.kafka;

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaConditionMatcherTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaConditionMatcherTest.java
@@ -28,7 +28,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldMatchAnyTopicWhenTopicsNotGiven()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
 
@@ -40,7 +40,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldMatchTopicWithinAllowList()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList("orders", "shipments"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -53,7 +53,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldNotMatchTopicOutsideAllowList()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList("orders", "shipments"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -65,7 +65,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldMatchTopicByGlobPrefix()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList("orders*"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -80,7 +80,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldMatchAnyTopicByBareWildcard()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList("*"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -93,7 +93,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldEscapeRegexMetacharactersInLiteralSegments()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList("orders.eu"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -106,7 +106,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldNotMatchAnyTopicWhenAllowListEmpty()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .topics(asList())
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
@@ -118,7 +118,7 @@ public class McpKafkaConditionMatcherTest
     public void shouldMatchToolExactly()
     {
         McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
-            .tool("produce")
+            .tool(asList("produce"))
             .build();
         McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
 
@@ -135,5 +135,54 @@ public class McpKafkaConditionMatcherTest
 
         assertTrue(matcher.matchesTool("produce"));
         assertTrue(matcher.matchesTool("consume"));
+    }
+
+    @Test
+    public void shouldMatchToolWithinAllowList()
+    {
+        McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
+            .tool(asList("produce", "consume"))
+            .build();
+        McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
+
+        assertTrue(matcher.matchesTool("produce"));
+        assertTrue(matcher.matchesTool("consume"));
+        assertFalse(matcher.matchesTool("list_topics"));
+    }
+
+    @Test
+    public void shouldMatchToolByGlobPrefix()
+    {
+        McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
+            .tool(asList("list_*"))
+            .build();
+        McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
+
+        assertTrue(matcher.matchesTool("list_topics"));
+        assertTrue(matcher.matchesTool("list_brokers"));
+        assertFalse(matcher.matchesTool("produce"));
+    }
+
+    @Test
+    public void shouldMatchAnyToolByBareWildcard()
+    {
+        McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
+            .tool(asList("*"))
+            .build();
+        McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
+
+        assertTrue(matcher.matchesTool("produce"));
+        assertTrue(matcher.matchesTool("consume"));
+    }
+
+    @Test
+    public void shouldNotMatchAnyToolWhenAllowListEmpty()
+    {
+        McpKafkaConditionConfig condition = McpKafkaConditionConfig.builder()
+            .tool(asList())
+            .build();
+        McpKafkaConditionMatcher matcher = new McpKafkaConditionMatcher(condition);
+
+        assertFalse(matcher.matchesTool("produce"));
     }
 }

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactoryTest.java
@@ -111,7 +111,7 @@ public class McpKafkaClientFactoryTest
 
         RouteConfig route = RouteConfig.builder()
             .when(McpKafkaConditionConfig.builder()
-                .tool("produce")
+                .tool(List.of("produce"))
                 .build())
             .build();
 

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
@@ -164,7 +164,7 @@ public class McpKafkaProxyFactoryTest
         final RouteConfig route = RouteConfig.builder()
             .exit("kafka0")
             .when(McpKafkaConditionConfig.builder()
-                .tool(tool)
+                .tool(List.of(tool))
                 .build())
             .build();
         route.id = ROUTE_ID;

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -98,8 +98,6 @@ public final class McpOpenapiCompositeGenerator
 {
     private static final String CATALOG_NAME = "catalog0";
     private static final String BINDING_NAME = "mcp_http0";
-    private static final String CAPABILITY_TOOL = "tool";
-    private static final String CAPABILITY_RESOURCE = "resource";
     private static final String ANNOTATIONS_EXTENSION_NAME = "x-mcp-annotations";
     private static final String METHOD_GET = "get";
     private static final String METHOD_HEAD = "head";
@@ -169,7 +167,6 @@ public final class McpOpenapiCompositeGenerator
 
             String tool = null;
             String resource = null;
-            List<String> capability = null;
             for (McpOpenapiConditionConfig when : route.when)
             {
                 if (when.tool != null)
@@ -180,16 +177,6 @@ public final class McpOpenapiCompositeGenerator
                 {
                     resource = when.resource;
                 }
-                if (when.capability != null)
-                {
-                    capability = when.capability;
-                }
-            }
-
-            final boolean wantsResource = resource != null;
-            if (capability != null && !capability.contains(wantsResource ? CAPABILITY_RESOURCE : CAPABILITY_TOOL))
-            {
-                continue;
             }
 
             if (tool != null)

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -16,7 +16,6 @@ package io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.composite;
 
 import static io.aklivity.zilla.config.engine.KindConfig.CLIENT;
 import static io.aklivity.zilla.config.engine.KindConfig.PROXY;
-import static java.util.List.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -2709,7 +2708,7 @@ public class McpOpenapiCompositeGeneratorTest
     }
 
     @Test
-    public void shouldExcludeBulkOperationsFilteredOutByCapability()
+    public void shouldGenerateToolsForBulkTagRouteWithNoCondition()
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
@@ -2729,52 +2728,6 @@ public class McpOpenapiCompositeGeneratorTest
                     .build()
                 .build())
             .route()
-                .when(McpOpenapiConditionConfig.builder()
-                    .capability(of("resource"))
-                    .build())
-                .with(McpOpenapiWithConfig.builder()
-                    .spec("openapi_github0")
-                    .tag("reads")
-                    .build())
-                .build()
-            .build();
-        binding.resolveId = resolveId;
-
-        McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
-
-        BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
-            .findFirst()
-            .orElse(null);
-        McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
-        assertThat(mcpHttpOptions.tools, nullValue());
-        assertThat(mcpHttpOptions.resources, nullValue());
-    }
-
-    @Test
-    public void shouldIncludeBulkOperationsAdmittedByCapability()
-    {
-        BindingConfig binding = GenericBindingConfig.builder()
-            .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
-            .kind(CLIENT)
-            .options(McpOpenapiOptionsConfig.builder()
-                .spec()
-                    .label("openapi_github0")
-                    .server("https://api.github.com")
-                    .catalog()
-                        .name("catalog0")
-                        .subject("rest-api")
-                        .version("latest")
-                        .build()
-                    .security(Map.of("bearerAuth", "guard0", "oauthScheme", "guard0"))
-                    .build()
-                .build())
-            .route()
-                .when(McpOpenapiConditionConfig.builder()
-                    .capability(of("tool"))
-                    .build())
                 .with(McpOpenapiWithConfig.builder()
                     .spec("openapi_github0")
                     .tag("reads")

--- a/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
+++ b/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiBindingConfig;
 import io.aklivity.zilla.config.binding.mcp.openapi.McpOpenapiBindingConfigBuilder;
@@ -34,6 +33,7 @@ import io.aklivity.zilla.runtime.binding.mcp.schema.registry.internal.config.Mcp
 import io.aklivity.zilla.runtime.binding.mcp.schema.registry.internal.config.McpSchemaRegistryCompositeConfig;
 import io.aklivity.zilla.runtime.binding.mcp.schema.registry.internal.config.McpSchemaRegistryCompositeRouteConfig;
 import io.aklivity.zilla.runtime.binding.mcp.schema.registry.internal.config.McpSchemaRegistryRouteConfig;
+import io.aklivity.zilla.runtime.common.lang.Matchers;
 
 public final class McpSchemaRegistryCompositeGenerator
 {
@@ -129,10 +129,10 @@ public final class McpSchemaRegistryCompositeGenerator
     }
 
     private static boolean matchesTool(
-        String pattern,
+        List<String> patterns,
         String tool)
     {
-        return compileGlob(pattern).matcher(tool).matches();
+        return Matchers.admits(Matchers.globAll(patterns), tool);
     }
 
     private <C> McpOpenapiRouteConfigBuilder<C> injectGuarded(
@@ -158,28 +158,6 @@ public final class McpSchemaRegistryCompositeGenerator
     {
         roles.forEach(guarded::role);
         return guarded;
-    }
-
-    private static Pattern compileGlob(
-        String glob)
-    {
-        StringBuilder regex = new StringBuilder();
-        String[] literals = glob.split("\\*", -1);
-
-        for (int index = 0; index < literals.length; index++)
-        {
-            if (index > 0)
-            {
-                regex.append(".*");
-            }
-
-            if (!literals[index].isEmpty())
-            {
-                regex.append(Pattern.quote(literals[index]));
-            }
-        }
-
-        return Pattern.compile(regex.toString());
     }
 
     private static String loadBundledSpec()

--- a/runtime/binding-mcp-schema-registry/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp-schema-registry/src/main/moditect/module-info.java
@@ -17,6 +17,7 @@ module io.aklivity.zilla.runtime.binding.mcp.schema.registry
     requires io.aklivity.zilla.runtime.engine;
     requires io.aklivity.zilla.runtime.binding.mcp.openapi;
     requires io.aklivity.zilla.runtime.catalog.inline;
+    requires io.aklivity.zilla.runtime.common.lang;
     requires io.aklivity.zilla.config.binding.mcp.schema.registry;
     requires io.aklivity.zilla.config.binding.mcp.openapi;
     requires io.aklivity.zilla.config.catalog.inline;

--- a/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
@@ -161,12 +161,43 @@ public class McpSchemaRegistryCompositeGeneratorTest
                 .build())
             .route()
                 .when(McpSchemaRegistryConditionConfig.builder()
-                    .tool("list_*")
+                    .tool(List.of("list_*"))
                     .build())
                 .build()
             .route()
                 .when(McpSchemaRegistryConditionConfig.builder()
-                    .tool("get_schema")
+                    .tool(List.of("get_schema"))
+                    .build())
+                .build()
+            .build();
+
+        McpSchemaRegistryBindingConfig attached = new McpSchemaRegistryBindingConfig(context, binding);
+
+        McpSchemaRegistryCompositeConfig composite = generator.generate(attached);
+
+        BindingConfig mcpOpenapi = composite.namespaces.get(0).bindings.get(0);
+        List<String> routedTools = mcpOpenapi.routes.stream()
+            .map(route -> ((McpOpenapiConditionConfig) route.when.get(0)).tool)
+            .toList();
+
+        assertThat(routedTools, hasSize(2));
+        assertThat(routedTools, equalTo(List.of("list_subjects", "get_schema")));
+    }
+
+    @Test
+    public void shouldMatchAnyToolNameWithinSingleRouteAllowlist()
+    {
+        BindingConfig binding = GenericBindingConfig.builder()
+            .namespace("test")
+            .name("app0")
+            .type("mcp_schema_registry")
+            .kind(CLIENT)
+            .options(McpSchemaRegistryOptionsConfig.builder()
+                .server("http://localhost:8080")
+                .build())
+            .route()
+                .when(McpSchemaRegistryConditionConfig.builder()
+                    .tool(List.of("list_subjects", "get_schema"))
                     .build())
                 .build()
             .build();
@@ -199,7 +230,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
                 .build())
             .route()
                 .when(McpSchemaRegistryConditionConfig.builder()
-                    .tool("register_schema")
+                    .tool(List.of("register_schema"))
                     .build())
                 .guarded()
                     .name("jwt0")
@@ -282,7 +313,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
                 .build())
             .route()
                 .when(McpSchemaRegistryConditionConfig.builder()
-                    .tool("nonexistent_tool")
+                    .tool(List.of("nonexistent_tool"))
                     .build())
                 .build()
             .build();

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionMatcher.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionMatcher.java
@@ -23,9 +23,9 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import io.aklivity.zilla.config.binding.mcp.McpConditionConfig;
+import io.aklivity.zilla.runtime.common.lang.Matchers;
 
 final class McpConditionMatcher
 {
@@ -34,12 +34,12 @@ final class McpConditionMatcher
 
     final String toolkit;
 
-    private final String toolsPrefix;
-    private final String promptsPrefix;
-    private final String resourcesPrefix;
-    private final List<Pattern> toolsAllow;
-    private final List<Pattern> promptsAllow;
-    private final List<Pattern> resourcesAllow;
+    private final String toolPrefix;
+    private final String promptPrefix;
+    private final String resourcePrefix;
+    private final List<Pattern> toolAllow;
+    private final List<Pattern> promptAllow;
+    private final List<Pattern> resourceAllow;
 
     McpConditionMatcher(
         McpConditionConfig condition)
@@ -49,32 +49,32 @@ final class McpConditionMatcher
 
         // a capability is active when its own allow-set field is given; when none of the three
         // are given at all, the condition is unrestricted and every capability is active
-        final boolean anyAllowSet = condition.tools != null || condition.prompts != null || condition.resources != null;
-        final boolean tools = !anyAllowSet || condition.tools != null;
-        final boolean prompts = !anyAllowSet || condition.prompts != null;
-        final boolean resources = !anyAllowSet || condition.resources != null;
+        final boolean anyAllowSet = condition.tool != null || condition.prompt != null || condition.resource != null;
+        final boolean tool = !anyAllowSet || condition.tool != null;
+        final boolean prompt = !anyAllowSet || condition.prompt != null;
+        final boolean resource = !anyAllowSet || condition.resource != null;
 
-        this.toolsPrefix = tools ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
-        this.promptsPrefix = prompts ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
-        this.resourcesPrefix = resources ? (toolkit != null ? toolkit + DELIMITER_URI : "") : null;
+        this.toolPrefix = tool ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
+        this.promptPrefix = prompt ? (toolkit != null ? toolkit + DELIMITER_NAME : "") : null;
+        this.resourcePrefix = resource ? (toolkit != null ? toolkit + DELIMITER_URI : "") : null;
 
-        this.toolsAllow = compile(condition.tools);
-        this.promptsAllow = compile(condition.prompts);
-        this.resourcesAllow = compile(condition.resources);
+        this.toolAllow = Matchers.globAll(condition.tool);
+        this.promptAllow = Matchers.globAll(condition.prompt);
+        this.resourceAllow = Matchers.globAll(condition.resource);
     }
 
     int serverCapabilities()
     {
         int bits = 0;
-        if (toolsPrefix != null)
+        if (toolPrefix != null)
         {
             bits |= SERVER_TOOLS.value();
         }
-        if (promptsPrefix != null)
+        if (promptPrefix != null)
         {
             bits |= SERVER_PROMPTS.value();
         }
-        if (resourcesPrefix != null)
+        if (resourcePrefix != null)
         {
             bits |= SERVER_RESOURCES.value();
         }
@@ -91,7 +91,7 @@ final class McpConditionMatcher
         if (prefix != null && identifier != null && identifier.startsWith(prefix))
         {
             final String stripped = identifier.substring(prefix.length());
-            if (admits(allow(capability), stripped))
+            if (Matchers.admits(allow(capability), stripped))
             {
                 result = stripped;
             }
@@ -110,7 +110,7 @@ final class McpConditionMatcher
         String capability,
         String name)
     {
-        return serves(capability) && admits(allow(capability), name);
+        return serves(capability) && Matchers.admits(allow(capability), name);
     }
 
     boolean filters(
@@ -124,9 +124,9 @@ final class McpConditionMatcher
     {
         return switch (capability)
         {
-        case CAPABILITY_TOOLS -> toolsPrefix;
-        case CAPABILITY_PROMPTS -> promptsPrefix;
-        case CAPABILITY_RESOURCES -> resourcesPrefix;
+        case CAPABILITY_TOOLS -> toolPrefix;
+        case CAPABILITY_PROMPTS -> promptPrefix;
+        case CAPABILITY_RESOURCES -> resourcePrefix;
         default -> null;
         };
     }
@@ -136,60 +136,10 @@ final class McpConditionMatcher
     {
         return switch (capability)
         {
-        case CAPABILITY_TOOLS -> toolsAllow;
-        case CAPABILITY_PROMPTS -> promptsAllow;
-        case CAPABILITY_RESOURCES -> resourcesAllow;
+        case CAPABILITY_TOOLS -> toolAllow;
+        case CAPABILITY_PROMPTS -> promptAllow;
+        case CAPABILITY_RESOURCES -> resourceAllow;
         default -> null;
         };
-    }
-
-    private static boolean admits(
-        List<Pattern> allow,
-        String name)
-    {
-        boolean result = allow == null;
-
-        if (!result)
-        {
-            for (Pattern pattern : allow)
-            {
-                if (pattern.matcher(name).matches())
-                {
-                    result = true;
-                    break;
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static List<Pattern> compile(
-        List<String> globs)
-    {
-        return globs == null
-            ? null
-            : globs.stream()
-                .map(McpConditionMatcher::compile)
-                .collect(Collectors.toList());
-    }
-
-    private static Pattern compile(
-        String glob)
-    {
-        final StringBuilder regex = new StringBuilder();
-        final String[] literals = glob.split("\\*", -1);
-        for (int index = 0; index < literals.length; index++)
-        {
-            if (index > 0)
-            {
-                regex.append(".*");
-            }
-            if (!literals[index].isEmpty())
-            {
-                regex.append(Pattern.quote(literals[index]));
-            }
-        }
-        return Pattern.compile(regex.toString());
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfigTest.java
@@ -66,7 +66,7 @@ public class McpBindingConfigTest
             .exit("test")
             .when(McpConditionConfig.builder()
                 .toolkit(toolkit)
-                .tools(tools)
+                .tool(tools)
                 .build())
             .guarded()
                 .name(guardName)
@@ -85,7 +85,7 @@ public class McpBindingConfigTest
             .exit("test")
             .when(McpConditionConfig.builder()
                 .toolkit("alpha")
-                .tools(List.of("*"))
+                .tool(List.of("*"))
                 .build());
         if (withCredentials != null)
         {

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionMatcherTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpConditionMatcherTest.java
@@ -32,8 +32,8 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("create_*", "get_*"))
-            .resources(asList("repo://*"))
+            .tool(asList("create_*", "get_*"))
+            .resource(asList("repo://*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -47,8 +47,8 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("create_*", "get_*"))
-            .resources(asList("repo://*"))
+            .tool(asList("create_*", "get_*"))
+            .resource(asList("repo://*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -61,7 +61,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("*"))
+            .tool(asList("*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -74,7 +74,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("slack")
-            .tools(emptyList())
+            .tool(emptyList())
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -86,7 +86,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("slack")
-            .tools(emptyList())
+            .tool(emptyList())
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -114,8 +114,8 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("get_*"))
-            .resources(asList("*"))
+            .tool(asList("get_*"))
+            .resource(asList("*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -130,7 +130,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("get_*"))
+            .tool(asList("get_*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -144,7 +144,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .tools(asList("*"))
+            .tool(asList("*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 
@@ -156,7 +156,7 @@ public class McpConditionMatcherTest
     {
         McpConditionConfig condition = McpConditionConfig.builder()
             .toolkit("github")
-            .resources(asList("*"))
+            .resource(asList("*"))
             .build();
         McpConditionMatcher matcher = new McpConditionMatcher(condition);
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStrings.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStrings.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+/**
+ * Reads and writes a {@code string | string[]} shorthand-permissive JSON property as a
+ * {@code List<String>}, for config adapters whose field accepts either a bare string or an
+ * array of strings.
+ */
+public final class JsonStrings
+{
+    private JsonStrings()
+    {
+    }
+
+    /**
+     * Returns {@code null} when {@code name} is absent from {@code object}, a singleton list
+     * when its value is a bare string, or the mapped list of elements when its value is an array.
+     */
+    public static List<String> asStringOrArray(
+        JsonObject object,
+        String name)
+    {
+        List<String> result = null;
+
+        if (object.containsKey(name))
+        {
+            JsonValue value = object.get(name);
+            result = value.getValueType() == JsonValue.ValueType.ARRAY
+                ? value.asJsonArray().stream()
+                    .map(JsonString.class::cast)
+                    .map(JsonString::getString)
+                    .collect(toList())
+                : List.of(((JsonString) value).getString());
+        }
+
+        return result;
+    }
+
+    /**
+     * Adds nothing when {@code values} is {@code null}; otherwise adds {@code name} as a bare
+     * string when {@code values} has exactly one element, or as an array otherwise (including
+     * an empty array, distinct from {@code null}, meaning "admit nothing" to an allow-set caller).
+     */
+    public static void addStringOrArray(
+        JsonObjectBuilder builder,
+        String name,
+        List<String> values)
+    {
+        if (values != null)
+        {
+            if (values.size() == 1)
+            {
+                builder.add(name, values.get(0));
+            }
+            else
+            {
+                JsonArrayBuilder array = Json.createArrayBuilder();
+                values.forEach(array::add);
+                builder.add(name, array);
+            }
+        }
+    }
+}

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonStringsTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonStringsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import org.junit.jupiter.api.Test;
+
+class JsonStringsTest
+{
+    @Test
+    void shouldReturnNullWhenNameAbsent()
+    {
+        JsonObject object = Json.createObjectBuilder().build();
+
+        assertNull(JsonStrings.asStringOrArray(object, "tool"));
+    }
+
+    @Test
+    void shouldReadBareStringAsSingletonList()
+    {
+        JsonObject object = Json.createObjectBuilder()
+            .add("tool", "produce")
+            .build();
+
+        assertEquals(List.of("produce"), JsonStrings.asStringOrArray(object, "tool"));
+    }
+
+    @Test
+    void shouldReadArrayAsList()
+    {
+        JsonObject object = Json.createObjectBuilder()
+            .add("tool", Json.createArrayBuilder().add("produce").add("consume"))
+            .build();
+
+        assertEquals(List.of("produce", "consume"), JsonStrings.asStringOrArray(object, "tool"));
+    }
+
+    @Test
+    void shouldNotAddAnythingWhenValuesNull()
+    {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+
+        JsonStrings.addStringOrArray(builder, "tool", null);
+
+        assertEquals(Json.createObjectBuilder().build(), builder.build());
+    }
+
+    @Test
+    void shouldWriteEmptyListAsEmptyArray()
+    {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+
+        JsonStrings.addStringOrArray(builder, "tool", List.of());
+
+        JsonObject expected = Json.createObjectBuilder().add("tool", Json.createArrayBuilder()).build();
+        assertEquals(expected, builder.build());
+    }
+
+    @Test
+    void shouldWriteSingleValueAsBareString()
+    {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+
+        JsonStrings.addStringOrArray(builder, "tool", List.of("produce"));
+
+        JsonObject expected = Json.createObjectBuilder().add("tool", "produce").build();
+        assertEquals(expected, builder.build());
+    }
+
+    @Test
+    void shouldWriteMultipleValuesAsArray()
+    {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+
+        JsonStrings.addStringOrArray(builder, "tool", asList("produce", "consume"));
+
+        JsonObject expected = Json.createObjectBuilder()
+            .add("tool", Json.createArrayBuilder().add("produce").add("consume"))
+            .build();
+        assertEquals(expected, builder.build());
+    }
+}

--- a/runtime/common-lang/src/main/java/io/aklivity/zilla/runtime/common/lang/Matchers.java
+++ b/runtime/common-lang/src/main/java/io/aklivity/zilla/runtime/common/lang/Matchers.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.lang;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Glob-pattern compilation and allow-list matching shared by route condition matchers that
+ * accept a {@code *}-wildcard glob (e.g. an MCP binding's {@code tool}/{@code prompt}/
+ * {@code resource} condition), so the split-quote-join compile algorithm and null-means-
+ * unrestricted allow-list semantics live in one place instead of being copied per binding.
+ */
+public final class Matchers
+{
+    private Matchers()
+    {
+    }
+
+    /**
+     * Compiles a single {@code *}-wildcard glob into a whole-string-matching {@link Pattern},
+     * quoting literal segments so regex metacharacters other than {@code *} are matched literally.
+     */
+    public static Pattern glob(
+        String glob)
+    {
+        final StringBuilder regex = new StringBuilder();
+        final String[] literals = glob.split("\\*", -1);
+        for (int index = 0; index < literals.length; index++)
+        {
+            if (index > 0)
+            {
+                regex.append(".*");
+            }
+            if (!literals[index].isEmpty())
+            {
+                regex.append(Pattern.quote(literals[index]));
+            }
+        }
+        return Pattern.compile(regex.toString());
+    }
+
+    /**
+     * Compiles each glob in {@code globs}, preserving {@code null} (meaning "unrestricted")
+     * rather than compiling an empty list.
+     */
+    public static List<Pattern> globAll(
+        List<String> globs)
+    {
+        return globs == null
+            ? null
+            : globs.stream()
+                .map(Matchers::glob)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Whether {@code name} is admitted by {@code allow}: {@code true} when {@code allow} is
+     * {@code null} (unrestricted), otherwise {@code true} when any pattern in {@code allow}
+     * matches {@code name}.
+     */
+    public static boolean admits(
+        List<Pattern> allow,
+        String name)
+    {
+        boolean result = allow == null;
+
+        if (!result)
+        {
+            for (Pattern pattern : allow)
+            {
+                if (pattern.matcher(name).matches())
+                {
+                    result = true;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/runtime/common-lang/src/test/java/io/aklivity/zilla/runtime/common/lang/MatchersTest.java
+++ b/runtime/common-lang/src/test/java/io/aklivity/zilla/runtime/common/lang/MatchersTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.lang;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+public class MatchersTest
+{
+    @Test
+    public void shouldMatchLiteralGlob()
+    {
+        Pattern pattern = Matchers.glob("produce");
+
+        assertTrue(pattern.matcher("produce").matches());
+        assertFalse(pattern.matcher("consume").matches());
+    }
+
+    @Test
+    public void shouldMatchGlobByPrefix()
+    {
+        Pattern pattern = Matchers.glob("orders*");
+
+        assertTrue(pattern.matcher("orders").matches());
+        assertTrue(pattern.matcher("orders-eu").matches());
+        assertFalse(pattern.matcher("shipments").matches());
+    }
+
+    @Test
+    public void shouldMatchAnyByBareWildcard()
+    {
+        Pattern pattern = Matchers.glob("*");
+
+        assertTrue(pattern.matcher("orders").matches());
+        assertTrue(pattern.matcher("").matches());
+    }
+
+    @Test
+    public void shouldEscapeRegexMetacharactersInLiteralSegments()
+    {
+        Pattern pattern = Matchers.glob("orders.eu");
+
+        assertTrue(pattern.matcher("orders.eu").matches());
+        assertFalse(pattern.matcher("ordersXeu").matches());
+    }
+
+    @Test
+    public void shouldMatchGlobWithMultipleWildcards()
+    {
+        Pattern pattern = Matchers.glob("get_*_by_*");
+
+        assertTrue(pattern.matcher("get_order_by_id").matches());
+        assertFalse(pattern.matcher("get_order").matches());
+    }
+
+    @Test
+    public void shouldReturnNullWhenCompilingNullGlobList()
+    {
+        assertNull(Matchers.globAll(null));
+    }
+
+    @Test
+    public void shouldCompileEachGlobInList()
+    {
+        List<Pattern> patterns = Matchers.globAll(asList("orders*", "shipments"));
+
+        assertTrue(patterns.get(0).matcher("orders-eu").matches());
+        assertTrue(patterns.get(1).matcher("shipments").matches());
+    }
+
+    @Test
+    public void shouldAdmitAnyNameWhenAllowListNull()
+    {
+        assertTrue(Matchers.admits(null, "orders"));
+        assertTrue(Matchers.admits(null, "anything"));
+    }
+
+    @Test
+    public void shouldNotAdmitAnyNameWhenAllowListEmpty()
+    {
+        assertFalse(Matchers.admits(List.of(), "orders"));
+    }
+
+    @Test
+    public void shouldAdmitNameWithinAllowList()
+    {
+        List<Pattern> allow = Matchers.globAll(asList("orders", "shipments"));
+
+        assertTrue(Matchers.admits(allow, "orders"));
+        assertTrue(Matchers.admits(allow, "shipments"));
+        assertFalse(Matchers.admits(allow, "payments"));
+    }
+
+    @Test
+    public void shouldAdmitNameMatchingGlobWithinAllowList()
+    {
+        List<Pattern> allow = Matchers.globAll(asList("orders*"));
+
+        assertTrue(Matchers.admits(allow, "orders"));
+        assertTrue(Matchers.admits(allow, "orders-eu"));
+        assertFalse(Matchers.admits(allow, "shipments"));
+    }
+}

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.allowlist.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.allowlist.yaml
@@ -16,12 +16,12 @@
 ---
 name: test
 bindings:
-  app0:
-    type: mcp_openapi
+  mcp0:
+    type: mcp_kafka
     kind: client
+    options:
+      servers:
+        - localhost:9092
     routes:
       - when:
-          - capability: [ bogus ]
-        with:
-          spec: github
-          tag: pulls
+          - tool: [produce, consume]

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.glob.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.glob.yaml
@@ -16,25 +16,12 @@
 ---
 name: test
 bindings:
-  app0:
-    type: mcp_openapi
+  mcp0:
+    type: mcp_kafka
     kind: client
     options:
-      specs:
-        github:
-          catalog:
-            catalog0:
-              subject: github
-              version: latest
+      servers:
+        - localhost:9092
     routes:
-      - with:
-          spec: github
-      - with:
-          spec: github
-          tag: pulls
-      - with:
-          spec: github
-          operation: "pulls/*"
-      - with:
-          spec: github
-          tag: issues
+      - when:
+          - tool: "list_*"

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/schema/mcp.kafka.schema.patch.json
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/schema/mcp.kafka.schema.patch.json
@@ -63,7 +63,11 @@
                                             "tool":
                                             {
                                                 "title": "Tool Name",
-                                                "type": "string"
+                                                "oneOf":
+                                                [
+                                                    { "type": "string" },
+                                                    { "type": "array", "items": { "type": "string" } }
+                                                ]
                                             },
                                             "resource":
                                             {
@@ -202,7 +206,11 @@
                                             "tool":
                                             {
                                                 "title": "Tool Name",
-                                                "type": "string"
+                                                "oneOf":
+                                                [
+                                                    { "type": "string" },
+                                                    { "type": "array", "items": { "type": "string" } }
+                                                ]
                                             },
                                             "resource":
                                             {

--- a/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/config/SchemaTest.java
+++ b/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/config/SchemaTest.java
@@ -157,4 +157,20 @@ public class SchemaTest
 
         assertThat(config, not(nullValue()));
     }
+
+    @Test
+    public void shouldValidateClientToolAllowlist()
+    {
+        JsonObject config = schema.validate("client.tool.allowlist.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateClientToolGlob()
+    {
+        JsonObject config = schema.validate("client.tool.glob.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
 }

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -305,17 +305,6 @@
                                             {
                                                 "title": "Resource",
                                                 "type": "string"
-                                            },
-                                            "capability":
-                                            {
-                                                "title": "Capability",
-                                                "type": "array",
-                                                "items":
-                                                {
-                                                    "enum": [ "tool", "resource" ]
-                                                },
-                                                "minItems": 1,
-                                                "uniqueItems": true
                                             }
                                         },
                                         "additionalProperties": false

--- a/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
+++ b/specs/binding-mcp-openapi.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/openapi/config/SchemaTest.java
@@ -104,12 +104,6 @@ public class SchemaTest
     }
 
     @Test(expected = JsonException.class)
-    public void shouldRejectUnknownCapability()
-    {
-        schema.validate("proxy.route.capability.invalid.yaml");
-    }
-
-    @Test(expected = JsonException.class)
     public void shouldRejectMissingRoutes()
     {
         schema.validate("proxy.routes.missing.invalid.yaml");

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.tool.array.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.tool.array.yaml
@@ -17,24 +17,10 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp_schema_registry
     kind: client
     options:
-      specs:
-        github:
-          catalog:
-            catalog0:
-              subject: github
-              version: latest
+      server: http://localhost:8080
     routes:
-      - with:
-          spec: github
-      - with:
-          spec: github
-          tag: pulls
-      - with:
-          spec: github
-          operation: "pulls/*"
-      - with:
-          spec: github
-          tag: issues
+      - when:
+          - tool: [list_subjects, get_schema]

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/schema/mcp_schema_registry.schema.patch.json
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/schema/mcp_schema_registry.schema.patch.json
@@ -57,7 +57,11 @@
                                             "tool":
                                             {
                                                 "title": "Tool name or glob pattern",
-                                                "type": "string"
+                                                "oneOf":
+                                                [
+                                                    { "type": "string" },
+                                                    { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+                                                ]
                                             }
                                         },
                                         "required": [ "tool" ],

--- a/specs/binding-mcp-schema-registry.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/SchemaTest.java
+++ b/specs/binding-mcp-schema-registry.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/SchemaTest.java
@@ -74,4 +74,12 @@ public class SchemaTest
     {
         schema.validate("proxy.route.with.invalid.yaml");
     }
+
+    @Test
+    public void shouldValidateRouteWithToolArray()
+    {
+        JsonObject config = schema.validate("proxy.routes.tool.array.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
 }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.per.tool.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.per.tool.yaml
@@ -29,11 +29,11 @@ bindings:
     routes:
       - exit: net0
         when:
-          - tools:
+          - tool:
               - get_weather
       - exit: net0
         when:
-          - tools:
+          - tool:
               - get_status
         guarded:
           test0: []

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.roles.per.tool.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/client.guarded.roles.per.tool.yaml
@@ -35,14 +35,14 @@ bindings:
     routes:
       - exit: net0
         when:
-          - tools:
+          - tool:
               - get_weather
         guarded:
           test0:
             - read
       - exit: net0
         when:
-          - tools:
+          - tool:
               - get_status
         guarded:
           test1:

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.credentials.toolkit.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.credentials.toolkit.yaml
@@ -36,7 +36,7 @@ bindings:
       - exit: app1
         when:
           - toolkit: alpha
-            tools: ["*"]
+            tool: ["*"]
         with:
           cache:
             credentials: "{token}"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.seeded.toolkit.multi.yaml
@@ -33,8 +33,8 @@ bindings:
       - exit: app1
         when:
           - toolkit: bluesky
-            tools: ["*"]
+            tool: ["*"]
       - exit: app2
         when:
           - toolkit: quartz
-            tools: ["*"]
+            tool: ["*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.filter.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.filter.yaml
@@ -29,4 +29,4 @@ bindings:
       - exit: app1
         when:
           - toolkit: bluesky
-            tools: ["get_*"]
+            tool: ["get_*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.refresh.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.refresh.yaml
@@ -30,8 +30,8 @@ bindings:
       - exit: app1
         when:
           - toolkit: bluesky
-            tools: ["*"]
+            tool: ["*"]
       - exit: app2
         when:
           - toolkit: quartz
-            tools: ["*"]
+            tool: ["*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.cache.toolkit.multi.yaml
@@ -29,8 +29,8 @@ bindings:
       - exit: app1
         when:
           - toolkit: bluesky
-            tools: ["*"]
+            tool: ["*"]
       - exit: app2
         when:
           - toolkit: quartz
-            tools: ["*"]
+            tool: ["*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.filter.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.filter.yaml
@@ -23,9 +23,9 @@ bindings:
       - exit: app1
         when:
           - toolkit: github
-            tools: ["create_*", "get_*"]
-            resources: ["repo://*"]
+            tool: ["create_*", "get_*"]
+            resource: ["repo://*"]
       - exit: app2
         when:
           - toolkit: slack
-            tools: []
+            tool: []

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.routes.missing.toolkit.invalid.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.routes.missing.toolkit.invalid.yaml
@@ -22,4 +22,4 @@ bindings:
     routes:
       - exit: app1
         when:
-          - tools: ["get_*"]
+          - tool: ["get_*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.filter.shorthand.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.filter.shorthand.yaml
@@ -17,24 +17,10 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
-    kind: client
-    options:
-      specs:
-        github:
-          catalog:
-            catalog0:
-              subject: github
-              version: latest
+    type: mcp
+    kind: proxy
     routes:
-      - with:
-          spec: github
-      - with:
-          spec: github
-          tag: pulls
-      - with:
-          spec: github
-          operation: "pulls/*"
-      - with:
-          spec: github
-          tag: issues
+      - exit: app1
+        when:
+          - toolkit: bluesky
+            tool: get_weather

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.filter.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/proxy.toolkit.filter.yaml
@@ -23,4 +23,4 @@ bindings:
       - exit: app1
         when:
           - toolkit: bluesky
-            tools: ["get_*"]
+            tool: ["get_*"]

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/mcp.schema.patch.json
@@ -182,32 +182,32 @@
                                                     "type": "object",
                                                     "properties":
                                                     {
-                                                        "tools":
+                                                        "tool":
                                                         {
-                                                            "title": "Tools",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Tool",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         },
-                                                        "prompts":
+                                                        "prompt":
                                                         {
-                                                            "title": "Prompts",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Prompt",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         },
-                                                        "resources":
+                                                        "resource":
                                                         {
-                                                            "title": "Resources",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Resource",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         }
                                                     },
                                                     "additionalProperties": false
@@ -426,32 +426,32 @@
                                                             "title": "Toolkit",
                                                             "type": "string"
                                                         },
-                                                        "tools":
+                                                        "tool":
                                                         {
-                                                            "title": "Tools",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Tool",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         },
-                                                        "prompts":
+                                                        "prompt":
                                                         {
-                                                            "title": "Prompts",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Prompt",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         },
-                                                        "resources":
+                                                        "resource":
                                                         {
-                                                            "title": "Resources",
-                                                            "type": "array",
-                                                            "items":
-                                                            {
-                                                                "type": "string"
-                                                            }
+                                                            "title": "Resource",
+                                                            "oneOf":
+                                                            [
+                                                                { "type": "string" },
+                                                                { "type": "array", "items": { "type": "string" } }
+                                                            ]
                                                         }
                                                     },
                                                     "required": [ "toolkit" ],

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/config/SchemaTest.java
@@ -65,6 +65,14 @@ public class SchemaTest
         assertThat(config, not(nullValue()));
     }
 
+    @Test
+    public void shouldValidateProxyToolkitFilterShorthand()
+    {
+        JsonObject config = schema.validate("proxy.toolkit.filter.shorthand.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
     @Test(expected = JsonException.class)
     public void shouldRejectProxyRouteMissingToolkit()
     {


### PR DESCRIPTION
## Description

Unifies the mcp-family binding route condition naming/shape, per the design in #2253:

- **`mcp` (base)**: `tools`/`prompts`/`resources` → `tool`/`prompt`/`resource`, now accepting a bare string as shorthand for a single-element array (in addition to the existing glob-capable array form)
- **`mcp_kafka`**: `tool` widened from exact-match `String` to glob-capable `string | string[]`
- **`mcp_schema_registry`**: `tool` widened the same way; its composite generator's existing glob-matching logic now iterates the new list shape instead of a single string
- **`mcp_openapi`**: removes the leftover `capability` condition field — a pre-GA cleanup that should have landed alongside #2047/#2046 when the equivalent field was removed from the base `mcp` binding, but was missed for this binding. Verified via the composite generator's actual logic that `capability` was a redundant route-level gate that could never do more than admit-or-reject an already-uniformly tool-shaped bulk match (no bulk resource generation is actually implemented), so removing it changes no observable behavior — routing is now driven purely by presence of `tool`/`resource`, mirroring the base `mcp` binding's existing pattern
- **`mcp_http`**: unchanged, as scoped by the issue

Also extracts two small shared utilities used by the above, to stop the glob-compile and `string | string[]` adapter logic from being copy-pasted per binding:
- `Matchers` (`runtime/common-lang`) — glob-pattern compilation and null-means-unrestricted allow-list matching
- `JsonStrings` (`runtime/common-json`) — reads/writes a `string | string[]` shorthand-permissive JSON property as a `List<String>`

All existing spec fixtures were renamed in place; new fixtures were added covering the bare-string shorthand and array/glob forms for each binding.

## Test plan

- [x] `./mvnw test` — unit tests pass for all touched modules (`common-lang`, `common-json`, all four `*.conf` modules, all four runtime binding modules)
- [x] `./mvnw verify` — k3po integration tests pass for `specs/binding-mcp.spec`, `specs/binding-mcp-kafka.spec`, `specs/binding-mcp-openapi.spec`, `specs/binding-mcp-schema-registry.spec`, and their corresponding `runtime/binding-mcp*` modules
- [x] Full reactor `./mvnw clean install -DskipTests` succeeds end-to-end (only the final `docker-image` module fails, due to no Docker daemon being available in the sandbox this was built in — unrelated to this change)

Fixes #2253

---

A companion docs update is at aklivity/zilla-docs#(pending) to keep the `mcp` binding reference pages in sync.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn8Qvoir4yDrwyuXTucLS4)_