### PR TITLE
fix(binding-http): guard flushNext against re-entrant drain

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2280,6 +2280,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private int httpQueueSlot = NO_SLOT;
         private int httpQueueSlotOffset;
         private int httpQueueSlotLimit;
+        private boolean flushing;
 
         private HttpClient(
             HttpClientPool pool)
@@ -4453,8 +4454,21 @@ public final class HttpClientFactory implements HttpStreamFactory
                 encoder == HttpEncoder.H2C;
         }
 
+        // dequeuing calls out to the exchange, which can close and re-enter here. A nested
+        // drain releases the queue slot and zeroes the offset that the outer frame is about
+        // to advance, leaving that frame pointing past a slot that is no longer there, and
+        // re-wraps the shared entry flyweight the outer frame still holds. One frame owns
+        // the queue for the duration; whatever a nested call would have drained is still
+        // reached by the loop below, which re-reads the offset on every pass.
         private void flushNext()
         {
+            if (flushing)
+            {
+                return;
+            }
+
+            flushing = true;
+
             dequeue:
             while (httpQueueSlotOffset != httpQueueSlotLimit)
             {
@@ -4493,6 +4507,8 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
 
             cleanupQueueSlotIfNecessary();
+
+            flushing = false;
         }
 
         private void cleanupQueueSlotIfNecessary()


### PR DESCRIPTION
## Description

An `http` client binding can kill its engine worker when a queued request is flushed and no connection is available to serve it. Found while diagnosing the intermittent `testing (mcp.proxy)` CI failure (#2304), which this appears to explain.

### The defect

`HttpClient.flushNext` advances `httpQueueSlotOffset` **after** calling out to the exchange, and that callout can come back into `flushNext`:

```java
while (httpQueueSlotOffset != httpQueueSlotLimit)
{
    queueEntry = queueEntryRO.wrap(buffer, httpQueueSlotOffset, httpQueueSlotLimit);
    ...
    httpExchange.doResponseAbort(...);            // ← re-enters flushNext
    ...
    httpQueueSlotOffset += queueEntry.sizeof();   // ← advances against state the callout reset
}
cleanupQueueSlotIfNecessary();                    // zeroes offset AND limit
```

When a queued entry finds no client — pool at `maximum.connections`, the existing HTTP/1.1 client holding an exchange so it is neither `available()` nor `reusable()`, so `supplyClient` returns `null` — the loop takes the `else` branch into `doResponseAbort`. That reaches `onExchangeClosed`, which calls `flushNext` again. The nested frame drains the queue, and `cleanupQueueSlotIfNecessary` releases the slot and zeroes both offset and limit.

The outer frame then resumes and runs `httpQueueSlotOffset += queueEntry.sizeof()` against the zeroed state, landing one entry past a limit of zero. The loop condition `offset != limit` still holds, so the next pass wraps the entry flyweight beyond the end of a slot that no longer exists:

```
java.lang.IndexOutOfBoundsException: offset=273 is beyond maxLimit=0
    at HttpQueueEntryFW.wrap(HttpQueueEntryFW.java:54)
    at HttpClient.flushNext(HttpClientFactory.java:4463)
    at HttpClient.onNetworkBegin(HttpClientFactory.java:2433)
    ...
    at EngineWorker.doWork(EngineWorker.java:947)
```

That propagates out of `EngineWorker.doWork` as an `AgentTerminationException`, killing the engine worker and taking the process down. `273` is one queue entry — `streamId` + `traceId` + `authorization` + a headers begin-extension.

There is a second hazard on the same path: `queueEntryRO` is a flyweight shared across the factory, and the nested frame re-wraps it while the outer frame still holds a reference — so the `sizeof()` the outer frame reads back is not necessarily the entry it was working on. `runtime/AGENTS.md` calls this out directly: "never hold a reference to a flyweight beyond the current call stack."

### The change

One frame owns the queue for the duration of a drain. A nested call returns immediately.

Nothing is dropped by suppressing it: the outer loop re-reads `httpQueueSlotOffset` on every pass, so any entry a nested drain would have handled is still reached, and the slot is released once, at the end of the owning frame. `flushNext` has exactly two callers — `onNetworkBegin` and `onExchangeClosed` — and the second is the one that re-enters from inside the first.

## Testing

`./mvnw clean verify -pl runtime/binding-http` — **122 unit tests and 394 integration tests, 0 failures** (41 skipped, all pre-existing `@Ignore`s, unchanged by this PR). Checkstyle and license checks pass.

**No new IT accompanies this fix, which is a deliberate gap I want to flag rather than paper over.** The project's test-first rule is clear, and I could not build a script pair that deterministically drives the re-entrant flush. Reaching it needs two requests enqueued on one client *before* its reply opens, then the connection opening while the pool is saturated — the enqueue window is not directly controllable from k3po, and the closest existing scenario, `ConnectionManagementPoolSize1IT.concurrentRequestsSameConnection`, is `@Ignore("GitHub Actions")` and fails for an unrelated reason (a k3po behavioural mismatch where `request3` is never issued), so it is not a usable starting point. I left that annotation untouched.

What the diagnosis does rest on:

- the production stack trace above, which names the exact method, line, and arithmetic;
- `273` matching a single queue entry, and `maxLimit=0` matching a slot released and zeroed by `cleanupQueueSlotIfNecessary` — the only code that zeroes those fields;
- a second stack trace in the same crash showing `onExchangeClosed → flushNext` re-entering from `doResponseAbort`, i.e. the re-entrant edge itself, observed rather than inferred.

If a reviewer sees a way to force the enqueue window from a script, a regression IT would be worth adding on top of this.

## Dependencies

None. Independent of #2313 and #2323, though #2323 is the branch on which the crash was observed — `mcp(client)` holding a request across a turn for an async guard decision changes when requests sit in the http queue versus flush, which makes this path far easier to hit. The defect itself predates that work and is not mcp-specific: any http client route that queues a request while its pool is saturated can reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS)_