### PR TITLE
fix(binding-mcp): use hyphenated type names for mcp-* bindings

### DIFF
--- a/config/binding-mcp-http.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/http/internal/McpHttpBindingInfo.java
+++ b/config/binding-mcp-http.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/http/internal/McpHttpBindingInfo.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.config.engine.WithConfig;
 
 public final class McpHttpBindingInfo implements BindingInfo
 {
-    public static final String TYPE = "mcp_http";
+    public static final String TYPE = "mcp-http";
 
     @Override
     public String type()

--- a/config/binding-mcp-http.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/http/McpHttpBindingConfigBuilderTest.java
+++ b/config/binding-mcp-http.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/http/McpHttpBindingConfigBuilderTest.java
@@ -34,7 +34,7 @@ public class McpHttpBindingConfigBuilderTest
     {
         McpHttpBindingConfig binding = McpHttpBindingConfig.builder()
             .namespace("test")
-            .name("mcp_http0")
+            .name("mcp-http0")
             .kind(PROXY)
             .options()
                 .tool(McpHttpToolConfig.builder()
@@ -52,7 +52,7 @@ public class McpHttpBindingConfigBuilderTest
             .build();
 
         assertThat(binding.namespace, equalTo("test"));
-        assertThat(binding.name, equalTo("mcp_http0"));
+        assertThat(binding.name, equalTo("mcp-http0"));
         assertThat(binding.type, equalTo(McpHttpBindingInfo.TYPE));
         assertThat(binding.kind, equalTo(PROXY));
 

--- a/config/binding-mcp-http.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/http/internal/McpHttpBindingInfoTest.java
+++ b/config/binding-mcp-http.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/http/internal/McpHttpBindingInfoTest.java
@@ -29,7 +29,7 @@ public class McpHttpBindingInfoTest
     @Test
     public void shouldResolveType()
     {
-        assertThat(info.type(), equalTo("mcp_http"));
+        assertThat(info.type(), equalTo("mcp-http"));
     }
 
     @Test

--- a/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaBindingInfo.java
+++ b/config/binding-mcp-kafka.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaBindingInfo.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class McpKafkaBindingInfo implements BindingInfo
 {
-    public static final String TYPE = "mcp_kafka";
+    public static final String TYPE = "mcp-kafka";
 
     @Override
     public String type()

--- a/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaBindingConfigBuilderTest.java
+++ b/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/McpKafkaBindingConfigBuilderTest.java
@@ -35,7 +35,7 @@ public class McpKafkaBindingConfigBuilderTest
     {
         McpKafkaBindingConfig binding = McpKafkaBindingConfig.builder()
             .namespace("test")
-            .name("mcp_kafka0")
+            .name("mcp-kafka0")
             .kind(SERVER)
             .options()
                 .server()
@@ -51,7 +51,7 @@ public class McpKafkaBindingConfigBuilderTest
             .build();
 
         assertThat(binding.namespace, equalTo("test"));
-        assertThat(binding.name, equalTo("mcp_kafka0"));
+        assertThat(binding.name, equalTo("mcp-kafka0"));
         assertThat(binding.type, equalTo(McpKafkaBindingInfo.TYPE));
         assertThat(binding.kind, equalTo(SERVER));
 

--- a/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaBindingInfoTest.java
+++ b/config/binding-mcp-kafka.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/kafka/internal/McpKafkaBindingInfoTest.java
@@ -29,7 +29,7 @@ public class McpKafkaBindingInfoTest
     @Test
     public void shouldResolveType()
     {
-        assertThat(info.type(), equalTo("mcp_kafka"));
+        assertThat(info.type(), equalTo("mcp-kafka"));
     }
 
     @Test

--- a/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiBindingInfo.java
+++ b/config/binding-mcp-openapi.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiBindingInfo.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.config.engine.WithConfig;
 
 public final class McpOpenapiBindingInfo implements BindingInfo
 {
-    public static final String TYPE = "mcp_openapi";
+    public static final String TYPE = "mcp-openapi";
 
     @Override
     public String type()

--- a/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiBindingConfigBuilderTest.java
+++ b/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/McpOpenapiBindingConfigBuilderTest.java
@@ -34,7 +34,7 @@ public class McpOpenapiBindingConfigBuilderTest
     {
         McpOpenapiBindingConfig binding = McpOpenapiBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
+            .name("mcp-openapi0")
             .kind(CLIENT)
             .options()
                 .spec()
@@ -54,7 +54,7 @@ public class McpOpenapiBindingConfigBuilderTest
             .build();
 
         assertThat(binding.namespace, equalTo("test"));
-        assertThat(binding.name, equalTo("mcp_openapi0"));
+        assertThat(binding.name, equalTo("mcp-openapi0"));
         assertThat(binding.type, equalTo(McpOpenapiBindingInfo.TYPE));
         assertThat(binding.kind, equalTo(CLIENT));
 

--- a/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiBindingInfoTest.java
+++ b/config/binding-mcp-openapi.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/openapi/internal/McpOpenapiBindingInfoTest.java
@@ -29,7 +29,7 @@ public class McpOpenapiBindingInfoTest
     @Test
     public void shouldResolveType()
     {
-        assertThat(info.type(), equalTo("mcp_openapi"));
+        assertThat(info.type(), equalTo("mcp-openapi"));
     }
 
     @Test

--- a/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryBindingInfo.java
+++ b/config/binding-mcp-schema-registry.conf/src/main/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryBindingInfo.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.config.engine.OptionsConfig;
 
 public final class McpSchemaRegistryBindingInfo implements BindingInfo
 {
-    public static final String TYPE = "mcp_schema_registry";
+    public static final String TYPE = "mcp-schema-registry";
 
     @Override
     public String type()

--- a/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryBindingConfigBuilderTest.java
+++ b/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/McpSchemaRegistryBindingConfigBuilderTest.java
@@ -35,7 +35,7 @@ public class McpSchemaRegistryBindingConfigBuilderTest
     {
         McpSchemaRegistryBindingConfig binding = McpSchemaRegistryBindingConfig.builder()
             .namespace("test")
-            .name("mcp_schema_registry0")
+            .name("mcp-schema-registry0")
             .kind(SERVER)
             .options()
                 .server("test")
@@ -48,7 +48,7 @@ public class McpSchemaRegistryBindingConfigBuilderTest
             .build();
 
         assertThat(binding.namespace, equalTo("test"));
-        assertThat(binding.name, equalTo("mcp_schema_registry0"));
+        assertThat(binding.name, equalTo("mcp-schema-registry0"));
         assertThat(binding.type, equalTo(McpSchemaRegistryBindingInfo.TYPE));
         assertThat(binding.kind, equalTo(SERVER));
 

--- a/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryBindingInfoTest.java
+++ b/config/binding-mcp-schema-registry.conf/src/test/java/io/aklivity/zilla/config/binding/mcp/schema/registry/internal/McpSchemaRegistryBindingInfoTest.java
@@ -29,7 +29,7 @@ public class McpSchemaRegistryBindingInfoTest
     @Test
     public void shouldResolveType()
     {
-        assertThat(info.type(), equalTo("mcp_schema_registry"));
+        assertThat(info.type(), equalTo("mcp-schema-registry"));
     }
 
     @Test

--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -9,14 +9,14 @@
 #      (options.authorization on a mcp(client) binding)
 #   4. tools/list is filtered by the caller's JWT scopes: unauthorized toolkits
 #      and tools are absent from the result, layered per binding hop
-#      (mcp proxy toolkit routes, mcp_http per-tool route, mcp_openapi
+#      (mcp proxy toolkit routes, mcp-http per-tool route, mcp-openapi
 #      OpenAPI-native per-operation security)
-#   5. mcp_http's create_pr forwards call arguments as the request body via
+#   5. mcp-http's create_pr forwards call arguments as the request body via
 #      with.body, scoped to exclude args already consumed by the :path
-#   6. mcp_openapi's search_pets renames an argument via with.params before
+#   6. mcp-openapi's search_pets renames an argument via with.params before
 #      building the request (options.specs.petstore.server also overrides
 #      the OpenAPI document's declared server to the local mock)
-#   7. mcp_http's pull_by_number resource template ({owner}/{repo}/{number})
+#   7. mcp-http's pull_by_number resource template ({owner}/{repo}/{number})
 #      is read end-to-end, with captured path params surfacing as ${params.x}
 #   8. petstore__create_pet actually succeeds for a pets:write-scoped caller,
 #      not just listed
@@ -35,12 +35,12 @@
 #  14. the cold tool is still directly callable by name -- "cold" only ever
 #      changes what tools/list reports, never what tools/call accepts
 #  15. kafka__produce writes a record to a real, single-node KRaft Kafka
-#      broker (mcp_kafka kind:client's own generated cache_client/client/
+#      broker (mcp-kafka kind:client's own generated cache_client/client/
 #      tcp_client pipeline, not the engine's test double)
 #  16. kafka__consume reads that same record back, round-tripping the exact
 #      value through the real broker
 #  17. kafka_sr__register_schema registers a real schema against a
-#      real Karapace instance (mcp_schema_registry kind:client's own
+#      real Karapace instance (mcp-schema-registry kind:client's own
 #      generated composite, not a mock), with ${result.id} interpolated
 #      into the tool's summary
 #  18. kafka_sr__list_subjects and describe_subject confirm the
@@ -53,12 +53,12 @@
 #      set_compatibility is called at least once
 #  21. kafka_sr__check_compatibility validates a schema against the
 #      configured compatibility level
-#  22. mcp_schema_registry's own routes[].guarded layers a tool-specific
+#  22. mcp-schema-registry's own routes[].guarded layers a tool-specific
 #      scope (kafka_sr:write) under the toolkit-level scope
 #      (kafka_sr:tools) for register_schema only -- no OpenAPI
 #      security scheme is involved, unlike petstore's create_pet
 #  23. kafka__create_topics creates a real topic on the same broker
-#      (mcp_kafka kind:client's own generated pipeline, not the engine's
+#      (mcp-kafka kind:client's own generated pipeline, not the engine's
 #      test double), gated by its own tool-specific kafka:admin scope
 #      layered under the toolkit-level kafka:tools scope -- the same
 #      layering mechanism as register_schema/kafka_sr:write, demonstrated
@@ -528,7 +528,7 @@ fi
 
 # WHEN: a pets:write-scoped caller calls petstore__create_pet
 # THEN: the call actually succeeds against the petstore mock (not just listed
-#       as available) -- the mcp_openapi OpenAPI-native security requirement
+#       as available) -- the mcp-openapi OpenAPI-native security requirement
 #       permits the call, and the auto-derived request/response schemas round-trip
 call_create_pet() {
   CREATE_PET_OUT=$(docker compose run --rm --no-deps \
@@ -553,8 +553,8 @@ SR_SCHEMA='{\"type\":\"record\",\"name\":\"Order\",\"fields\":[{\"name\":\"id\",
 
 # WHEN: a kafka_sr:write-scoped caller calls kafka_sr__register_schema
 # THEN: the schema is registered against the real Karapace instance (not a
-#       mock) -- mcp_schema_registry kind:client's own generated composite
-#       (mcp_openapi -> mcp_http -> http_client) talks to an actual Schema
+#       mock) -- mcp-schema-registry kind:client's own generated composite
+#       (mcp-openapi -> mcp-http -> http_client) talks to an actual Schema
 #       Registry end to end, and the tool's summary interpolates the id
 #       Karapace actually assigned via ${result.id}
 call_register_schema() {
@@ -700,7 +700,7 @@ fi
 # WHEN: a kafka:write-scoped caller calls kafka__produce
 # THEN: the record reaches the real, single-node KRaft Kafka broker started by
 #       this example -- not the engine's `type: test` double specs/ITs use --
-#       proving mcp_kafka's kind:client composite generator (kafka_cache_client
+#       proving mcp-kafka's kind:client composite generator (kafka_cache_client
 #       -> kafka_client -> tcp_client) talks to an actual broker end to end
 call_kafka_produce() {
   KAFKA_PRODUCE_OUT=$(docker compose run --rm --no-deps \
@@ -981,7 +981,7 @@ fi
 # FindCoordinator -> DescribeGroups -> OffsetCommit flow) is not exercised
 # end to end against a real broker here -- driving it to a real broker
 # surfaced a hang distinct from the request-encoding bug fixed alongside
-# this test, in how the mcp_kafka client's auto-generated composite routes
+# this test, in how the mcp-kafka client's auto-generated composite routes
 # an OffsetCommit stream to the dynamically resolved coordinator host/port
 # (as opposed to the statically configured options.servers). This is a
 # known gap, tracked for follow-up, not silently papered over: FindCoordinator

--- a/examples/mcp.proxy/README.md
+++ b/examples/mcp.proxy/README.md
@@ -15,7 +15,7 @@ every `tools/list` response.
 client ── Authorization: Bearer ───►│                                                                                                                                            │
                                      │             ┬                     ┬                    ┬                   ┬                        ┬                          ┬           │
                                      │             ▼                     ▼                    ▼                   ▼                        ▼                          ▼           │
-                                     │    mcp(client)         mcp(client)             mcp_http(proxy)    mcp_openapi(client)  mcp_schema_registry(client)  mcp_kafka(client)      │
+                                     │    mcp(client)         mcp(client)             mcp-http(proxy)    mcp-openapi(client)  mcp-schema-registry(client)  mcp-kafka(client)      │
                                      │    everything          urlelicit               github toolkit     petstore toolkit     kafka_sr toolkit             kafka toolkit          │
                                      │    http →              http →                  http(client) →     http(client) →       http(client) →               kafka_cache_client →   │
                                      │    tcp                 tcp                     tcp                tcp                  tcp                          kafka_client → tcp     │
@@ -33,10 +33,10 @@ This one configuration exercises all seven `mcp*` binding kinds:
 | `mcp` | `server` | Terminates Streamable HTTP, authenticates the session with the `authn_jwt` guard |
 | `mcp` | `proxy` | Aggregates toolkits behind one endpoint, gates each toolkit's routes with `guarded:` |
 | `mcp` | `client` | Talks to an upstream server that is itself MCP (`everything`, `urlelicit`); `urlelicit` also forwards the caller's own JWT upstream |
-| `mcp_http` | `proxy` | Synthesizes MCP tools from hand-authored config, backed by a plain REST API (`github` toolkit) |
-| `mcp_openapi` | `client` | Synthesizes MCP tools from an OpenAPI document, backed by a plain REST API (`petstore` toolkit) |
-| `mcp_schema_registry` | `client` | Exposes a fixed, bundled tool set for the Karapace/Confluent Schema Registry REST API -- no operator-authored OpenAPI document, unlike `mcp_openapi` (`kafka_sr` toolkit) |
-| `mcp_kafka` | `client` | Exposes Kafka broker operations (`produce`/`consume`/`create_topics`/`delete_topics`/`describe_configs`/`alter_configs`/`list_topics`/`describe_topic`/`cluster_overview`/`list_brokers`/`describe_cluster`/`list_consumer_groups`/`describe_consumer_group`/`reset_offsets`) as intrinsic MCP tools, generating its own `kafka_cache_client → kafka_client → tcp_client` pipeline against a real broker (`kafka` toolkit) |
+| `mcp-http` | `proxy` | Synthesizes MCP tools from hand-authored config, backed by a plain REST API (`github` toolkit) |
+| `mcp-openapi` | `client` | Synthesizes MCP tools from an OpenAPI document, backed by a plain REST API (`petstore` toolkit) |
+| `mcp-schema-registry` | `client` | Exposes a fixed, bundled tool set for the Karapace/Confluent Schema Registry REST API -- no operator-authored OpenAPI document, unlike `mcp-openapi` (`kafka_sr` toolkit) |
+| `mcp-kafka` | `client` | Exposes Kafka broker operations (`produce`/`consume`/`create_topics`/`delete_topics`/`describe_configs`/`alter_configs`/`list_topics`/`describe_topic`/`cluster_overview`/`list_brokers`/`describe_cluster`/`list_consumer_groups`/`describe_consumer_group`/`reset_offsets`) as intrinsic MCP tools, generating its own `kafka_cache_client → kafka_client → tcp_client` pipeline against a real broker (`kafka` toolkit) |
 
 ## Authorization model
 
@@ -50,30 +50,30 @@ the pipeline, each demonstrating a different mechanism:
 | --- | --- | --- |
 | `mcp(proxy)` route for `urlelicit` toolkit | `routes[].guarded` on the toolkit route | `urlelicit:authorize` |
 | `mcp(proxy)` route for `github` toolkit | `routes[].guarded` on the toolkit route | `github:tools` |
-| `mcp_http(proxy)` route for `create_pr` | a second, tool-specific `routes[].guarded`, layered under the `mcp_http` binding's base guarded route | `github:tools` **and** `github:pr:write` |
+| `mcp-http(proxy)` route for `create_pr` | a second, tool-specific `routes[].guarded`, layered under the `mcp-http` binding's base guarded route | `github:tools` **and** `github:pr:write` |
 | `mcp(proxy)` route for `petstore` toolkit | `routes[].guarded` on the toolkit route | `petstore:tools` |
-| `mcp_openapi(client)` operation `create_pet` | the OpenAPI document's own `security` requirement, mapped to `authn_jwt` via `options.specs.petstore.security` | `petstore:tools` **and** `pets:write` |
+| `mcp-openapi(client)` operation `create_pet` | the OpenAPI document's own `security` requirement, mapped to `authn_jwt` via `options.specs.petstore.security` | `petstore:tools` **and** `pets:write` |
 | `mcp(proxy)` route for `kafka_sr` toolkit | `routes[].guarded` on the toolkit route | `kafka_sr:tools` |
-| `mcp_schema_registry(client)` route for `register_schema` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka_sr:tools` **and** `kafka_sr:write` |
+| `mcp-schema-registry(client)` route for `register_schema` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka_sr:tools` **and** `kafka_sr:write` |
 | `mcp(proxy)` route for `kafka` toolkit | `routes[].guarded` on the toolkit route | `kafka:tools` |
-| `mcp_kafka(client)` route for `produce` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:write` |
-| `mcp_kafka(client)` route for `create_topics` / `delete_topics` / `alter_configs` / `reset_offsets` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route (all four tools coalesced into one route, since all four need the same scope), layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:admin` |
+| `mcp-kafka(client)` route for `produce` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:write` |
+| `mcp-kafka(client)` route for `create_topics` / `delete_topics` / `alter_configs` / `reset_offsets` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route (all four tools coalesced into one route, since all four need the same scope), layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:admin` |
 
 `list_pets`, `list_featured_pets`, and `get_pet` declare no OpenAPI `security`
 of their own, so they need only the toolkit-level `petstore:tools` scope --
-the same "toolkit access is not tool access" layering `mcp_http` demonstrates
+the same "toolkit access is not tool access" layering `mcp-http` demonstrates
 with `github:pr:write`, expressed through OpenAPI's own security model
 instead of an explicit `guarded:` route.
 
-`mcp_schema_registry` has no OpenAPI document of its own to attach a
+`mcp-schema-registry` has no OpenAPI document of its own to attach a
 `security` requirement to at all -- the bundled spec declares none -- so its
 `register_schema` route demonstrates the same layering the other way around,
-via an explicit `routes[].guarded` directly on the `mcp_schema_registry`
+via an explicit `routes[].guarded` directly on the `mcp-schema-registry`
 binding itself: `list_subjects`, `describe_subject`, `get_schema`, and every
 other read-only tool need only the toolkit-level `kafka_sr:tools`
 scope, while `register_schema` additionally requires `kafka_sr:write`.
 
-`mcp_kafka` demonstrates the identical layering a third way, on its own
+`mcp-kafka` demonstrates the identical layering a third way, on its own
 `when.tool` route, and splits it further into read/write/admin: `consume`,
 `describe_configs`, `list_topics`, `describe_topic`, `cluster_overview`,
 `list_brokers`, `describe_cluster`, `list_consumer_groups`, and
@@ -317,7 +317,7 @@ docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
 With the full-scope `$JWT_TOKEN` from above, calling `github__create_pr`
 reaches the `ghapi` mock and forwards the caller's own bearer credential and
 identity upstream (`options.authorization.credentials.headers` on the
-`mcp_http` binding):
+`mcp-http` binding):
 
 ```bash
 curl -N http://localhost:7114/mcp \
@@ -338,10 +338,10 @@ The response's `html_url` points at the fabricated `ghapi` pull request, and
 
 ### Schema-validated tool calls, and where the arguments go
 
-`mcp_http` requires every tool to declare an input schema
+`mcp-http` requires every tool to declare an input schema
 (`options.tools.create_pr.schemas.input`, backed by the `github_catalog`
 inline catalog) -- a call is validated against it before Zilla builds the
-upstream request at all. `mcp_openapi` makes the same `input`/`output`
+upstream request at all. `mcp-openapi` makes the same `input`/`output`
 override optional: `list_pets` relies on the schema auto-derived from the
 OpenAPI document, while `create_pet` explicitly overrides both
 (`options.tools.create_pet.input`/`output`, backed by `petstore_catalog`) to
@@ -359,7 +359,7 @@ remainder forwarded still needs an explicit `with.body` scoped to what's left.
 
 ### Browse petstore resources (static and templated)
 
-`mcp_openapi` maps OpenAPI `GET` operations to MCP resources instead of
+`mcp-openapi` maps OpenAPI `GET` operations to MCP resources instead of
 tools when the route's `when` says `resource:` instead of `tool:`. Whether
 the result is a fixed entry in `resources/list` or a `resources/templates`
 entry depends entirely on the OpenAPI path itself:
@@ -385,7 +385,7 @@ Read the templated resource for a specific pet with MCP Inspector's Resources
 tab, or with any MCP client that supports `resources/read` against
 `petstore+/pets/1`.
 
-### Redirect the outbound host, and rename an argument (mcp_openapi)
+### Redirect the outbound host, and rename an argument (mcp-openapi)
 
 The petstore OpenAPI document declares its public server as
 `https://api.petstore.example.com` -- a realistic, external-looking address,
@@ -411,9 +411,9 @@ said `category`, the request said `tag`.
 
 ### Register, look up, and configure schemas through a real Karapace instance
 
-`south_mcp_schema_registry_client` is an `mcp_schema_registry` `kind: client`
+`south_mcp_schema_registry_client` is an `mcp-schema-registry` `kind: client`
 binding -- like `petstore`, it proxies to a separate REST service, but unlike
-`mcp_openapi` there is no OpenAPI document to author at all: the tool set
+`mcp-openapi` there is no OpenAPI document to author at all: the tool set
 (`list_subjects`, `describe_subject`, `get_schema`, `register_schema`,
 `delete_subject`, `delete_schema_version`, `check_compatibility`,
 `get_compatibility`, `set_compatibility`) is bundled with the
@@ -487,7 +487,7 @@ docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
 
 ### Produce, consume, create/delete topics, describe/alter configs, and cluster introspection through a real Kafka broker
 
-`south_mcp_kafka_client` is an `mcp_kafka` `kind: client` binding -- unlike
+`south_mcp_kafka_client` is an `mcp-kafka` `kind: client` binding -- unlike
 every other toolkit in this example, it does not proxy to a separate MCP or
 REST server. It generates its own `kafka_cache_client → kafka_client →
 tcp_client` pipeline directly from `options.servers`, talking to the real,
@@ -669,7 +669,7 @@ that varies per broker startup.
 ### Manage consumer group offsets through a real Kafka broker
 
 `list_consumer_groups`, `describe_consumer_group`, and `reset_offsets` round
-out `mcp_kafka` with consumer group management, against the same real broker
+out `mcp-kafka` with consumer group management, against the same real broker
 as `produce`/`consume`/`create_topics`/`delete_topics` above.
 `list_consumer_groups` and `describe_consumer_group` are read-only, needing
 only the toolkit-level `kafka:tools` scope; `reset_offsets` shares
@@ -724,7 +724,7 @@ silently.
 `reset_offsets`' `FindCoordinator` and `DescribeGroups` hops (the same
 `DescribeGroups` call `describe_consumer_group` makes) against the real
 broker, but not its final `OffsetCommit` hop -- driving that hop against a
-real broker surfaced a hang in how the `mcp_kafka` client's auto-generated
+real broker surfaced a hang in how the `mcp-kafka` client's auto-generated
 composite routes an `OffsetCommit` stream to a dynamically resolved
 coordinator host/port (as opposed to the statically configured
 `options.servers`), tracked as a follow-up rather than papered over.
@@ -825,7 +825,7 @@ docker compose logs urlelicit | grep authorization:
 
 Each line shows the exact JWT a given caller presented at the gateway. This
 is the `mcp(client)` binding's own credential-forwarding mechanism -- a
-narrower, single-header equivalent of `mcp_http`'s
+narrower, single-header equivalent of `mcp-http`'s
 `options.authorization.credentials.headers` map used for `github__create_pr`
 above, without needing to name the header or interpolate `{identity}`
 separately.

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -83,7 +83,7 @@ services:
       - ./url-elicit:/app
     entrypoint: ["node", "/app/client.mjs"]
 
-  # Mock GitHub REST API backing the mcp_http "github" toolkit.
+  # Mock GitHub REST API backing the mcp-http "github" toolkit.
   ghapi:
     image: node:20-alpine
     hostname: ghapi
@@ -100,7 +100,7 @@ services:
       retries: 20
       test: ["CMD", "nc", "-z", "127.0.0.1", "4001"]
 
-  # Mock Petstore REST API backing the mcp_openapi "petstore" toolkit.
+  # Mock Petstore REST API backing the mcp-openapi "petstore" toolkit.
   petstore:
     image: node:20-alpine
     hostname: petstore
@@ -117,7 +117,7 @@ services:
       retries: 20
       test: ["CMD", "nc", "-z", "127.0.0.1", "4002"]
 
-  # Real single-node Kafka broker (KRaft mode) backing the mcp_kafka "kafka" toolkit.
+  # Real single-node Kafka broker (KRaft mode) backing the mcp-kafka "kafka" toolkit.
   kafka:
     image: apache/kafka:4.1.1
     restart: unless-stopped
@@ -169,7 +169,7 @@ services:
         echo "Successfully created the following topics:";
         /opt/kafka/bin/kafka-topics.sh --bootstrap-server $${KAFKA_BOOTSTRAP_SERVER} --list --exclude-internal;
 
-  # Real Karapace Schema Registry backing the mcp_schema_registry
+  # Real Karapace Schema Registry backing the mcp-schema-registry
   # "schemaregistry" toolkit -- talks to the same real Kafka broker as the
   # "kafka" toolkit above, storing schemas in its own _schemas topic.
   karapace-registry:

--- a/examples/mcp.proxy/etc/zilla.yaml
+++ b/examples/mcp.proxy/etc/zilla.yaml
@@ -418,7 +418,7 @@ bindings:
           credentials: "Bearer {credentials}"
     exit: sys:http_client
   south_mcp_http_github:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       authorization:
@@ -508,7 +508,7 @@ bindings:
       host: ghapi
       port: 4001
   south_mcp_openapi_petstore:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:
@@ -540,7 +540,7 @@ bindings:
           description: Add a new pet to the store.
           summary: "Added pet: ${result.name}"
           # explicit override of the auto-derived input/output schema,
-          # demonstrating the same schema-mapping mechanism as mcp_http,
+          # demonstrating the same schema-mapping mechanism as mcp-http,
           # this time optional rather than required
           input:
             model: json
@@ -593,7 +593,7 @@ bindings:
           spec: petstore
           operation: get_pet
   south_mcp_schema_registry_client:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: client
     options:
       server: http://karapace-registry:8081
@@ -612,7 +612,7 @@ bindings:
       - when:
           - tool: "*"
   south_mcp_kafka_client:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/examples/mcp.proxy/ghapi/package.json
+++ b/examples/mcp.proxy/ghapi/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Minimal mock of the GitHub REST API endpoints used by the mcp_http \"github\" toolkit",
+  "description": "Minimal mock of the GitHub REST API endpoints used by the mcp-http \"github\" toolkit",
   "dependencies": {
     "express": "^5.2.1"
   }

--- a/examples/mcp.proxy/ghapi/server.mjs
+++ b/examples/mcp.proxy/ghapi/server.mjs
@@ -1,7 +1,7 @@
-// Minimal mock of the subset of the GitHub REST API used by the mcp_http
+// Minimal mock of the subset of the GitHub REST API used by the mcp-http
 // "github" toolkit. Requires a Bearer credential on every request -- Zilla
 // forwards the caller's own JWT via options.authorization.credentials.headers
-// on the mcp_http binding -- and echoes the forwarded x-user-identity header
+// on the mcp-http binding -- and echoes the forwarded x-user-identity header
 // into the response so the credential-forwarding path is directly observable.
 
 import express from "express";
@@ -51,7 +51,7 @@ app.post("/repos/:owner/:repo/pulls", (req, res) =>
     res.status(201).json(pull);
 });
 
-// Backs the mcp_http "pull_by_number" resource template
+// Backs the mcp-http "pull_by_number" resource template
 // (pr://{owner}/{repo}/{number}) -- read-only, so no credential check here,
 // mirroring petstore's read operations.
 app.get("/repos/:owner/:repo/pulls/:number", (req, res) =>

--- a/examples/mcp.proxy/petstore/package.json
+++ b/examples/mcp.proxy/petstore/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Minimal mock Petstore REST API, described by the OpenAPI spec used by the mcp_openapi \"petstore\" toolkit",
+  "description": "Minimal mock Petstore REST API, described by the OpenAPI spec used by the mcp-openapi \"petstore\" toolkit",
   "dependencies": {
     "express": "^5.2.1"
   }

--- a/examples/mcp.proxy/petstore/server.mjs
+++ b/examples/mcp.proxy/petstore/server.mjs
@@ -1,7 +1,7 @@
 // Minimal mock Petstore REST API. Its OpenAPI 3.1 description (inlined in
 // etc/zilla.yaml) declares "create_pet" as requiring the "pets:write" scope
 // via a bearerAuth security scheme; Zilla enforces that scope requirement at
-// the mcp_openapi binding before a request ever reaches this service, so no
+// the mcp-openapi binding before a request ever reaches this service, so no
 // authorization check is duplicated here.
 
 import express from "express";
@@ -34,12 +34,12 @@ app.post("/pets", (req, res) =>
     res.status(201).json(pet);
 });
 
-// Static resource: no path params, so mcp_openapi exposes this as a single
+// Static resource: no path params, so mcp-openapi exposes this as a single
 // fixed-URI entry in resources/list rather than a resources/templates entry.
 app.get("/pets/featured", (req, res) => res.json(pets.filter((pet) => FEATURED_IDS.has(pet.id))));
 
 // The OpenAPI "tag" query param arrives as ?tag= regardless of what the tool
-// argument is named -- the mcp_openapi route's with.params renames it from
+// argument is named -- the mcp-openapi route's with.params renames it from
 // the caller-facing "category" back to "tag" before this request is built.
 // Logged (rather than asserted on the MCP response) so .github/test.sh can
 // confirm the rename reached this service exactly as configured.
@@ -50,7 +50,7 @@ app.get("/pets/search", (req, res) =>
     res.json(tag ? pets.filter((pet) => pet.tag === tag) : pets);
 });
 
-// Dynamic resource: the {petId} path param makes mcp_openapi expose this as
+// Dynamic resource: the {petId} path param makes mcp-openapi expose this as
 // a resources/templates entry, read with a concrete URI per pet.
 app.get("/pets/:petId", (req, res) =>
 {

--- a/examples/mcp.proxy/tools-list-client/client.mjs
+++ b/examples/mcp.proxy/tools-list-client/client.mjs
@@ -15,7 +15,7 @@
 // through unchanged, so it prints exactly like calling that tool directly;
 // every other tool's result prints its text content as-is, followed by a
 // second line with the raw structuredContent JSON if the result carries one
-// (e.g. mcp_kafka's consume tool) -- or READ_RESOURCE
+// (e.g. mcp-kafka's consume tool) -- or READ_RESOURCE
 // (a concrete URI, with any {template} placeholders already substituted) to
 // read one resource and print its contents. Optionally carries a bearer
 // token on the initial request so .github/test.sh can observe how the result

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpBinding.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/McpHttpBinding.java
@@ -19,7 +19,7 @@ import io.aklivity.zilla.runtime.engine.binding.Binding;
 
 public final class McpHttpBinding implements Binding
 {
-    public static final String TYPE = "mcp_http";
+    public static final String TYPE = "mcp-http";
 
     private final McpHttpConfiguration config;
 

--- a/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/events/McpHttpEventContext.java
+++ b/runtime/binding-mcp-http/src/main/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/events/McpHttpEventContext.java
@@ -44,7 +44,7 @@ public final class McpHttpEventContext
         EngineContext context)
     {
         this.mcpHttpTypeId = context.supplyTypeId(McpHttpBinding.TYPE);
-        this.schemaAccessorUnresolvedEventId = context.supplyEventId("binding.mcp_http.schema.accessor.unresolved");
+        this.schemaAccessorUnresolvedEventId = context.supplyEventId("binding.mcp.http.schema.accessor.unresolved");
         this.eventWriter = context.supplyEventWriter();
         this.clock = context.clock();
     }

--- a/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
+++ b/runtime/binding-mcp-http/src/test/java/io/aklivity/zilla/runtime/binding/mcp/http/internal/config/McpHttpBindingConfigTest.java
@@ -71,7 +71,7 @@ public class McpHttpBindingConfigTest
         BindingConfig config = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_http")
+            .type("mcp-http")
             .kind(KindConfig.PROXY)
             .routes(routes)
             .build();
@@ -181,7 +181,7 @@ public class McpHttpBindingConfigTest
         BindingConfig config = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_http")
+            .type("mcp-http")
             .kind(KindConfig.CLIENT)
             .routes(List.of(route))
             .build();
@@ -206,7 +206,7 @@ public class McpHttpBindingConfigTest
         BindingConfig config = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_http")
+            .type("mcp-http")
             .kind(KindConfig.CLIENT)
             .routes(List.of(route))
             .build();
@@ -232,7 +232,7 @@ public class McpHttpBindingConfigTest
         BindingConfig config = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_http")
+            .type("mcp-http")
             .kind(KindConfig.PROXY)
             .routes(List.of(route))
             .build();

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/McpKafkaBinding.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/McpKafkaBinding.java
@@ -19,7 +19,7 @@ import io.aklivity.zilla.runtime.engine.binding.Binding;
 
 public final class McpKafkaBinding implements Binding
 {
-    public static final String TYPE = "mcp_kafka";
+    public static final String TYPE = "mcp-kafka";
 
     private final McpKafkaConfiguration config;
 

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/composite/McpKafkaClientGenerator.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/composite/McpKafkaClientGenerator.java
@@ -63,7 +63,7 @@ public final class McpKafkaClientGenerator
         boolean secure = options.authorization != null || binding.vault != null;
 
         NamespaceConfig namespace = NamespaceConfig.builder()
-            .name("%s/mcp_kafka".formatted(binding.qname))
+            .name("%s/mcp-kafka".formatted(binding.qname))
             .inject(n -> injectKafkaCache(n, options))
             .inject(n -> injectKafkaClient(n, options, secure))
             .inject(n -> injectTlsClient(n, binding, secure))

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/composite/McpKafkaClientGeneratorTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/composite/McpKafkaClientGeneratorTest.java
@@ -62,7 +62,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();
@@ -126,7 +126,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();
@@ -156,7 +156,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();
@@ -189,7 +189,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();
@@ -234,7 +234,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();
@@ -269,7 +269,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .vault("vault0")
             .options(options)
@@ -304,7 +304,7 @@ public class McpKafkaClientGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .build();

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaClientFactoryTest.java
@@ -118,7 +118,7 @@ public class McpKafkaClientFactoryTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.CLIENT)
             .options(options)
             .routes(List.of(route))

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactoryTest.java
@@ -172,7 +172,7 @@ public class McpKafkaProxyFactoryTest
         final BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("mcp0")
-            .type("mcp_kafka")
+            .type("mcp-kafka")
             .kind(KindConfig.PROXY)
             .routes(List.of(route))
             .build();

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBinding.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/McpOpenapiBinding.java
@@ -20,7 +20,7 @@ import io.aklivity.zilla.runtime.engine.binding.Binding;
 
 public final class McpOpenapiBinding implements Binding
 {
-    public static final String TYPE = "mcp_openapi";
+    public static final String TYPE = "mcp-openapi";
 
     private final McpOpenapiConfiguration config;
 

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGenerator.java
@@ -97,7 +97,7 @@ import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 public final class McpOpenapiCompositeGenerator
 {
     private static final String CATALOG_NAME = "catalog0";
-    private static final String BINDING_NAME = "mcp_http0";
+    private static final String BINDING_NAME = "mcp-http0";
     private static final String ANNOTATIONS_EXTENSION_NAME = "x-mcp-annotations";
     private static final String METHOD_GET = "get";
     private static final String METHOD_HEAD = "head";
@@ -209,7 +209,7 @@ public final class McpOpenapiCompositeGenerator
         }
 
         final NamespaceConfig namespace = NamespaceConfig.builder()
-            .name("%s/mcp_http".formatted(binding.qname))
+            .name("%s/mcp-http".formatted(binding.qname))
             .inject(n -> injectCatalog(n, routed))
             .inject(n -> injectBinding(n, binding, routed))
             .build();
@@ -428,9 +428,9 @@ public final class McpOpenapiCompositeGenerator
                     : entry.operation.description != null
                         ? entry.operation.description
                         : entry.operation.id;
-                // mcp_http requires a non-null tool summary; prefer an authored override, then OpenAPI's
+                // mcp-http requires a non-null tool summary; prefer an authored override, then OpenAPI's
                 // own optional summary field, then a plain literal string naming the operation (not a
-                // ${...} template -- mcp_http only understands ${result.*} references, not operationId)
+                // ${...} template -- mcp-http only understands ${result.*} references, not operationId)
                 final String summary = entry.tool.summary != null
                     ? entry.tool.summary
                     : entry.operation.summary != null
@@ -995,7 +995,7 @@ public final class McpOpenapiCompositeGenerator
     {
         // an authored schemas.input/output's catalog reference names a catalog in the caller's own
         // namespace (e.g. "catalog0"), but this ModelConfig is forwarded as-is into the generated
-        // mcp_http binding, which lives in its own freshly-generated namespace that has its own,
+        // mcp-http binding, which lives in its own freshly-generated namespace that has its own,
         // unrelated, same-named "catalog0" -- rewrite the reference to be namespace-qualified
         // (qname) so it resolves absolutely, against the caller's namespace, from anywhere
         ModelConfig qualified = model;

--- a/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientFactory.java
+++ b/runtime/binding-mcp-openapi/src/main/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/stream/McpOpenapiClientFactory.java
@@ -383,7 +383,7 @@ public final class McpOpenapiClientFactory implements BindingHandler
             long traceId,
             OctetsFW extension)
         {
-            // an END must always be deliverable even if the reply was never opened (e.g. mcp_http0 ends its
+            // an END must always be deliverable even if the reply was never opened (e.g. mcp-http0 ends its
             // reply before ever sending a BEGIN) — open the reply first, mirroring doMcpOpenapiAbort below
             doMcpOpenapiBegin(sequence, acknowledge, maximum, traceId, extension);
 
@@ -403,7 +403,7 @@ public final class McpOpenapiClientFactory implements BindingHandler
             long traceId,
             OctetsFW extension)
         {
-            // an ABORT must always be deliverable even if the reply was never opened — e.g. mcp_http0's
+            // an ABORT must always be deliverable even if the reply was never opened — e.g. mcp-http0's
             // upstream aborts before ever sending a response, so no reply BEGIN has gone out yet. Without
             // opening the reply first, this abort is silently dropped and the real client hangs forever
             // waiting for any reply frame at all

--- a/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-openapi/src/test/java/io/aklivity/zilla/runtime/binding/mcp/openapi/internal/config/composite/McpOpenapiCompositeGeneratorTest.java
@@ -431,8 +431,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -475,12 +475,12 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
 
         assertThat(mcpHttp, notNullValue());
-        assertThat(mcpHttp.type, equalTo("mcp_http"));
+        assertThat(mcpHttp.type, equalTo("mcp-http"));
         assertThat(mcpHttp.kind, equalTo(CLIENT));
 
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -526,8 +526,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(PROXY)
             .exit("schema_registry0")
             .options(McpOpenapiOptionsConfig.builder()
@@ -562,7 +562,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
 
@@ -577,8 +577,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .authorization(new McpOpenapiAuthorizationConfig("guard0", Map.of("authorization", "Bearer {credentials}")))
@@ -608,7 +608,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
 
@@ -626,8 +626,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -661,7 +661,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
 
@@ -675,8 +675,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -740,8 +740,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -775,7 +775,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -793,8 +793,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -828,7 +828,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -855,8 +855,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -891,7 +891,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -904,7 +904,7 @@ public class McpOpenapiCompositeGeneratorTest
         assertThat(tool.input.model, equalTo("json"));
         assertThat(tool.input.cataloged, hasSize(1));
         // the authored reference names the bare "catalog0" from the caller's own namespace; forwarded
-        // into the generated mcp_http0 binding's own (different) namespace, it must be qualified
+        // into the generated mcp-http0 binding's own (different) namespace, it must be qualified
         // ("test:catalog0"), otherwise it would resolve against that namespace's own local "catalog0"
         assertThat(tool.input.cataloged.get(0).name, equalTo("test:catalog0"));
         assertThat(tool.input.cataloged.get(0).schemas.get(0).subject, equalTo("create_pr_input"));
@@ -917,8 +917,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -952,7 +952,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -970,8 +970,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1004,7 +1004,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1021,8 +1021,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1051,7 +1051,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1067,8 +1067,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1096,7 +1096,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1109,8 +1109,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1139,7 +1139,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1156,8 +1156,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1185,7 +1185,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1202,8 +1202,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1231,7 +1231,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1245,8 +1245,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1275,7 +1275,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1292,8 +1292,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1322,7 +1322,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1340,8 +1340,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1370,7 +1370,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1388,8 +1388,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1418,7 +1418,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1437,8 +1437,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1468,7 +1468,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1485,8 +1485,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1518,7 +1518,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1539,8 +1539,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1570,7 +1570,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1587,8 +1587,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1618,7 +1618,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1635,8 +1635,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1666,7 +1666,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1683,8 +1683,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1714,7 +1714,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpWithConfig with = mcpHttp.routes.stream()
@@ -1733,8 +1733,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1785,7 +1785,7 @@ public class McpOpenapiCompositeGeneratorTest
         assertThat(composite.routes.size(), equalTo(1));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -1821,8 +1821,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1851,7 +1851,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -1869,8 +1869,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1899,7 +1899,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -1916,8 +1916,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1946,7 +1946,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig putRoute = mcpHttp.routes.stream()
@@ -1964,8 +1964,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -1997,7 +1997,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig getRoute = mcpHttp.routes.stream()
@@ -2015,8 +2015,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2049,7 +2049,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -2071,8 +2071,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2105,7 +2105,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -2123,8 +2123,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2153,7 +2153,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig putRoute = mcpHttp.routes.stream()
@@ -2172,8 +2172,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2202,7 +2202,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -2221,8 +2221,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2251,7 +2251,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig getRoute = mcpHttp.routes.stream()
@@ -2268,8 +2268,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2297,7 +2297,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig postRoute = mcpHttp.routes.stream()
@@ -2314,8 +2314,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2344,7 +2344,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig putRoute = mcpHttp.routes.stream()
@@ -2364,8 +2364,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2393,7 +2393,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig getRoute = mcpHttp.routes.stream()
@@ -2411,8 +2411,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2441,7 +2441,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         RouteConfig getRoute = mcpHttp.routes.stream()
@@ -2458,8 +2458,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2488,7 +2488,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         assertThat(mcpHttp.routes.get(0).guarded, empty());
@@ -2499,8 +2499,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2526,7 +2526,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2539,8 +2539,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2565,7 +2565,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2580,8 +2580,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2607,7 +2607,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2620,8 +2620,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2647,7 +2647,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2662,8 +2662,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2698,7 +2698,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2712,8 +2712,8 @@ public class McpOpenapiCompositeGeneratorTest
     {
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2739,7 +2739,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2755,8 +2755,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2780,7 +2780,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2796,8 +2796,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2826,7 +2826,7 @@ public class McpOpenapiCompositeGeneratorTest
 
         NamespaceConfig namespace = composite.namespaces.get(0);
         BindingConfig mcpHttp = namespace.bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2867,8 +2867,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2901,7 +2901,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2923,8 +2923,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -2948,7 +2948,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -2986,8 +2986,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -3015,7 +3015,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;
@@ -3036,8 +3036,8 @@ public class McpOpenapiCompositeGeneratorTest
 
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
-            .name("mcp_openapi0")
-            .type("mcp_openapi")
+            .name("mcp-openapi0")
+            .type("mcp-openapi")
             .kind(CLIENT)
             .options(McpOpenapiOptionsConfig.builder()
                 .spec()
@@ -3072,7 +3072,7 @@ public class McpOpenapiCompositeGeneratorTest
         McpOpenapiCompositeConfig composite = generator.generate(new McpOpenapiBindingConfig(context, binding));
 
         BindingConfig mcpHttp = composite.namespaces.get(0).bindings.stream()
-            .filter(b -> "mcp_http0".equals(b.name))
+            .filter(b -> "mcp-http0".equals(b.name))
             .findFirst()
             .orElse(null);
         McpHttpOptionsConfig mcpHttpOptions = (McpHttpOptionsConfig) mcpHttp.options;

--- a/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/McpSchemaRegistryBinding.java
+++ b/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/McpSchemaRegistryBinding.java
@@ -20,7 +20,7 @@ import io.aklivity.zilla.runtime.engine.binding.Binding;
 
 public final class McpSchemaRegistryBinding implements Binding
 {
-    public static final String TYPE = "mcp_schema_registry";
+    public static final String TYPE = "mcp-schema-registry";
 
     private final McpSchemaRegistryConfiguration config;
 

--- a/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
+++ b/runtime/binding-mcp-schema-registry/src/main/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGenerator.java
@@ -40,7 +40,7 @@ public final class McpSchemaRegistryCompositeGenerator
     private static final String BUNDLED_SPEC_RESOURCE =
         "/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/schema/karapace-schema-registry.openapi.json";
     private static final String CATALOG_NAME = "catalog0";
-    private static final String BINDING_NAME = "mcp_openapi0";
+    private static final String BINDING_NAME = "mcp-openapi0";
     private static final String SUBJECT_NAME = "schemaregistry";
 
     private static final List<String> TOOLS = List.of(
@@ -60,7 +60,7 @@ public final class McpSchemaRegistryCompositeGenerator
         final String server = binding.options != null ? binding.options.server : null;
 
         NamespaceConfig namespace = NamespaceConfig.builder()
-            .name("%s/mcp_openapi".formatted(binding.qname))
+            .name("%s/mcp-openapi".formatted(binding.qname))
             .catalog()
                 .name(CATALOG_NAME)
                 .type("inline")

--- a/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
+++ b/runtime/binding-mcp-schema-registry/src/test/java/io/aklivity/zilla/runtime/binding/mcp/schema/registry/internal/config/composite/McpSchemaRegistryCompositeGeneratorTest.java
@@ -83,7 +83,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(CLIENT)
             .options(McpSchemaRegistryOptionsConfig.builder()
                 .server("http://localhost:8080")
@@ -113,8 +113,8 @@ public class McpSchemaRegistryCompositeGeneratorTest
         assertThat(schema.schema, containsString("\"operationId\":\"list_subjects\""));
 
         BindingConfig mcpOpenapi = namespace.bindings.get(0);
-        assertThat(mcpOpenapi.name, equalTo("mcp_openapi0"));
-        assertThat(mcpOpenapi.type, equalTo("mcp_openapi"));
+        assertThat(mcpOpenapi.name, equalTo("mcp-openapi0"));
+        assertThat(mcpOpenapi.type, equalTo("mcp-openapi"));
         assertThat(mcpOpenapi.kind, equalTo(CLIENT));
 
         McpOpenapiOptionsConfig mcpOpenapiOptions = (McpOpenapiOptionsConfig) mcpOpenapi.options;
@@ -154,7 +154,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(CLIENT)
             .options(McpSchemaRegistryOptionsConfig.builder()
                 .server("http://localhost:8080")
@@ -190,7 +190,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(CLIENT)
             .options(McpSchemaRegistryOptionsConfig.builder()
                 .server("http://localhost:8080")
@@ -223,7 +223,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(CLIENT)
             .options(McpSchemaRegistryOptionsConfig.builder()
                 .server("http://localhost:8080")
@@ -264,7 +264,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(PROXY)
             .exit("http0")
             .build();
@@ -306,7 +306,7 @@ public class McpSchemaRegistryCompositeGeneratorTest
         BindingConfig binding = GenericBindingConfig.builder()
             .namespace("test")
             .name("app0")
-            .type("mcp_schema_registry")
+            .type("mcp-schema-registry")
             .kind(CLIENT)
             .options(McpSchemaRegistryOptionsConfig.builder()
                 .server("http://localhost:8080")

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilterTest.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/transform/McpScopeFilterTest.java
@@ -131,7 +131,7 @@ public class McpScopeFilterTest
     public void shouldPreserveFieldsPrecedingNameKey()
     {
         // a real upstream MCP resource commonly orders "uri" before "name" (unlike Zilla's own
-        // mcp_http/mcp_openapi-generated lists, which always emit "name" first) -- fields preceding "name"
+        // mcp-http/mcp-openapi-generated lists, which always emit "name" first) -- fields preceding "name"
         // must still reach the output once the item is admitted, not be silently dropped or forwarded
         // without their key
         String json = """

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -110,7 +110,7 @@ The same pattern applies to all pluggable types:
 ### Schema conventions
 
 - Binding `type` values use the module artifact ID minus the `binding-` prefix
-  (e.g., `binding-http` → `type: http`; `binding-mcp-kafka` → `type: mcp_kafka`)
+  (e.g., `binding-http` → `type: http`; `binding-mcp-kafka` → `type: mcp-kafka`)
 - `options` is component-specific; fully described in that component's schema patch
 - `routes[].when` conditions are ordered — first match wins
 - `routes[].exit` names a downstream binding in the same namespace

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.cookie.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.cookie.yaml
@@ -41,7 +41,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.credentials.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.credentials.yaml
@@ -108,7 +108,7 @@ guards:
       credentials: ghp_secret
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       authorization:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.annotations.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.annotations.yaml
@@ -26,7 +26,7 @@ catalogs:
             {"type":"object","properties":{"id":{"type":"string"}}}
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.discovery.yaml
@@ -30,7 +30,7 @@ catalogs:
             {"type":"object","properties":{"id":{"type":"string"}}}
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.exit.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.exit.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     exit: http0
     routes:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.layered.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.layered.yaml
@@ -28,7 +28,7 @@ guards:
         - guest
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.guarded.yaml
@@ -109,7 +109,7 @@ guards:
         - pr:write
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.header.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.header.yaml
@@ -40,7 +40,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.options.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.options.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.nested.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.nested.yaml
@@ -53,7 +53,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.remap.yaml
@@ -48,7 +48,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.route.exit.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.route.exit.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.event.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.event.yaml
@@ -26,7 +26,7 @@ telemetry:
             name: ENGINE_STARTED
             message: Engine Started.
           - qname: test:app0
-            id: binding.mcp_http.schema.accessor.unresolved
+            id: binding.mcp.http.schema.accessor.unresolved
             name: BINDING_MCP_HTTP_SCHEMA_ACCESSOR_UNRESOLVED
             message: Expression "args.ownerr" is unresolved against the schema for "create_pr".
 catalogs:
@@ -117,7 +117,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.params.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.params.yaml
@@ -103,7 +103,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.unresolved.yaml
@@ -103,7 +103,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/client.yaml
@@ -266,7 +266,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: client
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.cookie.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.cookie.yaml
@@ -41,7 +41,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.credentials.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.credentials.yaml
@@ -108,7 +108,7 @@ guards:
       credentials: ghp_secret
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       authorization:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.discovery.annotations.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.discovery.annotations.yaml
@@ -26,7 +26,7 @@ catalogs:
             {"type":"object","properties":{"id":{"type":"string"}}}
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.discovery.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.discovery.yaml
@@ -30,7 +30,7 @@ catalogs:
             {"type":"object","properties":{"id":{"type":"string"}}}
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.exit.required.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.exit.required.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.global.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.global.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - guarded:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.layered.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.layered.yaml
@@ -28,7 +28,7 @@ guards:
         - guest
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.scoped.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.scoped.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.guarded.yaml
@@ -109,7 +109,7 @@ guards:
         - pr:write
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.header.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.header.yaml
@@ -40,7 +40,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.kind.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.kind.invalid.yaml
@@ -17,5 +17,5 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: server

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.options.unknown.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.options.unknown.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       bogus: true

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.options.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.options.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       authorization:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.remap.nested.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.remap.nested.yaml
@@ -53,7 +53,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.remap.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.remap.yaml
@@ -48,7 +48,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.resource.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.resource.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       resources:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.authority.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.authority.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.path.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.path.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.scheme.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.headers.scheme.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.both.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.both.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.multiple.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.multiple.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.required.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.route.when.required.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     routes:
       - exit: http0

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.tool.invalid.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.tool.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.event.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.event.yaml
@@ -26,7 +26,7 @@ telemetry:
             name: ENGINE_STARTED
             message: Engine Started.
           - qname: test:app0
-            id: binding.mcp_http.schema.accessor.unresolved
+            id: binding.mcp.http.schema.accessor.unresolved
             name: BINDING_MCP_HTTP_SCHEMA_ACCESSOR_UNRESOLVED
             message: Expression "args.ownerr" is unresolved against the schema for "create_pr".
 catalogs:
@@ -117,7 +117,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.params.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.params.yaml
@@ -103,7 +103,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.unresolved.yaml
@@ -103,7 +103,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.yaml
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/config/proxy.yaml
@@ -266,7 +266,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_http
+    type: mcp-http
     kind: proxy
     options:
       tools:

--- a/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
+++ b/specs/binding-mcp-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/http/schema/mcp_http.schema.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "add",
         "path": "/$defs/binding/properties/type/enum/-",
-        "value": "mcp_http"
+        "value": "mcp-http"
     },
     {
         "op": "add",
@@ -15,7 +15,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_http"
+                        "const": "mcp-http"
                     }
                 }
             },
@@ -25,7 +25,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_http"
+                        "const": "mcp-http"
                     },
                     "kind":
                     {

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.alter.configs.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.alter.configs.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.cluster.overview.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.cluster.overview.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.consume.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.consume.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.create.topics.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.create.topics.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.delete.topics.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.delete.topics.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.cluster.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.cluster.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.configs.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.configs.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.consumer.group.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.consumer.group.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.topic.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.describe.topic.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.brokers.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.brokers.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.consumer.groups.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.consumer.groups.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.topics.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.list.topics.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.missing.servers.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.missing.servers.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options: {}
     routes:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.produce.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.produce.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.reset.offsets.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.reset.offsets.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.allowlist.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.allowlist.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.glob.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.tool.glob.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.topics.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.topics.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.vault.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.vault.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     vault: vault0
     options:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/client.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: client
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.consume.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.consume.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     routes:
       - exit: kafka0

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.guarded.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.guarded.yaml
@@ -23,7 +23,7 @@ guards:
         - admin
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     routes:
       - guarded:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.topic.allowlist.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.topic.allowlist.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     routes:
       - exit: kafka0

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.topic.glob.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.topic.glob.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     routes:
       - exit: kafka0

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.produce.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     routes:
       - exit: kafka0

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.with.options.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.with.options.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     options:
       servers:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.with.vault.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.with.vault.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp0:
-    type: mcp_kafka
+    type: mcp-kafka
     kind: proxy
     vault: vault0
     routes:

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/schema/mcp.kafka.schema.patch.json
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/schema/mcp.kafka.schema.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "add",
         "path": "/$defs/binding/properties/type/enum/-",
-        "value": "mcp_kafka"
+        "value": "mcp-kafka"
     },
     {
         "op": "add",
@@ -15,7 +15,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_kafka"
+                        "const": "mcp-kafka"
                     },
                     "kind":
                     {
@@ -33,7 +33,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_kafka"
+                        "const": "mcp-kafka"
                     },
                     "kind":
                     {
@@ -109,7 +109,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_kafka"
+                        "const": "mcp-kafka"
                     },
                     "kind":
                     {
@@ -127,7 +127,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_kafka"
+                        "const": "mcp-kafka"
                     },
                     "kind":
                     {

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/exit.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/exit.invalid.yaml
@@ -17,6 +17,6 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     exit: http0

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.route.exit.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.route.exit.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: proxy
     routes:
       - when:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/kind.proxy.yaml
@@ -102,7 +102,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: proxy
     exit: http0
     options:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.body.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.body.yaml
@@ -101,7 +101,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.guarded.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.guarded.yaml
@@ -139,7 +139,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.input.schema.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.input.schema.yaml
@@ -57,7 +57,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.kind.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.kind.invalid.yaml
@@ -17,5 +17,5 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: server

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.options.unknown.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.options.unknown.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       bogus: true

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.cookie.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.cookie.yaml
@@ -88,7 +88,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.header.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.header.yaml
@@ -86,7 +86,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.resource.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.resource.yaml
@@ -57,7 +57,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.params.yaml
@@ -96,7 +96,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.query.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.query.yaml
@@ -57,7 +57,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.input.schema.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.input.schema.invalid.yaml
@@ -56,7 +56,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.override.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.resource.override.yaml
@@ -57,7 +57,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.bulk.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.bulk.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     routes:
       - when:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.tag.and.operation.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.route.tag.and.operation.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     routes:
       - with:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.routes.empty.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.routes.empty.invalid.yaml
@@ -17,6 +17,6 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     routes: []

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.routes.missing.invalid.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.routes.missing.invalid.yaml
@@ -17,5 +17,5 @@
 name: test
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.yaml
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/config/proxy.yaml
@@ -102,7 +102,7 @@ catalogs:
             }
 bindings:
   app0:
-    type: mcp_openapi
+    type: mcp-openapi
     kind: client
     options:
       specs:

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/schema/mcp_openapi.schema.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "add",
         "path": "/$defs/binding/properties/type/enum/-",
-        "value": "mcp_openapi"
+        "value": "mcp-openapi"
     },
     {
         "op": "add",
@@ -15,7 +15,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_openapi"
+                        "const": "mcp-openapi"
                     }
                 }
             },
@@ -25,7 +25,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_openapi"
+                        "const": "mcp-openapi"
                     },
                     "kind":
                     {

--- a/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/tools.list/client.rpt
+++ b/specs/binding-mcp-openapi.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/openapi/streams/mcp/tools.list/client.rpt
@@ -48,7 +48,7 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-# tools/list answered from the generated mcp_http config; create_pr inputSchema is the
+# tools/list answered from the generated mcp-http config; create_pr inputSchema is the
 # flattened (path params + requestBody) schema derived from the OpenAPI operation
 read  '{"tools":[{"name":"create_pr",'
         '"description":"Create a pull request to merge one branch into another.",'

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/kind.invalid.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/kind.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: server
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.kind.invalid.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.kind.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   mcp_schema_registry0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: proxy
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.kind.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.kind.yaml
@@ -17,6 +17,6 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: proxy
     exit: http0

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.route.with.invalid.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.route.with.invalid.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: client
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.tool.array.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.tool.array.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: client
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.routes.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: client
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.yaml
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/config/proxy.yaml
@@ -17,7 +17,7 @@
 name: test
 bindings:
   app0:
-    type: mcp_schema_registry
+    type: mcp-schema-registry
     kind: client
     options:
       server: http://localhost:8080

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/schema/mcp_schema_registry.schema.patch.json
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/schema/mcp_schema_registry.schema.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "add",
         "path": "/$defs/binding/properties/type/enum/-",
-        "value": "mcp_schema_registry"
+        "value": "mcp-schema-registry"
     },
     {
         "op": "add",
@@ -15,7 +15,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_schema_registry"
+                        "const": "mcp-schema-registry"
                     }
                 }
             },
@@ -25,7 +25,7 @@
                 {
                     "type":
                     {
-                        "const": "mcp_schema_registry"
+                        "const": "mcp-schema-registry"
                     },
                     "kind":
                     {

--- a/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/streams/mcp/tools.list/client.rpt
+++ b/specs/binding-mcp-schema-registry.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/schema/registry/streams/mcp/tools.list/client.rpt
@@ -48,7 +48,7 @@ write zilla:begin.ext ${mcp:beginEx()
 
 connected
 
-# tools/list answered from the generated mcp_openapi config, without any call
+# tools/list answered from the generated mcp-openapi config, without any call
 # reaching Karapace -- the fixed nine-tool set is known statically from the
 # bundled spec's routes.
 read  '{"tools":[{"name":"list_subjects","description":"list_subjects","inputSchema":{"type":"object","properties":{}},'


### PR DESCRIPTION
## Description

Every composite/proxy binding type in Zilla joins segments with a hyphen (`grpc-kafka`, `http-kafka`, `http-filesystem`, `kafka-grpc`, `mqtt-kafka`, `sse-kafka`). The four MCP composite bindings were the sole outliers, using underscores instead: `mcp_http`, `mcp_kafka`, `mcp_openapi`, `mcp_schema_registry`. This renames them to `mcp-http`, `mcp-kafka`, `mcp-openapi`, `mcp-schema-registry` for consistency with the rest of the codebase. The bare `mcp` binding (no suffix) is unaffected.

This is a breaking change to the `type:` discriminator for any existing `zilla.yaml` using these bindings.

**Changed:**
- `TYPE` constants in `runtime/binding-mcp-{http,kafka,openapi,schema-registry}` and the matching `config/binding-mcp-*.conf` modules
- JSON schema patch `enum`/`const` values (filenames unchanged, matching precedent — e.g. `binding-grpc-kafka`'s schema patch file is likewise not renamed)
- Generated composite sub-binding names (`McpKafkaClientGenerator`, `McpOpenapiCompositeGenerator`, `McpSchemaRegistryCompositeGenerator`)
- The `mcp-http` event-id taxonomy string (`binding.mcp_http...` → `binding.mcp.http...`), matching the dot-separated convention already used by `McpOpenapiEventContext`/`MqttKafkaEventContext`
- All spec YAML fixtures and unit test fixtures across the four binding/config/spec module sets
- `specs/AGENTS.md`'s naming-convention example
- The `mcp.proxy` example (`type:` fields only — binding *names* like `south_mcp_http_github` follow a separate, unrelated underscore convention used for every binding name in the file, and are unchanged)

**Not changed** (existing precedent elsewhere in the codebase, e.g. `binding-grpc-kafka`'s IDL scope is `grpc_kafka` while its `TYPE` is `"grpc-kafka"`):
- `.idl` scope names (`scope mcp_http`, `scope mcp_openapi`) — hyphens aren't valid Java/IDL identifiers
- JSON schema patch filenames
- `CHANGELOG.md` (historical record)

## Verification

- `./mvnw checkstyle:check` — clean
- `./mvnw install` on all 9 affected modules (`runtime/binding-mcp*`, `config/binding-mcp-*.conf`) — **BUILD SUCCESS**, every unit test and every k3po `*IT.java` integration test passing
- Built the Zilla docker image from this branch and ran the `examples/mcp.proxy` stack (real Kafka broker, real Karapace schema registry, JWT auth) against its own `.github/test.sh` — 74/74 checks passed, zero failures, confirming the renamed types resolve correctly through SPI binding lookup, JSON schema validation, and the full live request path
- Residual grep sweep confirms only the intended exceptions remain (`.idl` scope names, schema-patch filenames, binding-name labels, `CHANGELOG.md`)

Fixes # (issue) — no tracked issue; identified during a binding-type naming consistency review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BC3YGEYzbzPq1oi3GtbrV6)_