### PR TITLE
fix(engine,binding-mcp-openapi): fix mcp-kafka-connect hydration bug (#2273)

### DIFF
--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -57,58 +57,83 @@
 #      scope (kafka_sr:write) under the toolkit-level scope
 #      (kafka_sr:tools) for register_schema only -- no OpenAPI
 #      security scheme is involved, unlike petstore's create_pet
-#  23. kafka__create_topics creates a real topic on the same broker
+#  23. kafka_connect__list_connector_plugins lists the bundled FileStream
+#      source/sink connector plugins from a real Kafka Connect distributed
+#      worker (mcp-kafka-connect kind:client's own generated composite
+#      -- mcp-openapi -> mcp-http -> http_client -- not a mock)
+#  24. kafka_connect__create_connector creates a real FileStreamSourceConnector
+#      reading a file inside the worker container, gated by its own
+#      tool-specific kafka_connect:admin scope layered under the
+#      toolkit-level kafka_connect:tools scope -- the same layering
+#      mechanism as register_schema/kafka_sr:write, demonstrated on a
+#      third toolkit
+#  25. kafka_connect__list_connectors and describe_connector confirm the
+#      connector created above is real, running worker state, not just
+#      an echoed request
+#  26. kafka_connect__describe_connector_status reports the connector and
+#      its one task as RUNNING against the real worker
+#  27. kafka_connect__pause_connector then describe_connector_status
+#      confirm the connector transitions to PAUSED on the real worker
+#  28. kafka_connect__resume_connector then describe_connector_status
+#      confirm it transitions back to RUNNING
+#  29. kafka_connect__restart_connector succeeds against the running
+#      connector, sharing pause_connector/resume_connector's
+#      kafka_connect:admin-gated route
+#  30. kafka_connect__delete_connector removes the connector, confirmed by
+#      list_connectors reporting none remaining, sharing create_connector's
+#      kafka_connect:admin-gated route
+#  31. kafka__create_topics creates a real topic on the same broker
 #      (mcp-kafka kind:client's own generated pipeline, not the engine's
 #      test double), gated by its own tool-specific kafka:admin scope
 #      layered under the toolkit-level kafka:tools scope -- the same
-#      layering mechanism as register_schema/kafka_sr:write, demonstrated
-#      on a different toolkit
-#  24. kafka__delete_topics deletes that same topic on the same broker,
+#      layering mechanism as register_schema/kafka_sr:write and
+#      kafka_connect's admin-tier tools, demonstrated on a fourth toolkit
+#  32. kafka__delete_topics deletes that same topic on the same broker,
 #      sharing create_topics' route (one `when` list, two `tool` entries)
 #      and its kafka:admin scope -- both are structural, admin-risk
 #      mutations, so one route/guard covers both instead of duplicating it
-#  25. kafka__describe_configs reads back the real broker's effective
+#  33. kafka__describe_configs reads back the real broker's effective
 #      config for the orders topic, including a config every topic
 #      carries by default -- needs no scope beyond the toolkit-level
 #      kafka:tools guard already exercised by consume
-#  26. kafka__alter_configs changes the orders topic's cleanup.policy on
+#  34. kafka__alter_configs changes the orders topic's cleanup.policy on
 #      the same real broker, sharing create_topics/delete_topics' route
 #      and kafka:admin scope -- a third structural, admin-risk mutation
 #      coalesced onto the same route/guard
-#  27. kafka__list_topics lists the real topics on the same broker, gated
+#  35. kafka__list_topics lists the real topics on the same broker, gated
 #      by only the toolkit-level kafka:tools scope (no admin/write needed,
 #      same tier as consume)
-#  28. kafka__describe_topic describes the orders topic by name, reporting
+#  36. kafka__describe_topic describes the orders topic by name, reporting
 #      its partitions/leader/replicas/isr from the same real broker
-#  29. kafka__cluster_overview summarizes the same broker's topic/broker
+#  37. kafka__cluster_overview summarizes the same broker's topic/broker
 #      counts, sharing list_topics/describe_topic's read-only route
-#  30. kafka__list_brokers lists the real, single-node KRaft broker started
+#  38. kafka__list_brokers lists the real, single-node KRaft broker started
 #      by this example -- proving KafkaApiDescribeClusterClient's shared
 #      DescribeCluster request/response path (not the older, fully-decoded
 #      mechanism used elsewhere in binding-kafka) reaches a real broker
-#  31. kafka__describe_cluster reports that same broker as its controller --
+#  39. kafka__describe_cluster reports that same broker as its controller --
 #      both tools share one route/guard (kafka:tools only, no admin scope),
 #      being read-only cluster introspection like consume
-#  32. kafka__describe_consumer_group, called against a group id that has
+#  40. kafka__describe_consumer_group, called against a group id that has
 #      never committed an offset, reports real broker state "Dead" -- Kafka's
 #      actual behavior for a group that does not yet exist, not an error --
 #      needing only the toolkit-level kafka:tools scope
-#  33. kafka__describe_consumer_group_lag, called against that same
+#  41. kafka__describe_consumer_group_lag, called against that same
 #      never-used group, sequences a real OffsetFetch then ListOffsets and
 #      reports total lag 0 with an empty partitions array -- a group with no
 #      committed offsets has no lag to report, not an error -- sharing
 #      describe_consumer_group's read-only route/scope
-#  34. kafka__list_consumer_groups succeeds against the real broker, needing
+#  42. kafka__list_consumer_groups succeeds against the real broker, needing
 #      only the toolkit-level kafka:tools scope
-#  35. kafka__create_acls grants a real ACL on a dedicated test resource,
+#  43. kafka__create_acls grants a real ACL on a dedicated test resource,
 #      gated by its own kafka:acls scope -- deliberately distinct from
 #      kafka:admin per KIP-1318's "destructive-mutate" classification of ACL
 #      mutation (see the routes[] comment in etc/zilla.yaml)
-#  36. kafka__list_acls reads that same ACL back from the real broker,
+#  44. kafka__list_acls reads that same ACL back from the real broker,
 #      needing only the toolkit-level kafka:tools scope like describe_configs
-#  37. kafka__delete_acls revokes the ACL granted above, sharing
+#  45. kafka__delete_acls revokes the ACL granted above, sharing
 #      create_acls' route and kafka:acls scope
-#  38. a real MCP SDK client subscribes to an everything resource, triggers
+#  46. a real MCP SDK client subscribes to an everything resource, triggers
 #      the everything server's own toggle-subscriber-updates tool, and
 #      receives a relayed notifications/resources/updated -- exercising
 #      resources/subscribe, resources/unsubscribe, and the notification
@@ -150,8 +175,8 @@ encode_jwt() {
 
 JWT_NONE=""
 JWT_URLELICIT=$(encode_jwt "urlelicit:authorize")
-JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools")
-JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka:tools kafka:write kafka:admin kafka:acls")
+JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools kafka_connect:tools")
+JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka_connect:tools kafka_connect:admin kafka:tools kafka:write kafka:admin kafka:acls")
 
 # WHEN: a url-elicitation-capable client initializes against the gateway
 # THEN: the gateway negotiates protocol version 2025-11-25 in the response
@@ -225,6 +250,7 @@ assert_no_token() {
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka_sr__' &&
+    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'
@@ -235,6 +261,7 @@ if echo "$TOOLS_NONE" | grep -q '^everything__' &&
     ! echo "$TOOLS_NONE" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
+    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'; then
@@ -245,14 +272,17 @@ else
 fi
 
 # WHEN: a caller has toolkit-level scopes (github:tools, petstore:tools,
-#       kafka_sr:tools) but none of the finer-grained operation scopes
+#       kafka_sr:tools, kafka_connect:tools) but none of the finer-grained
+#       operation scopes
 # THEN: petstore__list_pets, both petstore resources, github's
-#       pull_by_number template, and kafka_sr__list_subjects are listed
-#       (none of them declare an extra scope beyond toolkit access) but
-#       petstore__create_pet, github__create_pr, and
-#       kafka_sr__register_schema are not (they require pets:write /
-#       github:pr:write / kafka_sr:write respectively) -- proof that
-#       toolkit access alone does not imply access to every tool/resource in it
+#       pull_by_number template, kafka_sr__list_subjects, and
+#       kafka_connect__list_connector_plugins are listed (none of them
+#       declare an extra scope beyond toolkit access) but
+#       petstore__create_pet, github__create_pr, kafka_sr__register_schema,
+#       and kafka_connect__create_connector are not (they require
+#       pets:write / github:pr:write / kafka_sr:write / kafka_connect:admin
+#       respectively) -- proof that toolkit access alone does not imply
+#       access to every tool/resource in it
 assert_partial_token() {
   TOOLS_PARTIAL=$(list_tools "$JWT_PARTIAL")
   echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
@@ -261,9 +291,11 @@ assert_partial_token() {
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
+    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
+    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'
 }
@@ -275,12 +307,14 @@ if echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
+    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
+    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'; then
-  echo "✅ toolkit-only scope: sees list_pets, search_pets, list_subjects, and all three read-only resources, but not create_pet, create_pr, or register_schema"
+  echo "✅ toolkit-only scope: sees list_pets, search_pets, list_subjects, list_connector_plugins, and all three read-only resources, but not create_pet, create_pr, register_schema, or create_connector"
 else
   echo "❌ toolkit-only scope did not layer as expected"
   EXIT=1
@@ -301,6 +335,11 @@ assert_full_token() {
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -333,6 +372,11 @@ if echo "$TOOLS_FULL" | grep -q '^everything__' &&
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -715,6 +759,228 @@ if echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'; then
   echo "✅ kafka_sr__check_compatibility reported the identical schema as compatible"
 else
   echo "❌ kafka_sr__check_compatibility did not succeed as expected"
+  EXIT=1
+fi
+
+KC_CONNECTOR="file-source-demo"
+
+# WHEN: a kafka_connect:tools-scoped caller calls kafka_connect__list_connector_plugins
+# THEN: the bundled FileStream source/sink connector plugins come back from a
+#       real Kafka Connect distributed worker (mcp-kafka-connect kind:client's
+#       own generated composite -- mcp-openapi -> mcp-http -> http_client --
+#       not a mock), proving the worker's plugin.path resolved the broker
+#       distribution's own libs/ directory
+call_kafka_connect_list_plugins() {
+  KC_LIST_PLUGINS_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connector_plugins" \
+      tools-list-client 2>&1)
+  echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'
+}
+retry_until 10 3 call_kafka_connect_list_plugins
+echo "KC_LIST_PLUGINS_OUT=$KC_LIST_PLUGINS_OUT"
+if echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'; then
+  echo "✅ kafka_connect__list_connector_plugins listed the bundled FileStreamSourceConnector from the real worker"
+else
+  echo "❌ kafka_connect__list_connector_plugins did not list the bundled FileStreamSourceConnector"
+  EXIT=1
+fi
+
+# WHEN: a kafka_connect:admin-scoped caller calls kafka_connect__create_connector
+#       to create a FileStreamSourceConnector reading a file already seeded
+#       inside the kafka-connect container
+# THEN: the connector is created against the real worker, gated by its own
+#       tool-specific kafka_connect:admin scope layered under the
+#       toolkit-level kafka_connect:tools scope -- the same layering
+#       mechanism as register_schema/kafka_sr:write, demonstrated on a
+#       third toolkit
+docker compose exec -T kafka-connect sh -c "echo 'hello from mcp-kafka-connect' > /tmp/kc-source.txt"
+call_kafka_connect_create_connector() {
+  KC_CREATE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__create_connector" \
+      -e CALL_ARGS="{\"name\":\"$KC_CONNECTOR\",\"config\":{\"connector.class\":\"org.apache.kafka.connect.file.FileStreamSourceConnector\",\"tasks.max\":\"1\",\"file\":\"/tmp/kc-source.txt\",\"topic\":\"connect-demo\"}}" \
+      tools-list-client 2>&1)
+  echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_create_connector
+echo "KC_CREATE_OUT=$KC_CREATE_OUT"
+if echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__create_connector created a real connector on the real worker"
+else
+  echo "❌ kafka_connect__create_connector did not succeed against the real worker"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__list_connectors and describe_connector
+# THEN: the connector created above comes back as real, running worker state --
+#       not just an echo of the create call
+call_kafka_connect_list_connectors() {
+  KC_LIST_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connectors" \
+      tools-list-client 2>&1)
+  echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_list_connectors
+echo "KC_LIST_OUT=$KC_LIST_OUT"
+if echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__list_connectors saw the created connector in real worker state"
+else
+  echo "❌ kafka_connect__list_connectors did not see the created connector"
+  EXIT=1
+fi
+
+call_kafka_connect_describe_connector() {
+  KC_DESCRIBE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'
+}
+retry_until 10 3 call_kafka_connect_describe_connector
+echo "KC_DESCRIBE_OUT=$KC_DESCRIBE_OUT"
+if echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'; then
+  echo "✅ kafka_connect__describe_connector read back the real connector's configuration"
+else
+  echo "❌ kafka_connect__describe_connector did not read back the connector's configuration"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__describe_connector_status
+# THEN: the connector and its one task report RUNNING against the real worker
+call_kafka_connect_status_running() {
+  KC_STATUS_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_status_running
+echo "KC_STATUS_OUT=$KC_STATUS_OUT"
+if echo "$KC_STATUS_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__describe_connector_status reported the real connector as RUNNING"
+else
+  echo "❌ kafka_connect__describe_connector_status did not report RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__pause_connector then
+#       describe_connector_status
+# THEN: the real connector transitions to PAUSED
+call_kafka_connect_pause() {
+  KC_PAUSE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__pause_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_PAUSED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'
+}
+retry_until 10 3 call_kafka_connect_pause
+echo "KC_PAUSE_OUT=$KC_PAUSE_OUT"
+echo "KC_STATUS_PAUSED_OUT=$KC_STATUS_PAUSED_OUT"
+if echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'; then
+  echo "✅ kafka_connect__pause_connector transitioned the real connector to PAUSED"
+else
+  echo "❌ kafka_connect__pause_connector did not transition the real connector to PAUSED"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__resume_connector then
+#       describe_connector_status
+# THEN: the real connector transitions back to RUNNING
+call_kafka_connect_resume() {
+  KC_RESUME_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__resume_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_RESUMED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_resume
+echo "KC_RESUME_OUT=$KC_RESUME_OUT"
+echo "KC_STATUS_RESUMED_OUT=$KC_STATUS_RESUMED_OUT"
+if echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__resume_connector transitioned the real connector back to RUNNING"
+else
+  echo "❌ kafka_connect__resume_connector did not transition the real connector back to RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__restart_connector
+# THEN: the real, running connector restarts successfully, sharing
+#       pause_connector/resume_connector's kafka_connect:admin-gated route
+call_kafka_connect_restart() {
+  KC_RESTART_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__restart_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_RESTARTED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_restart
+echo "KC_RESTART_OUT=$KC_RESTART_OUT"
+echo "KC_STATUS_RESTARTED_OUT=$KC_STATUS_RESTARTED_OUT"
+if echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__restart_connector left the real connector RUNNING"
+else
+  echo "❌ kafka_connect__restart_connector did not leave the real connector RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__delete_connector
+# THEN: the real connector is removed, confirmed by list_connectors
+#       reporting none remaining -- sharing create_connector's
+#       kafka_connect:admin-gated route
+call_kafka_connect_delete_connector() {
+  KC_DELETE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__delete_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_LIST_AFTER_DELETE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connectors" \
+      tools-list-client 2>&1)
+  ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_delete_connector
+echo "KC_DELETE_OUT=$KC_DELETE_OUT"
+echo "KC_LIST_AFTER_DELETE_OUT=$KC_LIST_AFTER_DELETE_OUT"
+if ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__delete_connector removed the real connector"
+else
+  echo "❌ kafka_connect__delete_connector did not remove the real connector"
   EXIT=1
 fi
 

--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -57,58 +57,83 @@
 #      scope (kafka_sr:write) under the toolkit-level scope
 #      (kafka_sr:tools) for register_schema only -- no OpenAPI
 #      security scheme is involved, unlike petstore's create_pet
-#  23. kafka__create_topics creates a real topic on the same broker
+#  23. kafka_connect__list_connector_plugins lists the bundled FileStream
+#      source/sink connector plugins from a real Kafka Connect distributed
+#      worker (mcp-kafka-connect kind:client's own generated composite
+#      -- mcp-openapi -> mcp-http -> http_client -- not a mock)
+#  24. kafka_connect__create_connector creates a real FileStreamSourceConnector
+#      reading a file inside the worker container, gated by its own
+#      tool-specific kafka_connect:admin scope layered under the
+#      toolkit-level kafka_connect:tools scope -- the same layering
+#      mechanism as register_schema/kafka_sr:write, demonstrated on a
+#      third toolkit
+#  25. kafka_connect__list_connectors and describe_connector confirm the
+#      connector created above is real, running worker state, not just
+#      an echoed request
+#  26. kafka_connect__describe_connector_status reports the connector and
+#      its one task as RUNNING against the real worker
+#  27. kafka_connect__pause_connector then describe_connector_status
+#      confirm the connector transitions to PAUSED on the real worker
+#  28. kafka_connect__resume_connector then describe_connector_status
+#      confirm it transitions back to RUNNING
+#  29. kafka_connect__restart_connector succeeds against the running
+#      connector, sharing pause_connector/resume_connector's
+#      kafka_connect:admin-gated route
+#  30. kafka_connect__delete_connector removes the connector, confirmed by
+#      list_connectors reporting none remaining, sharing create_connector's
+#      kafka_connect:admin-gated route
+#  31. kafka__create_topics creates a real topic on the same broker
 #      (mcp-kafka kind:client's own generated pipeline, not the engine's
 #      test double), gated by its own tool-specific kafka:admin scope
 #      layered under the toolkit-level kafka:tools scope -- the same
-#      layering mechanism as register_schema/kafka_sr:write, demonstrated
-#      on a different toolkit
-#  24. kafka__delete_topics deletes that same topic on the same broker,
+#      layering mechanism as register_schema/kafka_sr:write and
+#      kafka_connect's admin-tier tools, demonstrated on a fourth toolkit
+#  32. kafka__delete_topics deletes that same topic on the same broker,
 #      sharing create_topics' route (one `when` list, two `tool` entries)
 #      and its kafka:admin scope -- both are structural, admin-risk
 #      mutations, so one route/guard covers both instead of duplicating it
-#  25. kafka__describe_configs reads back the real broker's effective
+#  33. kafka__describe_configs reads back the real broker's effective
 #      config for the orders topic, including a config every topic
 #      carries by default -- needs no scope beyond the toolkit-level
 #      kafka:tools guard already exercised by consume
-#  26. kafka__alter_configs changes the orders topic's cleanup.policy on
+#  34. kafka__alter_configs changes the orders topic's cleanup.policy on
 #      the same real broker, sharing create_topics/delete_topics' route
 #      and kafka:admin scope -- a third structural, admin-risk mutation
 #      coalesced onto the same route/guard
-#  27. kafka__list_topics lists the real topics on the same broker, gated
+#  35. kafka__list_topics lists the real topics on the same broker, gated
 #      by only the toolkit-level kafka:tools scope (no admin/write needed,
 #      same tier as consume)
-#  28. kafka__describe_topic describes the orders topic by name, reporting
+#  36. kafka__describe_topic describes the orders topic by name, reporting
 #      its partitions/leader/replicas/isr from the same real broker
-#  29. kafka__cluster_overview summarizes the same broker's topic/broker
+#  37. kafka__cluster_overview summarizes the same broker's topic/broker
 #      counts, sharing list_topics/describe_topic's read-only route
-#  30. kafka__list_brokers lists the real, single-node KRaft broker started
+#  38. kafka__list_brokers lists the real, single-node KRaft broker started
 #      by this example -- proving KafkaApiDescribeClusterClient's shared
 #      DescribeCluster request/response path (not the older, fully-decoded
 #      mechanism used elsewhere in binding-kafka) reaches a real broker
-#  31. kafka__describe_cluster reports that same broker as its controller --
+#  39. kafka__describe_cluster reports that same broker as its controller --
 #      both tools share one route/guard (kafka:tools only, no admin scope),
 #      being read-only cluster introspection like consume
-#  32. kafka__describe_consumer_group, called against a group id that has
+#  40. kafka__describe_consumer_group, called against a group id that has
 #      never committed an offset, reports real broker state "Dead" -- Kafka's
 #      actual behavior for a group that does not yet exist, not an error --
 #      needing only the toolkit-level kafka:tools scope
-#  33. kafka__describe_consumer_group_lag, called against that same
+#  41. kafka__describe_consumer_group_lag, called against that same
 #      never-used group, sequences a real OffsetFetch then ListOffsets and
 #      reports total lag 0 with an empty partitions array -- a group with no
 #      committed offsets has no lag to report, not an error -- sharing
 #      describe_consumer_group's read-only route/scope
-#  34. kafka__list_consumer_groups succeeds against the real broker, needing
+#  42. kafka__list_consumer_groups succeeds against the real broker, needing
 #      only the toolkit-level kafka:tools scope
-#  35. kafka__create_acls grants a real ACL on a dedicated test resource,
+#  43. kafka__create_acls grants a real ACL on a dedicated test resource,
 #      gated by its own kafka:acls scope -- deliberately distinct from
 #      kafka:admin per KIP-1318's "destructive-mutate" classification of ACL
 #      mutation (see the routes[] comment in etc/zilla.yaml)
-#  36. kafka__list_acls reads that same ACL back from the real broker,
+#  44. kafka__list_acls reads that same ACL back from the real broker,
 #      needing only the toolkit-level kafka:tools scope like describe_configs
-#  37. kafka__delete_acls revokes the ACL granted above, sharing
+#  45. kafka__delete_acls revokes the ACL granted above, sharing
 #      create_acls' route and kafka:acls scope
-#  38. a real MCP SDK client subscribes to an everything resource, triggers
+#  46. a real MCP SDK client subscribes to an everything resource, triggers
 #      the everything server's own toggle-subscriber-updates tool, and
 #      receives a relayed notifications/resources/updated -- exercising
 #      resources/subscribe, resources/unsubscribe, and the notification
@@ -119,13 +144,6 @@
 # FindCoordinator -> DescribeGroups -> OffsetCommit flow) is a known,
 # tracked gap in this example's real-broker coverage -- see the note above
 # the kafka__list_consumer_groups check below.
-#
-# south_mcp_kafka_connect_client (mcp-kafka-connect kind:client, against a
-# real Kafka Connect worker also started by this example) is configured but
-# not exercised here: its tools never hydrate into north_mcp_proxy's cache,
-# even though the worker itself is reachable and answers correctly when
-# queried directly -- see "Manage connectors through a real Kafka Connect
-# worker" in README.md and aklivity/zilla#2273.
 #
 # Streamable HTTP responses arrive as Server-Sent Events; checks grep the
 # streamed body / client output rather than asserting exact-string equality.
@@ -157,8 +175,8 @@ encode_jwt() {
 
 JWT_NONE=""
 JWT_URLELICIT=$(encode_jwt "urlelicit:authorize")
-JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools")
-JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka:tools kafka:write kafka:admin kafka:acls")
+JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools kafka_connect:tools")
+JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka_connect:tools kafka_connect:admin kafka:tools kafka:write kafka:admin kafka:acls")
 
 # WHEN: a url-elicitation-capable client initializes against the gateway
 # THEN: the gateway negotiates protocol version 2025-11-25 in the response
@@ -232,6 +250,7 @@ assert_no_token() {
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka_sr__' &&
+    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'
@@ -242,6 +261,7 @@ if echo "$TOOLS_NONE" | grep -q '^everything__' &&
     ! echo "$TOOLS_NONE" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
+    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'; then
@@ -252,14 +272,17 @@ else
 fi
 
 # WHEN: a caller has toolkit-level scopes (github:tools, petstore:tools,
-#       kafka_sr:tools) but none of the finer-grained operation scopes
+#       kafka_sr:tools, kafka_connect:tools) but none of the finer-grained
+#       operation scopes
 # THEN: petstore__list_pets, both petstore resources, github's
-#       pull_by_number template, and kafka_sr__list_subjects are listed
-#       (none of them declare an extra scope beyond toolkit access) but
-#       petstore__create_pet, github__create_pr, and
-#       kafka_sr__register_schema are not (they require pets:write /
-#       github:pr:write / kafka_sr:write respectively) -- proof that
-#       toolkit access alone does not imply access to every tool/resource in it
+#       pull_by_number template, kafka_sr__list_subjects, and
+#       kafka_connect__list_connector_plugins are listed (none of them
+#       declare an extra scope beyond toolkit access) but
+#       petstore__create_pet, github__create_pr, kafka_sr__register_schema,
+#       and kafka_connect__create_connector are not (they require
+#       pets:write / github:pr:write / kafka_sr:write / kafka_connect:admin
+#       respectively) -- proof that toolkit access alone does not imply
+#       access to every tool/resource in it
 assert_partial_token() {
   TOOLS_PARTIAL=$(list_tools "$JWT_PARTIAL")
   echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
@@ -268,9 +291,11 @@ assert_partial_token() {
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
+    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
+    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'
 }
@@ -282,12 +307,14 @@ if echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
+    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
+    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'; then
-  echo "✅ toolkit-only scope: sees list_pets, search_pets, and list_subjects, and all three read-only resources, but not create_pet, create_pr, or register_schema"
+  echo "✅ toolkit-only scope: sees list_pets, search_pets, list_subjects, list_connector_plugins, and all three read-only resources, but not create_pet, create_pr, register_schema, or create_connector"
 else
   echo "❌ toolkit-only scope did not layer as expected"
   EXIT=1
@@ -308,6 +335,11 @@ assert_full_token() {
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -340,6 +372,11 @@ if echo "$TOOLS_FULL" | grep -q '^everything__' &&
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
+    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -722,6 +759,228 @@ if echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'; then
   echo "✅ kafka_sr__check_compatibility reported the identical schema as compatible"
 else
   echo "❌ kafka_sr__check_compatibility did not succeed as expected"
+  EXIT=1
+fi
+
+KC_CONNECTOR="file-source-demo"
+
+# WHEN: a kafka_connect:tools-scoped caller calls kafka_connect__list_connector_plugins
+# THEN: the bundled FileStream source/sink connector plugins come back from a
+#       real Kafka Connect distributed worker (mcp-kafka-connect kind:client's
+#       own generated composite -- mcp-openapi -> mcp-http -> http_client --
+#       not a mock), proving the worker's plugin.path resolved the broker
+#       distribution's own libs/ directory
+call_kafka_connect_list_plugins() {
+  KC_LIST_PLUGINS_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connector_plugins" \
+      tools-list-client 2>&1)
+  echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'
+}
+retry_until 10 3 call_kafka_connect_list_plugins
+echo "KC_LIST_PLUGINS_OUT=$KC_LIST_PLUGINS_OUT"
+if echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'; then
+  echo "✅ kafka_connect__list_connector_plugins listed the bundled FileStreamSourceConnector from the real worker"
+else
+  echo "❌ kafka_connect__list_connector_plugins did not list the bundled FileStreamSourceConnector"
+  EXIT=1
+fi
+
+# WHEN: a kafka_connect:admin-scoped caller calls kafka_connect__create_connector
+#       to create a FileStreamSourceConnector reading a file already seeded
+#       inside the kafka-connect container
+# THEN: the connector is created against the real worker, gated by its own
+#       tool-specific kafka_connect:admin scope layered under the
+#       toolkit-level kafka_connect:tools scope -- the same layering
+#       mechanism as register_schema/kafka_sr:write, demonstrated on a
+#       third toolkit
+docker compose exec -T kafka-connect sh -c "echo 'hello from mcp-kafka-connect' > /tmp/kc-source.txt"
+call_kafka_connect_create_connector() {
+  KC_CREATE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__create_connector" \
+      -e CALL_ARGS="{\"name\":\"$KC_CONNECTOR\",\"config\":{\"connector.class\":\"org.apache.kafka.connect.file.FileStreamSourceConnector\",\"tasks.max\":\"1\",\"file\":\"/tmp/kc-source.txt\",\"topic\":\"connect-demo\"}}" \
+      tools-list-client 2>&1)
+  echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_create_connector
+echo "KC_CREATE_OUT=$KC_CREATE_OUT"
+if echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__create_connector created a real connector on the real worker"
+else
+  echo "❌ kafka_connect__create_connector did not succeed against the real worker"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__list_connectors and describe_connector
+# THEN: the connector created above comes back as real, running worker state --
+#       not just an echo of the create call
+call_kafka_connect_list_connectors() {
+  KC_LIST_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connectors" \
+      tools-list-client 2>&1)
+  echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_list_connectors
+echo "KC_LIST_OUT=$KC_LIST_OUT"
+if echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__list_connectors saw the created connector in real worker state"
+else
+  echo "❌ kafka_connect__list_connectors did not see the created connector"
+  EXIT=1
+fi
+
+call_kafka_connect_describe_connector() {
+  KC_DESCRIBE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'
+}
+retry_until 10 3 call_kafka_connect_describe_connector
+echo "KC_DESCRIBE_OUT=$KC_DESCRIBE_OUT"
+if echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'; then
+  echo "✅ kafka_connect__describe_connector read back the real connector's configuration"
+else
+  echo "❌ kafka_connect__describe_connector did not read back the connector's configuration"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__describe_connector_status
+# THEN: the connector and its one task report RUNNING against the real worker
+call_kafka_connect_status_running() {
+  KC_STATUS_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_status_running
+echo "KC_STATUS_OUT=$KC_STATUS_OUT"
+if echo "$KC_STATUS_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__describe_connector_status reported the real connector as RUNNING"
+else
+  echo "❌ kafka_connect__describe_connector_status did not report RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__pause_connector then
+#       describe_connector_status
+# THEN: the real connector transitions to PAUSED
+call_kafka_connect_pause() {
+  KC_PAUSE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__pause_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_PAUSED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'
+}
+retry_until 10 3 call_kafka_connect_pause
+echo "KC_PAUSE_OUT=$KC_PAUSE_OUT"
+echo "KC_STATUS_PAUSED_OUT=$KC_STATUS_PAUSED_OUT"
+if echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'; then
+  echo "✅ kafka_connect__pause_connector transitioned the real connector to PAUSED"
+else
+  echo "❌ kafka_connect__pause_connector did not transition the real connector to PAUSED"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__resume_connector then
+#       describe_connector_status
+# THEN: the real connector transitions back to RUNNING
+call_kafka_connect_resume() {
+  KC_RESUME_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__resume_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_RESUMED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_resume
+echo "KC_RESUME_OUT=$KC_RESUME_OUT"
+echo "KC_STATUS_RESUMED_OUT=$KC_STATUS_RESUMED_OUT"
+if echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__resume_connector transitioned the real connector back to RUNNING"
+else
+  echo "❌ kafka_connect__resume_connector did not transition the real connector back to RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__restart_connector
+# THEN: the real, running connector restarts successfully, sharing
+#       pause_connector/resume_connector's kafka_connect:admin-gated route
+call_kafka_connect_restart() {
+  KC_RESTART_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__restart_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_STATUS_RESTARTED_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__describe_connector_status" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'
+}
+retry_until 10 3 call_kafka_connect_restart
+echo "KC_RESTART_OUT=$KC_RESTART_OUT"
+echo "KC_STATUS_RESTARTED_OUT=$KC_STATUS_RESTARTED_OUT"
+if echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'; then
+  echo "✅ kafka_connect__restart_connector left the real connector RUNNING"
+else
+  echo "❌ kafka_connect__restart_connector did not leave the real connector RUNNING"
+  EXIT=1
+fi
+
+# WHEN: that same caller calls kafka_connect__delete_connector
+# THEN: the real connector is removed, confirmed by list_connectors
+#       reporting none remaining -- sharing create_connector's
+#       kafka_connect:admin-gated route
+call_kafka_connect_delete_connector() {
+  KC_DELETE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__delete_connector" \
+      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
+      tools-list-client 2>&1)
+  KC_LIST_AFTER_DELETE_OUT=$(docker compose run --rm --no-deps \
+      -e JWT_TOKEN="$JWT_FULL" \
+      -e MCP_URL="http://zilla:$PORT/mcp" \
+      -e CALL_TOOL="kafka_connect__list_connectors" \
+      tools-list-client 2>&1)
+  ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"
+}
+retry_until 10 3 call_kafka_connect_delete_connector
+echo "KC_DELETE_OUT=$KC_DELETE_OUT"
+echo "KC_LIST_AFTER_DELETE_OUT=$KC_LIST_AFTER_DELETE_OUT"
+if ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"; then
+  echo "✅ kafka_connect__delete_connector removed the real connector"
+else
+  echo "❌ kafka_connect__delete_connector did not remove the real connector"
   EXIT=1
 fi
 

--- a/examples/mcp.proxy/.github/test.sh
+++ b/examples/mcp.proxy/.github/test.sh
@@ -57,83 +57,58 @@
 #      scope (kafka_sr:write) under the toolkit-level scope
 #      (kafka_sr:tools) for register_schema only -- no OpenAPI
 #      security scheme is involved, unlike petstore's create_pet
-#  23. kafka_connect__list_connector_plugins lists the bundled FileStream
-#      source/sink connector plugins from a real Kafka Connect distributed
-#      worker (mcp-kafka-connect kind:client's own generated composite
-#      -- mcp-openapi -> mcp-http -> http_client -- not a mock)
-#  24. kafka_connect__create_connector creates a real FileStreamSourceConnector
-#      reading a file inside the worker container, gated by its own
-#      tool-specific kafka_connect:admin scope layered under the
-#      toolkit-level kafka_connect:tools scope -- the same layering
-#      mechanism as register_schema/kafka_sr:write, demonstrated on a
-#      third toolkit
-#  25. kafka_connect__list_connectors and describe_connector confirm the
-#      connector created above is real, running worker state, not just
-#      an echoed request
-#  26. kafka_connect__describe_connector_status reports the connector and
-#      its one task as RUNNING against the real worker
-#  27. kafka_connect__pause_connector then describe_connector_status
-#      confirm the connector transitions to PAUSED on the real worker
-#  28. kafka_connect__resume_connector then describe_connector_status
-#      confirm it transitions back to RUNNING
-#  29. kafka_connect__restart_connector succeeds against the running
-#      connector, sharing pause_connector/resume_connector's
-#      kafka_connect:admin-gated route
-#  30. kafka_connect__delete_connector removes the connector, confirmed by
-#      list_connectors reporting none remaining, sharing create_connector's
-#      kafka_connect:admin-gated route
-#  31. kafka__create_topics creates a real topic on the same broker
+#  23. kafka__create_topics creates a real topic on the same broker
 #      (mcp-kafka kind:client's own generated pipeline, not the engine's
 #      test double), gated by its own tool-specific kafka:admin scope
 #      layered under the toolkit-level kafka:tools scope -- the same
-#      layering mechanism as register_schema/kafka_sr:write and
-#      kafka_connect's admin-tier tools, demonstrated on a fourth toolkit
-#  32. kafka__delete_topics deletes that same topic on the same broker,
+#      layering mechanism as register_schema/kafka_sr:write, demonstrated
+#      on a different toolkit
+#  24. kafka__delete_topics deletes that same topic on the same broker,
 #      sharing create_topics' route (one `when` list, two `tool` entries)
 #      and its kafka:admin scope -- both are structural, admin-risk
 #      mutations, so one route/guard covers both instead of duplicating it
-#  33. kafka__describe_configs reads back the real broker's effective
+#  25. kafka__describe_configs reads back the real broker's effective
 #      config for the orders topic, including a config every topic
 #      carries by default -- needs no scope beyond the toolkit-level
 #      kafka:tools guard already exercised by consume
-#  34. kafka__alter_configs changes the orders topic's cleanup.policy on
+#  26. kafka__alter_configs changes the orders topic's cleanup.policy on
 #      the same real broker, sharing create_topics/delete_topics' route
 #      and kafka:admin scope -- a third structural, admin-risk mutation
 #      coalesced onto the same route/guard
-#  35. kafka__list_topics lists the real topics on the same broker, gated
+#  27. kafka__list_topics lists the real topics on the same broker, gated
 #      by only the toolkit-level kafka:tools scope (no admin/write needed,
 #      same tier as consume)
-#  36. kafka__describe_topic describes the orders topic by name, reporting
+#  28. kafka__describe_topic describes the orders topic by name, reporting
 #      its partitions/leader/replicas/isr from the same real broker
-#  37. kafka__cluster_overview summarizes the same broker's topic/broker
+#  29. kafka__cluster_overview summarizes the same broker's topic/broker
 #      counts, sharing list_topics/describe_topic's read-only route
-#  38. kafka__list_brokers lists the real, single-node KRaft broker started
+#  30. kafka__list_brokers lists the real, single-node KRaft broker started
 #      by this example -- proving KafkaApiDescribeClusterClient's shared
 #      DescribeCluster request/response path (not the older, fully-decoded
 #      mechanism used elsewhere in binding-kafka) reaches a real broker
-#  39. kafka__describe_cluster reports that same broker as its controller --
+#  31. kafka__describe_cluster reports that same broker as its controller --
 #      both tools share one route/guard (kafka:tools only, no admin scope),
 #      being read-only cluster introspection like consume
-#  40. kafka__describe_consumer_group, called against a group id that has
+#  32. kafka__describe_consumer_group, called against a group id that has
 #      never committed an offset, reports real broker state "Dead" -- Kafka's
 #      actual behavior for a group that does not yet exist, not an error --
 #      needing only the toolkit-level kafka:tools scope
-#  41. kafka__describe_consumer_group_lag, called against that same
+#  33. kafka__describe_consumer_group_lag, called against that same
 #      never-used group, sequences a real OffsetFetch then ListOffsets and
 #      reports total lag 0 with an empty partitions array -- a group with no
 #      committed offsets has no lag to report, not an error -- sharing
 #      describe_consumer_group's read-only route/scope
-#  42. kafka__list_consumer_groups succeeds against the real broker, needing
+#  34. kafka__list_consumer_groups succeeds against the real broker, needing
 #      only the toolkit-level kafka:tools scope
-#  43. kafka__create_acls grants a real ACL on a dedicated test resource,
+#  35. kafka__create_acls grants a real ACL on a dedicated test resource,
 #      gated by its own kafka:acls scope -- deliberately distinct from
 #      kafka:admin per KIP-1318's "destructive-mutate" classification of ACL
 #      mutation (see the routes[] comment in etc/zilla.yaml)
-#  44. kafka__list_acls reads that same ACL back from the real broker,
+#  36. kafka__list_acls reads that same ACL back from the real broker,
 #      needing only the toolkit-level kafka:tools scope like describe_configs
-#  45. kafka__delete_acls revokes the ACL granted above, sharing
+#  37. kafka__delete_acls revokes the ACL granted above, sharing
 #      create_acls' route and kafka:acls scope
-#  46. a real MCP SDK client subscribes to an everything resource, triggers
+#  38. a real MCP SDK client subscribes to an everything resource, triggers
 #      the everything server's own toggle-subscriber-updates tool, and
 #      receives a relayed notifications/resources/updated -- exercising
 #      resources/subscribe, resources/unsubscribe, and the notification
@@ -144,6 +119,13 @@
 # FindCoordinator -> DescribeGroups -> OffsetCommit flow) is a known,
 # tracked gap in this example's real-broker coverage -- see the note above
 # the kafka__list_consumer_groups check below.
+#
+# south_mcp_kafka_connect_client (mcp-kafka-connect kind:client, against a
+# real Kafka Connect worker also started by this example) is configured but
+# not exercised here: its tools never hydrate into north_mcp_proxy's cache,
+# even though the worker itself is reachable and answers correctly when
+# queried directly -- see "Manage connectors through a real Kafka Connect
+# worker" in README.md and aklivity/zilla#2273.
 #
 # Streamable HTTP responses arrive as Server-Sent Events; checks grep the
 # streamed body / client output rather than asserting exact-string equality.
@@ -175,8 +157,8 @@ encode_jwt() {
 
 JWT_NONE=""
 JWT_URLELICIT=$(encode_jwt "urlelicit:authorize")
-JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools kafka_connect:tools")
-JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka_connect:tools kafka_connect:admin kafka:tools kafka:write kafka:admin kafka:acls")
+JWT_PARTIAL=$(encode_jwt "github:tools petstore:tools kafka_sr:tools")
+JWT_FULL=$(encode_jwt "urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka:tools kafka:write kafka:admin kafka:acls")
 
 # WHEN: a url-elicitation-capable client initializes against the gateway
 # THEN: the gateway negotiates protocol version 2025-11-25 in the response
@@ -250,7 +232,6 @@ assert_no_token() {
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka_sr__' &&
-    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'
@@ -261,7 +242,6 @@ if echo "$TOOLS_NONE" | grep -q '^everything__' &&
     ! echo "$TOOLS_NONE" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_NONE" | grep -q '^github__' &&
     ! echo "$TOOLS_NONE" | grep -q '^petstore__' &&
-    ! echo "$TOOLS_NONE" | grep -q '^kafka_connect__' &&
     ! echo "$TOOLS_NONE" | grep -q '^kafka__' &&
     ! echo "$TOOLS_NONE" | grep -q 'petstore+' &&
     ! echo "$TOOLS_NONE" | grep -q 'github+'; then
@@ -272,17 +252,14 @@ else
 fi
 
 # WHEN: a caller has toolkit-level scopes (github:tools, petstore:tools,
-#       kafka_sr:tools, kafka_connect:tools) but none of the finer-grained
-#       operation scopes
+#       kafka_sr:tools) but none of the finer-grained operation scopes
 # THEN: petstore__list_pets, both petstore resources, github's
-#       pull_by_number template, kafka_sr__list_subjects, and
-#       kafka_connect__list_connector_plugins are listed (none of them
-#       declare an extra scope beyond toolkit access) but
-#       petstore__create_pet, github__create_pr, kafka_sr__register_schema,
-#       and kafka_connect__create_connector are not (they require
-#       pets:write / github:pr:write / kafka_sr:write / kafka_connect:admin
-#       respectively) -- proof that toolkit access alone does not imply
-#       access to every tool/resource in it
+#       pull_by_number template, and kafka_sr__list_subjects are listed
+#       (none of them declare an extra scope beyond toolkit access) but
+#       petstore__create_pet, github__create_pr, and
+#       kafka_sr__register_schema are not (they require pets:write /
+#       github:pr:write / kafka_sr:write respectively) -- proof that
+#       toolkit access alone does not imply access to every tool/resource in it
 assert_partial_token() {
   TOOLS_PARTIAL=$(list_tools "$JWT_PARTIAL")
   echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
@@ -291,11 +268,9 @@ assert_partial_token() {
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
-    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
-    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'
 }
@@ -307,14 +282,12 @@ if echo "$TOOLS_PARTIAL" | grep -q '^petstore__list_pets$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:petstore+/pets/{petId}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__list_subjects$' &&
-    echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__list_connector_plugins$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^petstore__create_pet$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^github__create_pr$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_sr__register_schema$' &&
-    ! echo "$TOOLS_PARTIAL" | grep -q '^kafka_connect__create_connector$' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^urlelicit__' &&
     ! echo "$TOOLS_PARTIAL" | grep -q '^kafka__'; then
-  echo "✅ toolkit-only scope: sees list_pets, search_pets, list_subjects, list_connector_plugins, and all three read-only resources, but not create_pet, create_pr, register_schema, or create_connector"
+  echo "✅ toolkit-only scope: sees list_pets, search_pets, and list_subjects, and all three read-only resources, but not create_pet, create_pr, or register_schema"
 else
   echo "❌ toolkit-only scope did not layer as expected"
   EXIT=1
@@ -335,11 +308,6 @@ assert_full_token() {
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -372,11 +340,6 @@ if echo "$TOOLS_FULL" | grep -q '^everything__' &&
     echo "$TOOLS_FULL" | grep -q '^template:github+pr://{owner}/{repo}/{number}$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__list_subjects$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka_sr__register_schema$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connector_plugins$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__list_connectors$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__describe_connector$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__create_connector$' &&
-    echo "$TOOLS_FULL" | grep -q '^kafka_connect__delete_connector$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__produce$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__consume$' &&
     echo "$TOOLS_FULL" | grep -q '^kafka__create_topics$' &&
@@ -759,228 +722,6 @@ if echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'; then
   echo "✅ kafka_sr__check_compatibility reported the identical schema as compatible"
 else
   echo "❌ kafka_sr__check_compatibility did not succeed as expected"
-  EXIT=1
-fi
-
-KC_CONNECTOR="file-source-demo"
-
-# WHEN: a kafka_connect:tools-scoped caller calls kafka_connect__list_connector_plugins
-# THEN: the bundled FileStream source/sink connector plugins come back from a
-#       real Kafka Connect distributed worker (mcp-kafka-connect kind:client's
-#       own generated composite -- mcp-openapi -> mcp-http -> http_client --
-#       not a mock), proving the worker's plugin.path resolved the broker
-#       distribution's own libs/ directory
-call_kafka_connect_list_plugins() {
-  KC_LIST_PLUGINS_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__list_connector_plugins" \
-      tools-list-client 2>&1)
-  echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'
-}
-retry_until 10 3 call_kafka_connect_list_plugins
-echo "KC_LIST_PLUGINS_OUT=$KC_LIST_PLUGINS_OUT"
-if echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'; then
-  echo "✅ kafka_connect__list_connector_plugins listed the bundled FileStreamSourceConnector from the real worker"
-else
-  echo "❌ kafka_connect__list_connector_plugins did not list the bundled FileStreamSourceConnector"
-  EXIT=1
-fi
-
-# WHEN: a kafka_connect:admin-scoped caller calls kafka_connect__create_connector
-#       to create a FileStreamSourceConnector reading a file already seeded
-#       inside the kafka-connect container
-# THEN: the connector is created against the real worker, gated by its own
-#       tool-specific kafka_connect:admin scope layered under the
-#       toolkit-level kafka_connect:tools scope -- the same layering
-#       mechanism as register_schema/kafka_sr:write, demonstrated on a
-#       third toolkit
-docker compose exec -T kafka-connect sh -c "echo 'hello from mcp-kafka-connect' > /tmp/kc-source.txt"
-call_kafka_connect_create_connector() {
-  KC_CREATE_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__create_connector" \
-      -e CALL_ARGS="{\"name\":\"$KC_CONNECTOR\",\"config\":{\"connector.class\":\"org.apache.kafka.connect.file.FileStreamSourceConnector\",\"tasks.max\":\"1\",\"file\":\"/tmp/kc-source.txt\",\"topic\":\"connect-demo\"}}" \
-      tools-list-client 2>&1)
-  echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"
-}
-retry_until 10 3 call_kafka_connect_create_connector
-echo "KC_CREATE_OUT=$KC_CREATE_OUT"
-if echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"; then
-  echo "✅ kafka_connect__create_connector created a real connector on the real worker"
-else
-  echo "❌ kafka_connect__create_connector did not succeed against the real worker"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__list_connectors and describe_connector
-# THEN: the connector created above comes back as real, running worker state --
-#       not just an echo of the create call
-call_kafka_connect_list_connectors() {
-  KC_LIST_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__list_connectors" \
-      tools-list-client 2>&1)
-  echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"
-}
-retry_until 10 3 call_kafka_connect_list_connectors
-echo "KC_LIST_OUT=$KC_LIST_OUT"
-if echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"; then
-  echo "✅ kafka_connect__list_connectors saw the created connector in real worker state"
-else
-  echo "❌ kafka_connect__list_connectors did not see the created connector"
-  EXIT=1
-fi
-
-call_kafka_connect_describe_connector() {
-  KC_DESCRIBE_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__describe_connector" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'
-}
-retry_until 10 3 call_kafka_connect_describe_connector
-echo "KC_DESCRIBE_OUT=$KC_DESCRIBE_OUT"
-if echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'; then
-  echo "✅ kafka_connect__describe_connector read back the real connector's configuration"
-else
-  echo "❌ kafka_connect__describe_connector did not read back the connector's configuration"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__describe_connector_status
-# THEN: the connector and its one task report RUNNING against the real worker
-call_kafka_connect_status_running() {
-  KC_STATUS_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__describe_connector_status" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  echo "$KC_STATUS_OUT" | grep -q 'RUNNING'
-}
-retry_until 10 3 call_kafka_connect_status_running
-echo "KC_STATUS_OUT=$KC_STATUS_OUT"
-if echo "$KC_STATUS_OUT" | grep -q 'RUNNING'; then
-  echo "✅ kafka_connect__describe_connector_status reported the real connector as RUNNING"
-else
-  echo "❌ kafka_connect__describe_connector_status did not report RUNNING"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__pause_connector then
-#       describe_connector_status
-# THEN: the real connector transitions to PAUSED
-call_kafka_connect_pause() {
-  KC_PAUSE_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__pause_connector" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  KC_STATUS_PAUSED_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__describe_connector_status" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'
-}
-retry_until 10 3 call_kafka_connect_pause
-echo "KC_PAUSE_OUT=$KC_PAUSE_OUT"
-echo "KC_STATUS_PAUSED_OUT=$KC_STATUS_PAUSED_OUT"
-if echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'; then
-  echo "✅ kafka_connect__pause_connector transitioned the real connector to PAUSED"
-else
-  echo "❌ kafka_connect__pause_connector did not transition the real connector to PAUSED"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__resume_connector then
-#       describe_connector_status
-# THEN: the real connector transitions back to RUNNING
-call_kafka_connect_resume() {
-  KC_RESUME_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__resume_connector" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  KC_STATUS_RESUMED_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__describe_connector_status" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'
-}
-retry_until 10 3 call_kafka_connect_resume
-echo "KC_RESUME_OUT=$KC_RESUME_OUT"
-echo "KC_STATUS_RESUMED_OUT=$KC_STATUS_RESUMED_OUT"
-if echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'; then
-  echo "✅ kafka_connect__resume_connector transitioned the real connector back to RUNNING"
-else
-  echo "❌ kafka_connect__resume_connector did not transition the real connector back to RUNNING"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__restart_connector
-# THEN: the real, running connector restarts successfully, sharing
-#       pause_connector/resume_connector's kafka_connect:admin-gated route
-call_kafka_connect_restart() {
-  KC_RESTART_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__restart_connector" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  KC_STATUS_RESTARTED_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__describe_connector_status" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'
-}
-retry_until 10 3 call_kafka_connect_restart
-echo "KC_RESTART_OUT=$KC_RESTART_OUT"
-echo "KC_STATUS_RESTARTED_OUT=$KC_STATUS_RESTARTED_OUT"
-if echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'; then
-  echo "✅ kafka_connect__restart_connector left the real connector RUNNING"
-else
-  echo "❌ kafka_connect__restart_connector did not leave the real connector RUNNING"
-  EXIT=1
-fi
-
-# WHEN: that same caller calls kafka_connect__delete_connector
-# THEN: the real connector is removed, confirmed by list_connectors
-#       reporting none remaining -- sharing create_connector's
-#       kafka_connect:admin-gated route
-call_kafka_connect_delete_connector() {
-  KC_DELETE_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__delete_connector" \
-      -e CALL_ARGS="{\"connector\":\"$KC_CONNECTOR\"}" \
-      tools-list-client 2>&1)
-  KC_LIST_AFTER_DELETE_OUT=$(docker compose run --rm --no-deps \
-      -e JWT_TOKEN="$JWT_FULL" \
-      -e MCP_URL="http://zilla:$PORT/mcp" \
-      -e CALL_TOOL="kafka_connect__list_connectors" \
-      tools-list-client 2>&1)
-  ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"
-}
-retry_until 10 3 call_kafka_connect_delete_connector
-echo "KC_DELETE_OUT=$KC_DELETE_OUT"
-echo "KC_LIST_AFTER_DELETE_OUT=$KC_LIST_AFTER_DELETE_OUT"
-if ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"; then
-  echo "✅ kafka_connect__delete_connector removed the real connector"
-else
-  echo "❌ kafka_connect__delete_connector did not remove the real connector"
   EXIT=1
 fi
 

--- a/examples/mcp.proxy/README.md
+++ b/examples/mcp.proxy/README.md
@@ -10,23 +10,23 @@ synthesized `zilla__search_tools` keyword-search tool instead of crowding out
 every `tools/list` response.
 
 ```text
-                                     ┌────────────────────────────────────────────────────────────────── Zilla ───────────────────────────────────────────────────────────────────┐
-                                     │ tcp(7114) → http → mcp(server, jwt) → mcp(proxy, guarded routes)                                                                           │
-client ── Authorization: Bearer ───►│                                                                                                                                            │
-                                     │             ┬                     ┬                    ┬                   ┬                        ┬                          ┬           │
-                                     │             ▼                     ▼                    ▼                   ▼                        ▼                          ▼           │
-                                     │    mcp(client)         mcp(client)             mcp-http(proxy)    mcp-openapi(client)  mcp-schema-registry(client)  mcp-kafka(client)      │
-                                     │    everything          urlelicit               github toolkit     petstore toolkit     kafka_sr toolkit             kafka toolkit          │
-                                     │    http →              http →                  http(client) →     http(client) →       http(client) →               kafka_cache_client →   │
-                                     │    tcp                 tcp                     tcp                tcp                  tcp                          kafka_client → tcp     │
-                                     └─────────────┼─────────────────────┼────────────────────┼───────────────────┼────────────────────────┼──────────────────────────┼───────────┘
-                                                   ▼                     ▼                    ▼                   ▼                        ▼                          ▼
-                                          everything:3001     urlelicit:3003          ghapi:4001         petstore:4002        karapace-registry:8081       kafka.examples.dev:9092
-                                          (reference server)  (url-mode elicitation)  (mock GitHub API)  (mock REST API,      (real Karapace               (real, single-node
-                                                                                                         OpenAPI-described)   schema registry)             KRaft Kafka broker)
+                                     ┌────────────────────────────────────────────────────────────────────────────────── Zilla ──────────────────────────────────────────────────────────────────────────────────┐
+                                     │ tcp(7114) → http → mcp(server, jwt) → mcp(proxy, guarded routes)                                                                                                          │
+client ── Authorization: Bearer ───►│                                                                                                                                                                          │
+                                     │         ┬                     ┬                     ┬                   ┬                        ┬                              ┬                            ┬            │
+                                     │         ▼                     ▼                     ▼                   ▼                        ▼                              ▼                            ▼            │
+                                     │ mcp(client)         mcp(client)             mcp-http(proxy)    mcp-openapi(client)  mcp-schema-registry(client)  mcp-kafka-connect(client)        mcp-kafka(client)       │
+                                     │ everything          urlelicit               github toolkit     petstore toolkit     kafka_sr toolkit             kafka_connect toolkit             kafka toolkit           │
+                                     │ http →              http →                  http(client) →     http(client) →       http(client) →               http(client) →                   kafka_cache_client →    │
+                                     │ tcp                 tcp                     tcp                tcp                  tcp                          tcp                              kafka_client → tcp      │
+                                     └─────────┼─────────────────────┼─────────────────────┼───────────────────┼────────────────────────┼──────────────────────────────┼────────────────────────────┼────────────┘
+                                               ▼                     ▼                     ▼                   ▼                        ▼                              ▼                            ▼           
+                                       everything:3001     urlelicit:3003          ghapi:4001         petstore:4002        karapace-registry:8081       kafka-connect.examples.dev:8083  kafka.examples.dev:9092
+                                       (reference server)  (url-mode elicitation)  (mock GitHub API)  (mock REST API,      (real Karapace               (real Kafka Connect              (real, single-node
+                                                                                                      OpenAPI-described)   schema registry)             worker)                          KRaft Kafka broker)
 ```
 
-This one configuration exercises all seven `mcp*` binding kinds:
+This one configuration exercises all eight `mcp*` binding kinds:
 
 | Binding | Kind | Role in this example |
 | --- | --- | --- |
@@ -36,6 +36,7 @@ This one configuration exercises all seven `mcp*` binding kinds:
 | `mcp-http` | `proxy` | Synthesizes MCP tools from hand-authored config, backed by a plain REST API (`github` toolkit) |
 | `mcp-openapi` | `client` | Synthesizes MCP tools from an OpenAPI document, backed by a plain REST API (`petstore` toolkit) |
 | `mcp-schema-registry` | `client` | Exposes a fixed, bundled tool set for the Karapace/Confluent Schema Registry REST API -- no operator-authored OpenAPI document, unlike `mcp-openapi` (`kafka_sr` toolkit) |
+| `mcp-kafka-connect` | `client` | Exposes a fixed, bundled tool set for the Kafka Connect REST API (`list_connectors`/`create_connector`/`describe_connector`/`delete_connector`/`describe_connector_config`/`update_connector_config`/`validate_connector_config`/`describe_connector_status`/`restart_connector`/`pause_connector`/`resume_connector`/`stop_connector`/`list_connector_tasks`/`restart_connector_task`/`describe_connector_offsets`/`alter_connector_offsets`/`reset_connector_offsets`/`list_connector_plugins`) as intrinsic MCP tools against a real Kafka Connect worker (`kafka_connect` toolkit) |
 | `mcp-kafka` | `client` | Exposes Kafka broker operations (`produce`/`consume`/`create_topics`/`delete_topics`/`describe_configs`/`alter_configs`/`list_acls`/`create_acls`/`delete_acls`/`list_topics`/`describe_topic`/`cluster_overview`/`list_brokers`/`describe_cluster`/`list_consumer_groups`/`describe_consumer_group`/`describe_consumer_group_lag`/`reset_offsets`) as intrinsic MCP tools, generating its own `kafka_cache_client → kafka_client → tcp_client` pipeline against a real broker (`kafka` toolkit) |
 
 ## Authorization model
@@ -55,6 +56,8 @@ the pipeline, each demonstrating a different mechanism:
 | `mcp-openapi(client)` operation `create_pet` | the OpenAPI document's own `security` requirement, mapped to `authn_jwt` via `options.specs.petstore.security` | `petstore:tools` **and** `pets:write` |
 | `mcp(proxy)` route for `kafka_sr` toolkit | `routes[].guarded` on the toolkit route | `kafka_sr:tools` |
 | `mcp-schema-registry(client)` route for `register_schema` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka_sr:tools` **and** `kafka_sr:write` |
+| `mcp(proxy)` route for `kafka_connect` toolkit | `routes[].guarded` on the toolkit route | `kafka_connect:tools` |
+| `mcp-kafka-connect(client)` route for connector/task/offset-mutating tools | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route (every mutating tool coalesced into one route), layered under the toolkit-level gate above | `kafka_connect:tools` **and** `kafka_connect:admin` |
 | `mcp(proxy)` route for `kafka` toolkit | `routes[].guarded` on the toolkit route | `kafka:tools` |
 | `mcp-kafka(client)` route for `produce` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route, layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:write` |
 | `mcp-kafka(client)` route for `create_topics` / `delete_topics` / `alter_configs` / `reset_offsets` | a second, tool-specific `routes[].guarded` on the binding's own `when.tool` route (all four tools coalesced into one route, since all four need the same scope), layered under the toolkit-level gate above | `kafka:tools` **and** `kafka:admin` |
@@ -73,6 +76,20 @@ via an explicit `routes[].guarded` directly on the `mcp-schema-registry`
 binding itself: `list_subjects`, `describe_subject`, `get_schema`, and every
 other read-only tool need only the toolkit-level `kafka_sr:tools`
 scope, while `register_schema` additionally requires `kafka_sr:write`.
+
+`mcp-kafka-connect` demonstrates the same layering on a fixed, bundled tool
+set for the Kafka Connect REST API rather than a schema registry: every tool
+that creates, deletes, or otherwise mutates connector, task, or offset state
+(`create_connector`, `delete_connector`, `update_connector_config`,
+`restart_connector`, `pause_connector`, `resume_connector`, `stop_connector`,
+`restart_connector_task`, `alter_connector_offsets`,
+`reset_connector_offsets`) shares one route requiring `kafka_connect:admin` in
+addition to the toolkit-level `kafka_connect:tools`, while every read-only
+tool (`list_connectors`, `describe_connector`, `describe_connector_config`,
+`validate_connector_config`, `describe_connector_status`,
+`list_connector_tasks`, `describe_connector_offsets`,
+`list_connector_plugins`) needs only the toolkit-level scope, sharing the
+catch-all glob route.
 
 `mcp-kafka` demonstrates the identical layering a third way, on its own
 `when.tool` route, and splits it further into read/write/admin: `consume`,
@@ -128,15 +145,18 @@ exist.
 docker compose up -d
 ```
 
-This starts Zilla plus six locally-reachable upstream services: a Node
+This starts Zilla plus seven locally-reachable upstream services: a Node
 `everything` reference MCP server on `:3001`, a minimal `urlelicit` MCP server
 on `:3003` demonstrating url-mode elicitation, two plain REST mocks --
 `ghapi` on `:4001` (subset of the GitHub API) and `petstore` on `:4002`
 (a small Petstore API, described by an inline OpenAPI document) -- a real,
 single-node KRaft-mode Kafka broker on `:9092` (`kafka.examples.dev`), with an
-`orders` topic created by the one-shot `kafka-init` service, and a real
+`orders` topic created by the one-shot `kafka-init` service, a real
 Karapace Schema Registry on `:8081` (`karapace-registry`), storing schemas in
-its own `_schemas` topic on that same broker.
+its own `_schemas` topic on that same broker, and a real Kafka Connect
+distributed worker on `:8083` (`kafka-connect.examples.dev`), storing its own
+config/offset/status state in three internal compacted topics on that same
+broker.
 
 ## Verify
 
@@ -168,7 +188,7 @@ export JWT_TOKEN=$(docker compose run --rm jwt-cli encode \
     --aud "https://api.example.com" \
     --exp=+1d \
     --no-iat \
-    --payload "scope=urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka:tools kafka:write kafka:admin kafka:acls" \
+    --payload "scope=urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka_connect:tools kafka_connect:admin kafka:tools kafka:write kafka:admin kafka:acls" \
     --secret @/private.pem | tr -d '\r\n')
 ```
 
@@ -183,16 +203,17 @@ name per line -- pass a token (or none) as `JWT_TOKEN`:
 # No token: only the ungated "everything" toolkit is visible
 docker compose run --rm tools-list-client
 
-# Toolkit-level scopes only, no operation-level scopes: petstore__list_pets
-# and kafka_sr__list_subjects appear (neither requires an extra scope
-# beyond toolkit access) but petstore__create_pet, github__create_pr, and
-# kafka_sr__register_schema do not -- toolkit access alone is not tool
+# Toolkit-level scopes only, no operation-level scopes: petstore__list_pets,
+# kafka_sr__list_subjects, and kafka_connect__list_connector_plugins appear
+# (none of them require an extra scope beyond toolkit access) but
+# petstore__create_pet, github__create_pr, kafka_sr__register_schema, and
+# kafka_connect__create_connector do not -- toolkit access alone is not tool
 # access
 export JWT_TOKEN=$(docker compose run --rm jwt-cli encode \
     --alg "RS256" --kid "example" \
     --iss "https://auth.example.com" --aud "https://api.example.com" \
     --exp=+1d --no-iat \
-    --payload "scope=github:tools petstore:tools kafka_sr:tools" \
+    --payload "scope=github:tools petstore:tools kafka_sr:tools kafka_connect:tools" \
     --secret @/private.pem | tr -d '\r\n')
 docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" tools-list-client
 
@@ -201,7 +222,7 @@ export JWT_TOKEN=$(docker compose run --rm jwt-cli encode \
     --alg "RS256" --kid "example" \
     --iss "https://auth.example.com" --aud "https://api.example.com" \
     --exp=+1d --no-iat \
-    --payload "scope=urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka:tools kafka:write kafka:admin kafka:acls" \
+    --payload "scope=urlelicit:authorize github:tools github:pr:write petstore:tools pets:write kafka_sr:tools kafka_sr:write kafka_connect:tools kafka_connect:admin kafka:tools kafka:write kafka:admin kafka:acls" \
     --secret @/private.pem | tr -d '\r\n')
 docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" tools-list-client
 ```
@@ -212,7 +233,10 @@ docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" tools-list-client
 frequently used tools -- `everything__echo`, `urlelicit__authorize`,
 `github__create_pr`, `petstore__list_pets`, `petstore__search_pets`,
 `petstore__create_pet`, `kafka_sr__list_subjects`,
-`kafka_sr__register_schema`, `kafka__produce`, `kafka__consume`,
+`kafka_sr__register_schema`, `kafka_connect__list_connector_plugins`,
+`kafka_connect__list_connectors`, `kafka_connect__describe_connector`,
+`kafka_connect__create_connector`, `kafka_connect__delete_connector`,
+`kafka__produce`, `kafka__consume`,
 `kafka__create_topics`, `kafka__delete_topics`, `kafka__describe_configs`,
 `kafka__alter_configs`, `kafka__list_acls`, `kafka__create_acls`,
 `kafka__delete_acls`, `kafka__list_topics`, `kafka__describe_topic`,
@@ -247,6 +271,11 @@ petstore__search_pets
 petstore__create_pet
 kafka_sr__list_subjects
 kafka_sr__register_schema
+kafka_connect__list_connector_plugins
+kafka_connect__list_connectors
+kafka_connect__describe_connector
+kafka_connect__create_connector
+kafka_connect__delete_connector
 kafka__produce
 kafka__consume
 kafka__create_topics
@@ -967,6 +996,7 @@ docker compose down -v
 - [Zilla docs -- `mcp` bindings](https://docs.aklivity.io/zilla/latest/reference/config/bindings/mcp/README.html)
 - [Zilla docs -- `mcp-http` binding](https://docs.aklivity.io/zilla/latest/reference/config/bindings/mcp-http/README.html)
 - [Zilla docs -- `mcp-kafka` binding](https://docs.aklivity.io/zilla/latest/reference/config/bindings/mcp-kafka/README.html)
+- [Zilla docs -- `mcp-kafka-connect` binding](https://docs.aklivity.io/zilla/latest/reference/config/bindings/mcp-kafka-connect/README.html)
 - [Zilla docs -- `jwt` guard](https://docs.aklivity.io/zilla/latest/reference/config/guards/jwt.html)
 - [MCP -- Streamable HTTP transport](https://modelcontextprotocol.io/docs/concepts/transports)
 - [MCP -- elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)

--- a/examples/mcp.proxy/README.md
+++ b/examples/mcp.proxy/README.md
@@ -540,36 +540,109 @@ docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
 ### Manage connectors through a real Kafka Connect worker
 
 `south_mcp_kafka_connect_client` is an `mcp-kafka-connect` `kind: client`
-binding -- like `kafka_sr`, it proxies to a separate REST service with a
-fixed, bundled tool set (`list_connectors`, `create_connector`,
-`describe_connector`, `delete_connector`, `describe_connector_config`,
-`update_connector_config`, `validate_connector_config`,
-`describe_connector_status`, `restart_connector`, `pause_connector`,
-`resume_connector`, `stop_connector`, `list_connector_tasks`,
-`restart_connector_task`, `describe_connector_offsets`,
-`alter_connector_offsets`, `reset_connector_offsets`,
-`list_connector_plugins`) derived from a bundled Kafka Connect OpenAPI
-document, and `options.server` is the only required configuration. This
-example points it at `kafka-connect`, a real Kafka Connect distributed
-worker (not a mock) started against the same real Kafka broker the `kafka`
-toolkit talks to, using the broker distribution's own bundled
-`FileStreamSourceConnector`/`FileStreamSinkConnector` plugins -- no
-separate connector plugin download.
+binding -- like `mcp-schema-registry`, its tool set
+(`list_connectors`/`create_connector`/`describe_connector`/`delete_connector`/
+`describe_connector_config`/`update_connector_config`/
+`validate_connector_config`/`describe_connector_status`/`restart_connector`/
+`pause_connector`/`resume_connector`/`stop_connector`/`list_connector_tasks`/
+`restart_connector_task`/`describe_connector_offsets`/
+`alter_connector_offsets`/`reset_connector_offsets`/`list_connector_plugins`)
+is bundled with the binding itself, with `options.server` the only required
+configuration. This example points it at `kafka-connect`, a real Kafka
+Connect distributed worker (`apache/kafka:4.1.1`'s own
+`connect-distributed.sh`, not a mock) that stores its own config/offset/status
+state in three internal compacted topics on the same Kafka broker the `kafka`
+toolkit above talks to.
 
-**Known gap:** the `kafka_connect` toolkit's tools never appear in
-`tools/list` and were verified end to end against the real worker directly
-(`docker compose exec kafka-connect` plus raw HTTP requests from inside the
-`zilla` container both confirm the worker itself is reachable and correctly
-answers `GET /connectors`, `GET /connector-plugins`, connector create/pause/
-resume/restart/delete), but `north_mcp_proxy` never hydrates this toolkit's
-tools into its cache the way it does for the structurally-identical
-`kafka_sr` toolkit, even after a full `options.cache.ttl` cycle. The
-binding's own `McpKafkaConnectClientIT` k3po suite passes cleanly in
-isolation, and its composite-generation code is byte-identical to the
-working `mcp-schema-registry` implementation, so the gap is tracked as
-[aklivity/zilla#2273](https://github.com/aklivity/zilla/issues/2273) rather
-than papered over -- the binding and route configuration below reflect the
-intended, documented usage once that issue is resolved.
+`list_connector_plugins` lists the bundled FileStream source/sink connector
+plugins -- proof `plugin.path` resolved the broker distribution's own `libs/`
+directory rather than a separately downloaded plugin:
+
+```bash
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__list_connector_plugins tools-list-client
+# org.apache.kafka.connect.file.FileStreamSinkConnector
+# org.apache.kafka.connect.file.FileStreamSourceConnector
+```
+
+`create_connector` creates a real `FileStreamSourceConnector` reading a file
+already seeded inside the worker container, gated by its own tool-specific
+`kafka_connect:admin` scope layered under the toolkit-level
+`kafka_connect:tools` scope -- the same layering mechanism as
+`register_schema`/`kafka_sr:write`:
+
+```bash
+docker compose exec kafka-connect sh -c \
+    "echo 'hello from mcp-kafka-connect' > /tmp/kc-source.txt"
+
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__create_connector \
+    -e CALL_ARGS='{"name":"file-source-demo","config":{"connector.class":"org.apache.kafka.connect.file.FileStreamSourceConnector","tasks.max":"1","file":"/tmp/kc-source.txt","topic":"connect-demo"}}' \
+    tools-list-client
+# Created connector file-source-demo
+```
+
+`list_connectors` and `describe_connector_status` confirm it is now real,
+running worker state, not just an echoed request:
+
+```bash
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__list_connectors tools-list-client
+# ["file-source-demo"]
+
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__describe_connector_status \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+# Connector file-source-demo is RUNNING
+```
+
+`pause_connector` and `resume_connector` transition the connector and its one
+task between `PAUSED` and `RUNNING` on the real worker, each confirmed by a
+follow-up `describe_connector_status` call:
+
+```bash
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__pause_connector \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__describe_connector_status \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+# Connector file-source-demo is PAUSED
+
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__resume_connector \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__describe_connector_status \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+# Connector file-source-demo is RUNNING
+```
+
+`restart_connector` succeeds against the running connector, sharing
+`pause_connector`/`resume_connector`'s `kafka_connect:admin`-gated route.
+`delete_connector` then removes it, confirmed by `list_connectors` reporting
+none remaining:
+
+```bash
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__restart_connector \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__delete_connector \
+    -e CALL_ARGS='{"connector":"file-source-demo"}' \
+    tools-list-client
+
+docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
+    -e CALL_TOOL=kafka_connect__list_connectors tools-list-client
+# []
+```
 
 ### Produce, consume, create/delete topics, describe/alter configs, and cluster introspection through a real Kafka broker
 

--- a/examples/mcp.proxy/README.md
+++ b/examples/mcp.proxy/README.md
@@ -537,6 +537,40 @@ docker compose run --rm -e JWT_TOKEN="$JWT_TOKEN" \
 # Compatibility check result: true
 ```
 
+### Manage connectors through a real Kafka Connect worker
+
+`south_mcp_kafka_connect_client` is an `mcp-kafka-connect` `kind: client`
+binding -- like `kafka_sr`, it proxies to a separate REST service with a
+fixed, bundled tool set (`list_connectors`, `create_connector`,
+`describe_connector`, `delete_connector`, `describe_connector_config`,
+`update_connector_config`, `validate_connector_config`,
+`describe_connector_status`, `restart_connector`, `pause_connector`,
+`resume_connector`, `stop_connector`, `list_connector_tasks`,
+`restart_connector_task`, `describe_connector_offsets`,
+`alter_connector_offsets`, `reset_connector_offsets`,
+`list_connector_plugins`) derived from a bundled Kafka Connect OpenAPI
+document, and `options.server` is the only required configuration. This
+example points it at `kafka-connect`, a real Kafka Connect distributed
+worker (not a mock) started against the same real Kafka broker the `kafka`
+toolkit talks to, using the broker distribution's own bundled
+`FileStreamSourceConnector`/`FileStreamSinkConnector` plugins -- no
+separate connector plugin download.
+
+**Known gap:** the `kafka_connect` toolkit's tools never appear in
+`tools/list` and were verified end to end against the real worker directly
+(`docker compose exec kafka-connect` plus raw HTTP requests from inside the
+`zilla` container both confirm the worker itself is reachable and correctly
+answers `GET /connectors`, `GET /connector-plugins`, connector create/pause/
+resume/restart/delete), but `north_mcp_proxy` never hydrates this toolkit's
+tools into its cache the way it does for the structurally-identical
+`kafka_sr` toolkit, even after a full `options.cache.ttl` cycle. The
+binding's own `McpKafkaConnectClientIT` k3po suite passes cleanly in
+isolation, and its composite-generation code is byte-identical to the
+working `mcp-schema-registry` implementation, so the gap is tracked as
+[aklivity/zilla#2273](https://github.com/aklivity/zilla/issues/2273) rather
+than papered over -- the binding and route configuration below reflect the
+intended, documented usage once that issue is resolved.
+
 ### Produce, consume, create/delete topics, describe/alter configs, and cluster introspection through a real Kafka broker
 
 `south_mcp_kafka_client` is an `mcp-kafka` `kind: client` binding -- unlike

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -32,6 +32,8 @@ services:
         condition: service_healthy
       karapace-registry:
         condition: service_started
+      kafka-connect:
+        condition: service_healthy
       kafka:
         condition: service_healthy
       kafka-init:
@@ -206,6 +208,52 @@ services:
       KARAPACE_TOPIC_NAME: _schemas
       KARAPACE_LOG_LEVEL: WARNING
       KARAPACE_COMPATIBILITY: BACKWARD
+
+  # Real Kafka Connect distributed worker backing the mcp-kafka-connect
+  # "kafkaconnect" toolkit -- talks to the same real Kafka broker as the
+  # "kafka" toolkit above, storing its own config/offset/status state in
+  # three internal compacted topics rather than a separate database.
+  # plugin.path points at the broker distribution's own libs/ directory,
+  # which bundles the FileStreamSource/FileStreamSinkConnector classes this
+  # example's test.sh exercises -- no separate connector plugin download.
+  kafka-connect:
+    image: apache/kafka:4.1.1
+    restart: unless-stopped
+    hostname: kafka-connect.examples.dev
+    ports:
+      - 8083:8083
+    depends_on:
+      kafka:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "8083"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+      start_period: 20s
+    environment:
+      KAFKA_BOOTSTRAP_SERVER: kafka.examples.dev:29092
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat > /tmp/connect-distributed.properties <<EOF
+        bootstrap.servers=$${KAFKA_BOOTSTRAP_SERVER}
+        group.id=connect-cluster
+        key.converter=org.apache.kafka.connect.json.JsonConverter
+        value.converter=org.apache.kafka.connect.json.JsonConverter
+        key.converter.schemas.enable=false
+        value.converter.schemas.enable=false
+        offset.storage.topic=connect-offsets
+        offset.storage.replication.factor=1
+        config.storage.topic=connect-configs
+        config.storage.replication.factor=1
+        status.storage.topic=connect-status
+        status.storage.replication.factor=1
+        listeners=HTTP://0.0.0.0:8083
+        rest.advertised.host.name=kafka-connect.examples.dev
+        plugin.path=/opt/kafka/libs
+        EOF
+        exec /opt/kafka/bin/connect-distributed.sh /tmp/connect-distributed.properties
 
   # Mints JWTs for the authn_jwt guard. Run on demand, e.g.:
   #   docker compose run --rm jwt-cli encode --alg RS256 --kid example \

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -219,7 +219,7 @@ services:
   kafka-connect:
     image: apache/kafka:4.1.1
     restart: unless-stopped
-    hostname: kafka-connect.examples.dev
+    hostname: kafka-connect
     ports:
       - 8083:8083
     depends_on:
@@ -250,7 +250,7 @@ services:
         status.storage.topic=connect-status
         status.storage.replication.factor=1
         listeners=HTTP://0.0.0.0:8083
-        rest.advertised.host.name=kafka-connect.examples.dev
+        rest.advertised.host.name=kafka-connect
         plugin.path=/opt/kafka/libs
         EOF
         exec /opt/kafka/bin/connect-distributed.sh /tmp/connect-distributed.properties

--- a/examples/mcp.proxy/etc/zilla.yaml
+++ b/examples/mcp.proxy/etc/zilla.yaml
@@ -330,7 +330,7 @@ bindings:
         # works fine since real calls use the caller's own JWT, not this one
         authorization:
           authn_jwt:
-            credentials: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.eyJhdWQiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImV4cCI6NDkzODM1MDk3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmV4YW1wbGUuY29tIiwic2NvcGUiOiJnaXRodWI6dG9vbHMgcGV0c3RvcmU6dG9vbHMgdXJsZWxpY2l0OmF1dGhvcml6ZSBrYWZrYTp0b29scyBrYWZrYV9zcjp0b29scyBrYWZrYWNvbm5lY3Q6dG9vbHMifQ.Dchcpcn5_IS5sTkdabpi81NQ2wvFyB-vMXHQULELilIe7aGog26s2ixnscfUzmOV1eGBsbswkRnBevEl9agolEr4NM4owCWNae7XUfAoob0WZlpivEvqqgMRcFADHD9R_6hePY3Ej-6GyJXkkOUDBaOpO4Hx3zLOfSOJRn67uliUWWJ2g4cOLS58AaG7S4Si_9_S509DGoskEYU6XE5E0s0al-TjczlXSR-OdKfiZD9ZmBPkr798uKEH9Pcda33kRHZkg4qeFE1LsP5OjUVGAJm50OZQKWOYZaJjera9bVFXKjyK70U_ALBR44mf_CATdZQnPneeCFm7IzkZobTeew"
+            credentials: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.eyJhdWQiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImV4cCI6NDkzODM1MDk3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmV4YW1wbGUuY29tIiwic2NvcGUiOiJnaXRodWI6dG9vbHMgcGV0c3RvcmU6dG9vbHMgdXJsZWxpY2l0OmF1dGhvcml6ZSBrYWZrYTp0b29scyBrYWZrYV9zcjp0b29scyBrYWZrYV9jb25uZWN0OnRvb2xzIn0.e5n0XM_a0wb1BYhJiWXvPnSXaWOJyYbAj_1e3dMdNOVFBwmWv5BwHm-LYdf7DbbJk5u09I0MtgBqVnLsntwrnxcNIPzsKSs2U17Yb6NnPz6K41TljV9HCP4nAR6KK7Lt7uwJbpuSz-yY91FqjDQFjGuOGv79oPygMaomyzz4NchnAECUysrvlYlFun-X4klQsMr3h5ik-M5hDJ5rHjkefBFBR1JZOKvJEQpgSQ9Z2i4x9KiLTV4V-UfUmYrLwFuQaHalU20Rmkl8sEJ8L16PU5tuXRnUGdLyg68_i_BV-Wc0PuAHMYIWxERIfoCBrPDrVpeK1zlNYZ4lWfgbN_onLA"
         # a fixed handful of frequently used tools stay eagerly listed; every other
         # tool across every toolkit (the "everything" reference server's dozen-plus
         # demo tools, most visibly) is omitted from tools/list -- because the search
@@ -630,7 +630,7 @@ bindings:
     type: mcp-kafka-connect
     kind: client
     options:
-      server: http://kafka-connect.examples.dev:8083
+      server: http://kafka-connect:8083
     # a second, tool-specific guard layered under the toolkit-level
     # kafka_connect:tools gate above -- every tool that mutates connector,
     # task, or offset state additionally requires kafka_connect:admin, while

--- a/examples/mcp.proxy/etc/zilla.yaml
+++ b/examples/mcp.proxy/etc/zilla.yaml
@@ -330,7 +330,7 @@ bindings:
         # works fine since real calls use the caller's own JWT, not this one
         authorization:
           authn_jwt:
-            credentials: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.eyJhdWQiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImV4cCI6NDkzODM1MDk3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmV4YW1wbGUuY29tIiwic2NvcGUiOiJnaXRodWI6dG9vbHMgcGV0c3RvcmU6dG9vbHMgdXJsZWxpY2l0OmF1dGhvcml6ZSBrYWZrYTp0b29scyBrYWZrYV9zcjp0b29scyJ9.YVgIJhaeJKXJqvXufzQbczxq6i7RiKa8WWt424ApOqQNeSNoX00IRoABHrb-SQHd9za5O9OJke0-VC7FdOlYpSXlF9fAJin4DDI2EPu3xGKGJt4PnZJCc6QUbQlOIcVHH3cldIveb9fYT4D152tL-b4njJ7lofcsyUHcTfXJ5OsDHX1lGnIyEKWeF7AeC6T7C5K5fzw5WqmC-P8owujfjqt8SgKjexoJxjKmsPdaC9rakPnP54wSUQcPpGB2bMJk1MU2sxxlGXYJ8YAa3Ms2V4P7X5eG-AbPTFk-_xOicEXDR0TOP11UE2J9ifDCi8_oH-88lSm9EXToQ865eDNxBg"
+            credentials: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.eyJhdWQiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImV4cCI6NDkzODM1MDk3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmV4YW1wbGUuY29tIiwic2NvcGUiOiJnaXRodWI6dG9vbHMgcGV0c3RvcmU6dG9vbHMgdXJsZWxpY2l0OmF1dGhvcml6ZSBrYWZrYTp0b29scyBrYWZrYV9zcjp0b29scyBrYWZrYWNvbm5lY3Q6dG9vbHMifQ.Dchcpcn5_IS5sTkdabpi81NQ2wvFyB-vMXHQULELilIe7aGog26s2ixnscfUzmOV1eGBsbswkRnBevEl9agolEr4NM4owCWNae7XUfAoob0WZlpivEvqqgMRcFADHD9R_6hePY3Ej-6GyJXkkOUDBaOpO4Hx3zLOfSOJRn67uliUWWJ2g4cOLS58AaG7S4Si_9_S509DGoskEYU6XE5E0s0al-TjczlXSR-OdKfiZD9ZmBPkr798uKEH9Pcda33kRHZkg4qeFE1LsP5OjUVGAJm50OZQKWOYZaJjera9bVFXKjyK70U_ALBR44mf_CATdZQnPneeCFm7IzkZobTeew"
         # a fixed handful of frequently used tools stay eagerly listed; every other
         # tool across every toolkit (the "everything" reference server's dozen-plus
         # demo tools, most visibly) is omitted from tools/list -- because the search
@@ -366,6 +366,11 @@ bindings:
               - kafka__describe_consumer_group
               - kafka__describe_consumer_group_lag
               - kafka__reset_offsets
+              - kafka_connect__list_connector_plugins
+              - kafka_connect__list_connectors
+              - kafka_connect__describe_connector
+              - kafka_connect__create_connector
+              - kafka_connect__delete_connector
           search:
             toolkit: zilla
     routes:
@@ -397,6 +402,12 @@ bindings:
         guarded:
           authn_jwt:
             - kafka_sr:tools
+      - exit: south_mcp_kafka_connect_client
+        when:
+          - toolkit: kafka_connect
+        guarded:
+          authn_jwt:
+            - kafka_connect:tools
       - exit: south_mcp_kafka_client
         when:
           - toolkit: kafka
@@ -613,6 +624,38 @@ bindings:
         guarded:
           authn_jwt:
             - kafka_sr:write
+      - when:
+          - tool: "*"
+  south_mcp_kafka_connect_client:
+    type: mcp-kafka-connect
+    kind: client
+    options:
+      server: http://kafka-connect.examples.dev:8083
+    # a second, tool-specific guard layered under the toolkit-level
+    # kafka_connect:tools gate above -- every tool that mutates connector,
+    # task, or offset state additionally requires kafka_connect:admin, while
+    # every read-only tool (list_connectors, describe_connector,
+    # describe_connector_config, validate_connector_config,
+    # describe_connector_status, list_connector_tasks,
+    # describe_connector_offsets, list_connector_plugins) needs no scope
+    # beyond the toolkit-level gate above, sharing the catch-all glob route.
+    # Order matters: routes match in declaration order, so the admin-tier
+    # route must come before the catch-all glob or its guard would never apply
+    routes:
+      - when:
+          - tool: create_connector
+          - tool: delete_connector
+          - tool: update_connector_config
+          - tool: restart_connector
+          - tool: pause_connector
+          - tool: resume_connector
+          - tool: stop_connector
+          - tool: restart_connector_task
+          - tool: alter_connector_offsets
+          - tool: reset_connector_offsets
+        guarded:
+          authn_jwt:
+            - kafka_connect:admin
       - when:
           - tool: "*"
   south_mcp_kafka_client:

--- a/runtime/binding-mcp-openapi/src/main/moditect/module-info.java
+++ b/runtime/binding-mcp-openapi/src/main/moditect/module-info.java
@@ -31,4 +31,6 @@ module io.aklivity.zilla.runtime.binding.mcp.openapi
 
     provides io.aklivity.zilla.runtime.engine.event.EventFormatterFactorySpi
         with io.aklivity.zilla.runtime.binding.mcp.openapi.internal.event.McpOpenapiEventFormatterFactory;
+
+    opens io.aklivity.zilla.runtime.binding.mcp.openapi.internal.config.composite;
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistry.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistry.java
@@ -97,13 +97,17 @@ public class EngineRegistry
     public void attachNow(
         NamespaceConfig namespace)
     {
-        attach(namespace).run();
+        NamespaceTask task = attach(namespace);
+        task.run();
+        task.future().join();
     }
 
     public void detachNow(
         NamespaceConfig namespace)
     {
-        detach(namespace).run();
+        NamespaceTask task = detach(namespace);
+        task.run();
+        task.future().join();
     }
 
     public NamespaceTask attach(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRegistryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.internal.registry;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.BindingConfig;
+import io.aklivity.zilla.config.engine.KindConfig;
+import io.aklivity.zilla.config.engine.NamespaceConfig;
+import io.aklivity.zilla.runtime.engine.binding.BindingContext;
+
+public class EngineRegistryTest
+{
+    @Test
+    public void shouldPropagateExceptionWhenAttachNowFails()
+    {
+        RuntimeException attachFailure = new RuntimeException("boom");
+
+        NamespaceConfig namespace = NamespaceConfig.builder()
+            .name("test")
+            .binding()
+                .name("test0")
+                .type("test")
+                .kind(KindConfig.CLIENT)
+                .build()
+            .build();
+
+        EngineRegistry registry = new EngineRegistry(
+            type -> new BindingContext()
+            {
+                @Override
+                public io.aklivity.zilla.runtime.engine.binding.BindingHandler attach(
+                    BindingConfig binding)
+                {
+                    throw attachFailure;
+                }
+            },
+            type -> null,
+            type -> null,
+            type -> null,
+            name -> null,
+            type -> null,
+            type -> null,
+            String::hashCode,
+            EngineRegistryTest::noop,
+            EngineRegistryTest::noop,
+            (kind, value1, value2, value3, kindConfig) -> EngineRegistryTest::noop,
+            EngineRegistryTest::noop,
+            null,
+            EngineRegistryTest::noop);
+
+        try
+        {
+            registry.attachNow(namespace);
+            fail("expected attachNow to propagate the attach failure");
+        }
+        catch (CompletionException ex)
+        {
+            assertSame(attachFailure, ex.getCause());
+        }
+    }
+
+    private static void noop(
+        long id)
+    {
+    }
+
+    private static void noop(
+        NamespaceConfig namespace)
+    {
+    }
+}


### PR DESCRIPTION
## Description

`mcp-kafka-connect`'s tools never hydrated into `north_mcp_proxy`'s cache, even though the worker itself was reachable and answered correctly when queried directly (`examples/mcp.proxy`). Root-caused to two stacked bugs, both fixed here:

1. **`EngineRegistry.attachNow()`/`detachNow()`** ran a `NamespaceTask` but discarded its `CompletableFuture`, silently swallowing any exception thrown while attaching a generated composite binding — no log, no error, just zero tools. Fixed by joining the future so failures propagate through the engine's normal config-reload error path (logged, rolled back). This is what made the real failure below visible in the first place.
2. **Actual root cause**: `binding-mcp-openapi`'s `module-info.java` never `opens`'d the package containing `McpAnnotationsEx`, so Yasson's reflective deserialization of the `x-mcp-annotations` OpenAPI extension threw `IllegalAccessException` at runtime — invisible to unit/IT tests (which run on the classpath, not the module path) and only hit by the real jlinked runtime image. Only `mcp-kafka-connect`'s bundled OpenAPI doc uses `x-mcp-annotations` (`mcp-schema-registry`'s and the example's `petstore` mock don't), which is why this binding alone was affected. Fixed with one `opens` line, mirroring the existing precedent in `binding-mcp`'s own module-info.

Also included: `examples/mcp.proxy` changes that add a real Kafka Connect worker to the example and restore the `kafka_connect` `test.sh` assertions / README walkthrough that had to be pulled when the bug was first discovered (see #2273 for the original repro).

Verified by rebuilding the full Docker image locally and running it against the real `kafka` + `kafka-connect` + `karapace-registry` stack: `tools/list` now hydrates all `kafka_connect__*` tools, and the full `create → list → describe → pause → resume → restart → delete` connector lifecycle succeeds against the live worker. Added `EngineRegistryTest` covering the future-swallowing fix.

Fixes #2273

## Test plan

- [x] `./mvnw test -pl runtime/engine` — 195 tests pass, including new `EngineRegistryTest`
- [x] `./mvnw checkstyle:check -pl runtime/engine` — clean
- [x] Full local Docker image rebuild + `examples/mcp.proxy` docker-compose stack (real `kafka`, `kafka-connect`, `karapace-registry`) — confirmed `tools/list` hydration and full connector lifecycle via direct MCP protocol calls
- [ ] `./mvnw verify` across the full reactor (not run in this environment; CI will cover)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ikToCpeJTceYRhdyZNGRw)_