### PR TITLE
feat(binding-mcp-kafka): populate tools/list securitySchemes from guarded routes

### DIFF
--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaBindingConfig.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaBindingConfig.java
@@ -16,9 +16,11 @@ package io.aklivity.zilla.runtime.binding.mcp.kafka.internal.config;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.aklivity.zilla.config.engine.BindingConfig;
+import io.aklivity.zilla.config.engine.GuardedConfig;
 import io.aklivity.zilla.config.engine.KindConfig;
 
 public final class McpKafkaBindingConfig
@@ -27,6 +29,9 @@ public final class McpKafkaBindingConfig
     public final String name;
     public final KindConfig kind;
     public final List<McpKafkaRouteConfig> routes;
+
+    // memoized tools/list reply; derived solely from static binding config, built once on first request
+    private byte[] toolsListJson;
 
     public McpKafkaBindingConfig(
         BindingConfig binding)
@@ -46,5 +51,30 @@ public final class McpKafkaBindingConfig
             .filter(r -> r.matches(tool, topic) && r.authorized(authorization))
             .findFirst()
             .orElse(null);
+    }
+
+    public List<GuardedConfig> toolGuarded(
+        String name)
+    {
+        final List<GuardedConfig> result = new ArrayList<>();
+        for (McpKafkaRouteConfig route : routes)
+        {
+            if (route.matches(name, null))
+            {
+                result.addAll(route.guarded);
+            }
+        }
+        return result;
+    }
+
+    public byte[] toolsListJson()
+    {
+        return toolsListJson;
+    }
+
+    public void toolsListJson(
+        byte[] json)
+    {
+        this.toolsListJson = json;
     }
 }

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaRouteConfig.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/config/McpKafkaRouteConfig.java
@@ -21,12 +21,14 @@ import java.util.List;
 import java.util.function.UnaryOperator;
 
 import io.aklivity.zilla.config.binding.mcp.kafka.McpKafkaConditionConfig;
+import io.aklivity.zilla.config.engine.GuardedConfig;
 import io.aklivity.zilla.config.engine.RouteConfig;
 import io.aklivity.zilla.runtime.common.lang.util.function.LongObjectPredicate;
 
 public final class McpKafkaRouteConfig
 {
     public long id;
+    public final List<GuardedConfig> guarded;
 
     private final List<McpKafkaConditionMatcher> when;
     private final LongObjectPredicate<UnaryOperator<String>> authorized;
@@ -35,6 +37,7 @@ public final class McpKafkaRouteConfig
         RouteConfig route)
     {
         this.id = route.id;
+        this.guarded = route.guarded;
         this.when = route.when.stream()
             .map(McpKafkaConditionConfig.class::cast)
             .map(McpKafkaConditionMatcher::new)

--- a/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
+++ b/runtime/binding-mcp-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyFactory.java
@@ -45,6 +45,7 @@ import jakarta.json.JsonObjectBuilder;
 import org.agrona.collections.Long2ObjectHashMap;
 
 import io.aklivity.zilla.config.engine.BindingConfig;
+import io.aklivity.zilla.config.engine.GuardedConfig;
 import io.aklivity.zilla.runtime.binding.kafka.api.KafkaAclTypes;
 import io.aklivity.zilla.runtime.binding.kafka.api.KafkaAlterConfigsRequest;
 import io.aklivity.zilla.runtime.binding.kafka.api.KafkaAlterConfigsResponse;
@@ -303,8 +304,6 @@ public class McpKafkaProxyFactory implements BindingHandler
     private final Signaler signaler;
     private final int mcpTypeId;
     private final int kafkaTypeId;
-    private final byte[] toolsListPayload;
-    private final UnsafeBufferEx toolsListBuffer;
     private final BufferPool decodePool;
     private final BufferPool encodePool;
     private final KafkaCreateTopicsRequest.Generator createTopicsRequestGenerator;
@@ -354,8 +353,6 @@ public class McpKafkaProxyFactory implements BindingHandler
         this.bindings = new Long2ObjectHashMap<>();
         this.mcpTypeId = context.supplyTypeId(MCP_TYPE_NAME);
         this.kafkaTypeId = context.supplyTypeId(KAFKA_TYPE_NAME);
-        this.toolsListPayload = buildToolsList();
-        this.toolsListBuffer = new UnsafeBufferEx(toolsListPayload);
         this.decodePool = context.bufferPool();
         this.encodePool = context.bufferPool().duplicate();
         this.createTopicsRequestGenerator = new KafkaCreateTopicsRequest.Generator();
@@ -469,7 +466,7 @@ public class McpKafkaProxyFactory implements BindingHandler
                 case KIND_TOOLS_LIST:
                 {
                     final McpToolsListProxy toolsList = new McpToolsListProxy(
-                        sender, originId, routedId, initialId, authorization, affinity);
+                        sender, originId, routedId, initialId, binding, authorization, affinity);
                     newStream = toolsList::onMcpMessage;
                     break;
                 }
@@ -862,7 +859,20 @@ public class McpKafkaProxyFactory implements BindingHandler
         receiver.accept(window.typeId(), window.buffer(), window.offset(), window.sizeof());
     }
 
-    private byte[] buildToolsList()
+    private byte[] toolsList(
+        McpKafkaBindingConfig binding)
+    {
+        byte[] json = binding.toolsListJson();
+        if (json == null)
+        {
+            json = buildToolsList(binding);
+            binding.toolsListJson(json);
+        }
+        return json;
+    }
+
+    private byte[] buildToolsList(
+        McpKafkaBindingConfig binding)
     {
         final JsonArrayBuilder tools = Json.createArrayBuilder();
         for (String tool : TOOL_NAMES)
@@ -880,6 +890,11 @@ public class McpKafkaProxyFactory implements BindingHandler
             {
                 item.add("outputSchema", outputSchema);
             }
+            final JsonArrayBuilder toolSchemes = securitySchemes(binding.toolGuarded(tool));
+            if (toolSchemes != null)
+            {
+                item.add("securitySchemes", toolSchemes);
+            }
             final JsonObject annotations = buildToolAnnotations(tool);
             if (annotations != null)
             {
@@ -892,6 +907,31 @@ public class McpKafkaProxyFactory implements BindingHandler
             .build();
 
         return toolsList.toString().getBytes(UTF_8);
+    }
+
+    private static JsonArrayBuilder securitySchemes(
+        List<GuardedConfig> guarded)
+    {
+        JsonArrayBuilder schemes = null;
+        for (GuardedConfig g : guarded)
+        {
+            if (!g.roles.isEmpty())
+            {
+                if (schemes == null)
+                {
+                    schemes = Json.createArrayBuilder();
+                }
+                final JsonArrayBuilder scopes = Json.createArrayBuilder();
+                for (String role : g.roles)
+                {
+                    scopes.add(role);
+                }
+                schemes.add(Json.createObjectBuilder()
+                    .add("type", "oauth2")
+                    .add("scopes", scopes));
+            }
+        }
+        return schemes;
     }
 
     private static String buildToolTitle(
@@ -2034,6 +2074,8 @@ public class McpKafkaProxyFactory implements BindingHandler
         private final long replyId;
         private final long authorization;
         private final long affinity;
+        private final byte[] toolsListPayload;
+        private final UnsafeBufferEx toolsListBuffer;
 
         private int state;
 
@@ -2049,6 +2091,7 @@ public class McpKafkaProxyFactory implements BindingHandler
             long originId,
             long routedId,
             long initialId,
+            McpKafkaBindingConfig binding,
             long authorization,
             long affinity)
         {
@@ -2059,6 +2102,8 @@ public class McpKafkaProxyFactory implements BindingHandler
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.authorization = authorization;
             this.affinity = affinity;
+            this.toolsListPayload = toolsList(binding);
+            this.toolsListBuffer = new UnsafeBufferEx(toolsListPayload);
         }
 
         private void onMcpMessage(

--- a/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
+++ b/runtime/binding-mcp-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mcp/kafka/internal/stream/McpKafkaProxyIT.java
@@ -207,6 +207,15 @@ public class McpKafkaProxyIT
         k3po.finish();
     }
 
+    @Test
+    @Configuration("proxy.guarded.layered.yaml")
+    @Specification({
+        "${mcp}/tools.list.security.schemes/client"})
+    public void shouldListToolsSecuritySchemes() throws Exception
+    {
+        k3po.finish();
+    }
+
     public static String sessionId()
     {
         return "session-1";

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.guarded.layered.yaml
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/config/proxy.guarded.layered.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+guards:
+  test1:
+    type: test
+    options:
+      roles:
+        - admin
+  test0:
+    type: test
+    options:
+      roles:
+        - write:kafka
+bindings:
+  mcp0:
+    type: mcp-kafka
+    kind: proxy
+    routes:
+      - guarded:
+          test1:
+            - admin
+        exit: kafka0
+        when:
+          - tool: produce
+      - guarded:
+          test0:
+            - write:kafka
+        exit: kafka0
+        when:
+          - tool: produce

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list.security.schemes/client.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list.security.schemes/client.rpt
@@ -1,0 +1,257 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property authorization 0L
+
+connect "zilla://streams/mcp0"
+        option zilla:window 16384
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/mcp0"
+        option zilla:window 3000
+        option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+
+connected
+
+# produce matches two distinct tool-scoped routes (test1/admin, test0/write:kafka), so its
+# securitySchemes aggregate both, in route declaration order -- proving toolGuarded accumulates
+# across every route whose condition applies to the tool rather than stopping at the first match.
+# consume matches neither route, so it carries no securitySchemes field at all.
+read  '{"tools":[{"name":"produce","title":"Produce Message",'
+        '"description":"Produce a message to a Kafka topic.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"value":{"type":"string"},"key":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","value"]},'
+        '"securitySchemes":[{"type":"oauth2","scopes":["admin"]},'
+        '{"type":"oauth2","scopes":["write:kafka"]}]},'
+        '{"name":"consume","title":"Consume Messages",'
+        '"description":"Consume messages from a Kafka topic partition.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"limit":{"type":"integer"}},"required":["topic"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"create_topics","title":"Create Topics",'
+        '"description":"Create one or more Kafka topics.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"partitions":{"type":"integer"},"replicas":{"type":"integer"},'
+        '"assignments":{"type":"array"},"configs":{"type":"object"}},"required":'
+        '["name","partitions","replicas"]}},"timeout":{"type":"integer"},'
+        '"validate_only":{"type":"boolean"}},"required":["topics"]},'
+        '"outputSchema":{"type":"object","properties":{"topics":{"type":"array",'
+        '"items":{"type":"object","properties":{"name":{"type":"string"},'
+        '"error":{"type":"integer"},"error_message":{"type":"string"}},'
+        '"required":["name","error"]}}},"required":["topics"]},'
+        '"annotations":{"destructiveHint":false}},'
+        '{"name":"delete_topics","title":"Delete Topics",'
+        '"description":"Delete one or more Kafka topics.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"string"}},"timeout":{"type":"integer"}},'
+        '"required":["topics"]},"outputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"error":{"type":"integer"},"error_message":{"type":"string"}},'
+        '"required":["name","error"]}}},"required":["topics"]},'
+        '"annotations":{"destructiveHint":true,"idempotentHint":true}},'
+        '{"name":"describe_configs","title":"Describe Configs",'
+        '"description":"Describe the configuration of a Kafka topic or broker resource.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"}},"required":["resource_type","resource_name"]},'
+        '"outputSchema":{"type":"object","properties":{"configs":{"type":"array","items":'
+        '{"type":"object","properties":{"name":{"type":"string"},"value":{"type":"string"},'
+        '"is_default":{"type":"boolean"},"is_sensitive":{"type":"boolean"}},"required":'
+        '["name","is_default","is_sensitive"]}}},"required":["configs"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"alter_configs","title":"Alter Configs",'
+        '"description":"Alter the configuration of a Kafka topic or broker resource.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"},"configs":{"type":"object",'
+        '"additionalProperties":{"type":"string"}}},"required":'
+        '["resource_type","resource_name","configs"]},"outputSchema":{"type":"object",'
+        '"properties":{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"},'
+        '"updated":{"type":"boolean"}},"required":["resource_type","resource_name","updated"]},'
+        '"annotations":{"readOnlyHint":false,"destructiveHint":true}},'
+        '{"name":"list_acls","title":"List ACLs",'
+        '"description":"List Kafka ACL bindings matching a filter.",'
+        '"inputSchema":{"type":"object","properties":{"resour'
+        'ce_type":{"type":"string","enum":["topic","group","cluster","transaction'
+        'al_id","delegation_token","user","any"]},"resource_name":{"type":"string'
+        '"},"pattern_type":{"type":"string","enum":["literal","prefixed","match",'
+        '"any"]},"principal":{"type":"string"},"host":{"type":"string"},"operatio'
+        'n":{"type":"string","enum":["any","all","read","write","create","delete"'
+        ',"alter","describe","cluster_action","describe_configs","alter_configs",'
+        '"idempotent_write","create_tokens","describe_tokens","two_phase_commit"]'
+        '},"permission_type":{"type":"string","enum":["allow","deny","any"]}}},"o'
+        'utputSchema":{"type":"object","properties":{"acls":{"type":"array","item'
+        's":{"type":"object","properties":{"resource_type":{"type":"string"},"res'
+        'ource_name":{"type":"string"},"pattern_type":{"type":"string"},"principa'
+        'l":{"type":"string"},"host":{"type":"string"},"operation":{"type":"strin'
+        'g"},"permission_type":{"type":"string"}},"required":["resource_type","re'
+        'source_name","pattern_type","principal","host","operation","permission_t'
+        'ype"]}}},"required":["acls"]},"annotations":{"readOnlyHint":true,"destru'
+        'ctiveHint":false,"idempotentHint":true}},{"name":"create_acls","title":"'
+        'Create ACLs","description":"Create one or more Kafka ACL bindings.","inp'
+        'utSchema":{"type":"object","properties":{"acls":{"type":"array","items":{"typ'
+        'e":"object","properties":{"resource_type":{"type":"string","enum":["topi'
+        'c","group","cluster","transactional_id","delegation_token","user","any"]'
+        '},"resource_name":{"type":"string"},"pattern_type":{"type":"string","enu'
+        'm":["literal","prefixed"]},"principal":{"type":"string"},"host":{"type":'
+        '"string"},"operation":{"type":"string","enum":["any","all","read","write'
+        '","create","delete","alter","describe","cluster_action","describe_config'
+        's","alter_configs","idempotent_write","create_tokens","describe_tokens",'
+        '"two_phase_commit"]},"permission_type":{"type":"string","enum":["allow",'
+        '"deny"]}},"required":["resource_type","resource_name","principal","opera'
+        'tion","permission_type"]}}},"required":["acls"]},"outputSchema":{"type":'
+        '"object","properties":{"acls":{"type":"array","items":{"type":"object","'
+        'properties":{"resource_type":{"type":"string"},"resource_name":{"type":"'
+        'string"},"pattern_type":{"type":"string"},"principal":{"type":"string"},'
+        '"host":{"type":"string"},"operation":{"type":"string"},"permission_type"'
+        ':{"type":"string"},"error":{"type":"integer"},"error_message":{"type":"s'
+        'tring"}},"required":["resource_type","resource_name","principal","operat'
+        'ion","permission_type","error"]}}},"required":["acls"]}},{"name":"delete'
+        '_acls","title":"Delete ACLs","description":"Delete Kafka ACL bindings ma'
+        'tching a filter.","inputSchema":{"type":"object","properties":{"acls":{"type":"arra'
+        'y","items":{"type":"object","properties":{"resource_type":{"type":"strin'
+        'g","enum":["topic","group","cluster","transactional_id","delegation_toke'
+        'n","user","any"]},"resource_name":{"type":"string"},"pattern_type":{"typ'
+        'e":"string","enum":["literal","prefixed","match","any"]},"principal":{"t'
+        'ype":"string"},"host":{"type":"string"},"operation":{"type":"string","en'
+        'um":["any","all","read","write","create","delete","alter","describe","cl'
+        'uster_action","describe_configs","alter_configs","idempotent_write","cre'
+        'ate_tokens","describe_tokens","two_phase_commit"]},"permission_type":{"t'
+        'ype":"string","enum":["allow","deny","any"]}}}}},"required":["acls"]},"o'
+        'utputSchema":{"type":"object","properties":{"deleted":{"type":"array","i'
+        'tems":{"type":"object","properties":{"resource_type":{"type":"string"},"'
+        'resource_name":{"type":"string"},"pattern_type":{"type":"string"},"princ'
+        'ipal":{"type":"string"},"host":{"type":"string"},"operation":{"type":"st'
+        'ring"},"permission_type":{"type":"string"},"error":{"type":"integer"},"e'
+        'rror_message":{"type":"string"}},"required":["resource_type","resource_n'
+        'ame","principal","operation","permission_type","error"]}}},"required":["'
+        'deleted"]}},'
+        '{"name":"list_topics","title":"List Topics",'
+        '"description":"List all Kafka topics in the cluster.",'
+        '"inputSchema":{"type":"object","properties":{},"additionalProperties":false},'
+        '"outputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"partition_count":{"type":"integer"},'
+        '"replication_factor":{"type":"integer"}},"required":'
+        '["name","partition_count","replication_factor"]}}},"required":["topics"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_topic","title":"Describe Topic",'
+        '"description":"Describe the partitions and replicas of a Kafka topic.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"}},"required":["topic"]},'
+        '"outputSchema":{"type":"object","properties":{"name":{"type":"string"},'
+        '"partitions":{"type":"array","items":{"type":"object","properties":'
+        '{"partition_id":{"type":"integer"},"leader":{"type":"integer"},'
+        '"replicas":{"type":"array","items":{"type":"integer"}},'
+        '"isr":{"type":"array","items":{"type":"integer"}}},"required":'
+        '["partition_id","leader","replicas","isr"]}}},"required":["name","partitions"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"cluster_overview","title":"Cluster Overview",'
+        '"description":"Summarize the health and size of the Kafka cluster.",'
+        '"inputSchema":{"type":"object","properties":{},"additionalProperties":false},'
+        '"outputSchema":{"type":"object","properties":'
+        '{"broker_count":{"type":"integer"},"controller_id":{"type":"integer"},'
+        '"under_replicated_partitions":{"type":"integer"},"offline_partitions":{"type":"integer"},'
+        '"topic_count":{"type":"integer"}},"required":'
+        '["broker_count","controller_id","under_replicated_partitions","offline_partitions","topic_count"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"list_brokers","title":"List Brokers",'
+        '"description":"List the brokers in the Kafka cluster.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"brokers":{"type":"array",'
+        '"items":{"type":"object","properties":{"broker_id":{"type":"integer"},'
+        '"host":{"type":"string"},"port":{"type":"integer"},"rack":{"type":"string"}},'
+        '"required":["broker_id","host","port"]}}},"required":["brokers"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_cluster","title":"Describe Cluster",'
+        '"description":"Describe the Kafka cluster id, controller, and authorized operations.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"cluster_id":{"type":"string"},'
+        '"controller_id":{"type":"integer"},"authorized_operations":{"type":"integer"}},'
+        '"required":["controller_id","authorized_operations"]},"annotations":{"readOnlyHint":true,'
+        '"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"list_consumer_groups","title":"List Consumer Groups",'
+        '"description":"List the Kafka consumer groups in the cluster.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"groups":{"type":"array","items":'
+        '{"type":"object","properties":{"group_id":{"type":"string"},"state":{"type":"string"}},'
+        '"required":["group_id","state"]}}},"required":["groups"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_consumer_group","title":"Describe Consumer Group",'
+        '"description":"Describe the members and state of a Kafka consumer group.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"}},"required":["group_id"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"state":{"type":"string"},"members":{"type":"array","items":{"type":"object","properties":'
+        '{"member_id":{"type":"string"},"client_id":{"type":"string"},"assignments":'
+        '{"type":"array","items":{"type":"object","properties":{"topic":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","partition"]}}},'
+        '"required":["member_id","client_id"]}}},"required":["group_id","state","members"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_consumer_group_lag","title":"Describe Consumer Group Lag",'
+        '"description":"Describe the per-partition lag of a Kafka consumer group.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"}},"required":["group_id"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"partitions":{"type":"array","items":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"committed_offset":{"type":"integer"},"end_offset":{"type":"integer"},'
+        '"lag":{"type":"integer"}},"required":'
+        '["topic","partition","committed_offset","end_offset","lag"]}}},'
+        '"required":["group_id","partitions"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"reset_offsets","title":"Reset Consumer Group Offsets",'
+        '"description":"Reset the committed offset for a Kafka consumer group topic partition.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"reset":{"type":"boolean"}},"required":["group_id","topic","partition","offset","reset"]},'
+        '"annotations":{"readOnlyHint":false,"destructiveHint":true,"idempotentHint":true}}]}'
+read closed
+
+write close

--- a/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list.security.schemes/server.rpt
+++ b/specs/binding-mcp-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/kafka/streams/mcp/tools.list.security.schemes/server.rpt
@@ -1,0 +1,255 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/mcp0"
+property authorization 0L
+
+accept ${serverAddress}
+       option zilla:window 16384
+       option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("session-1")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write  '{"tools":[{"name":"produce","title":"Produce Message",'
+        '"description":"Produce a message to a Kafka topic.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"value":{"type":"string"},"key":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","value"]},'
+        '"securitySchemes":[{"type":"oauth2","scopes":["admin"]},'
+        '{"type":"oauth2","scopes":["write:kafka"]}]},'
+        '{"name":"consume","title":"Consume Messages",'
+        '"description":"Consume messages from a Kafka topic partition.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"limit":{"type":"integer"}},"required":["topic"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"create_topics","title":"Create Topics",'
+        '"description":"Create one or more Kafka topics.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"partitions":{"type":"integer"},"replicas":{"type":"integer"},'
+        '"assignments":{"type":"array"},"configs":{"type":"object"}},"required":'
+        '["name","partitions","replicas"]}},"timeout":{"type":"integer"},'
+        '"validate_only":{"type":"boolean"}},"required":["topics"]},'
+        '"outputSchema":{"type":"object","properties":{"topics":{"type":"array",'
+        '"items":{"type":"object","properties":{"name":{"type":"string"},'
+        '"error":{"type":"integer"},"error_message":{"type":"string"}},'
+        '"required":["name","error"]}}},"required":["topics"]},'
+        '"annotations":{"destructiveHint":false}},'
+        '{"name":"delete_topics","title":"Delete Topics",'
+        '"description":"Delete one or more Kafka topics.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"string"}},"timeout":{"type":"integer"}},'
+        '"required":["topics"]},"outputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"error":{"type":"integer"},"error_message":{"type":"string"}},'
+        '"required":["name","error"]}}},"required":["topics"]},'
+        '"annotations":{"destructiveHint":true,"idempotentHint":true}},'
+        '{"name":"describe_configs","title":"Describe Configs",'
+        '"description":"Describe the configuration of a Kafka topic or broker resource.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"}},"required":["resource_type","resource_name"]},'
+        '"outputSchema":{"type":"object","properties":{"configs":{"type":"array","items":'
+        '{"type":"object","properties":{"name":{"type":"string"},"value":{"type":"string"},'
+        '"is_default":{"type":"boolean"},"is_sensitive":{"type":"boolean"}},"required":'
+        '["name","is_default","is_sensitive"]}}},"required":["configs"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"alter_configs","title":"Alter Configs",'
+        '"description":"Alter the configuration of a Kafka topic or broker resource.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"},"configs":{"type":"object",'
+        '"additionalProperties":{"type":"string"}}},"required":'
+        '["resource_type","resource_name","configs"]},"outputSchema":{"type":"object",'
+        '"properties":{"resource_type":{"type":"string","enum":["topic","broker"]},'
+        '"resource_name":{"type":"string"},'
+        '"updated":{"type":"boolean"}},"required":["resource_type","resource_name","updated"]},'
+        '"annotations":{"readOnlyHint":false,"destructiveHint":true}},'
+        '{"name":"list_acls","title":"List ACLs",'
+        '"description":"List Kafka ACL bindings matching a filter.",'
+        '"inputSchema":{"type":"object","properties":{"resour'
+        'ce_type":{"type":"string","enum":["topic","group","cluster","transaction'
+        'al_id","delegation_token","user","any"]},"resource_name":{"type":"string'
+        '"},"pattern_type":{"type":"string","enum":["literal","prefixed","match",'
+        '"any"]},"principal":{"type":"string"},"host":{"type":"string"},"operatio'
+        'n":{"type":"string","enum":["any","all","read","write","create","delete"'
+        ',"alter","describe","cluster_action","describe_configs","alter_configs",'
+        '"idempotent_write","create_tokens","describe_tokens","two_phase_commit"]'
+        '},"permission_type":{"type":"string","enum":["allow","deny","any"]}}},"o'
+        'utputSchema":{"type":"object","properties":{"acls":{"type":"array","item'
+        's":{"type":"object","properties":{"resource_type":{"type":"string"},"res'
+        'ource_name":{"type":"string"},"pattern_type":{"type":"string"},"principa'
+        'l":{"type":"string"},"host":{"type":"string"},"operation":{"type":"strin'
+        'g"},"permission_type":{"type":"string"}},"required":["resource_type","re'
+        'source_name","pattern_type","principal","host","operation","permission_t'
+        'ype"]}}},"required":["acls"]},"annotations":{"readOnlyHint":true,"destru'
+        'ctiveHint":false,"idempotentHint":true}},{"name":"create_acls","title":"'
+        'Create ACLs","description":"Create one or more Kafka ACL bindings.","inp'
+        'utSchema":{"type":"object","properties":{"acls":{"type":"array","items":{"typ'
+        'e":"object","properties":{"resource_type":{"type":"string","enum":["topi'
+        'c","group","cluster","transactional_id","delegation_token","user","any"]'
+        '},"resource_name":{"type":"string"},"pattern_type":{"type":"string","enu'
+        'm":["literal","prefixed"]},"principal":{"type":"string"},"host":{"type":'
+        '"string"},"operation":{"type":"string","enum":["any","all","read","write'
+        '","create","delete","alter","describe","cluster_action","describe_config'
+        's","alter_configs","idempotent_write","create_tokens","describe_tokens",'
+        '"two_phase_commit"]},"permission_type":{"type":"string","enum":["allow",'
+        '"deny"]}},"required":["resource_type","resource_name","principal","opera'
+        'tion","permission_type"]}}},"required":["acls"]},"outputSchema":{"type":'
+        '"object","properties":{"acls":{"type":"array","items":{"type":"object","'
+        'properties":{"resource_type":{"type":"string"},"resource_name":{"type":"'
+        'string"},"pattern_type":{"type":"string"},"principal":{"type":"string"},'
+        '"host":{"type":"string"},"operation":{"type":"string"},"permission_type"'
+        ':{"type":"string"},"error":{"type":"integer"},"error_message":{"type":"s'
+        'tring"}},"required":["resource_type","resource_name","principal","operat'
+        'ion","permission_type","error"]}}},"required":["acls"]}},{"name":"delete'
+        '_acls","title":"Delete ACLs","description":"Delete Kafka ACL bindings ma'
+        'tching a filter.","inputSchema":{"type":"object","properties":{"acls":{"type":"arra'
+        'y","items":{"type":"object","properties":{"resource_type":{"type":"strin'
+        'g","enum":["topic","group","cluster","transactional_id","delegation_toke'
+        'n","user","any"]},"resource_name":{"type":"string"},"pattern_type":{"typ'
+        'e":"string","enum":["literal","prefixed","match","any"]},"principal":{"t'
+        'ype":"string"},"host":{"type":"string"},"operation":{"type":"string","en'
+        'um":["any","all","read","write","create","delete","alter","describe","cl'
+        'uster_action","describe_configs","alter_configs","idempotent_write","cre'
+        'ate_tokens","describe_tokens","two_phase_commit"]},"permission_type":{"t'
+        'ype":"string","enum":["allow","deny","any"]}}}}},"required":["acls"]},"o'
+        'utputSchema":{"type":"object","properties":{"deleted":{"type":"array","i'
+        'tems":{"type":"object","properties":{"resource_type":{"type":"string"},"'
+        'resource_name":{"type":"string"},"pattern_type":{"type":"string"},"princ'
+        'ipal":{"type":"string"},"host":{"type":"string"},"operation":{"type":"st'
+        'ring"},"permission_type":{"type":"string"},"error":{"type":"integer"},"e'
+        'rror_message":{"type":"string"}},"required":["resource_type","resource_n'
+        'ame","principal","operation","permission_type","error"]}}},"required":["'
+        'deleted"]}},'
+        '{"name":"list_topics","title":"List Topics",'
+        '"description":"List all Kafka topics in the cluster.",'
+        '"inputSchema":{"type":"object","properties":{},"additionalProperties":false},'
+        '"outputSchema":{"type":"object","properties":'
+        '{"topics":{"type":"array","items":{"type":"object","properties":'
+        '{"name":{"type":"string"},"partition_count":{"type":"integer"},'
+        '"replication_factor":{"type":"integer"}},"required":'
+        '["name","partition_count","replication_factor"]}}},"required":["topics"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_topic","title":"Describe Topic",'
+        '"description":"Describe the partitions and replicas of a Kafka topic.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"topic":{"type":"string"}},"required":["topic"]},'
+        '"outputSchema":{"type":"object","properties":{"name":{"type":"string"},'
+        '"partitions":{"type":"array","items":{"type":"object","properties":'
+        '{"partition_id":{"type":"integer"},"leader":{"type":"integer"},'
+        '"replicas":{"type":"array","items":{"type":"integer"}},'
+        '"isr":{"type":"array","items":{"type":"integer"}}},"required":'
+        '["partition_id","leader","replicas","isr"]}}},"required":["name","partitions"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"cluster_overview","title":"Cluster Overview",'
+        '"description":"Summarize the health and size of the Kafka cluster.",'
+        '"inputSchema":{"type":"object","properties":{},"additionalProperties":false},'
+        '"outputSchema":{"type":"object","properties":'
+        '{"broker_count":{"type":"integer"},"controller_id":{"type":"integer"},'
+        '"under_replicated_partitions":{"type":"integer"},"offline_partitions":{"type":"integer"},'
+        '"topic_count":{"type":"integer"}},"required":'
+        '["broker_count","controller_id","under_replicated_partitions","offline_partitions","topic_count"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"list_brokers","title":"List Brokers",'
+        '"description":"List the brokers in the Kafka cluster.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"brokers":{"type":"array",'
+        '"items":{"type":"object","properties":{"broker_id":{"type":"integer"},'
+        '"host":{"type":"string"},"port":{"type":"integer"},"rack":{"type":"string"}},'
+        '"required":["broker_id","host","port"]}}},"required":["brokers"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_cluster","title":"Describe Cluster",'
+        '"description":"Describe the Kafka cluster id, controller, and authorized operations.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"cluster_id":{"type":"string"},'
+        '"controller_id":{"type":"integer"},"authorized_operations":{"type":"integer"}},'
+        '"required":["controller_id","authorized_operations"]},"annotations":{"readOnlyHint":true,'
+        '"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"list_consumer_groups","title":"List Consumer Groups",'
+        '"description":"List the Kafka consumer groups in the cluster.",'
+        '"inputSchema":{"type":"object","properties":{}},'
+        '"outputSchema":{"type":"object","properties":{"groups":{"type":"array","items":'
+        '{"type":"object","properties":{"group_id":{"type":"string"},"state":{"type":"string"}},'
+        '"required":["group_id","state"]}}},"required":["groups"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_consumer_group","title":"Describe Consumer Group",'
+        '"description":"Describe the members and state of a Kafka consumer group.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"}},"required":["group_id"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"state":{"type":"string"},"members":{"type":"array","items":{"type":"object","properties":'
+        '{"member_id":{"type":"string"},"client_id":{"type":"string"},"assignments":'
+        '{"type":"array","items":{"type":"object","properties":{"topic":{"type":"string"},'
+        '"partition":{"type":"integer"}},"required":["topic","partition"]}}},'
+        '"required":["member_id","client_id"]}}},"required":["group_id","state","members"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"describe_consumer_group_lag","title":"Describe Consumer Group Lag",'
+        '"description":"Describe the per-partition lag of a Kafka consumer group.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"}},"required":["group_id"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"partitions":{"type":"array","items":{"type":"object","properties":'
+        '{"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"committed_offset":{"type":"integer"},"end_offset":{"type":"integer"},'
+        '"lag":{"type":"integer"}},"required":'
+        '["topic","partition","committed_offset","end_offset","lag"]}}},'
+        '"required":["group_id","partitions"]},'
+        '"annotations":{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true}},'
+        '{"name":"reset_offsets","title":"Reset Consumer Group Offsets",'
+        '"description":"Reset the committed offset for a Kafka consumer group topic partition.",'
+        '"inputSchema":{"type":"object","properties":'
+        '{"group_id":{"type":"string"},"topic":{"type":"string"},"partition":{"type":"integer"},'
+        '"offset":{"type":"integer"}},"required":["group_id","topic","partition","offset"]},'
+        '"outputSchema":{"type":"object","properties":{"group_id":{"type":"string"},'
+        '"topic":{"type":"string"},"partition":{"type":"integer"},"offset":{"type":"integer"},'
+        '"reset":{"type":"boolean"}},"required":["group_id","topic","partition","offset","reset"]},'
+        '"annotations":{"readOnlyHint":false,"destructiveHint":true,"idempotentHint":true}}]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
+++ b/specs/binding-mcp-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/kafka/streams/McpIT.java
@@ -182,6 +182,15 @@ public class McpIT
 
     @Test
     @Specification({
+        "${mcp}/tools.list.security.schemes/client",
+        "${mcp}/tools.list.security.schemes/server"})
+    public void shouldListToolsSecuritySchemes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mcp}/create.topics/client",
         "${mcp}/create.topics/server"})
     public void shouldCreateTopics() throws Exception


### PR DESCRIPTION
## Description

Every other client/proxy-capable `mcp*` binding (`mcp-http`, `mcp(client)`, and the `mcp-openapi`-based composites `mcp-kafka-connect`/`mcp-schema-registry`) derives each tool's `securitySchemes` entry in `tools/list` from that tool's own `routes[].guarded` roles — computed internally and consumed by `McpProxyCache`/`McpScopeFilter` for scope-based list filtering (the field itself is stripped before the wire, pending SEP-1488). `mcp-kafka` was the one exception: its `tools/list` was a fixed, static payload built once in the factory constructor, with no reference to any binding config, route, or guard at all.

This PR brings `mcp-kafka` in line with its siblings:

- `McpKafkaRouteConfig` now keeps `route.guarded` (previously discarded — only the compiled `authorized` predicate used for yes/no call-time gating was kept).
- `McpKafkaBindingConfig` gains `toolGuarded(String name)`, accumulating guarded roles across **every** route whose condition matches the tool (not just the first match), mirroring `McpHttpBindingConfig.toolGuarded`. It also gains a per-binding `tools/list` JSON cache (`toolsListJson()`/`toolsListJson(byte[])`).
- `McpKafkaProxyFactory` threads the resolved binding config into `buildToolsList()` (adding a `securitySchemes` entry per tool when its accumulated guarded roles are non-empty) and into `McpToolsListProxy`, replacing the previously factory-wide (and therefore binding-config-blind) `toolsListPayload`/`toolsListBuffer` fields with per-binding ones built lazily on first request — mirroring `McpHttpProxyFactory`'s existing per-binding caching pattern.

## Test plan

- [x] New k3po spec (`tools.list.security.schemes` client+server pair) proves `securitySchemes` aggregates across two distinct guarded routes matching the same tool (`produce`), in route declaration order, and is entirely absent for a tool matching no guarded route (`consume`) — verified peer-to-peer via `McpIT` (self-consistency) and against a live engine via `McpKafkaProxyIT`
- [x] `./mvnw verify -pl runtime/binding-mcp-kafka` — full unit + integration test suite green, including all pre-existing `McpKafkaProxyIT` scenarios (no regressions from the tools-list caching refactor)
- [x] `./mvnw verify -pl specs/binding-mcp-kafka.spec` — full suite green, including all pre-existing `McpIT`/`KafkaIT` scenarios
- [x] `./mvnw checkstyle:check -pl runtime/binding-mcp-kafka` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_014ikToCpeJTceYRhdyZNGRw)_