### PR TITLE
fix(examples/mcp.proxy): remove unnecessary waits and bound the gates that remain

### DIFF
--- a/examples/.github/test-lib.sh
+++ b/examples/.github/test-lib.sh
@@ -75,6 +75,12 @@ retry_until() {
 # a long log the failing assertion can be past the reach of the log-tail APIs
 # altogether, leaving nothing to diagnose from but the exit code.
 FAILURES=""
+# When FAIL_FAST is 1, the first failure stops the run instead of letting the
+# remaining assertions execute. That matters when the diagnosis is frame-level:
+# `zilla dump` reads what the engine directory still holds, so the frames worth
+# looking at have to be the most recent ones. Traffic after the first failure
+# buries them. Off by default, so every other example behaves exactly as before.
+FAIL_FAST=${FAIL_FAST:-0}
 
 fail() {
   _message="$*"
@@ -83,6 +89,13 @@ fail() {
   FAILURES="$FAILURES$_message
 "
   EXIT=1
+
+  if [ "$FAIL_FAST" = "1" ]
+  then
+    echo "FAIL_FAST=1, stopping at the first failure so the engine directory still holds its frames"
+    report_failures
+    exit 1
+  fi
 }
 
 # report_failures

--- a/examples/.github/test-lib.sh
+++ b/examples/.github/test-lib.sh
@@ -92,7 +92,7 @@ fail() {
 
   if [ "$FAIL_FAST" = "1" ]
   then
-    echo "FAIL_FAST=1, stopping at the first failure so the engine directory still holds its frames"
+    echo "FAIL_FAST=1, stopping at the first failure so the collected diagnostics still point at it"
     report_failures
     exit 1
   fi

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -39,7 +39,7 @@ services:
       petstore:
         condition: service_healthy
       karapace-registry:
-        condition: service_started
+        condition: service_healthy
       kafka-connect:
         condition: service_healthy
       kafka:
@@ -224,6 +224,19 @@ services:
       KARAPACE_TOPIC_NAME: _schemas
       KARAPACE_LOG_LEVEL: WARNING
       KARAPACE_COMPATIBILITY: BACKWARD
+    # python3 rather than wget/curl: this image ships neither, nor nc -- the
+    # venv's python is the only HTTP client in it, so a probe copied from the
+    # kafka-connect healthcheck below would never succeed and would leave the
+    # container permanently unhealthy. /subjects is the registry's own API, so
+    # this is ready only when it can actually serve a schema request, which
+    # `service_started` could never establish.
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8081/subjects', timeout=3).status == 200 else 1)"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 60s
+      start_interval: 1s
 
   # Real Kafka Connect distributed worker backing the mcp-kafka-connect
   # "kafkaconnect" toolkit -- talks to the same real Kafka broker as the

--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -175,7 +175,7 @@ timed() {
   _start=$(date +%s)
   "$@"
   _rc=$?
-  TIMINGS="$TIMINGS$(( $(date +%s) - _start ))s $_label
+  TIMINGS="$TIMINGS$(( $(date +%s) - _start )) $_label
 "
   return $_rc
 }
@@ -184,7 +184,8 @@ report_timings() {
   if [ -n "$TIMINGS" ]
   then
     echo "=== elapsed by assertion ==="
-    printf '%s' "$TIMINGS"
+    printf '%s' "$TIMINGS" |
+      awk '{ total += $1 + 0; printf "%5ds  %s\n", $1 + 0, $2 } END { printf "%5ds  total\n", total }'
   fi
 }
 
@@ -295,7 +296,7 @@ initialize_mcp() {
       -d "$INITIALIZE")
   echo "$INIT_BODY" | grep -q '"protocolVersion":"2025-11-25"'
 }
-retry_until 10 3 initialize_mcp
+timed initialize_mcp retry_until 10 3 initialize_mcp
 echo INIT_BODY="$INIT_BODY"
 if echo "$INIT_BODY" | grep -q '"protocolVersion":"2025-11-25"'; then
   echo ✅ initialize negotiated 2025-11-25
@@ -369,7 +370,7 @@ cache_hydrated() {
     TOOLS_FULL=$(list_tools "$JWT_FULL") &&
     full_toolset_present
 }
-retry_until 60 5 cache_hydrated
+timed cache_hydrated retry_until 60 5 cache_hydrated
 if echo "$CACHE_INIT_BODY" | grep -q '"subscribe":true' && full_toolset_present; then
   echo "✅ tools/resources/prompts cache and resources.subscribe capability are hydrated"
 else
@@ -565,7 +566,7 @@ call_create_pr() {
       tools-list-client 2>&1)
   echo "$CREATE_PR_OUT" | grep -q 'Add feature'
 }
-retry_until 5 3 call_create_pr
+timed create_pr retry_until 5 3 call_create_pr
 echo "CREATE_PR_OUT=$CREATE_PR_OUT"
 if echo "$CREATE_PR_OUT" | grep -q 'Add feature'; then
   echo "✅ github__create_pr forwarded title/head/base to ghapi as the request body"
@@ -587,7 +588,7 @@ call_search_pets() {
   PETSTORE_LOGS=$(service_logs petstore)
   echo "$PETSTORE_LOGS" | grep -q 'search_pets query: {"tag":"cat"}'
 }
-retry_until 5 3 call_search_pets
+timed search_pets retry_until 5 3 call_search_pets
 echo "PETSTORE_LOGS=$PETSTORE_LOGS"
 if echo "$PETSTORE_LOGS" | grep -q 'search_pets query: {"tag":"cat"}'; then
   echo "✅ petstore__search_pets renamed category -> tag via with.params"
@@ -613,7 +614,7 @@ read_pull_by_number() {
   PULL_OUT=$(read_resource "$JWT_PARTIAL" "github+pr://acme/widget/42")
   echo "$PULL_OUT" | grep -q 'Seed data for the pull_by_number resource demo'
 }
-retry_until 5 3 read_pull_by_number
+timed pull_by_number retry_until 5 3 read_pull_by_number
 echo "PULL_OUT=$PULL_OUT"
 if echo "$PULL_OUT" | grep -q 'Seed data for the pull_by_number resource demo'; then
   echo "✅ github+pr://acme/widget/42 read end-to-end via the pull_by_number template"
@@ -628,7 +629,7 @@ read_featured_pets() {
   FEATURED_OUT=$(read_resource "$JWT_PARTIAL" "petstore+/pets/featured")
   echo "$FEATURED_OUT" | grep -q 'Bramble'
 }
-retry_until 10 5 read_featured_pets
+timed featured_pets retry_until 10 5 read_featured_pets
 echo "FEATURED_OUT=$FEATURED_OUT"
 if echo "$FEATURED_OUT" | grep -q 'Bramble'; then
   echo "✅ petstore+/pets/featured read end-to-end"
@@ -649,7 +650,7 @@ call_create_pet() {
       tools-list-client 2>&1)
   echo "$CREATE_PET_OUT" | grep -q 'Nibbles'
 }
-retry_until 5 3 call_create_pet
+timed create_pet retry_until 5 3 call_create_pet
 echo "CREATE_PET_OUT=$CREATE_PET_OUT"
 if echo "$CREATE_PET_OUT" | grep -q 'Nibbles'; then
   echo "✅ petstore__create_pet succeeded for a pets:write-scoped caller"
@@ -675,7 +676,7 @@ call_register_schema() {
       tools-list-client 2>&1)
   echo "$REGISTER_OUT" | grep -q 'Registered schema with id'
 }
-retry_until 10 3 call_register_schema
+timed register_schema retry_until 10 3 call_register_schema
 echo "REGISTER_OUT=$REGISTER_OUT"
 if echo "$REGISTER_OUT" | grep -q 'Registered schema with id'; then
   echo "✅ kafka_sr__register_schema registered a real schema against Karapace"
@@ -694,7 +695,7 @@ call_list_subjects() {
       tools-list-client 2>&1)
   echo "$LIST_SUBJECTS_OUT" | grep -q "$SR_SUBJECT"
 }
-retry_until 10 3 call_list_subjects
+timed list_subjects retry_until 10 3 call_list_subjects
 echo "LIST_SUBJECTS_OUT=$LIST_SUBJECTS_OUT"
 if echo "$LIST_SUBJECTS_OUT" | grep -q "$SR_SUBJECT"; then
   echo "✅ kafka_sr__list_subjects saw the registered subject in real Karapace state"
@@ -711,7 +712,7 @@ call_describe_subject() {
       tools-list-client 2>&1)
   echo "$DESCRIBE_SUBJECT_OUT" | grep -q '\[1\]'
 }
-retry_until 10 3 call_describe_subject
+timed describe_subject retry_until 10 3 call_describe_subject
 echo "DESCRIBE_SUBJECT_OUT=$DESCRIBE_SUBJECT_OUT"
 if echo "$DESCRIBE_SUBJECT_OUT" | grep -q '\[1\]'; then
   echo "✅ kafka_sr__describe_subject listed version 1 of the registered subject"
@@ -732,7 +733,7 @@ call_get_schema() {
       tools-list-client 2>&1)
   echo "$GET_SCHEMA_OUT" | grep -q 'Retrieved schema id 1, version 1'
 }
-retry_until 10 3 call_get_schema
+timed get_schema retry_until 10 3 call_get_schema
 echo "GET_SCHEMA_OUT=$GET_SCHEMA_OUT"
 if echo "$GET_SCHEMA_OUT" | grep -q 'Retrieved schema id 1, version 1'; then
   echo "✅ kafka_sr__get_schema read the schema back with both result fields interpolated"
@@ -754,7 +755,7 @@ call_set_compatibility() {
       tools-list-client 2>&1)
   echo "$SET_COMPAT_OUT" | grep -q 'Compatibility level set to FULL'
 }
-retry_until 10 3 call_set_compatibility
+timed set_compatibility retry_until 10 3 call_set_compatibility
 echo "SET_COMPAT_OUT=$SET_COMPAT_OUT"
 if echo "$SET_COMPAT_OUT" | grep -q 'Compatibility level set to FULL'; then
   echo "✅ kafka_sr__set_compatibility set a compatibility level on the registered subject"
@@ -771,7 +772,7 @@ call_get_compatibility() {
       tools-list-client 2>&1)
   echo "$GET_COMPAT_OUT" | grep -q 'Compatibility level is FULL'
 }
-retry_until 10 3 call_get_compatibility
+timed get_compatibility retry_until 10 3 call_get_compatibility
 echo "GET_COMPAT_OUT=$GET_COMPAT_OUT"
 if echo "$GET_COMPAT_OUT" | grep -q 'Compatibility level is FULL'; then
   echo "✅ kafka_sr__get_compatibility read back the level set above"
@@ -791,7 +792,7 @@ call_check_compatibility() {
       tools-list-client 2>&1)
   echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'
 }
-retry_until 10 3 call_check_compatibility
+timed check_compatibility retry_until 10 3 call_check_compatibility
 echo "CHECK_COMPAT_OUT=$CHECK_COMPAT_OUT"
 if echo "$CHECK_COMPAT_OUT" | grep -q 'Compatibility check result: true'; then
   echo "✅ kafka_sr__check_compatibility reported the identical schema as compatible"
@@ -824,7 +825,7 @@ call_kafka_connect_list_plugins() {
       tools-list-client 2>&1)
   echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'
 }
-retry_until 30 5 call_kafka_connect_list_plugins
+timed kafka_connect_list_plugins retry_until 30 5 call_kafka_connect_list_plugins
 echo "KC_LIST_PLUGINS_OUT=$KC_LIST_PLUGINS_OUT"
 if echo "$KC_LIST_PLUGINS_OUT" | grep -q 'FileStreamSourceConnector'; then
   echo "✅ kafka_connect__list_connector_plugins listed the bundled FileStreamSourceConnector from the real worker"
@@ -851,7 +852,7 @@ call_kafka_connect_create_connector() {
       tools-list-client 2>&1)
   echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"
 }
-retry_until 10 3 call_kafka_connect_create_connector
+timed kafka_connect_create_connector retry_until 10 3 call_kafka_connect_create_connector
 echo "KC_CREATE_OUT=$KC_CREATE_OUT"
 if echo "$KC_CREATE_OUT" | grep -q "$KC_CONNECTOR"; then
   echo "✅ kafka_connect__create_connector created a real connector on the real worker"
@@ -870,7 +871,7 @@ call_kafka_connect_list_connectors() {
       tools-list-client 2>&1)
   echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"
 }
-retry_until 10 3 call_kafka_connect_list_connectors
+timed kafka_connect_list_connectors retry_until 10 3 call_kafka_connect_list_connectors
 echo "KC_LIST_OUT=$KC_LIST_OUT"
 if echo "$KC_LIST_OUT" | grep -q "$KC_CONNECTOR"; then
   echo "✅ kafka_connect__list_connectors saw the created connector in real worker state"
@@ -887,7 +888,7 @@ call_kafka_connect_describe_connector() {
       tools-list-client 2>&1)
   echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'
 }
-retry_until 10 3 call_kafka_connect_describe_connector
+timed kafka_connect_describe_connector retry_until 10 3 call_kafka_connect_describe_connector
 echo "KC_DESCRIBE_OUT=$KC_DESCRIBE_OUT"
 if echo "$KC_DESCRIBE_OUT" | grep -q 'FileStreamSourceConnector'; then
   echo "✅ kafka_connect__describe_connector read back the real connector's configuration"
@@ -906,7 +907,7 @@ call_kafka_connect_status_running() {
       tools-list-client 2>&1)
   echo "$KC_STATUS_OUT" | grep -q 'RUNNING'
 }
-retry_until 10 3 call_kafka_connect_status_running
+timed kafka_connect_status_running retry_until 10 3 call_kafka_connect_status_running
 echo "KC_STATUS_OUT=$KC_STATUS_OUT"
 if echo "$KC_STATUS_OUT" | grep -q 'RUNNING'; then
   echo "✅ kafka_connect__describe_connector_status reported the real connector as RUNNING"
@@ -932,7 +933,7 @@ call_kafka_connect_pause() {
       tools-list-client 2>&1)
   echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'
 }
-retry_until 10 3 call_kafka_connect_pause
+timed kafka_connect_pause retry_until 10 3 call_kafka_connect_pause
 echo "KC_PAUSE_OUT=$KC_PAUSE_OUT"
 echo "KC_STATUS_PAUSED_OUT=$KC_STATUS_PAUSED_OUT"
 if echo "$KC_STATUS_PAUSED_OUT" | grep -q 'PAUSED'; then
@@ -959,7 +960,7 @@ call_kafka_connect_resume() {
       tools-list-client 2>&1)
   echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'
 }
-retry_until 10 3 call_kafka_connect_resume
+timed kafka_connect_resume retry_until 10 3 call_kafka_connect_resume
 echo "KC_RESUME_OUT=$KC_RESUME_OUT"
 echo "KC_STATUS_RESUMED_OUT=$KC_STATUS_RESUMED_OUT"
 if echo "$KC_STATUS_RESUMED_OUT" | grep -q 'RUNNING'; then
@@ -986,7 +987,7 @@ call_kafka_connect_restart() {
       tools-list-client 2>&1)
   echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'
 }
-retry_until 10 3 call_kafka_connect_restart
+timed kafka_connect_restart retry_until 10 3 call_kafka_connect_restart
 echo "KC_RESTART_OUT=$KC_RESTART_OUT"
 echo "KC_STATUS_RESTARTED_OUT=$KC_STATUS_RESTARTED_OUT"
 if echo "$KC_STATUS_RESTARTED_OUT" | grep -q 'RUNNING'; then
@@ -1013,7 +1014,7 @@ call_kafka_connect_delete_connector() {
       tools-list-client 2>&1)
   ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"
 }
-retry_until 10 3 call_kafka_connect_delete_connector
+timed kafka_connect_delete_connector retry_until 10 3 call_kafka_connect_delete_connector
 echo "KC_DELETE_OUT=$KC_DELETE_OUT"
 echo "KC_LIST_AFTER_DELETE_OUT=$KC_LIST_AFTER_DELETE_OUT"
 if ! echo "$KC_LIST_AFTER_DELETE_OUT" | grep -q "$KC_CONNECTOR"; then
@@ -1036,7 +1037,7 @@ call_kafka_produce() {
       tools-list-client 2>&1)
   echo "$KAFKA_PRODUCE_OUT" | grep -q 'Produced record to orders topic'
 }
-retry_until 10 3 call_kafka_produce
+timed kafka_produce retry_until 10 3 call_kafka_produce
 echo "KAFKA_PRODUCE_OUT=$KAFKA_PRODUCE_OUT"
 if echo "$KAFKA_PRODUCE_OUT" | grep -q 'Produced record to orders topic'; then
   echo "✅ kafka__produce_message wrote a record to the real Kafka broker"
@@ -1056,7 +1057,7 @@ call_kafka_consume_messages() {
       tools-list-client 2>&1)
   echo "$KAFKA_CONSUME_OUT" | grep -q 'hello from mcp-kafka'
 }
-retry_until 10 3 call_kafka_consume_messages
+timed kafka_consume_messages retry_until 10 3 call_kafka_consume_messages
 echo "KAFKA_CONSUME_OUT=$KAFKA_CONSUME_OUT"
 if echo "$KAFKA_CONSUME_OUT" | grep -q 'hello from mcp-kafka'; then
   echo "✅ kafka__consume_messages read the produced record back from the real Kafka broker"
@@ -1078,7 +1079,7 @@ call_kafka_describe_topic_configs() {
       tools-list-client 2>&1)
   echo "$KAFKA_DESCRIBE_CONFIGS_OUT" | grep -q '"name":"cleanup.policy"'
 }
-retry_until 10 3 call_kafka_describe_topic_configs
+timed kafka_describe_topic_configs retry_until 10 3 call_kafka_describe_topic_configs
 echo "KAFKA_DESCRIBE_CONFIGS_OUT=$KAFKA_DESCRIBE_CONFIGS_OUT"
 if echo "$KAFKA_DESCRIBE_CONFIGS_OUT" | grep -q '"name":"cleanup.policy"'; then
   echo "✅ kafka__describe_topic_configs read the real broker's effective topic config"
@@ -1101,7 +1102,7 @@ call_kafka_alter_topic_configs() {
       tools-list-client 2>&1)
   echo "$KAFKA_ALTER_CONFIGS_OUT" | grep -q 'Updated configs for topic orders'
 }
-retry_until 10 3 call_kafka_alter_topic_configs
+timed kafka_alter_topic_configs retry_until 10 3 call_kafka_alter_topic_configs
 echo "KAFKA_ALTER_CONFIGS_OUT=$KAFKA_ALTER_CONFIGS_OUT"
 if echo "$KAFKA_ALTER_CONFIGS_OUT" | grep -q 'Updated configs for topic orders'; then
   echo "✅ kafka__alter_topic_configs updated the topic config on the real Kafka broker"
@@ -1123,7 +1124,7 @@ call_kafka_create_topics() {
       tools-list-client 2>&1)
   echo "$KAFKA_CREATE_TOPICS_OUT" | grep -q 'Created topic(s): widgets'
 }
-retry_until 10 3 call_kafka_create_topics
+timed kafka_create_topics retry_until 10 3 call_kafka_create_topics
 echo "KAFKA_CREATE_TOPICS_OUT=$KAFKA_CREATE_TOPICS_OUT"
 if echo "$KAFKA_CREATE_TOPICS_OUT" | grep -q 'Created topic(s): widgets'; then
   echo "✅ kafka__create_topics created a new topic on the real Kafka broker"
@@ -1146,7 +1147,7 @@ call_kafka_delete_topics() {
       tools-list-client 2>&1)
   echo "$KAFKA_DELETE_TOPICS_OUT" | grep -q 'Deleted topic(s): widgets'
 }
-retry_until 10 3 call_kafka_delete_topics
+timed kafka_delete_topics retry_until 10 3 call_kafka_delete_topics
 echo "KAFKA_DELETE_TOPICS_OUT=$KAFKA_DELETE_TOPICS_OUT"
 if echo "$KAFKA_DELETE_TOPICS_OUT" | grep -q 'Deleted topic(s): widgets'; then
   echo "✅ kafka__delete_topics deleted the topic from the real Kafka broker"
@@ -1166,7 +1167,7 @@ call_kafka_list_topics() {
       tools-list-client 2>&1)
   echo "$KAFKA_LIST_TOPICS_OUT" | grep -q '"topic":"orders"'
 }
-retry_until 10 3 call_kafka_list_topics
+timed kafka_list_topics retry_until 10 3 call_kafka_list_topics
 echo "KAFKA_LIST_TOPICS_OUT=$KAFKA_LIST_TOPICS_OUT"
 if echo "$KAFKA_LIST_TOPICS_OUT" | grep -q '"topic":"orders"'; then
   echo "✅ kafka__list_topics listed the real orders topic from the real Kafka broker"
@@ -1187,7 +1188,7 @@ call_kafka_describe_topic() {
       tools-list-client 2>&1)
   echo "$KAFKA_DESCRIBE_TOPIC_OUT" | grep -q 'Described topic orders'
 }
-retry_until 10 3 call_kafka_describe_topic
+timed kafka_describe_topic retry_until 10 3 call_kafka_describe_topic
 echo "KAFKA_DESCRIBE_TOPIC_OUT=$KAFKA_DESCRIBE_TOPIC_OUT"
 if echo "$KAFKA_DESCRIBE_TOPIC_OUT" | grep -q 'Described topic orders' &&
     echo "$KAFKA_DESCRIBE_TOPIC_OUT" | grep -q '"partition":0'; then
@@ -1208,7 +1209,7 @@ call_kafka_cluster_overview() {
       tools-list-client 2>&1)
   echo "$KAFKA_CLUSTER_OVERVIEW_OUT" | grep -q 'Cluster overview:'
 }
-retry_until 10 3 call_kafka_cluster_overview
+timed kafka_cluster_overview retry_until 10 3 call_kafka_cluster_overview
 echo "KAFKA_CLUSTER_OVERVIEW_OUT=$KAFKA_CLUSTER_OVERVIEW_OUT"
 if echo "$KAFKA_CLUSTER_OVERVIEW_OUT" | grep -q '"broker_count":1'; then
   echo "✅ kafka__cluster_overview summarized the real Kafka broker"
@@ -1231,7 +1232,7 @@ call_kafka_list_brokers() {
       tools-list-client 2>&1)
   echo "$KAFKA_LIST_BROKERS_OUT" | grep -q 'Brokers: 1@kafka.examples.dev:29092'
 }
-retry_until 10 3 call_kafka_list_brokers
+timed kafka_list_brokers retry_until 10 3 call_kafka_list_brokers
 echo "KAFKA_LIST_BROKERS_OUT=$KAFKA_LIST_BROKERS_OUT"
 if echo "$KAFKA_LIST_BROKERS_OUT" | grep -q 'Brokers: 1@kafka.examples.dev:29092'; then
   echo "✅ kafka__list_brokers listed the real Kafka broker"
@@ -1252,7 +1253,7 @@ call_kafka_describe_cluster() {
       tools-list-client 2>&1)
   echo "$KAFKA_DESCRIBE_CLUSTER_OUT" | grep -q 'Described cluster .*, controller 1'
 }
-retry_until 10 3 call_kafka_describe_cluster
+timed kafka_describe_cluster retry_until 10 3 call_kafka_describe_cluster
 echo "KAFKA_DESCRIBE_CLUSTER_OUT=$KAFKA_DESCRIBE_CLUSTER_OUT"
 if echo "$KAFKA_DESCRIBE_CLUSTER_OUT" | grep -q 'Described cluster .*, controller 1'; then
   echo "✅ kafka__describe_cluster reported the real broker as controller"
@@ -1277,7 +1278,7 @@ call_describe_group_before_reset() {
       tools-list-client 2>&1)
   echo "$DESCRIBE_GROUP_BEFORE_OUT" | grep -q "Consumer group $CONSUMER_GROUP is Dead"
 }
-retry_until 10 3 call_describe_group_before_reset
+timed describe_group_before_reset retry_until 10 3 call_describe_group_before_reset
 echo "DESCRIBE_GROUP_BEFORE_OUT=$DESCRIBE_GROUP_BEFORE_OUT"
 if echo "$DESCRIBE_GROUP_BEFORE_OUT" | grep -q "Consumer group $CONSUMER_GROUP is Dead"; then
   echo "✅ kafka__describe_consumer_group reported state Dead for a never-used group"
@@ -1301,7 +1302,7 @@ call_describe_group_lag() {
       tools-list-client 2>&1)
   echo "$DESCRIBE_GROUP_LAG_OUT" | grep -q "Consumer group $CONSUMER_GROUP has total lag 0"
 }
-retry_until 10 3 call_describe_group_lag
+timed describe_group_lag retry_until 10 3 call_describe_group_lag
 echo "DESCRIBE_GROUP_LAG_OUT=$DESCRIBE_GROUP_LAG_OUT"
 if echo "$DESCRIBE_GROUP_LAG_OUT" | grep -q "Consumer group $CONSUMER_GROUP has total lag 0"; then
   echo "✅ kafka__describe_consumer_group_lag reported total lag 0 for a never-used group"
@@ -1333,7 +1334,7 @@ call_kafka_list_consumer_groups() {
       tools-list-client 2>&1)
   echo "$KAFKA_LIST_GROUPS_OUT" | grep -qE "Consumer groups:|No consumer groups found"
 }
-retry_until 10 3 call_kafka_list_consumer_groups
+timed kafka_list_consumer_groups retry_until 10 3 call_kafka_list_consumer_groups
 echo "KAFKA_LIST_GROUPS_OUT=$KAFKA_LIST_GROUPS_OUT"
 if echo "$KAFKA_LIST_GROUPS_OUT" | grep -qE "Consumer groups:|No consumer groups found"; then
   echo "✅ kafka__list_consumer_groups succeeded against the real Kafka broker"
@@ -1362,7 +1363,7 @@ call_kafka_create_acls() {
       tools-list-client 2>&1)
   echo "$KAFKA_CREATE_ACLS_OUT" | grep -q 'Created 1 ACL(s)'
 }
-retry_until 10 3 call_kafka_create_acls
+timed kafka_create_acls retry_until 10 3 call_kafka_create_acls
 echo "KAFKA_CREATE_ACLS_OUT=$KAFKA_CREATE_ACLS_OUT"
 if echo "$KAFKA_CREATE_ACLS_OUT" | grep -q 'Created 1 ACL(s)'; then
   echo "✅ kafka__create_acls granted a real ACL on the real Kafka broker"
@@ -1384,7 +1385,7 @@ call_kafka_list_acls() {
       tools-list-client 2>&1)
   echo "$KAFKA_LIST_ACLS_OUT" | grep -q "\"principal\":\"$ACL_PRINCIPAL\""
 }
-retry_until 10 3 call_kafka_list_acls
+timed kafka_list_acls retry_until 10 3 call_kafka_list_acls
 echo "KAFKA_LIST_ACLS_OUT=$KAFKA_LIST_ACLS_OUT"
 if echo "$KAFKA_LIST_ACLS_OUT" | grep -q "\"principal\":\"$ACL_PRINCIPAL\"" &&
     echo "$KAFKA_LIST_ACLS_OUT" | grep -q '"resource_name":"acl-test-topic"'; then
@@ -1407,7 +1408,7 @@ call_kafka_delete_acls() {
       tools-list-client 2>&1)
   echo "$KAFKA_DELETE_ACLS_OUT" | grep -q 'Deleted 1 ACL(s)'
 }
-retry_until 10 3 call_kafka_delete_acls
+timed kafka_delete_acls retry_until 10 3 call_kafka_delete_acls
 echo "KAFKA_DELETE_ACLS_OUT=$KAFKA_DELETE_ACLS_OUT"
 if echo "$KAFKA_DELETE_ACLS_OUT" | grep -q 'Deleted 1 ACL(s)'; then
   echo "✅ kafka__delete_acls revoked the real ACL on the real Kafka broker"
@@ -1423,7 +1424,7 @@ fi
 # cannot see coming. Re-check freshly right before the one assertion that
 # still depends on it, rather than re-adding a retry around the assertion
 # itself for what is really the same one-time-per-window race as before
-retry_until 60 5 cache_hydrated
+timed cache_rehydrated retry_until 60 5 cache_hydrated
 if echo "$CACHE_INIT_BODY" | grep -q '"subscribe":true' && full_toolset_present; then
   echo "✅ tools/resources/prompts cache is still hydrated ahead of the resources/subscribe round-trip"
 else

--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -160,6 +160,34 @@ set -x
 
 . /test-lib.sh
 
+
+# Wall-clock per assertion, accumulated here and reported as one block at the end
+# rather than printed where it is measured. The log is read back tail-first under a
+# hard line cap, and this script emits enough output that everything before the last
+# few assertions falls outside that window -- which is why the subscribe round-trip
+# could be measured from CI and the url-elicit one could not. Reporting at the end
+# puts every timing in the tail. Whole seconds, because the delays worth naming are
+# tens of seconds and `date +%N` is not portable to the busybox date in here.
+TIMINGS=""
+timed() {
+  _label=$1
+  shift
+  _start=$(date +%s)
+  "$@"
+  _rc=$?
+  TIMINGS="$TIMINGS$(( $(date +%s) - _start ))s $_label
+"
+  return $_rc
+}
+
+report_timings() {
+  if [ -n "$TIMINGS" ]
+  then
+    echo "=== elapsed by assertion ==="
+    printf '%s' "$TIMINGS"
+  fi
+}
+
 EXIT=0
 PORT="7114"
 INITIALIZE='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"elicitation":{"url":{}}},"clientInfo":{"name":"zilla-mcp-proxy-test","version":"0.0.1"}}}'
@@ -363,7 +391,7 @@ relay_elicitation() {
       urlelicit-client 2>&1)
   echo "$ELICIT_OUT" | grep -q 'OK url-mode elicitation relayed end-to-end'
 }
-retry_until 10 3 relay_elicitation
+timed elicitation retry_until 10 3 relay_elicitation
 echo "$ELICIT_OUT"
 if echo "$ELICIT_OUT" | grep -q 'OK url-mode elicitation relayed end-to-end'; then
   echo ✅ url-mode elicitation relayed end-to-end
@@ -1430,7 +1458,7 @@ subscribe_resource() {
   SUBSCRIBE_OUT=$(MCP_TIMEOUT_S="$MCP_SUBSCRIBE_TIMEOUT_S" mcp_run resource-subscribe-client 2>&1)
   echo "$SUBSCRIBE_OUT" | grep -q 'OK resource subscription relayed end-to-end'
 }
-retry_until 3 5 subscribe_resource
+timed subscribe retry_until 3 5 subscribe_resource
 echo "SUBSCRIBE_OUT=$SUBSCRIBE_OUT"
 if echo "$SUBSCRIBE_OUT" | grep -q 'OK resource subscription relayed end-to-end'; then
   echo "✅ resources/subscribe, notifications/resources/updated, and resources/unsubscribe relayed end-to-end"
@@ -1438,6 +1466,7 @@ else
   fail "resource subscription round-trip did not relay end-to-end"
 fi
 
+report_timings
 report_failures
 
 exit $EXIT

--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -158,6 +158,13 @@
 # streamed body / client output rather than asserting exact-string equality.
 set -x
 
+# Stop at the first failure so a failing run is diagnosable from its own logs
+# rather than needing a rerun. The workflow collects docker logs on failure, and
+# ~40 further assertions after the first one buries the relevant output under
+# traffic that is no longer about the failure. Override with FAIL_FAST=0 to see
+# the full assertion sweep instead.
+FAIL_FAST=${FAIL_FAST:-1}
+
 . /test-lib.sh
 
 

--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -267,6 +267,46 @@ service_logs() {
 
 COMPOSE_PROJECT=$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "$(hostname)")
 
+# retry_deadline <total_seconds> <delay_seconds> <command...>
+#
+# retry_until bounds attempts, not time, so its real cost is attempts x how long
+# the probe takes to fail -- and that is set by the failure path, not by whoever
+# wrote the count. `retry_until 60 5` over the cache_hydrated probe reads like a
+# short gate but bills ~37s per failed attempt, so it consumed the whole 30m
+# Execute Test budget at attempt 50 without ever reaching the assertion it guards.
+# A deadline states what the gate actually means -- wait this long for the cache to
+# hydrate -- and costs the same whether the probe fails fast or slow.
+#
+# As in retry_until, the first retry is immediate and the delay applies from the
+# second retry onward: the probe's own duration is already the settle time, so a
+# gate that needs exactly one retry should not also pay <delay_seconds> to
+# re-observe a condition that has since become true.
+retry_deadline() {
+  _deadline=$(( $(date +%s) + $1 ))
+  _delay=$2
+  shift 2
+
+  _retried=0
+  until "$@"
+  do
+    _status=$?
+    if [ "$(date +%s)" -ge "$_deadline" ]
+    then
+      return "$_status"
+    fi
+    if [ "$_retried" -eq 1 ]
+    then
+      sleep "$_delay"
+    fi
+    _retried=1
+  done
+}
+
+# 7m per hydration gate, so the two of them cannot crowd out the assertions between
+# them inside the step cap. Comfortably longer than a healthy hydrate, which lands
+# in seconds.
+CACHE_HYDRATE_TIMEOUT_S=${CACHE_HYDRATE_TIMEOUT_S:-420}
+
 # The JWTs the authn_jwt guard validates are minted by .github/test.sh before
 # this container starts and arrive as environment, one per scope combination
 # under test. They are signed by jwt-cli, which is a container of its own with
@@ -370,7 +410,7 @@ cache_hydrated() {
     TOOLS_FULL=$(list_tools "$JWT_FULL") &&
     full_toolset_present
 }
-timed cache_hydrated retry_until 60 5 cache_hydrated
+timed cache_hydrated retry_deadline "$CACHE_HYDRATE_TIMEOUT_S" 5 cache_hydrated
 if echo "$CACHE_INIT_BODY" | grep -q '"subscribe":true' && full_toolset_present; then
   echo "✅ tools/resources/prompts cache and resources.subscribe capability are hydrated"
 else
@@ -588,7 +628,7 @@ call_search_pets() {
   PETSTORE_LOGS=$(service_logs petstore)
   echo "$PETSTORE_LOGS" | grep -q 'search_pets query: {"tag":"cat"}'
 }
-timed search_pets retry_until 5 3 call_search_pets
+timed search_pets retry_deadline 90 3 call_search_pets
 echo "PETSTORE_LOGS=$PETSTORE_LOGS"
 if echo "$PETSTORE_LOGS" | grep -q 'search_pets query: {"tag":"cat"}'; then
   echo "✅ petstore__search_pets renamed category -> tag via with.params"
@@ -907,7 +947,7 @@ call_kafka_connect_status_running() {
       tools-list-client 2>&1)
   echo "$KC_STATUS_OUT" | grep -q 'RUNNING'
 }
-timed kafka_connect_status_running retry_until 10 3 call_kafka_connect_status_running
+timed kafka_connect_status_running retry_deadline 120 5 call_kafka_connect_status_running
 echo "KC_STATUS_OUT=$KC_STATUS_OUT"
 if echo "$KC_STATUS_OUT" | grep -q 'RUNNING'; then
   echo "✅ kafka_connect__describe_connector_status reported the real connector as RUNNING"
@@ -1424,7 +1464,7 @@ fi
 # cannot see coming. Re-check freshly right before the one assertion that
 # still depends on it, rather than re-adding a retry around the assertion
 # itself for what is really the same one-time-per-window race as before
-timed cache_rehydrated retry_until 60 5 cache_hydrated
+timed cache_rehydrated retry_deadline "$CACHE_HYDRATE_TIMEOUT_S" 5 cache_hydrated
 if echo "$CACHE_INIT_BODY" | grep -q '"subscribe":true' && full_toolset_present; then
   echo "✅ tools/resources/prompts cache is still hydrated ahead of the resources/subscribe round-trip"
 else

--- a/examples/mcp.proxy/resource-subscribe-client/client.mjs
+++ b/examples/mcp.proxy/resource-subscribe-client/client.mjs
@@ -43,6 +43,14 @@ const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 const START = Date.now();
 const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
+// node's own startup and the evaluation of the hoisted imports above both run
+// before START, so they are charged to the caller's wall-clock while landing
+// outside every stamp below. That blind spot is not theoretical: a 20.7s
+// round-trip measured here accounted for only 0.489s of client work, and the
+// missing ~20s was invisible until this line existed. process.uptime() is
+// exactly that span.
+log(`node startup and imports took ${process.uptime().toFixed(3)}s, before the stamps below`);
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const attempt = async () =>

--- a/examples/mcp.proxy/resource-subscribe-client/client.mjs
+++ b/examples/mcp.proxy/resource-subscribe-client/client.mjs
@@ -36,7 +36,12 @@ const RETRY_DELAY_MS = Number(process.env.RETRY_DELAY_MS ?? 3000);
 
 const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 
-const log = (...args) => console.error("[client]", ...args);
+// Elapsed rather than wall-clock: this process's stderr is captured by the
+// caller and only reaches the log when it exits, so every line lands with the
+// same flush timestamp. Stamping each line with its own offset from start is
+// what makes the sequence -- and any gap in it -- readable after the fact.
+const START = Date.now();
+const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/examples/mcp.proxy/resource-subscribe-client/client.mjs
+++ b/examples/mcp.proxy/resource-subscribe-client/client.mjs
@@ -90,17 +90,24 @@ const attempt = async () =>
     }
     finally
     {
+        // Each step is logged on completion because this block runs before the process
+        // exits, and therefore before the caller sees any result -- so a slow step here
+        // is charged to the whole round-trip while looking like a slow notification.
         await client.callTool({ name: "everything__toggle-subscriber-updates", arguments: {} });
+        log("toggled subscriber updates off");
         await client.unsubscribeResource({ uri });
+        log(`unsubscribed from ${uri}`);
         try
         {
             await transport.terminateSession();
+            log("terminated session");
         }
         catch (err)
         {
             log(`failed to terminate session: ${err}`);
         }
         await client.close();
+        log("closed client");
     }
 
     if (updatedUri !== uri)

--- a/examples/mcp.proxy/resource-subscribe-client/client.mjs
+++ b/examples/mcp.proxy/resource-subscribe-client/client.mjs
@@ -51,6 +51,28 @@ const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1
 // exactly that span.
 log(`node startup and imports took ${process.uptime().toFixed(3)}s, before the stamps below`);
 
+// A pending setTimeout keeps node's event loop alive, so this deadline has to be
+// cleared once the race settles. Left armed, it holds the process open until it
+// fires -- TIMEOUT_MS of dead wall-clock after all the work is already done,
+// charged to the caller as though the gateway were slow. That misread is what it
+// looks like from outside: a round-trip measured at 20.7s whose client work took
+// 0.45s, chased through three wrong explanations before the timer was found.
+const awaitWithin = async (promise, ms, message) =>
+{
+    let timer;
+    try
+    {
+        await Promise.race([
+            promise,
+            new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), ms); })
+        ]);
+    }
+    finally
+    {
+        clearTimeout(timer);
+    }
+};
+
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const attempt = async () =>
@@ -90,11 +112,7 @@ const attempt = async () =>
 
     try
     {
-        await Promise.race([
-            updated,
-            new Promise((_, reject) => setTimeout(
-                () => reject(new Error("timed out waiting for notifications/resources/updated")), TIMEOUT_MS))
-        ]);
+        await awaitWithin(updated, TIMEOUT_MS, "timed out waiting for notifications/resources/updated");
     }
     finally
     {

--- a/examples/mcp.proxy/tools-list-client/client.mjs
+++ b/examples/mcp.proxy/tools-list-client/client.mjs
@@ -34,7 +34,12 @@ const READ_RESOURCE = process.env.READ_RESOURCE;
 
 const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 
-const log = (...args) => console.error("[client]", ...args);
+// Elapsed rather than wall-clock: this process's stderr is captured by the
+// caller and only reaches the log when it exits, so every line lands with the
+// same flush timestamp. Stamping each line with its own offset from start is
+// what makes the sequence -- and any gap in it -- readable after the fact.
+const START = Date.now();
+const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
 const main = async () =>
 {

--- a/examples/mcp.proxy/tools-list-client/client.mjs
+++ b/examples/mcp.proxy/tools-list-client/client.mjs
@@ -41,6 +41,14 @@ const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 const START = Date.now();
 const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
+// node's own startup and the evaluation of the hoisted imports above both run
+// before START, so they are charged to the caller's wall-clock while landing
+// outside every stamp below. That blind spot is not theoretical: a 20.7s
+// round-trip measured here accounted for only 0.489s of client work, and the
+// missing ~20s was invisible until this line existed. process.uptime() is
+// exactly that span.
+log(`node startup and imports took ${process.uptime().toFixed(3)}s, before the stamps below`);
+
 const main = async () =>
 {
     const client = new Client(

--- a/examples/mcp.proxy/tools-list-client/client.mjs
+++ b/examples/mcp.proxy/tools-list-client/client.mjs
@@ -104,12 +104,14 @@ const main = async () =>
         try
         {
             await transport.terminateSession();
+            log("terminated session");
         }
         catch (err)
         {
             log(`failed to terminate session: ${err}`);
         }
         await client.close();
+        log("closed client");
     }
 };
 

--- a/examples/mcp.proxy/url-elicit/client.mjs
+++ b/examples/mcp.proxy/url-elicit/client.mjs
@@ -40,6 +40,28 @@ const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1
 // exactly that span.
 log(`node startup and imports took ${process.uptime().toFixed(3)}s, before the stamps below`);
 
+// A pending setTimeout keeps node's event loop alive, so this deadline has to be
+// cleared once the race settles. Left armed, it holds the process open until it
+// fires -- TIMEOUT_MS of dead wall-clock after all the work is already done,
+// charged to the caller as though the gateway were slow. That misread is what it
+// looks like from outside: a round-trip measured at 20.7s whose client work took
+// 0.45s, chased through three wrong explanations before the timer was found.
+const awaitWithin = async (promise, ms, message) =>
+{
+    let timer;
+    try
+    {
+        await Promise.race([
+            promise,
+            new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), ms); })
+        ]);
+    }
+    finally
+    {
+        clearTimeout(timer);
+    }
+};
+
 let sawUrlRequest = false;
 let sawComplete = false;
 let completeResolve;
@@ -85,10 +107,7 @@ const main = async () =>
     log(`tool result: ${text}`);
 
     // Wait for the completion notification (fires shortly after the call).
-    await Promise.race([
-        completed,
-        new Promise((_, reject) => setTimeout(() => reject(new Error("timed out waiting for completion")), TIMEOUT_MS))
-    ]);
+    await awaitWithin(completed, TIMEOUT_MS, "timed out waiting for completion");
 
     try
     {

--- a/examples/mcp.proxy/url-elicit/client.mjs
+++ b/examples/mcp.proxy/url-elicit/client.mjs
@@ -85,12 +85,14 @@ const main = async () =>
     try
     {
         await transport.terminateSession();
+        log("terminated session");
     }
     catch (err)
     {
         log(`failed to terminate session: ${err}`);
     }
     await client.close();
+    log("closed client");
 
     if (!sawUrlRequest)
     {

--- a/examples/mcp.proxy/url-elicit/client.mjs
+++ b/examples/mcp.proxy/url-elicit/client.mjs
@@ -25,7 +25,12 @@ const JWT_TOKEN = process.env.JWT_TOKEN;
 
 const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 
-const log = (...args) => console.error("[client]", ...args);
+// Elapsed rather than wall-clock: this process's stderr is captured by the
+// caller and only reaches the log when it exits, so every line lands with the
+// same flush timestamp. Stamping each line with its own offset from start is
+// what makes the sequence -- and any gap in it -- readable after the fact.
+const START = Date.now();
+const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
 let sawUrlRequest = false;
 let sawComplete = false;

--- a/examples/mcp.proxy/url-elicit/client.mjs
+++ b/examples/mcp.proxy/url-elicit/client.mjs
@@ -32,6 +32,14 @@ const headers = JWT_TOKEN ? { authorization: `Bearer ${JWT_TOKEN}` } : {};
 const START = Date.now();
 const log = (...args) => console.error("[client]", `+${((Date.now() - START) / 1000).toFixed(3)}s`, ...args);
 
+// node's own startup and the evaluation of the hoisted imports above both run
+// before START, so they are charged to the caller's wall-clock while landing
+// outside every stamp below. That blind spot is not theoretical: a 20.7s
+// round-trip measured here accounted for only 0.489s of client work, and the
+// missing ~20s was invisible until this line existed. process.uptime() is
+// exactly that span.
+log(`node startup and imports took ${process.uptime().toFixed(3)}s, before the stamps below`);
+
 let sawUrlRequest = false;
 let sawComplete = false;
 let completeResolve;


### PR DESCRIPTION
## Description

Speeds up `examples/mcp.proxy` verification and makes what remains measurable. Opened as instrumentation only; the instrumentation found a real defect, so the fixes are here too.

### 1. Clear the deadline timer once the race settles (`c603cfbb`)

`resource-subscribe-client` and `url-elicit` each raced their wait against a `setTimeout` and never cleared it. A pending, non-unref'd timer keeps node's event loop alive, so when the awaited work won the race the process finished everything and then sat idle until the timer fired. Each caller captures the client with `$(...)`, which blocks on EOF, so that idle time was charged to the caller as though the gateway were slow.

Reproduced standalone — 300 ms of work raced against a 20 s deadline:

```
before: work done at +0.301s, process exits at +20.020s  (wall 20.07s)
 after: work done at +0.300s, process exits at  +0.308s  (wall  0.35s)
```

The timeout values name the two delays reported against this example: `resource-subscribe-client`'s `TIMEOUT_MS` is 20000 and its assertion measured 20.63 s; `url-elicit`'s is 15000. `tools-list-client` already unref'd and cleared its watchdog, which is why its ~45 invocations were never implicated. `awaitWithin()` clears the timer in a `finally`, so it cannot outlive the race.

Measured: the subscribe assertion's window went **20.63 s → 1.12 s**. Teardown was never the cause, contrary to this PR's original speculation — toggle-off 32 ms, unsubscribe 39 ms, `terminateSession` 35 ms, `close` 4 ms, notification 54 ms after subscribe.

### 2. Bound the slow gates by time, not attempt count (`2a40023f`)

`retry_until` bounds attempts, so its real cost is attempts × how long the probe takes to fail — set by the failure path, not by whoever wrote the count. `retry_until 60 5` over `cache_hydrated` reads like a short gate but bills tens of seconds per attempt when the probe is slow, and can exhaust the whole step budget before reaching the assertion it guards. That already happened downstream, at attempt 50 of 60.

| gate | was | now |
|---|---|---|
| `cache_hydrated` / `cache_rehydrated` | `retry_until 60 5` | `retry_deadline 420 5` |
| `search_pets` | `retry_until 5 3` | `retry_deadline 90 3` |
| `kafka_connect_status_running` | `retry_until 10 3` | `retry_deadline 120 5` |

### 3. Gate on karapace readiness (`4930a27b`)

`karapace-registry` had no healthcheck, so zilla could only depend on `service_started` — the container existing, which says nothing about serving requests. Every other component is gated on `service_healthy`; this was the one hole. The probe is `python3`, not the `wget` used for kafka-connect: this image ships no wget, curl or nc, verified by running it. A wget probe would never succeed and would hang `up --wait`.

### 4. Instrumentation, kept

- **Elapsed stamp per client line.** Callers capture with `2>&1`, so nothing reaches the log until the process exits and every `[client]` line shares one flush timestamp — in one run that made the notification appear *before* the call that triggers it.
- **`process.uptime()` at start.** ESM imports are hoisted and evaluated before the module body, so node startup and SDK loading land outside every stamp. Measured 0.27–0.76 s across ~25 invocations, which ruled startup out.
- **Per-assertion elapsed, reported at the end.** The log is read back tail-first under a hard line cap and this script out-produces it (5000 lines per 6 seconds near the end), so a marker printed at an assertion is unreachable. All 43 call sites are timed and totalled.
- **`FAIL_FAST`** (`ec39e8a9`) defaults on for this example so a failing run is diagnosable from its own logs instead of needing a rerun; the mechanism sits in `test-lib.sh` at default 0, so the other 22 examples are unchanged.

## Where the time actually goes

Two runs with the full timing block:

| assertion | run 1 | run 2 |
|---|---|---|
| `cache_hydrated` | 17s | 17s |
| `kafka_consume_messages` | 31s | **0s** |
| everything else | ≤3s | ≤2s |
| **total** | **77s** | **48s** |

`cache_hydrated` at 17s is reproducible and is the real remaining cost — it is zilla's own post-start warm-up, which no compose healthcheck can observe (`/var/run/zilla/ready` means config loaded, not that every south binding has handshaked). That is what the gate exists for.

`kafka_consume_messages` is **not** systematic: 31s then 0s here, and 1s then 31s in the downstream copy of this example, which has byte-identical assertion code. It is an intermittent stall that affects both. Worth flagging for a reviewer: 31s is close to the ~34s ceiling of its `retry_until 10 3` gate, so when it stalls it is passing on roughly its last allowed attempt. One slower attempt fails the build. I have **not** changed that gate in this PR — it deserves its own look rather than being bundled here.

## Testing

- `node --check` clean on all three clients; `sh -n` clean on `verify.sh` and `test-lib.sh`; both compose files pass `docker compose config`.
- `retry_deadline` verified to keep `retry_until`'s immediate-first-retry pacing (4 attempts, 10s, rc=0) and to bound the failure path by wall-clock, not attempts (rc=9 at 8s).
- `FAIL_FAST=0` runs every assertion, `FAIL_FAST=1` stops at the first, other examples unaffected.
- Karapace probe exit semantics verified against the real image both ways: 1 with nothing listening, 0 against a 200 on `/subjects`.
- Timing helper driven against the real `retry_until`: retries counted, assertion globals still reach the checks that follow, exit status propagated. Verified in `node:20-alpine` — busybox awk matches the host.