### PR TITLE
feat(release): create GitHub Release with version-specific changelog section

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Prints the version-specific section of a generated CHANGELOG.md: the
+# "## [<version>](...)" heading through to the line before the next version
+# heading, with trailing blank lines removed. Prints nothing when the changelog
+# has no section for <version>, leaving the fallback to the caller.
+
+set -euo pipefail
+
+VERSION="${1:?usage: release-notes.sh <version> [changelog]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+if [[ -f "$CHANGELOG" ]]; then
+  awk -v prefix="## [$VERSION]" '
+    substr($0, 1, 4) == "## [" { if (found) exit; found = substr($0, 1, length(prefix)) == prefix }
+    found { print }
+  ' "$CHANGELOG" | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba'
+fi

--- a/.github/scripts/release-tags.sh
+++ b/.github/scripts/release-tags.sh
@@ -2,10 +2,15 @@
 # Emits the derived tag facts for a release version as key=value lines,
 # suitable for appending to $GITHUB_OUTPUT.
 #
+#   semver  true when <version> is a x.y.z release version, false otherwise
 #   major   major version, empty unless <version> is x.y.z
 #   minor   major.minor version, empty unless <version> is x.y.z
 #   latest  docker "latest" tag, empty unless <version> is the highest release
 #   highest true when <version> is the highest release, false otherwise
+#
+# Pre-release versions such as 2.0.0-alpha-42 or 1.3.1-rc1 are not x.y.z, so
+# they float no docker tag and get no GitHub Release; only the exact version is
+# published for them.
 #
 # A release is the highest release when no existing release tag sorts above it,
 # so the newest released line keeps the latest marker until a higher line ships
@@ -16,12 +21,14 @@ set -euo pipefail
 
 VERSION="${1:?usage: release-tags.sh <version>}"
 
+SEMVER="false"
 MAJOR=""
 MINOR=""
 LATEST=""
 HIGHEST="false"
 
 if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+  SEMVER="true"
   MAJOR="${BASH_REMATCH[1]}"
   MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
 
@@ -33,6 +40,7 @@ if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
   fi
 fi
 
+echo "semver=$SEMVER"
 echo "major=$MAJOR"
 echo "minor=$MINOR"
 echo "latest=$LATEST"

--- a/.github/scripts/release-tags.sh
+++ b/.github/scripts/release-tags.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Emits the derived tag facts for a release version as key=value lines,
+# suitable for appending to $GITHUB_OUTPUT.
+#
+#   major   major version, empty unless <version> is x.y.z
+#   minor   major.minor version, empty unless <version> is x.y.z
+#   latest  docker "latest" tag, empty unless <version> is the highest release
+#   highest true when <version> is the highest release, false otherwise
+#
+# A release is the highest release when no existing release tag sorts above it,
+# so the newest released line keeps the latest marker until a higher line ships
+# its first release. Deliberately derived from released versions rather than
+# from the branch, so this stays correct once develop branches to support/N.x.
+
+set -euo pipefail
+
+VERSION="${1:?usage: release-tags.sh <version>}"
+
+MAJOR=""
+MINOR=""
+LATEST=""
+HIGHEST="false"
+
+if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+  RELEASED=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; echo "$VERSION"; } | sort -V -u | tail -n1)
+
+  if [[ "$RELEASED" == "$VERSION" ]]; then
+    LATEST="latest"
+    HIGHEST="true"
+  fi
+fi
+
+echo "major=$MAJOR"
+echo "minor=$MINOR"
+echo "latest=$LATEST"
+echo "highest=$HIGHEST"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,24 +210,7 @@ jobs:
 
     - name: Determine docker tags
       id: tag
-      run: |
-        VERSION="${{ inputs.version }}"
-        MAJOR=""
-        MINOR=""
-        LATEST=""
-        if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
-          MAJOR="${BASH_REMATCH[1]}"
-          MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          HIGHEST=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; echo "$VERSION"; } | sort -V | tail -n1)
-          if [[ "$HIGHEST" == "$VERSION" ]]; then
-            LATEST="latest"
-          fi
-        fi
-        {
-          echo "major=$MAJOR"
-          echo "minor=$MINOR"
-          echo "latest=$LATEST"
-        } >> "$GITHUB_OUTPUT"
+      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
 
     - name: Deploy via Maven
       run: |
@@ -354,6 +337,29 @@ jobs:
         git branch ${{ github.ref_name }} origin/${{ github.ref_name }} || true
         git flow init -df
 
+    - name: Extract release notes from CHANGELOG on release branch
+      run: |
+        NOTES="$RUNNER_TEMP/release-notes.md"
+        CHANGELOG="$RUNNER_TEMP/CHANGELOG.md"
+        git show release/${{ inputs.version }}:CHANGELOG.md > "$CHANGELOG" || true
+        .github/scripts/release-notes.sh "${{ inputs.version }}" "$CHANGELOG" > "$NOTES"
+        if [ ! -s "$NOTES" ]; then
+          echo "::warning::CHANGELOG.md on release/${{ inputs.version }} has no [${{ inputs.version }}] section; the GitHub Release will link to the full changelog instead."
+          PREVIOUS=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; echo "${{ inputs.version }}"; } \
+              | sort -V -u | grep -B1 -x -- "${{ inputs.version }}" | head -n1)
+          {
+            echo "## [${{ inputs.version }}](https://github.com/${{ github.repository }}/tree/${{ inputs.version }})"
+            echo
+            if [ "$PREVIOUS" != "${{ inputs.version }}" ]; then
+              echo "[Full Changelog](https://github.com/${{ github.repository }}/compare/$PREVIOUS...${{ inputs.version }})"
+            fi
+          } > "$NOTES"
+        fi
+
+    - name: Determine release latest marker
+      id: tag
+      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+
     - name: Tag the release
       if: startsWith(github.ref_name, 'support/')
       run: |
@@ -398,3 +404,21 @@ jobs:
       run: |
         git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
         git push origin ${{ github.ref_name }}
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        NOTES="$RUNNER_TEMP/release-notes.md"
+        if gh release view ${{ inputs.version }} --repo ${{ github.repository }} >/dev/null 2>&1; then
+          gh release edit ${{ inputs.version }} --repo ${{ github.repository }} \
+              --title ${{ inputs.version }} \
+              --notes-file "$NOTES" \
+              --latest=${{ steps.tag.outputs.highest }}
+        else
+          gh release create ${{ inputs.version }} --repo ${{ github.repository }} \
+              --title ${{ inputs.version }} \
+              --notes-file "$NOTES" \
+              --latest=${{ steps.tag.outputs.highest }} \
+              --verify-tag
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,12 @@ jobs:
         git branch ${{ github.ref_name }} origin/${{ github.ref_name }} || true
         git flow init -df
 
+    - name: Determine release version facts
+      id: tag
+      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+
     - name: Extract release notes from CHANGELOG on release branch
+      if: steps.tag.outputs.semver == 'true'
       run: |
         NOTES="$RUNNER_TEMP/release-notes.md"
         CHANGELOG="$RUNNER_TEMP/CHANGELOG.md"
@@ -355,10 +360,6 @@ jobs:
             fi
           } > "$NOTES"
         fi
-
-    - name: Determine release latest marker
-      id: tag
-      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
 
     - name: Tag the release
       if: startsWith(github.ref_name, 'support/')
@@ -406,6 +407,7 @@ jobs:
         git push origin ${{ github.ref_name }}
 
     - name: Create GitHub Release
+      if: steps.tag.outputs.semver == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -422,3 +424,7 @@ jobs:
               --latest=${{ steps.tag.outputs.highest }} \
               --verify-tag
         fi
+
+    - name: Skip GitHub Release for pre-release version
+      if: steps.tag.outputs.semver != 'true'
+      run: echo "::notice::${{ inputs.version }} is not an x.y.z release version; skipping GitHub Release creation."


### PR DESCRIPTION
## Description

The `release` workflow tagged, deployed and regenerated `CHANGELOG.md` but never created a **GitHub Release**, leaving that manual — the [2.0.0 release](https://github.com/aklivity/zilla/releases/tag/2.0.0) body is a hand-pasted changelog section with an empty release name.

`finalize` now creates the Release on the release tag, named for the version, with a body holding only that version's `CHANGELOG.md` section.

### Only `x.y.z` versions get a Release

Pre-releases are frequent on this workflow — `2.0.0` alone shipped 37 `2.0.0-alpha-N` tags, and the maintenance line regularly tags `-rcN` — so creating a Release for every version string would fill the Releases page with pre-release entries. `release-tags.sh` emits an explicit `semver` output, and both notes extraction and Release creation are gated on it. A pre-release publishes only its exact version: no floating docker tag, no Release. That matches how docker tagging already treated non-`x.y.z` versions. A skipped run emits a `::notice::` rather than passing silently.

### `make_latest` compares released versions, not the branch

A `github.ref_name`-based rule (`develop` → latest, `support/*` → not) is correct today but breaks the moment `develop` is branched to `support/2.x`: that same workflow, now on `support/2.x`, would stop marking `2.0.1` as latest even though `3.0.0` doesn't exist yet, stranding `2.0.0` as latest. Comparing released versions is right in every window and needs no edit at branch time:

| scenario | released | highest tag | `make_latest` |
| --- | --- | --- | --- |
| `develop` is `2.x` mainline | `2.0.0` | `1.2.4` | `true` |
| `support/1.x` patch after `2.0.0` | `1.2.5` | `2.0.0` | `false` |
| branched to `support/2.x`, `3.0.0` not yet shipped | `2.0.1` | `2.0.0` | `true` |
| same line, after `3.0.0` shipped | `2.0.2` | `3.0.0` | `false` |

Pre-release tags never participate in that comparison — the tag list is filtered to `x.y.z` first, so `2.0.1` resolves to `true` even with `2.0.0-alpha-42` present.

The comparison lives in `.github/scripts/release-tags.sh`, shared with the docker `latest` tag in `deploy` (previously inline there), so the image tag and the Release marker cannot disagree. Same algorithm as before, so docker tagging behaviour is unchanged.

### Two deviations from the issue's plan

- **Notes are read via `git show release/{version}:CHANGELOG.md`, not the working tree.** The step sits after `Initialize GitFlow`, and `git flow init -df` can move `HEAD` off the release branch — and on a `develop` release the base branch's `CHANGELOG.md` has no `[{version}]` section yet (it got `merge -s ours`). Reading the working tree would have silently hit the fallback on every release.
- **Release creation is the last step of `finalize`,** not immediately after `Finish release`, so a Release failure cannot leave the base-branch CHANGELOG push undone.

### Robustness

- `Generate CHANGELOG` is `continue-on-error`, so the section can be absent. That warns and falls back to a heading plus a compare link against the preceding release, rather than failing the release after artifacts are out or publishing an empty body. The compare link is omitted when there is no predecessor tag.
- Rerun-safe: `gh release view` → `edit` when the Release exists, else `create --verify-tag`.

## Verification

No test harness covers workflow YAML, so the extracted scripts were exercised directly:

- All four `make_latest` rows above, plus: rerun with the tag already present, `2.10.0` vs `2.9.0` ordering (`sort -V`, not string sort), older patch while a newer minor exists, and no tags at all.
- The semver gate against this repo's real version names: `2.0.0-alpha-43`, `1.3.1-rc1` and `1.2.7-rc11` all yield `semver=false` (no Release, no floating docker tag), while `2.0.1`, `3.0.0`, `1.3.1` and `2.0.0` yield `semver=true`. Also confirmed `2.0.1` → `highest=true` with `2.0.0-alpha-42` in the tag list.
- Notes extraction against the real 297KB `CHANGELOG.md`: 437 lines for `2.0.0` (exactly lines 3–439), one heading, no bleed into the `1.2.4` section; also checked a mid-file section.
- Fallback body generation, including correct per-line predecessor (`1.2.5` → `1.2.4`, not `2.0.0`).
- `--latest=false` and `--verify-tag` confirmed against the `gh` CLI source: both `release create` and `release edit` declare `--latest` as `NilBoolFlag`; `--verify-tag` exists on `create` only, matching usage here.
- YAML parses; `bash -n` clean. `shellcheck` was unavailable in the dev environment, so the scripts are unlinted beyond syntax.

Note that the Release path cannot be exercised end to end until a real release runs, since `workflow_dispatch` on `release.yml` only takes effect once merged to the base branch. The script logic is covered by the checks above; the first live proof will be the next release.

The `support/1.x` port is #2305.

Fixes #2303
