### PR TITLE
feat(release): create GitHub Release with version-specific changelog section

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Prints the version-specific section of a generated CHANGELOG.md: the
+# "## [<version>](...)" heading through to the line before the next version
+# heading, with trailing blank lines removed. Prints nothing when the changelog
+# has no section for <version>, leaving the fallback to the caller.
+
+set -euo pipefail
+
+VERSION="${1:?usage: release-notes.sh <version> [changelog]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+if [[ -f "$CHANGELOG" ]]; then
+  awk -v prefix="## [$VERSION]" '
+    substr($0, 1, 4) == "## [" { if (found) exit; found = substr($0, 1, length(prefix)) == prefix }
+    found { print }
+  ' "$CHANGELOG" | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba'
+fi

--- a/.github/scripts/release-tags.sh
+++ b/.github/scripts/release-tags.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Emits the derived tag facts for a release version as key=value lines,
+# suitable for appending to $GITHUB_OUTPUT.
+#
+#   semver  true when <version> is a x.y.z release version, false otherwise
+#   major   major version, empty unless <version> is x.y.z
+#   minor   major.minor version, empty unless <version> is x.y.z
+#   latest  docker "latest" tag, empty unless <version> is the highest release
+#   highest true when <version> is the highest release, false otherwise
+#
+# Pre-release versions such as 2.0.0-alpha-42 or 1.3.1-rc1 are not x.y.z, so
+# they float no docker tag and get no GitHub Release; only the exact version is
+# published for them.
+#
+# A release is the highest release when no existing release tag sorts above it,
+# so the newest released line keeps the latest marker until a higher line ships
+# its first release. Deliberately derived from released versions rather than
+# from the branch, so this stays correct once develop branches to support/N.x.
+
+set -euo pipefail
+
+VERSION="${1:?usage: release-tags.sh <version>}"
+
+SEMVER="false"
+MAJOR=""
+MINOR=""
+LATEST=""
+HIGHEST="false"
+
+if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+  SEMVER="true"
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+  RELEASED=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; echo "$VERSION"; } | sort -V -u | tail -n1)
+
+  if [[ "$RELEASED" == "$VERSION" ]]; then
+    LATEST="latest"
+    HIGHEST="true"
+  fi
+fi
+
+echo "semver=$SEMVER"
+echo "major=$MAJOR"
+echo "minor=$MINOR"
+echo "latest=$LATEST"
+echo "highest=$HIGHEST"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,24 +198,7 @@ jobs:
 
     - name: Determine docker tags
       id: tag
-      run: |
-        VERSION="${{ inputs.version }}"
-        MAJOR=""
-        MINOR=""
-        LATEST=""
-        if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
-          MAJOR="${BASH_REMATCH[1]}"
-          MINOR="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          HIGHEST=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; echo "$VERSION"; } | sort -V | tail -n1)
-          if [[ "$HIGHEST" == "$VERSION" ]]; then
-            LATEST="latest"
-          fi
-        fi
-        {
-          echo "major=$MAJOR"
-          echo "minor=$MINOR"
-          echo "latest=$LATEST"
-        } >> "$GITHUB_OUTPUT"
+      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
 
     - name: Deploy via Maven
       run: |
@@ -330,6 +313,30 @@ jobs:
         git branch ${{ github.ref_name }} origin/${{ github.ref_name }} || true
         git flow init -df
 
+    - name: Determine release version facts
+      id: tag
+      run: .github/scripts/release-tags.sh "${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+
+    - name: Extract release notes from CHANGELOG on release branch
+      if: steps.tag.outputs.semver == 'true'
+      run: |
+        NOTES="$RUNNER_TEMP/release-notes.md"
+        CHANGELOG="$RUNNER_TEMP/CHANGELOG.md"
+        git show release/${{ inputs.version }}:CHANGELOG.md > "$CHANGELOG" || true
+        .github/scripts/release-notes.sh "${{ inputs.version }}" "$CHANGELOG" > "$NOTES"
+        if [ ! -s "$NOTES" ]; then
+          echo "::warning::CHANGELOG.md on release/${{ inputs.version }} has no [${{ inputs.version }}] section; the GitHub Release will link to the full changelog instead."
+          PREVIOUS=$({ git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; echo "${{ inputs.version }}"; } \
+              | sort -V -u | grep -B1 -x -- "${{ inputs.version }}" | head -n1)
+          {
+            echo "## [${{ inputs.version }}](https://github.com/${{ github.repository }}/tree/${{ inputs.version }})"
+            echo
+            if [ "$PREVIOUS" != "${{ inputs.version }}" ]; then
+              echo "[Full Changelog](https://github.com/${{ github.repository }}/compare/$PREVIOUS...${{ inputs.version }})"
+            fi
+          } > "$NOTES"
+        fi
+
     - name: Tag the release
       run: |
         git tag -a ${{ inputs.version }} -m "${{ inputs.version }}" release/${{ inputs.version }}
@@ -369,3 +376,26 @@ jobs:
       run: |
         git diff --quiet && git diff --cached --quiet || git commit -a -m "Update CHANGELOG.md"
         git push origin ${{ github.ref_name }}
+
+    - name: Create GitHub Release
+      if: steps.tag.outputs.semver == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        NOTES="$RUNNER_TEMP/release-notes.md"
+        if gh release view ${{ inputs.version }} --repo ${{ github.repository }} >/dev/null 2>&1; then
+          gh release edit ${{ inputs.version }} --repo ${{ github.repository }} \
+              --title ${{ inputs.version }} \
+              --notes-file "$NOTES" \
+              --latest=${{ steps.tag.outputs.highest }}
+        else
+          gh release create ${{ inputs.version }} --repo ${{ github.repository }} \
+              --title ${{ inputs.version }} \
+              --notes-file "$NOTES" \
+              --latest=${{ steps.tag.outputs.highest }} \
+              --verify-tag
+        fi
+
+    - name: Skip GitHub Release for pre-release version
+      if: steps.tag.outputs.semver != 'true'
+      run: echo "::notice::${{ inputs.version }} is not an x.y.z release version; skipping GitHub Release creation."


### PR DESCRIPTION
## Description

Port of #2304 (merged to `develop` as `d890eea25`) to the `1.x` line, so `1.x` maintenance releases also get a GitHub Release carrying that version's changelog section — and, importantly, do **not** displace `2.0.0` as latest.

`finalize` creates the Release on the release tag, named for the version, with a body holding only that version's `CHANGELOG.md` section, read from `release/{version}` via `git show` so extraction does not depend on where `git flow` leaves `HEAD`.

### Only `x.y.z` versions get a Release

This matters especially on this branch, which regularly tags pre-releases — `1.3.1-rc1`, `1.2.7-rc11`, `1.2.6-rc3`, `1.2.5-rc3`, `1.2.4-rc2` — so creating a Release for every version string would fill the Releases page with `-rcN` entries. `release-tags.sh` emits an explicit `semver` output, and both notes extraction and Release creation are gated on it. A pre-release publishes only its exact version: no floating docker tag, no Release, matching how docker tagging already treated non-`x.y.z` versions. A skipped run emits a `::notice::` rather than passing silently.

Pre-release tags also never participate in the highest-version comparison — the tag list is filtered to `x.y.z` first.

### `make_latest` compares released versions

Derived by comparing released versions rather than the branch, via the shared `.github/scripts/release-tags.sh` (which also feeds the docker `latest` tag, so the image tag and the Release marker cannot disagree). On this branch that yields `false` for `1.x` releases while `2.0.0` exists — while a `1.x` release made before any higher line had shipped would still have been marked latest. Same algorithm as the previous inline code, so docker tagging behaviour is unchanged.

### Relationship to #2304

One commit, whose subject is character-identical to `d890eea25`'s (modulo the `(#NNNN)` suffix that subject normalization strips), carrying `Ports: d890eea25`.

The five added/changed workflow steps are **byte-identical** to the merged `develop` versions, and both scripts are the same blobs — verified by parsing both files and comparing the step objects. Only the surrounding file differs, because this branch's `Tag the release` and `Finish release` steps are unconditional rather than gated on `github.ref_name`, which makes this a partial port by patch content and is why the `Ports:` trailer is there. The rest of the two `release.yml` files is deliberately left divergent; they need not be identical now. What matters is that the `develop` copy stays correct unedited once it becomes `support/2.x`.

### Robustness

- `Generate CHANGELOG` is `continue-on-error`, so the section can be absent. That warns and falls back to a heading plus a compare link against the preceding release, rather than failing the release after artifacts are out or publishing an empty body.
- Release creation is the last step of `finalize`, so a failure there cannot leave the base-branch CHANGELOG push undone.
- Rerun-safe: `gh release view` → `edit` when the Release exists, else `create --verify-tag`.

## Verification

Verified as described in #2304 — the scripts here are the same blobs, and the workflow steps were compared step-by-step against merged `develop` to confirm they are identical. The semver gate was exercised against this branch's real version names: `1.3.1-rc1` and `1.2.7-rc11` yield `semver=false`; `1.3.1` yields `semver=true` with `highest=false`, since `2.0.0` exists. YAML parses on this branch.

As on #2304, the Release path cannot be exercised end to end until a real release runs from this branch, since `workflow_dispatch` on `release.yml` only takes effect once merged.

Relates to #2303
