### PR TITLE
feat(engine): guarantee async guard reauthorize completes strictly later

### DIFF
--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -423,4 +423,13 @@ public class EchoWorker implements EngineContext
     {
         return null;
     }
+
+    // this harness has no event loop to defer onto, so it runs the task inline rather than
+    // strictly later; nothing here depends on the async SPI contracts that guarantee builds on
+    @Override
+    public void dispatch(
+        Runnable task)
+    {
+        task.run();
+    }
 }

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -493,6 +493,15 @@ public class TlsWorker implements EngineContext
         return Clock.systemUTC();
     }
 
+    // this harness has no event loop to defer onto, so it runs the task inline rather than
+    // strictly later; nothing here depends on the async SPI contracts that guarantee builds on
+    @Override
+    public void dispatch(
+        Runnable task)
+    {
+        task.run();
+    }
+
     public void doWork()
     {
         streamsBuffer.readEx(this::handleRead, Integer.MAX_VALUE);

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -618,17 +618,21 @@ public interface EngineContext
     Clock clock();
 
     /**
-     * Dispatches a task for execution.
+     * Dispatches a task for execution on this worker.
      * <p>
-     * The default implementation executes the task inline on the calling thread.
-     * Override to schedule the task on a specific thread or executor.
+     * The task runs <em>strictly later</em> than this call returns — never inline on the
+     * calling stack — so a caller deferring work by one tick can rely on it. SPI contracts
+     * that promise asynchronous completion, such as {@code StoreHandler} and the async
+     * {@code GuardHandler.reauthorize}, are built on that guarantee.
+     * </p>
+     * <p>
+     * There is deliberately no default: running the task inline is a legitimate choice for
+     * a harness that has no event loop to defer onto, but it breaks those contracts, so an
+     * implementation has to state which it provides rather than inherit one silently.
      * </p>
      *
      * @param task  the task to execute
      */
-    default void dispatch(
-        Runnable task)
-    {
-        task.run();
-    }
+    void dispatch(
+        Runnable task);
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
@@ -63,10 +63,17 @@ public interface GuardHandler
     /**
      * Validates the given credentials and returns a session id for the authorized session.
      * <p>
+     * <b>Decides locally and returns on the caller's stack.</b> This variant never performs
+     * I/O and never blocks; it answers only from what the guard already holds. A guard that
+     * cannot reach a decision without I/O returns {@link #NOT_AUTHORIZED} here, and the
+     * caller uses {@link #reauthorize(long, long, long, String, LongCompletionCallback)}
+     * instead when it is prepared to wait for a decision.
+     * </p>
+     * <p>
      * Possible outcomes:
      * <ul>
      *   <li>positive session id — credentials accepted, session created</li>
-     *   <li>{@link #NOT_AUTHORIZED} — credentials rejected</li>
+     *   <li>{@link #NOT_AUTHORIZED} — credentials rejected, or no local decision available</li>
      *   <li>{@link #NEEDS_PREAUTHORIZE} — credentials recognized but the upstream has no
      *       prior consent for this subject; the caller should invoke {@link #preauthorize}
      *       to obtain a URL for the user to visit</li>
@@ -87,16 +94,24 @@ public interface GuardHandler
         String credentials);
 
     /**
-     * Async variant of {@link #reauthorize} for guards whose authorization decision
-     * requires non-blocking I/O (for example, an upstream token exchange after an
-     * out-of-band consent step). The result is delivered to {@code completion} on
-     * the same engine worker thread that invoked this method; implementations that
-     * do off-thread work must dispatch back via {@code EngineContext.signaler()}
-     * before invoking the callback.
+     * Async variant of {@link #reauthorize} for callers prepared to wait for an
+     * authorization decision, including one that requires non-blocking I/O (for example,
+     * an upstream token exchange after an out-of-band consent step).
      * <p>
-     * The default implementation delegates to the synchronous {@link #reauthorize},
-     * so guards that always decide locally need no source change. Exceptions thrown
-     * by the synchronous variant are routed to {@link CompletionCallback#failed}.
+     * <b>Completes asynchronously, always.</b> {@code completion} fires <em>strictly
+     * later</em> than this call returns — never on the caller's stack, even when the guard
+     * could decide locally and inline. A guard that decides locally still defers delivery
+     * by one tick, typically via {@code EngineContext.dispatch}. The callback fires on the
+     * engine worker thread that invoked this method; an implementation doing off-thread
+     * work is responsible for hopping back onto that thread first. So the caller observes
+     * "callback runs on my thread, later" in every case, and never has to handle a
+     * reentrant completion.
+     * </p>
+     * <p>
+     * Whether authorization is resolved synchronously or asynchronously is therefore the
+     * caller's choice, expressed by which overload it invokes — not something an individual
+     * guard varies. Exceptions raised while deciding are routed to
+     * {@link CompletionCallback#failed}, also strictly later than this call returns.
      * </p>
      * <p>
      * The {@code contextId} supplied at the call site is echoed back through the
@@ -113,23 +128,12 @@ public interface GuardHandler
      *                     {@link #NOT_AUTHORIZED} on failure, or {@link #NEEDS_PREAUTHORIZE}
      *                     if pre-authorization is required first
      */
-    default void reauthorize(
+    void reauthorize(
         long traceId,
         long bindingId,
         long contextId,
         String credentials,
-        LongCompletionCallback completion)
-    {
-        try
-        {
-            long result = reauthorize(traceId, bindingId, contextId, credentials);
-            completion.completed(contextId, result);
-        }
-        catch (Throwable ex)
-        {
-            completion.failed(contextId, ex);
-        }
-    }
+        LongCompletionCallback completion);
 
     /**
      * Invalidates and releases the given session.

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/guard/GuardFactoryTest.java
@@ -20,6 +20,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import org.agrona.collections.MutableLong;
 import org.junit.Test;
 
@@ -47,16 +50,17 @@ public final class GuardFactoryTest
     public void shouldReturnNullPreauthorizeByDefault()
     {
         GuardConfig config = GenericGuardConfig.builder().namespace("test").name("test").type("test").build();
-        GuardHandler handler = new TestGuardHandler(new TestGuardConfig(config));
+        GuardHandler handler = new TestGuardHandler(new TestGuardConfig(config), Runnable::run);
 
         assertThat(handler.preauthorize(0L, 0L, 0L, 0L, null), nullValue());
     }
 
     @Test
-    public void shouldDelegateAsyncReauthorizeToSyncByDefault()
+    public void shouldDeferAsyncReauthorize()
     {
         GuardConfig config = GenericGuardConfig.builder().namespace("test").name("test").type("test").build();
-        GuardHandler handler = new TestGuardHandler(new TestGuardConfig(config));
+        Deque<Runnable> dispatched = new ArrayDeque<>();
+        GuardHandler handler = new TestGuardHandler(new TestGuardConfig(config), dispatched::offer);
 
         MutableLong result = new MutableLong(Long.MIN_VALUE);
         MutableLong completedContextId = new MutableLong(Long.MIN_VALUE);
@@ -81,6 +85,13 @@ public final class GuardFactoryTest
         };
 
         handler.reauthorize(0L, 0L, 42L, null, completion);
+
+        // the async variant is async unconditionally: the decision is available locally here,
+        // yet the caller must still not observe it before this call returns
+        assertThat("completed on the caller's stack", result.value, equalTo(Long.MIN_VALUE));
+        assertThat(dispatched.size(), equalTo(1));
+
+        dispatched.remove().run();
 
         assertThat(result.value, equalTo(handler.reauthorize(0L, 0L, 42L, null)));
         assertThat(completedContextId.value, equalTo(42L));

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardContext.java
@@ -15,6 +15,8 @@
  */
 package io.aklivity.zilla.runtime.engine.test.internal.guard;
 
+import java.util.function.Consumer;
+
 import org.agrona.collections.Long2ObjectHashMap;
 
 import io.aklivity.zilla.config.engine.GuardConfig;
@@ -23,11 +25,14 @@ import io.aklivity.zilla.runtime.engine.guard.GuardContext;
 
 public final class TestGuardContext implements GuardContext
 {
+    private final Consumer<Runnable> dispatcher;
+
     private Long2ObjectHashMap<TestGuardHandler> handlersById;
 
     public TestGuardContext(
         EngineContext context)
     {
+        this.dispatcher = context::dispatch;
         this.handlersById = new Long2ObjectHashMap<>();
     }
 
@@ -36,7 +41,7 @@ public final class TestGuardContext implements GuardContext
         GuardConfig guard)
     {
         TestGuardConfig config = new TestGuardConfig(guard);
-        TestGuardHandler handler = new TestGuardHandler(config);
+        TestGuardHandler handler = new TestGuardHandler(config, dispatcher);
         handlersById.put(guard.id, handler);
         return handler;
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,13 +46,16 @@ public final class TestGuardHandler implements GuardHandler
     private final List<String> roles;
     private final Map<String, String> attributes;
     private final String preauthorize;
+    private final Consumer<Runnable> dispatcher;
 
     private final Long2LongHashMap sessions;
     private final MutableLong nextSessionId;
 
     public TestGuardHandler(
-        TestGuardConfig config)
+        TestGuardConfig config,
+        Consumer<Runnable> dispatcher)
     {
+        this.dispatcher = dispatcher;
         this.credentials = config.options != null ? config.options.credentials : null;
         this.lifetime = config.options != null ? config.options.lifetime : DEFAULT_LIFETIME_FOREVER;
         this.challenge = config.options != null ? config.options.challenge : DEFAULT_CHALLENGE_NEVER;
@@ -89,6 +93,34 @@ public final class TestGuardHandler implements GuardHandler
         }
 
         return sessionId;
+    }
+
+    @Override
+    public void reauthorize(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        dispatcher.accept(() -> complete(traceId, bindingId, contextId, credentials, completion));
+    }
+
+    private void complete(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        try
+        {
+            completion.completed(contextId, reauthorize(traceId, bindingId, contextId, credentials));
+        }
+        catch (Throwable ex)
+        {
+            completion.failed(contextId, ex);
+        }
     }
 
     @Override

--- a/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardContext.java
+++ b/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardContext.java
@@ -44,7 +44,7 @@ public class InlineGuardContext implements GuardContext
         InlineOptionsConfig options = guard.options instanceof InlineOptionsConfig
             ? (InlineOptionsConfig) guard.options
             : null;
-        InlineGuardHandler handler = new InlineGuardHandler(supplyAuthorizedId, options);
+        InlineGuardHandler handler = new InlineGuardHandler(supplyAuthorizedId, options, context::dispatch);
         handlersById.put(guard.id, handler);
         return handler;
     }

--- a/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandler.java
+++ b/runtime/guard-inline/src/main/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandler.java
@@ -35,11 +35,14 @@ public class InlineGuardHandler implements GuardHandler
     private final String identity;
     private final String credentials;
     private final Matcher formatMatcher;
+    private final Consumer<Runnable> dispatcher;
 
     public InlineGuardHandler(
         LongSupplier supplyAuthorizedId,
-        InlineOptionsConfig options)
+        InlineOptionsConfig options,
+        Consumer<Runnable> dispatcher)
     {
+        this.dispatcher = dispatcher;
         this.supplyAuthorizedId = supplyAuthorizedId;
         this.sessionsById = new Long2ObjectHashMap<>();
         this.sessionStoresByContextId = new Long2ObjectHashMap<>();
@@ -84,6 +87,37 @@ public class InlineGuardHandler implements GuardHandler
         assert previous != session && session.refs == 0 || previous == session && session.refs > 0;
         session.refs++;
         return session != null ? session.authorized : NOT_AUTHORIZED;
+    }
+
+    // credentials are matched against inline configuration, so the decision above is always
+    // available locally; delivery is still deferred a tick because the async contract promises
+    // the caller a later callback
+    @Override
+    public void reauthorize(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        dispatcher.accept(() -> complete(traceId, bindingId, contextId, credentials, completion));
+    }
+
+    private void complete(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        try
+        {
+            completion.completed(contextId, reauthorize(traceId, bindingId, contextId, credentials));
+        }
+        catch (Throwable ex)
+        {
+            completion.failed(contextId, ex);
+        }
     }
 
     @Override

--- a/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandlerTest.java
+++ b/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineGuardHandlerTest.java
@@ -18,20 +18,103 @@ import static java.util.Collections.emptyList;
 import static java.util.List.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.config.guard.inline.InlineOptionsConfig;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
 
 public class InlineGuardHandlerTest
 {
     @Test
+    public void shouldDeferAsyncReauthorize()
+    {
+        Deque<Runnable> dispatched = new ArrayDeque<>();
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null, dispatched::offer);
+
+        long[] completed = new long[] { Long.MIN_VALUE, Long.MIN_VALUE };
+        LongCompletionCallback completion = new LongCompletionCallback()
+        {
+            @Override
+            public void completed(
+                long contextId,
+                long sessionId)
+            {
+                completed[0] = contextId;
+                completed[1] = sessionId;
+            }
+
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                throw new AssertionError("unexpected failure", ex);
+            }
+        };
+
+        handler.reauthorize(0L, 0L, 42L, "user", completion);
+
+        assertThat("completed on the caller's stack", completed[1], equalTo(Long.MIN_VALUE));
+        assertThat(dispatched.size(), equalTo(1));
+
+        dispatched.remove().run();
+
+        assertThat(completed[0], equalTo(42L));
+        assertTrue(handler.verify(completed[1], emptyList()));
+    }
+
+    @Test
+    public void shouldFailAsyncReauthorizeWhenCredentialsAbsent()
+    {
+        Deque<Runnable> dispatched = new ArrayDeque<>();
+        InlineOptionsConfig options = InlineOptionsConfig.builder()
+            .format("{identity}:{credentials}")
+            .build();
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options, dispatched::offer);
+
+        Throwable[] failure = new Throwable[1];
+        LongCompletionCallback completion = new LongCompletionCallback()
+        {
+            @Override
+            public void completed(
+                long contextId,
+                long sessionId)
+            {
+                throw new AssertionError("unexpected completion");
+            }
+
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                failure[0] = ex;
+            }
+        };
+
+        handler.reauthorize(0L, 0L, 42L, null, completion);
+
+        // a null credential trips the format matcher inside the synchronous decision; the
+        // failure has to reach the caller through failed(), and no sooner than the tick
+        assertThat("failed on the caller's stack", failure[0], nullValue());
+
+        dispatched.remove().run();
+
+        assertThat(failure[0], instanceOf(NullPointerException.class));
+    }
+
+    @Test
     public void shouldVerifyRolesForSession()
     {
-        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null);
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null, Runnable::run);
 
         long sessionId = handler.reauthorize(0L, 0L, 0L, "user");
 
@@ -47,7 +130,7 @@ public class InlineGuardHandlerTest
         InlineOptionsConfig options = InlineOptionsConfig.builder()
             .format("{identity}:{credentials}")
             .build();
-        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options, Runnable::run);
 
         long sessionId = handler.reauthorize(0L, 0L, 0L, "alice:secret");
 
@@ -62,7 +145,7 @@ public class InlineGuardHandlerTest
             .credentials("default-credentials")
             .format("{identity}:{credentials}")
             .build();
-        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options, Runnable::run);
 
         long sessionId = handler.reauthorize(0L, 0L, 0L, "malformed-input-without-separator");
 
@@ -76,7 +159,7 @@ public class InlineGuardHandlerTest
         InlineOptionsConfig options = InlineOptionsConfig.builder()
             .format("{identity}:{credentials}")
             .build();
-        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options);
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, options, Runnable::run);
 
         long sessionId = handler.reauthorize(0L, 0L, 0L, "malformed-input-without-separator");
 
@@ -87,7 +170,7 @@ public class InlineGuardHandlerTest
     @Test
     public void shouldReturnSameValueForIdentityAndCredentialsWhenFormatNotConfigured()
     {
-        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null);
+        InlineGuardHandler handler = new InlineGuardHandler(() -> 1L, null, Runnable::run);
 
         long sessionId = handler.reauthorize(0L, 0L, 0L, "alice:secret");
 

--- a/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineIT.java
+++ b/runtime/guard-inline/src/test/java/io/aklivity/zilla/runtime/guard/inline/internal/InlineIT.java
@@ -64,7 +64,7 @@ public class InlineIT
     @Test
     public void shouldVerifyIdentityAndRolesWhenAllowAccess() throws Exception
     {
-        InlineGuardHandler guard = new InlineGuardHandler(new MutableLong(1L)::getAndIncrement, null);
+        InlineGuardHandler guard = new InlineGuardHandler(new MutableLong(1L)::getAndIncrement, null, Runnable::run);
 
         String token = "authorization-token";
         long sessionId = guard.reauthorize(0L, 0L, 101L, token);
@@ -84,7 +84,7 @@ public class InlineIT
         InlineOptionsConfig options = InlineOptionsConfig.builder()
             .format("{identity}:{credentials}")
             .build();
-        InlineGuardHandler guard = new InlineGuardHandler(new MutableLong(1L)::getAndIncrement, options);
+        InlineGuardHandler guard = new InlineGuardHandler(new MutableLong(1L)::getAndIncrement, options, Runnable::run);
 
         long sessionId = guard.reauthorize(0L, 0L, 101L, "alice:secret");
 

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
@@ -65,6 +65,7 @@ public class JwtGuardHandler implements GuardHandler
     private final Long2ObjectHashMap<JwtSessionStore> sessionStoresByContextId;
     private final JwtEventContext event;
     private final Map<String, String> attributes;
+    private final Consumer<Runnable> dispatcher;
 
     public JwtGuardHandler(
         JwtOptionsConfig options,
@@ -119,6 +120,7 @@ public class JwtGuardHandler implements GuardHandler
         this.sessionStoresByContextId = new Long2ObjectHashMap<>();
         this.event = new JwtEventContext(context);
         this.attributes = options.attributes;
+        this.dispatcher = context::dispatch;
     }
 
     @Override
@@ -229,6 +231,36 @@ public class JwtGuardHandler implements GuardHandler
             event.authorizationFailed(traceId, bindingId, identity, reason);
         }
         return session != null ? session.authorized : NOT_AUTHORIZED;
+    }
+
+    // a JWT is self-contained, so the decision above is always available locally; delivery is
+    // still deferred a tick because the async contract promises the caller a later callback
+    @Override
+    public void reauthorize(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        dispatcher.accept(() -> complete(traceId, bindingId, contextId, credentials, completion));
+    }
+
+    private void complete(
+        long traceId,
+        long bindingId,
+        long contextId,
+        String credentials,
+        LongCompletionCallback completion)
+    {
+        try
+        {
+            completion.completed(contextId, reauthorize(traceId, bindingId, contextId, credentials));
+        }
+        catch (Throwable ex)
+        {
+            completion.failed(contextId, ex);
+        }
     }
 
     @Override

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
@@ -24,6 +24,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +33,8 @@ import java.security.KeyPair;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +49,7 @@ import org.junit.Test;
 import io.aklivity.zilla.config.guard.jwt.JwtOptionsConfig;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
 
 public class JwtGuardHandlerTest
 {
@@ -56,6 +61,65 @@ public class JwtGuardHandlerTest
         context = mock(EngineContext.class);
         when(context.clock()).thenReturn(mock(Clock.class));
         when(context.supplyEventWriter()).thenReturn(mock(MessageConsumer.class));
+    }
+
+    @Test
+    public void shouldDeferAsyncReauthorize() throws Exception
+    {
+        Deque<Runnable> dispatched = new ArrayDeque<>();
+        doAnswer(invocation -> dispatched.add(invocation.getArgument(0))).when(context).dispatch(any());
+
+        JwtOptionsConfig options = JwtOptionsConfig.builder()
+            .inject(identity())
+            .issuer("test issuer")
+            .audience("testAudience")
+            .key(RFC7515_RS256_CONFIG)
+            .build();
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+
+        Instant now = Instant.now();
+
+        JwtClaims claims = new JwtClaims();
+        claims.setClaim("iss", "test issuer");
+        claims.setClaim("aud", "testAudience");
+        claims.setClaim("sub", "testSubject");
+        claims.setClaim("exp", now.getEpochSecond() + 10L);
+
+        String token = sign(claims.toJson(), "test", RFC7515_RS256, "RS256");
+
+        long[] completed = new long[] { Long.MIN_VALUE, Long.MIN_VALUE };
+        LongCompletionCallback completion = new LongCompletionCallback()
+        {
+            @Override
+            public void completed(
+                long contextId,
+                long sessionId)
+            {
+                completed[0] = contextId;
+                completed[1] = sessionId;
+            }
+
+            @Override
+            public void failed(
+                long contextId,
+                Throwable ex)
+            {
+                throw new AssertionError("unexpected failure", ex);
+            }
+        };
+
+        guard.reauthorize(0L, 0L, 101L, token, completion);
+
+        // the token carries everything needed to decide, so the temptation is to answer inline;
+        // the contract says the caller still must not observe the result before this returns
+        assertThat("completed on the caller's stack", completed[1], equalTo(Long.MIN_VALUE));
+        assertThat(dispatched.size(), equalTo(1));
+
+        dispatched.remove().run();
+
+        assertThat(completed[0], equalTo(101L));
+        assertThat(completed[1], not(equalTo(0L)));
+        assertThat(guard.identity(completed[1]), equalTo("testSubject"));
     }
 
     @Test


### PR DESCRIPTION
## Description

`GuardHandler`'s async `reauthorize` carried a default that delegated to the synchronous overload and completed on the caller's stack. That made completion timing a property of the individual guard rather than of the method, so a caller could not know whether its callback would fire during the call or after it, and had to handle both.

Two problems followed.

**Callers had to tolerate reentrancy.** A completion that may fire mid-call, before the caller has finished setting up its own state, is a hazard every call site must reason about. The in-tree consumer — `binding-mcp`'s outbound credential acquisition, currently on a feature branch — carries a flag and a dual-path return purely to absorb that ambiguity.

**Coverage was inverted.** Every guard that decides locally (`jwt`, `inline`, and every test config built on them) completed inline, so the deferred branch of a caller was the one path integration tests never exercised — while being the path a guard that genuinely acquires upstream always takes. The first such guard would run production code no IT had covered.

So the async variant is now async unconditionally, matching what `StoreHandler` already guarantees: the callback fires **strictly later** than the call returns, never on the caller's stack, even when the decision is available locally. Whether authorization resolves synchronously becomes the caller's choice, expressed by which overload it invokes.

Removing the default is the point — a guard now has to state how it completes rather than inherit inline delivery silently. The synchronous overload is documented as the local, cache-only decision it always was: it performs no I/O and returns `NOT_AUTHORIZED` when it cannot decide locally.

`EngineContext.dispatch` loses its default for the same reason. It is the primitive the guards defer onto, yet its own default ran the task inline, so the new guarantee would have rested on every implementor happening to override it. `EchoWorker` and `TlsWorker` now state inline execution explicitly, which is correct for a benchmark harness with no event loop and nothing depending on the async contracts.

### Breaking change

`GuardHandler` implementations must now implement the async `reauthorize`, and `EngineContext` implementations must now implement `dispatch`. In-tree: `JwtGuardHandler`, `InlineGuardHandler`, `TestGuardHandler`, `EchoWorker`, `TlsWorker` — all updated here. Each guard implements its own one-tick deferral via `EngineContext.dispatch`; no shared helper, so the mechanism stays visible at each implementation.

### Testing

`GuardFactoryTest.shouldDelegateAsyncReauthorizeToSyncByDefault` asserted the behaviour being removed and is replaced by `shouldDeferAsyncReauthorize`, which asserts the callback has *not* fired when the call returns, then drains the dispatcher and asserts it fires with the expected session and context id. Equivalent tests added for `JwtGuardHandler` and `InlineGuardHandler`, the latter also covering the `failed()` path.

Written test-first; the new engine test failed against the old default for the right reason, observing `NOT_AUTHORIZED` delivered on the stack before the call returned.

Full reactor build: 183/189 modules pass, 34,888 tests, 0 failures. The only failing module is `incubator/command-dump`, whose Testcontainers-based `DumpRule` requires a Docker daemon unavailable in the environment used to verify this; all 48 of its errors trace to that single initialiser and no error occurs outside that module.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS)_