### PR TITLE
engine: change ModelVisitor.onField to take a FieldEvent

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -497,15 +497,17 @@ public final class KafkaCachePartition
         if (transformKey != KafkaCacheModel.NONE &&
             transforms != null && transforms.extractKey != null)
         {
-            final ModelVisitor writeKey = (path, buffer, index, length) ->
+            final ModelVisitor writeKey = event ->
             {
+                final DirectBufferEx value = event.value();
+                final int length = value.capacity();
                 final int position = entryMark.value + FIELD_OFFSET_PADDED_KEY;
                 KafkaCachePaddedKeyFW paddedKey =
                     logFile.readBytes(position, paddedKeyRO::wrap);
                 final int paddedKeySize = paddedKey.sizeof();
                 KafkaCachePaddedKeyFW.Builder paddedKeyBuilder = paddedKeyRW;
                 final int keySize = paddedKeyBuilder
-                    .key(k -> k.length(length).value(buffer, index, length)).sizeof();
+                    .key(k -> k.length(length).value(value, 0, length)).sizeof();
                 paddedKeyBuilder.padding(logFile.buffer(), 0, paddedKeySize - keySize - SIZE_OF_INT);
                 KafkaCachePaddedKeyFW newPaddedKey = paddedKeyBuilder.build();
                 logFile.writeBytes(position, newPaddedKey.buffer(), newPaddedKey.offset(), newPaddedKey.sizeof());
@@ -651,7 +653,7 @@ public final class KafkaCachePartition
                             h.nameLen(name.length())
                                 .name(name.value(), 0, name.length())
                                 .valueLen(transformValue.extractedLength(path));
-                            transformValue.extracted(path, (p, b, i, l) -> h.value(b, i, l));
+                            transformValue.extracted(path, event -> h.value(event.value(), 0, event.value().capacity()));
                         });
                     }
                     trailers = builder.build();

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaExtractor.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaExtractor.java
@@ -22,7 +22,9 @@ import org.agrona.collections.Object2LongHashMap;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableArrayBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.model.FieldEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 final class KafkaExtractor implements ModelVisitor
 {
@@ -31,6 +33,7 @@ final class KafkaExtractor implements ModelVisitor
     private final Set<String> paths;
     private final MutableDirectBufferEx captures;
     private final Object2LongHashMap<String> regionByPath;
+    private final MutableFieldEvent fieldEvent;
 
     private int capturesOffset;
 
@@ -40,20 +43,21 @@ final class KafkaExtractor implements ModelVisitor
         this.paths = paths;
         this.captures = new ExpandableArrayBufferEx();
         this.regionByPath = new Object2LongHashMap<>(MISSING_REGION);
+        this.fieldEvent = new MutableFieldEvent();
     }
 
     @Override
     public void onField(
-        String path,
-        DirectBufferEx buffer,
-        int index,
-        int length)
+        FieldEvent event)
     {
         // the model surfaces every top-level field; capture only the configured extraction paths
+        final String path = event.path();
         if (paths.contains(path))
         {
+            final DirectBufferEx value = event.value();
+            final int length = value.capacity();
             final int offset = capturesOffset;
-            captures.putBytes(offset, buffer, index, length);
+            captures.putBytes(offset, value, 0, length);
             capturesOffset += length;
             regionByPath.put(path, (long) offset << Integer.SIZE | (length & 0xFFFF_FFFFL));
         }
@@ -75,7 +79,8 @@ final class KafkaExtractor implements ModelVisitor
         {
             final int offset = (int)(region >>> Integer.SIZE);
             final int length = (int)(region & 0xFFFF_FFFFL);
-            visitor.onField(path, captures, offset, length);
+            fieldEvent.wrap(path, captures, offset, length);
+            visitor.onField(fieldEvent);
         }
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
@@ -130,7 +130,7 @@ public class KafkaCacheModelTest
         assertEquals(0, KafkaCacheModel.NONE.extractedLength("$.id"));
 
         boolean[] visited = { false };
-        KafkaCacheModel.NONE.extracted("$.id", (p, b, i, l) -> visited[0] = true);
+        KafkaCacheModel.NONE.extracted("$.id", event -> visited[0] = true);
         assertEquals(false, visited[0]);
 
         KafkaCacheModel.NONE.reset();
@@ -146,7 +146,7 @@ public class KafkaCacheModelTest
 
         assertEquals(4, model.extractedLength("$.id"));
         String[] captured = { null };
-        model.extracted("$.id", (p, b, i, l) -> captured[0] = b.getStringWithoutLengthUtf8(i, l));
+        model.extracted("$.id", event -> captured[0] = event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         assertEquals("1234", captured[0]);
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -58,6 +58,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 import io.aklivity.zilla.runtime.engine.test.internal.model.TestModelHandler;
 
 public class KafkaCachePartitionTest
@@ -406,6 +407,7 @@ public class KafkaCachePartitionTest
         private final ModelVisitor visitor;
         private final String path;
         private final ModelPipelineResult result = new ModelPipelineResult();
+        private final MutableFieldEvent fieldEvent = new MutableFieldEvent();
 
         private ExtractingPipeline(
             ModelVisitor visitor,
@@ -429,7 +431,8 @@ public class KafkaCachePartitionTest
         {
             int srcLength = srcLimit - srcIndex;
             dst.putBytes(dstIndex, src, srcIndex, srcLength);
-            visitor.onField(path, src, srcIndex, srcLength);
+            fieldEvent.wrap(path, src, srcIndex, srcLength);
+            visitor.onField(fieldEvent);
             return result.set(ModelStatus.COMPLETE, srcLength, srcLength);
         }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaExtractorTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaExtractorTest.java
@@ -28,10 +28,12 @@ import org.junit.Test;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 public class KafkaExtractorTest
 {
     private final MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[256]);
+    private final MutableFieldEvent fieldEvent = new MutableFieldEvent();
 
     @Test
     public void shouldCaptureSingleField()
@@ -74,7 +76,7 @@ public class KafkaExtractorTest
 
         assertEquals(0, extractor.extractedLength("$.other"));
         boolean[] visited = { false };
-        extractor.extracted("$.other", (p, b, i, l) -> visited[0] = true);
+        extractor.extracted("$.other", event -> visited[0] = true);
         assertFalse(visited[0]);
     }
 
@@ -88,7 +90,7 @@ public class KafkaExtractorTest
         assertEquals(0, extractor.extractedLength("$.missing"));
 
         boolean[] visited = { false };
-        extractor.extracted("$.missing", (p, b, i, l) -> visited[0] = true);
+        extractor.extracted("$.missing", event -> visited[0] = true);
         assertFalse(visited[0]);
     }
 
@@ -100,7 +102,7 @@ public class KafkaExtractorTest
         onField(extractor, "$.id", "abc");
 
         boolean[] visited = { false };
-        extractor.extracted("$.id", (p, b, i, l) -> visited[0] = true);
+        extractor.extracted("$.id", event -> visited[0] = true);
         assertTrue(visited[0]);
     }
 
@@ -139,7 +141,8 @@ public class KafkaExtractorTest
     {
         byte[] bytes = value.getBytes(UTF_8);
         buffer.putBytes(0, bytes);
-        extractor.onField(path, buffer, 0, bytes.length);
+        fieldEvent.wrap(path, buffer, 0, bytes.length);
+        extractor.onField(fieldEvent);
     }
 
     private String read(
@@ -147,7 +150,7 @@ public class KafkaExtractorTest
         String path)
     {
         String[] result = { null };
-        extractor.extracted(path, (p, b, i, l) -> result[0] = b.getStringWithoutLengthUtf8(i, l));
+        extractor.extracted(path, event -> result[0] = event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         return result[0];
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/FieldEvent.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/FieldEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.model;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * A field value extracted from a value as a {@link ModelPipeline} transforms it.
+ * <p>
+ * {@link #value()} is valid only for the duration of the {@link ModelVisitor#onField} call;
+ * an implementation that needs the bytes beyond the call must copy them out.
+ * </p>
+ */
+public interface FieldEvent
+{
+    /**
+     * @return the registered extraction path the value was found at
+     */
+    String path();
+
+    /**
+     * @return the field value, already bounded to exactly its own bytes
+     */
+    DirectBufferEx value();
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelVisitor.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelVisitor.java
@@ -15,16 +15,14 @@
  */
 package io.aklivity.zilla.runtime.engine.model;
 
-import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
-
 /**
  * Receives field values extracted from a value as a {@link ModelPipeline} transforms it.
  * <p>
  * A {@code ModelVisitor} is wired to a pipeline at {@link ModelHandler#supplyDecoder} time and
  * confined to the same single I/O thread. The pipeline invokes {@link #onField} once per registered
- * path that is present in a value, when that value completes. The supplied buffer slice is valid
- * only for the duration of the call; an implementation that needs the bytes beyond the call must
- * copy them out.
+ * path that is present in a value, when that value completes. The supplied {@link FieldEvent} is
+ * valid only for the duration of the call; an implementation that needs the bytes beyond the call
+ * must copy them out.
  * </p>
  *
  * @see ModelHandler#supplyDecoder(ModelVisitor)
@@ -35,19 +33,13 @@ public interface ModelVisitor
     /**
      * No-op visitor that ignores every extracted field.
      */
-    ModelVisitor NONE = (path, buffer, index, length) -> {};
+    ModelVisitor NONE = event -> {};
 
     /**
-     * Called with the buffer slice containing an extracted field value.
+     * Called with the extracted field value.
      *
-     * @param path    the registered extraction path the value was found at
-     * @param buffer  the buffer containing the field value
-     * @param index   the offset of the field value
-     * @param length  the length of the field value
+     * @param event  the extracted field
      */
     void onField(
-        String path,
-        DirectBufferEx buffer,
-        int index,
-        int length);
+        FieldEvent event);
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/MutableFieldEvent.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/MutableFieldEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.model;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+
+/**
+ * A reusable, mutable {@link FieldEvent}. Callers wrap it fresh before each
+ * {@link ModelVisitor#onField} call rather than allocating a new instance per field.
+ */
+public final class MutableFieldEvent implements FieldEvent
+{
+    private final DirectBufferEx value;
+
+    private String path;
+
+    public MutableFieldEvent()
+    {
+        this.value = new UnsafeBufferEx(new byte[0]);
+    }
+
+    public void wrap(
+        String path,
+        DirectBufferEx buffer,
+        int index,
+        int length)
+    {
+        this.path = path;
+        this.value.wrap(buffer, index, length);
+    }
+
+    @Override
+    public String path()
+    {
+        return path;
+    }
+
+    @Override
+    public DirectBufferEx value()
+    {
+        return value;
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
@@ -26,6 +26,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 // Per-stream transform mirroring the test model's whole-value length check: the value is accepted only when
 // the total length across fragments equals the configured length. A length mismatch is treated as a
@@ -48,6 +49,7 @@ final class TestModelPipeline implements ModelPipeline
     private final boolean lenient;
     private final ModelVisitor visitor;
     private final ModelPipelineResult result;
+    private final MutableFieldEvent fieldEvent;
 
     private int processed;
 
@@ -64,6 +66,7 @@ final class TestModelPipeline implements ModelPipeline
         this.lenient = lenient;
         this.visitor = visitor;
         this.result = new ModelPipelineResult();
+        this.fieldEvent = new MutableFieldEvent();
     }
 
     @Override
@@ -161,7 +164,8 @@ final class TestModelPipeline implements ModelPipeline
         {
             for (int i = 0; i < fields.size(); i++)
             {
-                visitor.onField("$." + fields.get(i), extractedValue, 0, extractedValue.capacity());
+                fieldEvent.wrap("$." + fields.get(i), extractedValue, 0, extractedValue.capacity());
+                visitor.onField(fieldEvent);
             }
         }
     }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -30,6 +30,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 // Per-stream read transform session vended by AvroModelHandlerImpl: owns its own JSON generator, extractor
 // and schema-keyed pipeline cache so concurrent streams on a worker never share in-flight state. transform
@@ -47,6 +48,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
     private final AvroExtractor extractor;
     private final Int2ObjectCache<AvroPipeline> pipelines;
     private final ModelPipelineResult result;
+    private final MutableFieldEvent fieldEvent;
 
     private AvroPipeline active;
     private String diagnostic;
@@ -62,6 +64,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         this.extractor = visitor != ModelVisitor.NONE ? new AvroExtractor() : null;
         this.pipelines = new Int2ObjectCache<>(1, 16, p -> {});
         this.result = new ModelPipelineResult();
+        this.fieldEvent = new MutableFieldEvent();
     }
 
     @Override
@@ -153,7 +156,8 @@ final class AvroModelDecoderPipeline implements ModelPipeline
     {
         for (int i = 0; i < extractor.captured(); i++)
         {
-            visitor.onField("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            fieldEvent.wrap("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            visitor.onField(fieldEvent);
         }
     }
 

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -132,8 +132,8 @@ public class AvroModelDecoderPipelineTest
         AvroModelHandlerImpl handler = newHandler();
 
         Map<String, String> extracted = new HashMap<>();
-        ModelVisitor visitor = (path, buffer, index, length) ->
-            extracted.put(path, buffer.getStringWithoutLengthUtf8(index, length));
+        ModelVisitor visitor = event ->
+            extracted.put(event.path(), event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         ModelPipeline pipeline = handler.supplyDecoder(visitor);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
@@ -151,8 +151,8 @@ public class AvroModelDecoderPipelineTest
         AvroModelHandlerImpl handler = newHandler(SCALARS_SCHEMA, "json");
 
         Map<String, String> extracted = new HashMap<>();
-        ModelVisitor visitor = (path, buffer, index, length) ->
-            extracted.put(path, buffer.getStringWithoutLengthUtf8(index, length));
+        ModelVisitor visitor = event ->
+            extracted.put(event.path(), event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         ModelPipeline pipeline = handler.supplyDecoder(visitor);
 
         // i=5, l=7, f=1.5, d=2.5, b=true, e=index 1

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -30,6 +30,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 // Per-stream read transform session vended by JsonModelHandlerImpl: owns its own generator, extractor and
 // schema-keyed pipeline cache so concurrent streams on a worker never share in-flight state. transform
@@ -46,6 +47,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
     private final JsonExtractor extractor;
     private final Int2ObjectCache<JsonPipeline> pipelines;
     private final ModelPipelineResult result;
+    private final MutableFieldEvent fieldEvent;
 
     private JsonPipeline active;
     private String diagnostic;
@@ -65,6 +67,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         this.extractor = visitor != ModelVisitor.NONE ? new JsonExtractor() : null;
         this.pipelines = new Int2ObjectCache<>(1, 16, p -> {});
         this.result = new ModelPipelineResult();
+        this.fieldEvent = new MutableFieldEvent();
     }
 
     @Override
@@ -158,7 +161,8 @@ final class JsonModelDecoderPipeline implements ModelPipeline
     {
         for (int i = 0; i < extractor.captured(); i++)
         {
-            visitor.onField("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            fieldEvent.wrap("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            visitor.onField(fieldEvent);
         }
     }
 

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -32,6 +32,7 @@ import io.aklivity.zilla.config.engine.GenericCatalogConfig;
 import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
 import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
 import io.aklivity.zilla.config.model.json.JsonModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
@@ -107,11 +108,12 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler();
         Map<String, String> extracted = new HashMap<>();
-        ModelVisitor visitor = (path, buffer, index, length) ->
+        ModelVisitor visitor = event ->
         {
-            byte[] bytes = new byte[length];
-            buffer.getBytes(index, bytes);
-            extracted.put(path, new String(bytes, UTF_8));
+            DirectBufferEx value = event.value();
+            byte[] bytes = new byte[value.capacity()];
+            value.getBytes(0, bytes);
+            extracted.put(event.path(), new String(bytes, UTF_8));
         };
         ModelPipeline pipeline = handler.supplyDecoder(visitor);
 

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -30,6 +30,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelVisitor;
+import io.aklivity.zilla.runtime.engine.model.MutableFieldEvent;
 
 // Per-stream read transform session vended by ProtobufModelHandlerImpl: owns its own extractor and
 // message-keyed pipeline cache so concurrent streams on a worker never share in-flight state. transform
@@ -46,6 +47,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
     private final ProtobufExtractor extractor;
     private final Map<String, ProtobufPipeline> pipelines;
     private final ModelPipelineResult result;
+    private final MutableFieldEvent fieldEvent;
 
     private ProtobufPipeline active;
     private String diagnostic;
@@ -60,6 +62,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         this.extractor = visitor != ModelVisitor.NONE ? new ProtobufExtractor() : null;
         this.pipelines = new HashMap<>();
         this.result = new ModelPipelineResult();
+        this.fieldEvent = new MutableFieldEvent();
     }
 
     @Override
@@ -154,7 +157,8 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
     {
         for (int i = 0; i < extractor.captured(); i++)
         {
-            visitor.onField("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            fieldEvent.wrap("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            visitor.onField(fieldEvent);
         }
     }
 

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
@@ -138,8 +138,8 @@ public class ProtobufModelDecoderPipelineTest
         ProtobufModelHandlerImpl handler = newHandler(null);
 
         Map<String, String> extracted = new HashMap<>();
-        ModelVisitor visitor = (path, buffer, index, length) ->
-            extracted.put(path, buffer.getStringWithoutLengthUtf8(index, length));
+        ModelVisitor visitor = event ->
+            extracted.put(event.path(), event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         ModelPipeline pipeline = handler.supplyDecoder(visitor);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
@@ -177,8 +177,8 @@ public class ProtobufModelDecoderPipelineTest
         ProtobufModelHandlerImpl handler = new ProtobufModelHandlerImpl(model, context);
 
         Map<String, String> extracted = new HashMap<>();
-        ModelVisitor visitor = (path, buffer, index, length) ->
-            extracted.put(path, buffer.getStringWithoutLengthUtf8(index, length));
+        ModelVisitor visitor = event ->
+            extracted.put(event.path(), event.value().getStringWithoutLengthUtf8(0, event.value().capacity()));
         ModelPipeline pipeline = handler.supplyDecoder(visitor);
 
         // leading message index 0, then the complex message's scalar fields (matches the legacy extract case)


### PR DESCRIPTION
## Description

Replaces `ModelVisitor.onField(String path, DirectBufferEx buffer, int index, int length)` with `onField(FieldEvent event)`, where `FieldEvent` exposes `path()` and an already-bounded `value()`. A new `MutableFieldEvent` gives callers a reusable, non-allocating flyweight to wrap before each call, following the same buffer-reuse convention already used throughout the codebase.

This is a signature cleanup, not a behavior change — every call site is updated to match:

- `KafkaExtractor` (implementation + its `extracted()` replay path)
- `KafkaCachePartition`'s key and header extraction (`writeKey`, the `extractHeaders` trailer builder)
- The three model decoder pipelines (`AvroModelDecoderPipeline`, `JsonModelDecoderPipeline`, `ProtobufModelDecoderPipeline`)
- `TestModelPipeline`
- The corresponding unit tests in each of the above

`ModelVisitor` remains a `@FunctionalInterface` with a single abstract method, so `NONE` and every lambda-based caller still compile with a one-line signature change; no `ModelVisitor` implementer keeps the old 4-argument shape.

## Testing

`./mvnw install` (with `-Dskip.checks=true -DskipITs -Djacoco.skip=true` locally to bypass unrelated infrastructure gates — notice-plugin license lookups and jacoco coverage checks on modules this change doesn't touch) for `runtime/engine`, `runtime/model-core`, `runtime/model-avro`, `runtime/model-json`, `runtime/model-protobuf`, and `runtime/binding-kafka` and their dependencies: 467 tests, 0 failures, 0 errors.

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzxN4tJLhiHQ8ikNeuN8WS)_