### PR TITLE
fix(binding-mcp): fall back to annotations.title for tool title collisions

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguator.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguator.java
@@ -40,12 +40,16 @@ import jakarta.json.JsonWriter;
 // distinct toolkits. A route with no toolkit configured has no identifier to disambiguate with, so
 // its items never contribute to collision detection and are never themselves rewritten -- a title
 // shared with only one other toolkit-identified route (or with a toolkit-less route) is left alone.
+// Per the MCP spec's own display precedence order (title, then annotations.title, then name), the
+// effective title checked for a collision -- and the one rewritten -- is the top-level "title" when
+// present, falling back to "annotations.title" only when the tool has no top-level title at all.
 // This runs once per cache hydration cycle (not on the request hot path), so the jakarta.json object
 // model is used freely, mirroring McpProxyCacheHydrater's own per-item JSON rewrites (nameFirst,
 // injectToolScopes).
 final class McpToolTitleDisambiguator
 {
     private static final String TITLE = "title";
+    private static final String ANNOTATIONS = "annotations";
 
     private McpToolTitleDisambiguator()
     {
@@ -75,7 +79,7 @@ final class McpToolTitleDisambiguator
             {
                 for (JsonObject item : parsed)
                 {
-                    final String title = item.getString(TITLE, null);
+                    final String title = effectiveTitle(item);
                     if (title != null)
                     {
                         toolkitsByTitle.computeIfAbsent(title, t -> new LinkedHashSet<>()).add(toolkit);
@@ -120,7 +124,7 @@ final class McpToolTitleDisambiguator
 
         for (JsonObject item : items)
         {
-            final String title = item.getString(TITLE, null);
+            final String title = effectiveTitle(item);
             if (title != null && collidingTitles.contains(title))
             {
                 rewritten.add(withDisambiguatedTitle(item, title, toolkit));
@@ -135,16 +139,39 @@ final class McpToolTitleDisambiguator
         return changed ? writeItems(rewritten) : null;
     }
 
+    private static String effectiveTitle(
+        JsonObject item)
+    {
+        final String title = item.getString(TITLE, null);
+        return title != null ? title : annotationsTitle(item);
+    }
+
+    private static String annotationsTitle(
+        JsonObject item)
+    {
+        return item.get(ANNOTATIONS) instanceof JsonObject annotations ? annotations.getString(TITLE, null) : null;
+    }
+
     private static JsonObject withDisambiguatedTitle(
         JsonObject item,
         String title,
         String toolkit)
     {
         final String disambiguated = title + " (" + toolkit + ")";
+        return item.containsKey(TITLE)
+            ? withField(item, TITLE, Json.createValue(disambiguated))
+            : withField(item, ANNOTATIONS, withField(item.getJsonObject(ANNOTATIONS), TITLE, Json.createValue(disambiguated)));
+    }
+
+    private static JsonObject withField(
+        JsonObject object,
+        String key,
+        JsonValue value)
+    {
         final JsonObjectBuilder builder = Json.createObjectBuilder();
-        for (Map.Entry<String, JsonValue> field : item.entrySet())
+        for (Map.Entry<String, JsonValue> field : object.entrySet())
         {
-            builder.add(field.getKey(), TITLE.equals(field.getKey()) ? Json.createValue(disambiguated) : field.getValue());
+            builder.add(field.getKey(), key.equals(field.getKey()) ? value : field.getValue());
         }
         return builder.build();
     }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguatorTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/cache/McpToolTitleDisambiguatorTest.java
@@ -135,4 +135,75 @@ public class McpToolTitleDisambiguatorTest
         assertEquals("{\"name\":\"bluesky__send_message\"}", fragments.get("bluesky__"));
         assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}", fragments.get("quartz__"));
     }
+
+    @Test
+    public void shouldFallBackToAnnotationsTitleWhenTopLevelTitleAbsent()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__",
+            "{\"name\":\"bluesky__send_message\",\"annotations\":{\"title\":\"Send Message\",\"readOnlyHint\":true}}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message\"}}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals(
+            "{\"name\":\"bluesky__send_message\"," +
+            "\"annotations\":{\"title\":\"Send Message (bluesky)\",\"readOnlyHint\":true}}",
+            fragments.get("bluesky__"));
+        assertEquals(
+            "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message (quartz)\"}}",
+            fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldPreferTopLevelTitleOverAnnotationsTitleForCollisionAndRewrite()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__",
+            "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"," +
+            "\"annotations\":{\"title\":\"Different Title\"}}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"title\":\"Send Message\"}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals(
+            "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message (bluesky)\"," +
+            "\"annotations\":{\"title\":\"Different Title\"}}",
+            fragments.get("bluesky__"));
+        assertEquals("{\"name\":\"quartz__send_message\",\"title\":\"Send Message (quartz)\"}", fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldDisambiguateAcrossTopLevelTitleAndAnnotationsTitleFallback()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\",\"title\":\"Send Message\"}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message\"}}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"bluesky__send_message\",\"title\":\"Send Message (bluesky)\"}", fragments.get("bluesky__"));
+        assertEquals(
+            "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message (quartz)\"}}",
+            fragments.get("quartz__"));
+    }
+
+    @Test
+    public void shouldLeaveItemsWithoutTitleOrAnnotationsTitleUnchanged()
+    {
+        final Map<String, String> fragments = new LinkedHashMap<>();
+        fragments.put("bluesky__", "{\"name\":\"bluesky__send_message\",\"annotations\":{\"readOnlyHint\":true}}");
+        fragments.put("quartz__", "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message\"}}");
+        final Map<String, String> toolkits = Map.of("bluesky__", "bluesky", "quartz__", "quartz");
+
+        McpToolTitleDisambiguator.disambiguate(fragments, toolkits);
+
+        assertEquals("{\"name\":\"bluesky__send_message\",\"annotations\":{\"readOnlyHint\":true}}", fragments.get("bluesky__"));
+        assertEquals(
+            "{\"name\":\"quartz__send_message\",\"annotations\":{\"title\":\"Send Message\"}}",
+            fragments.get("quartz__"));
+    }
 }


### PR DESCRIPTION
## Description

Follow-up to #2262 / #2260. `McpToolTitleDisambiguator` previously only checked the top-level `title` field. Per the MCP spec's own documented display precedence — `title`, then `annotations.title`, then `name` (schema/2025-11-25/schema.ts, `Tool.annotations` doc comment: "Display name precedence order is: title, annotations.title, then name.") — a tool with no top-level `title` can still have a client-visible display label via `annotations.title`, which was previously invisible to collision detection entirely.

This adds `annotations.title` as a fallback:
- The effective title used for collision detection is `title` when present, else `annotations.title`.
- When disambiguating, the field actually rewritten is whichever one held the effective title — top-level `title` when present, `annotations.title` only when the tool has no top-level title.
- Behavior is otherwise unchanged: collision-only, cache path only (`options.cache.tools`), toolkit-less routes never contribute to or receive disambiguation.

## Testing

- New unit tests in `McpToolTitleDisambiguatorTest`: fallback to `annotations.title` when top-level `title` is absent, preference for top-level `title` over `annotations.title` when both are present, cross-field collision (one tool's top-level `title` colliding with another's `annotations.title` fallback), and items with neither field left unchanged.
- `./mvnw clean verify -pl runtime/binding-mcp` passes in full (165 unit tests, 285 integration tests, checkstyle, license headers, JaCoCo coverage).

Fixes #2270
Refs #2260


---
_Generated by [Claude Code](https://claude.ai/code/session_01GigP5EY5KusjbJASWMhm7k)_