### PR TITLE
fix(binding-http): scope client connection capacity per origin, not per route

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/HttpConfiguration.java
@@ -72,7 +72,7 @@ public class HttpConfiguration extends Configuration
         userAgentHeader = userAgent != null ? new String16FW(userAgent) : null;
     }
 
-    public int maximumConnectionsPerRoute()
+    public int maximumConnectionsPerOrigin()
     {
         return HTTP_MAXIMUM_CONNECTIONS.getAsInt(this);
     }

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -350,7 +350,7 @@ public final class HttpClientFactory implements HttpStreamFactory
     private final int encodeMax;
     private final int decodeMax;
     private final int maximumRequestQueueSize;
-    private final int maximumConnectionsPerRoute;
+    private final int maximumConnectionsPerOrigin;
     private final int maximumPushPromiseListSize;
 
     public HttpClientFactory(
@@ -388,7 +388,7 @@ public final class HttpClientFactory implements HttpStreamFactory
         this.maximumRequestQueueSize = bufferPool.slotCapacity();
 
         this.clientPools = new Long2ObjectHashMap<>();
-        this.maximumConnectionsPerRoute = config.maximumConnectionsPerRoute();
+        this.maximumConnectionsPerOrigin = config.maximumConnectionsPerOrigin();
         this.maximumPushPromiseListSize = config.maxPushPromiseListSize();
         this.decodeMax = bufferPool.slotCapacity();
         this.encodeMax = bufferPool.slotCapacity();
@@ -2173,7 +2173,7 @@ public final class HttpClientFactory implements HttpStreamFactory
                 .findFirst()
                 .orElse(null);
 
-            if (client == null && clients.size() < maximumConnectionsPerRoute)
+            if (client == null && countConnections(scheme, authority) < maximumConnectionsPerOrigin)
             {
                 client = new HttpClient(this);
                 client.scheme = scheme;
@@ -2192,18 +2192,33 @@ public final class HttpClientFactory implements HttpStreamFactory
             return client;
         }
 
+        // a connection is pinned at creation to the origin it was created for, and canServe never
+        // offers it to another, so bounding on the whole pool charged a request for connections
+        // that could never carry it -- one busy origin refused every other origin reaching the
+        // same exit. The bound is over the connections this origin can actually use; the total
+        // across origins is already bounded by the engine, which caps combined inbound and
+        // outbound connections.
+        private long countConnections(
+            String scheme,
+            String authority)
+        {
+            return clients.stream()
+                .filter(c -> c.canServe(scheme, authority))
+                .count();
+        }
+
         private void onCreated(
             HttpClient client)
         {
             clients.add(client);
-            assert clients.size() <= maximumConnectionsPerRoute;
+            assert countConnections(client.scheme, client.authority) <= maximumConnectionsPerOrigin;
         }
 
         private void onUpgradedOrClosed(
             HttpClient client)
         {
             clients.remove(client);
-            assert clients.size() <= maximumConnectionsPerRoute;
+            assert countConnections(client.scheme, client.authority) <= maximumConnectionsPerOrigin;
         }
     }
 

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/streams/rfc7230/client/ConnectionManagementPoolSize1IT.java
@@ -94,6 +94,26 @@ public class ConnectionManagementPoolSize1IT
     }
 
     @Test
+    @Configuration("client.authority.yaml")
+    @Specification({
+        "${app}/requests.different.authorities/client",
+        "${net}/requests.different.authorities/server" })
+    public void shouldConnectToSecondAuthorityWhenFirstAuthorityAtCapacity() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.authority.yaml")
+    @Specification({
+        "${app}/concurrent.requests.different.authorities/client",
+        "${net}/concurrent.requests.different.authorities/server" })
+    public void shouldConnectToSecondAuthorityWhileFirstAuthorityRequestInFlight() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.yaml")
     @Specification({
         "${app}/request.and.503.response.with.retry/client",


### PR DESCRIPTION
## Description

`HttpClientPool` is keyed by `resolvedId`, so the pool and the `clients` list it owns are per **route**, and admission was gated by `clients.size()` against `maximum.connections` (default 10). Ten connections were therefore shared by every origin reachable through that route. For `sys:http_client`, which routes on scheme alone, that means every `https` origin in the configuration contending for one bound of ten.

A connection is pinned at creation to the origin it was created for — `scheme` and `authority` are assigned once in `supplyClient` and never reassigned — and `canServe` never offers it to another origin. So the pool total charged a request for connections that could never carry it: a busy origin refused unrelated origins that merely shared an exit, and #2337's 503 named the pool rather than the origin responsible.

### The change

Count the connections that can serve this origin instead of the whole pool:

```java
if (client == null && countConnections(scheme, authority) < maximumConnectionsPerOrigin)
```

```java
private long countConnections(
    String scheme,
    String authority)
{
    return clients.stream()
        .filter(c -> c.canServe(scheme, authority))
        .count();
}
```

This leaves the existing selection logic untouched. `canServe` already governs which connection serves a request, on both the ready path and the at-limit fallback; admission now agrees with it, so one predicate decides both instead of a filter for selection and a bare `size()` for admission. The two nearby asserts are re-expressed per-origin.

### Design notes

**No per-origin map.** The key would restate what each connection already stores in its own fields, giving two sources of truth that can drift apart, and it would still need the same `available` / `reusable` filtering within a bucket. Keeping the flat per-exit list also means there are no per-origin entries that can go stale, so no idle eviction is needed for this change.

**No new property for the total.** The engine already caps combined inbound and outbound connections through `TcpUsageTracker`, whose capacity is `ENGINE_WORKER_CAPACITY_LIMIT` and which is shared between `TcpServerFactory` and `TcpClientFactory`. `maximumConnectionsPerRoute()` is renamed `maximumConnectionsPerOrigin()` to match what it now bounds; the property name is unchanged and internal.

Both bounds are per-worker, since `clientPools` is an instance field of `HttpClientFactory` and `HttpBindingContext` constructs one factory per `EngineContext` — as is `TcpUsageTracker`, so the per-origin allowance and the total sit at the same scope.

### Testing

Test-first, in two commits: the failing ITs land before the fix.

`ConnectionManagementPoolSize1IT` already runs at `maximum.connections=1`, so reusing #1811's `requests.different.authorities` and `concurrent.requests.different.authorities` pairs there isolates capacity from reuse — those scripts already pass in `ConnectionManagementIT` at the default cap of 10, so the cap is the only variable. No new `.rpt` scripts, and therefore no additional spec-level `NetworkIT` / `ApplicationIT` coverage required.

Both fail before the change and pass after, verified alone and in class order.

Dumping the engine directory on the pre-fix run shows the mechanism precisely: both authorities present app-side, but net-side carries only `Host: authority-a:8080`, one `200`, one `503` and one `retry-after` — so the second authority was refused locally with `HEADERS_503_RETRY_AFTER` and no connect was attempted.

Full module `verify` with the coverage gate enabled:

| | Result |
| --- | --- |
| Unit tests | 122 run, 0 failures |
| ITs | 397 run, 0 failures, 41 skipped |
| jacoco | All coverage checks met |

#2337 recorded 395 ITs and 41 skips, so this is exactly two more ITs with an unchanged skip count — no existing test changed status. `pool.exhausted.and.503.response` still answers 503, since same-authority-at-allowance takes the identical null-client path.

### Not covered

**The global bound itself is not exercised by a test.** `worker.capacity` is derived from machine memory and is far too large to reach in an IT; covering it needs `ENGINE_WORKER_CAPACITY_LIMIT` configured down in a dedicated test. That is a separate concern from the keying and is not attempted here.

**~~Error quality at the new saturation point~~ — corrected after merge.** An earlier version of this section claimed that with no `binding-http` total, exhausting the engine cap surfaces as a declined connect and a network reset rather than a synthesized 503, and suggested that might deserve its own issue. That was wrong, and no issue is needed. `TcpClientFactory:171` returns a null stream when `usage.available() == 0`, the engine resets the network stream, and `HttpClient.onNetworkReset` runs `exchanges.forEach((id, exchange) -> exchange.cleanup(...))`; `HttpExchange.cleanup` calls `doResponseAbort`, which synthesizes `HEADERS_503_RETRY_AFTER` whenever the reply has not yet opened. Both saturation points therefore answer the same status — origin-at-allowance synthesizes it up front in `newStream`, exit-declines-connect reaches it via the reset path — and the latter is already covered by `shouldGive503ResponseAndFreeConnectionWhenConnectStreamIsResetBeforeResponseHeadersComplete` and its abort / end / no-response siblings. See https://github.com/aklivity/zilla/issues/2339#issuecomment-5227600580. This mischaracterised pre-existing behaviour rather than describing anything wrong with the merged change, so nothing needs reverting.

**`serviceableNames` is left in place.** Its HTTP/2 arm of `canServe` is never populated and so is inert — tracked separately in #2340. It is now a dead disjunct inside the predicate this change's capacity model depends on, so it may be worth removing here; I have not done so, as that is a scope call.

`concurrent.requests.different.authorities` is worth a note for reviewers: pre-fix it diverges at *request one's* response rather than request two's, because the server script holds `response1` behind `write await REQUEST_B_RECEIVED` and request two never reaches the wire. Same root cause, surfacing as a cascade — it earns its place as a post-fix assertion that concurrent cross-origin traffic works, but `requests.different.authorities` is the test that isolates the defect.

Fixes #2339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALdmyhgwytrQuTPpUpzVWS
