### PR TITLE
fix(binding-http): guard flushNext against re-entrant drain

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2040,6 +2040,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         private int httpQueueSlot = NO_SLOT;
         private int httpQueueSlotOffset;
         private int httpQueueSlotLimit;
+        private boolean flushing;
         private SortedSet<HttpVersion> versions;
 
         private HttpClientPool(
@@ -2137,8 +2138,21 @@ public final class HttpClientFactory implements HttpStreamFactory
             return newStream;
         }
 
+        // dequeuing calls out to the exchange, which can close and re-enter here. A nested
+        // drain releases the queue slot and zeroes the offset that the outer frame is about
+        // to advance, leaving that frame pointing past a slot that is no longer there, and
+        // re-wraps the shared entry flyweight the outer frame still holds. One frame owns
+        // the queue for the duration; whatever a nested call would have drained is still
+        // reached by the loop below, which re-reads the offset on every pass.
         private void flushNext()
         {
+            if (flushing)
+            {
+                return;
+            }
+
+            flushing = true;
+
             dequeue:
             while (httpQueueSlotOffset != httpQueueSlotLimit)
             {
@@ -2176,6 +2190,8 @@ public final class HttpClientFactory implements HttpStreamFactory
             }
 
             cleanupQueueSlotIfNecessary();
+
+            flushing = false;
         }
 
         private void cleanupQueueSlotIfNecessary()


### PR DESCRIPTION
## Description

Backport of #2327 (`9e8f83aa1` on `develop`) to `support/1.x`. The defect is present on this branch unchanged.

`HttpClient.flushNext` advances `httpQueueSlotOffset` **after** calling out to the exchange, and that callout can come back into `flushNext`:

```java
while (httpQueueSlotOffset != httpQueueSlotLimit)
{
    queueEntry = queueEntryRO.wrap(buffer, httpQueueSlotOffset, httpQueueSlotLimit);
    ...
    httpExchange.doResponseAbort(...);            // ← re-enters flushNext
    ...
    httpQueueSlotOffset += queueEntry.sizeof();   // ← advances against state the callout reset
}
cleanupQueueSlotIfNecessary();                    // zeroes offset AND limit
```

When a queued entry finds no client — pool at `maximum.connections`, the existing HTTP/1.1 client holding an exchange so it is neither `available()` nor `reusable()`, so `supplyClient` returns `null` — the loop takes the `else` branch into `doResponseAbort`. That reaches `onExchangeClosed`, which calls `flushNext` again. The nested frame drains the queue, and `cleanupQueueSlotIfNecessary` releases the slot and zeroes both offset and limit. The outer frame then resumes, lands one entry past a limit of zero, and the next pass wraps the entry flyweight past the end of a slot that no longer exists:

```
java.lang.IndexOutOfBoundsException: offset=273 is beyond maxLimit=0
    at HttpQueueEntryFW.wrap(HttpQueueEntryFW.java:54)
    at HttpClient.flushNext(HttpClientFactory.java:4463)
    at HttpClient.onNetworkBegin(HttpClientFactory.java:2433)
    ...
    at EngineWorker.doWork(EngineWorker.java:947)
```

That propagates as an `AgentTerminationException`, killing the engine worker and taking the process down. Any http client route that queues a request while its pool is saturated can reach it.

There is a second hazard on the same path: `queueEntryRO` is a flyweight shared across the factory, and the nested frame re-wraps it while the outer frame still holds a reference.

### The change

One frame owns the queue for the duration of a drain; a nested call returns immediately. Nothing is dropped — the outer loop re-reads `httpQueueSlotOffset` on every pass, so entries a nested drain would have handled are still reached, and the slot is released once at the end of the owning frame.

## Porting notes

Identical in substance to #2327 — same 16 lines, same three edit sites, nothing added or dropped — so the commit subject is kept byte-for-byte to match the original.

Applied by hand rather than by `git cherry-pick -x`. `flushNext` and the queue-slot fields live at different offsets on this branch, so the automated pick could not match context and produced a conflict that would have spliced whole duplicate method blocks. The resulting diff is the same three edits: the `flushing` field, the guard clause with its comment, and the reset after `cleanupQueueSlotIfNecessary()`. The only incidental difference on this branch is that the loop calls the no-arg `supplyClient()`, which the change does not touch.

## Testing

`./mvnw clean verify -pl runtime/binding-http` on this branch — **122 unit tests and 376 integration tests, 0 failures** (42 skipped, all pre-existing `@Ignore`s). Checkstyle and license checks pass.

As on #2327, no new IT accompanies the fix. Driving the re-entrant flush needs two requests enqueued on one client before its reply opens and the connection then opening while the pool is saturated; that enqueue window is not controllable from a k3po script, and the nearest existing scenario (`ConnectionManagementPoolSize1IT.concurrentRequestsSameConnection`) is `@Ignore`d and fails for an unrelated k3po mismatch. The diagnosis rests on the production stack trace, which names the method, line, and arithmetic, and on a second trace in the same crash showing the `onExchangeClosed → flushNext` re-entrant edge directly.

## Dependencies

Depends on nothing; #2327 is already merged to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS)_