### PR TITLE
fix(binding-asyncapi): stop rejecting shrinking WINDOW.maximum when acknowledge advances

### DIFF
--- a/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientFactory.java
+++ b/runtime/binding-asyncapi/src/main/java/io/aklivity/zilla/runtime/binding/asyncapi/internal/stream/AsyncapiClientFactory.java
@@ -498,7 +498,7 @@ public final class AsyncapiClientFactory implements AsyncapiStreamFactory
             assert acknowledge <= sequence;
             assert sequence <= replySeq;
             assert acknowledge >= replyAck;
-            assert maximum >= replyMax;
+            assert maximum + acknowledge >= replyMax + replyAck;
 
             replyAck = acknowledge;
             replyMax = maximum;
@@ -750,7 +750,7 @@ public final class AsyncapiClientFactory implements AsyncapiStreamFactory
 
             assert acknowledge <= sequence;
             assert acknowledge >= delegate.initialAck;
-            assert maximum >= delegate.initialMax;
+            assert maximum + acknowledge >= delegate.initialMax + delegate.initialAck;
 
             initialAck = acknowledge;
             initialMax = maximum;


### PR DESCRIPTION
## Description

`AsyncapiClientIT#shouldCreatePet` fails intermittently (reproduces at roughly a 50% rate locally) with:

```
org.agrona.concurrent.AgentTerminationException: java.lang.AssertionError
	at ...AsyncapiClientFactory$CompositeStream.onCompositeWindow(AsyncapiClientFactory.java:753)
```

`CompositeStream.onCompositeWindow` and `AsyncapiStream.onAsyncapiWindow` asserted that `maximum` alone never decreases across successive `WINDOW` frames on the same stream. In Zilla's flow-control model `maximum` is a window size *relative to* `acknowledge`, not an absolute floor (see `runtime/AGENTS.md`'s per-stream field naming: "Max: maximum window size (bytes in flight)") — it legitimately shrinks as `acknowledge` advances, as long as the effective limit (`acknowledge + maximum`) doesn't decrease. `TcpServerFactory` and `GrpcClientFactory` already encode this correctly with `assert maximum + acknowledge >= initialMax + initialAck;`.

For the `createPets` composite scenario, once the stream had fully drained (`acknowledge` caught up to `sequence`), the downstream peer sent a final `WINDOW` with `maximum` reset toward 0 — same effective limit as before (`44`), but a smaller raw `maximum` — which tripped the stricter assertion and crashed the engine worker.

**Root-caused via reproduction + temporary debug logging** (removed before this commit): confirmed the crashing `WINDOW` arrived with `acknowledge == sequence` (nothing in flight) and `maximum = 0`, immediately after a prior `WINDOW` had granted `maximum = 44` at `acknowledge = 0` — an unchanged effective limit both times.

**Fix:** switch both assertions to the combined `acknowledge + maximum` invariant already used elsewhere in the codebase for this exact scenario.

**Verification:**
- ~30 repeated single-attempt runs of `AsyncapiClientIT#shouldCreatePet` before the fix: roughly 50% failure rate.
- 31/31 consecutive passes after the fix, 0 failures.
- Full `./mvnw verify -pl runtime/binding-asyncapi` (all ITs + JaCoCo) green.
- `./mvnw checkstyle:check -pl runtime/binding-asyncapi` clean.

This was discovered while investigating an unrelated `Build (25)` CI failure on #2288 — confirmed pre-existing and unrelated to that PR's diff (reproduces the same way on a clean, unrelated `develop` checkout).

---
_Generated by [Claude Code](https://claude.ai/code/session_015bpBNGFfsKTH6ZVpPv5zev)_