### PR TITLE
ci: cache and authenticate Docker Hub image pulls to survive rate limits

### DIFF
--- a/cloud/helm-chart/pom.xml
+++ b/cloud/helm-chart/pom.xml
@@ -57,6 +57,7 @@
           <chartDirectory>src/main/helm</chartDirectory>
           <chartVersion>${project.version}</chartVersion>
           <appVersion>${project.version}</appVersion>
+          <helmVersion>${helm.version}</helmVersion>
           <skipUpload>true</skipUpload>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <mockito.version>5.23.0</mockito.version>
     <k3po.version>3.4.0</k3po.version>
     <jmh.version>1.37</jmh.version>
+    <helm.version>3.16.4</helm.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
## Description

Ports the `helm-chart` slice of `c26b351cc` to `support/1.x`, where `helm-maven-plugin`'s `init` goal is still unpinned. With `helmVersion` unset, `init` resolves helm's latest release through `api.github.com` — an unauthenticated call from a shared runner IP that 403s whenever the 60-request/hour anonymous limit happens to be exhausted, failing `cloud/helm-chart` after every earlier module has already succeeded.

Two lines, byte-identical to the `develop` original (only the unrelated `k3po.version` context line differs):

- `pom.xml` — add a `helm.version` property, `3.16.4`, matching `develop`
- `cloud/helm-chart/pom.xml` — add `<helmVersion>${helm.version}</helmVersion>` to the `helm-maven-plugin` configuration

`init` now pulls the binary straight from the get.helm.sh CDN and never touches the GitHub API.

### Verification

Run against this branch with the pin in place, not assumed:

- `helm-maven-plugin:6.17.0:init` resolves and downloads the pinned binary with no `api.github.com` request; `cloud/helm-chart/target/helm/helm version` reports `v3.16.4`. (`init` then failed locally on `helm repo add stable` because the sandbox proxy blocks `charts.helm.sh` — environment, not this change.)
- The chart lints and packages with that binary: `1 chart(s) linted, 0 chart(s) failed`, `Successfully packaged chart … zilla-1.0.0.tgz`.
- Packaging had to run against a copy of `src/main/helm/zilla` with a semver chart version. In-tree `helm:package` on `support/1.x` fails with `Invalid Semantic Version` on `1.x-SNAPSHOT` — pre-existing, and exactly why the default profile sets `helm.package.skip`; under `-Drelease` the chart version is a real semver. A true `-Drelease` build was not run here (it enforces release dependency versions and needs `docker-image` built).

### Commit subject

The subject is `develop`'s squash subject verbatim, so merge-report pairs the two by subject normalization. On `develop` the pin exists only inside `ci: cache and authenticate Docker Hub image pulls to survive rate limits (#1901)`; the authored sub-commit subject `ci(helm-chart): pin helmVersion to avoid GitHub API rate-limit 403` is not a commit on any branch. Since `.gitflow-changelog.yml` excludes `.github/**`, these two pom lines are the original's entire tracked content, making this a full port rather than a partial one. The remaining `.github/**` workflow caching from the original is not ported and already diverges between the branches.

If the readable `ci(helm-chart): pin helmVersion…` subject is preferred instead, this becomes a partial port needing a `Ports: c26b351cc` line plus a `.gitflow-changelog-merge-ignore.yml` entry on `develop` — that file does not exist on `support/1.x` — and I can switch it.

### Not in scope

The issue's "worth considering" items are left alone: skipping `init` in the `develop` profile (affects `develop` too, better as its own issue), and `useLocalHelmBinary` / `autoDetectLocalHelmBinary`.

Fixes #2316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV4jCLP7aVvi8F7oBfVpSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV4jCLP7aVvi8F7oBfVpSy)_