### PR TITLE
fix(binding-kafka): resolve SASL identity/credentials from existing authorization before reauthorizing

### DIFF
--- a/examples/http.kafka.oneway/etc/zilla.yaml
+++ b/examples/http.kafka.oneway/etc/zilla.yaml
@@ -12,8 +12,8 @@ guards:
   sasl_credentials:
     type: inline
     options:
-      identity: ${{env.SASL_USERNAME}}
-      credentials: ${{env.SASL_PASSWORD}}
+      format: "{identity}:{credentials}"
+      credentials: ${{env.SASL_USERNAME}}:${{env.SASL_PASSWORD}}
 bindings:
   north_tcp_server:
     type: tcp

--- a/examples/http.kafka.oneway/etc/zilla.yaml
+++ b/examples/http.kafka.oneway/etc/zilla.yaml
@@ -12,8 +12,8 @@ guards:
   sasl_credentials:
     type: inline
     options:
-      format: "{identity}:{credentials}"
-      credentials: ${{env.SASL_USERNAME}}:${{env.SASL_PASSWORD}}
+      identity: ${{env.SASL_USERNAME}}
+      credentials: ${{env.SASL_PASSWORD}}
 bindings:
   north_tcp_server:
     type: tcp

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientApiFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientApiFactory.java
@@ -1340,9 +1340,11 @@ public final class KafkaClientApiFactory implements BindingHandler
             long budgetId,
             long authorization)
         {
-            guardSession = guard.reauthorize(traceId, routedId, initialId, guard.credentials(authorization));
+            final String resolved = guard.credentials(authorization);
+            final boolean authorized = resolved != null;
+            guardSession = authorized ? authorization : guard.reauthorize(traceId, routedId, initialId, null);
 
-            if ((guardSession & MASK_AUTHORIZED) == 0L)
+            if (!authorized && (guardSession & MASK_AUTHORIZED) == 0L)
             {
                 event.saslAuthenticationFailed(traceId, routedId, null);
                 cleanupNetPending(traceId, ERROR_SASL_AUTHENTICATION_FAILED);

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
@@ -213,8 +213,10 @@ public abstract class KafkaClientSaslHandshaker
             if (guard != null &&
                 (CREDENTIALS_TEMPLATE.equals(sasl.token) || CREDENTIALS_TEMPLATE.equals(sasl.password)))
             {
-                final String credentials = guard.credentials(saslAuthorization);
-                guardSession = guard.reauthorize(traceId, routedId, initialId, credentials);
+                final String resolved = guard.credentials(saslAuthorization);
+                guardSession = resolved != null
+                        ? saslAuthorization
+                        : guard.reauthorize(traceId, routedId, initialId, null);
             }
 
             final MutableDirectBufferEx encodeBuffer = writeBuffer;


### PR DESCRIPTION
## Description

The `http.kafka.oneway` example was broken locally (though its own CI passed) after the recent migration off the deprecated `binding-kafka` `options.sasl` onto `options.authorization` + an inline guard (#2293). Reproduced against a freshly built `develop-SNAPSHOT` image and a real Kafka broker: Zilla authenticated to Kafka as `alice-secret` (the configured password) instead of `alice` (the configured username), so SASL SCRAM-SHA-512 auth failed in a loop and the HTTP POST to `/events` hung forever.

**Root cause:** `KafkaClientSaslHandshaker.doEncodeSaslHandshakeRequest()` (and the identical pattern in `KafkaClientApiFactory`) unconditionally resolved the guard's current credentials and fed that value straight back into `guard.reauthorize(...)`:

```java
final String credentials = guard.credentials(saslAuthorization);
guardSession = guard.reauthorize(traceId, routedId, initialId, credentials);
```

For a guard that derives identity by structurally parsing its `reauthorize()` input (e.g. a JWT, where decoding the same token always yields the same identity), this round-trip is harmless. But for `guard-inline` configured with separate static `identity`/`credentials` options and no `format`, `reauthorize()` has no way to know the incoming string is *only* the password — it treats the whole string as both the new session's identity and credentials, silently overwriting the configured username.

This was invisible to `specs/binding-kafka.spec`'s own SASL ITs because they use `type: test`'s `TestGuardHandler`, whose `identity()`/`credentials()` always return their statically-configured values regardless of what's passed to `reauthorize()` — so the corruption path in a real identity-deriving guard was never exercised.

**Fix:** align with the existing `binding-mcp` client pattern (`McpClientFactory`), which already handles this correctly — try `guard.credentials(authorization)` against the connection's existing authorization first, and only fall back to `reauthorize()` (passed `null`, letting the guard establish its own fresh session, e.g. via a token exchange) when nothing is already resolvable:

```java
final String resolved = guard.credentials(saslAuthorization);
guardSession = resolved != null
        ? saslAuthorization
        : guard.reauthorize(traceId, routedId, initialId, null);
```

This fixes the example without any change to `guard-inline` or the example's `zilla.yaml` — the original, natural `identity:`/`credentials:` config shape (as documented in `MIGRATING.md`) now resolves correctly. `KafkaClientApiFactory` has the identical pattern for its own (admin API) SASL handshake and receives the same fix, with its success/failure check adjusted accordingly since reusing the existing `authorization` value can legitimately be `0`.

Filed #2300 separately for an unrelated resource-lifecycle issue found along the way: neither class ever calls `guard.deauthorize()` on the session `reauthorize()` returns, which leaks reference-counted guard sessions over the process lifetime (also present in `binding-mcp`).

## Testing

- Full `runtime/binding-kafka` test suite: `./mvnw clean verify -pl runtime/binding-kafka` — 394 tests, 0 failures, including every existing SASL IT (`ClientProduceSaslIT`, `CreateTopicsSaslIT`, `ClientFetchSaslIT`, `ClientGroupSaslIT`, `AlterConfigsSaslIT`, `DeleteTopicsSaslIT`, `ClientMetaSaslIT`, `ClientOffsetCommitSaslIT`, `ClientOffsetFetchSaslIT`, `ClientInitProducerIdSaslIT`, `DescribeClusterSaslIT`, `KafkaSaslHandshakeIT`, `KafkaSaslAuthenticateIT`) — no regressions.
- `./mvnw checkstyle:check -pl runtime/binding-kafka` — 0 violations.
- Manually traced the fix against `InlineGuardHandler`'s actual source for both the static-credentials case (`http.kafka.oneway`) and the token-only case (`http.kafka.oneway.oauthbearer`) — both resolve correctly.
- Earlier verified the underlying pipeline (HTTP → Kafka cache → SASL SCRAM → real Kafka broker) end-to-end via `docker compose` against a locally built `develop-SNAPSHOT` image, using a workaround (`options.format` + combined credentials string) that confirmed the identity-corruption diagnosis; that workaround is reverted here now that the real fix lives in `binding-kafka` and the example needs no change. I was not able to re-run that live `docker compose` pass against this exact commit in this sandbox (rebuilding the full image hit an unrelated pre-existing `incubator` module packaging failure) — worth a maintainer or CI double-check of the live example alongside the unit/IT suite above.

Fixes the `http.kafka.oneway` example regression from #2293.


---
_Generated by [Claude Code](https://claude.ai/code/session_013vMWVhL8d4ZEAwHGwSNdqD)_