### PR TITLE
fix(binding-http): answer 503, not 431, when the client pool is exhausted

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -2090,7 +2090,11 @@ public final class HttpClientFactory implements HttpStreamFactory
             HttpClient client = supplyClient(scheme, authority);
             final int queuedRequestLength = HttpQueueEntryFW.FIELD_OFFSET_VALUE_LENGTH + begin.extension().sizeof();
 
-            if (client == null || queuedRequestLength > maximumRequestQueueSize)
+            if (client == null)
+            {
+                newStream = rejectWithStatusCode(sender, begin, HEADERS_503_RETRY_AFTER);
+            }
+            else if (queuedRequestLength > maximumRequestQueueSize)
             {
                 newStream = rejectWithStatusCode(sender, begin, HEADERS_431_REQUEST_TOO_LARGE);
             }

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -86,6 +86,16 @@ public class ConnectionManagementPoolSize1IT
     @Test
     @Configuration("client.yaml")
     @Specification({
+        "${app}/pool.exhausted.and.503.response/client",
+        "${net}/pool.exhausted.and.503.response/server" })
+    public void shouldGive503ResponseWhenConnectionPoolExhausted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
         "${app}/request.and.503.response.with.retry/client",
         "${net}/request.incomplete.response.headers.and.abort/server" })
     public void shouldGive503ResponseAndFreeConnectionWhenConnectReplyStreamIsAbortedBeforeResponseHeadersComplete()

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pool.exhausted.and.503.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pool.exhausted.and.503.response/client.rpt
@@ -1,0 +1,63 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "200")
+                             .header("content-length", "11")
+                             .build()}
+
+read "hello"
+read notify RESPONSE_ONE_PENDING
+
+connect await RESPONSE_ONE_PENDING
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":scheme", "http")
+                              .header(":method", "GET")
+                              .header(":path", "/")
+                              .header(":authority", "localhost:8080")
+                              .build()}
+connected
+
+write close
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":status", "503")
+                             .header("retry-after", "0")
+                             .build()}
+
+read closed

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pool.exhausted.and.503.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/connection.management/pool.exhausted.and.503.response/server.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "200")
+                              .header("content-length", "11")
+                              .build()}
+write "hello"
+write flush
+
+accepted
+
+read zilla:begin.ext ${http:beginEx()
+                             .typeId(zilla:id("http"))
+                             .header(":scheme", "http")
+                             .header(":method", "GET")
+                             .header(":path", "/")
+                             .header(":authority", "localhost:8080")
+                             .build()}
+connected
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                              .typeId(zilla:id("http"))
+                              .header(":status", "503")
+                              .header("retry-after", "0")
+                              .build()}
+write close

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pool.exhausted.and.503.response/client.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pool.exhausted.and.503.response/client.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+connected
+
+write "GET / HTTP/1.1" "\r\n"
+write "Host: localhost:8080" "\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Content-Length: 11" "\r\n"
+read "\r\n"
+read "hello"

--- a/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pool.exhausted.and.503.response/server.rpt
+++ b/specs/binding-http.spec/src/main/scripts/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/connection.management/pool.exhausted.and.503.response/server.rpt
@@ -1,0 +1,31 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+accepted
+connected
+
+read "GET / HTTP/1.1" "\r\n"
+read "Host: localhost:8080" "\r\n"
+read "\r\n"
+
+write "HTTP/1.1 200 OK\r\n"
+write "Content-Length: 11" "\r\n"
+write "\r\n"
+write "hello"
+write flush

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/application/rfc7230/ConnectionManagementIT.java
@@ -350,6 +350,15 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${app}/pool.exhausted.and.503.response/client",
+        "${app}/pool.exhausted.and.503.response/server" })
+    public void shouldGive503ResponseWhenConnectionPoolExhausted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/http.patch.exchange/client",
         "${app}/http.patch.exchange/server" })
     public void httpPatchExchange() throws Exception

--- a/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
+++ b/specs/binding-http.spec/src/test/java/io/aklivity/zilla/specs/binding/http/streams/network/rfc7230/ConnectionManagementIT.java
@@ -233,6 +233,15 @@ public class ConnectionManagementIT
 
     @Test
     @Specification({
+        "${net}/pool.exhausted.and.503.response/client",
+        "${net}/pool.exhausted.and.503.response/server" })
+    public void shouldGive503ResponseWhenConnectionPoolExhausted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/request.response.headers.incomplete.data.and.end/client",
         "${net}/request.response.headers.incomplete.data.and.end/server" })
     public void shouldReportResponseEndedWithIncompleteData() throws Exception


### PR DESCRIPTION
## Description

`HttpClientPool.newStream` collapsed two unrelated rejections onto one status:

```java
if (client == null || queuedRequestLength > maximumRequestQueueSize)
{
    newStream = rejectWithStatusCode(sender, begin, HEADERS_431_REQUEST_TOO_LARGE);
}
```

A request whose queued length exceeds the queue slot really is too large, and `431` is right for it. A null client from `supplyClient` is not about the request at all — every connection for the route is in use and none is reusable, so there is nowhere to send it. Reporting that as `431 Request Header Fields Too Large` tells the caller its headers are at fault when they are fine, and hides an exhausted pool behind a message about the request.

`503` with `retry-after` is what this binding already answers when a connection cannot carry a request (`HEADERS_503_RETRY_AFTER`, used a few lines below for a full queue slot), so the exhausted case now shares it rather than inventing a status. The over-long queue entry keeps `431`.

### Why it matters

This was expensive to diagnose in practice. In aklivity/zilla-plus#1104 an `mcp(client)` POST to an upstream MCP server was answered `431` by `http_client` itself — 0.7 ms in, with no upstream connection behind it — because `clientPools` is keyed by resolved route id, so six upstream hosts shared one route's pool of `maximum.connections` (default 10). The status pointed at request headers, so the pool was never suspected, and finding the real cause took a packet capture of the engine's stream frames.

Note this changes only which status is reported. The pool being per-route rather than per-authority is left alone here.

## Testing

New scenario `pool.exhausted.and.503.response`, authored as paired `client.rpt` / `server.rpt` under both `streams/application/rfc7230/connection.management/` and `streams/network/rfc7230/connection.management/`. It fills the single connection with a response that stays incomplete, so the client is neither `available()` nor `reusable()`, then issues a second request and expects `503`.

- `ConnectionManagementPoolSize1IT#shouldGive503ResponseWhenConnectionPoolExhausted` — runs it against the engine at `HTTP_MAXIMUM_CONNECTIONS = 1`
- `application.rfc7230.ConnectionManagementIT` and `network.rfc7230.ConnectionManagementIT` — run each pair peer-to-peer for self-consistency

Confirmed the scenario reproduces the old behavior before the fix by dumping the IT's engine directory: the rejection frame carried `:status 431`.

- `runtime/binding-http` — 395 ITs, 41 pre-existing skips, unit tests, checkstyle, license and the coverage gate all green
- `specs/binding-http.spec` — green
- `request.headers.too.long` still passes, so the genuine `431` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS)_