### PR TITLE
feat(manager): log phase and elapsed time during zpm install

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/ZpmInstall.java
@@ -197,7 +197,10 @@ public final class ZpmInstall extends ZpmCommand
             List<RemoteRepository> remoteRepositories = asRemoteRepositories(settings, repositories);
 
             ZpmCache cache = new ZpmCache(remoteRepositories, excludeRemoteRepos, cacheDir, logger);
+
+            long begin = System.nanoTime();
             Collection<ZpmArtifact> artifacts = cache.resolve(config.imports, config.dependencies);
+            logger.info(String.format("resolved %d dependencies in %s", artifacts.size(), elapsed(begin)));
 
             Map<ZpmDependency, ZpmDependency> resolvables = artifacts.stream()
                 .map(a -> a.id)
@@ -223,22 +226,51 @@ public final class ZpmInstall extends ZpmCommand
             createDirectories(generatedDir);
 
             ZpmModule delegate = new ZpmModule();
+
+            begin = System.nanoTime();
+            logger.info("discovering modules");
             Collection<ZpmModule> modules = discoverModules(artifacts);
             migrateUnnamed(modules, delegate);
+            logger.info(String.format("discovered %d modules in %s", modules.size(), elapsed(begin)));
+
+            begin = System.nanoTime();
+            logger.info("generating module info for system-only automatic modules");
             generateSystemOnlyAutomatic(logger, modules);
+            logger.info(String.format("generated module info for system-only automatic modules in %s", elapsed(begin)));
+
+            begin = System.nanoTime();
+            logger.info("delegating automatic modules");
             delegateAutomatic(modules, delegate);
+            logger.info(String.format("delegated automatic modules in %s", elapsed(begin)));
+
+            begin = System.nanoTime();
+            logger.info("copying non-delegating modules");
             copyNonDelegating(modules);
+            logger.info(String.format("copied non-delegating modules in %s", elapsed(begin)));
 
             if (!delegate.paths.isEmpty())
             {
+                begin = System.nanoTime();
+                logger.info("resolving optional dependencies");
                 Collection<ZpmArtifact> optional = cache.resolveOptional(config.imports, config.dependencies);
+                logger.info(String.format("resolved %d optional dependencies in %s", optional.size(), elapsed(begin)));
+
+                begin = System.nanoTime();
+                logger.info("generating delegate module");
                 generateDelegate(logger, delegate, optional);
+                logger.info(String.format("generated delegate module in %s", elapsed(begin)));
+
+                begin = System.nanoTime();
+                logger.info("generating delegating modules");
                 generateDelegating(modules);
+                logger.info(String.format("generated delegating modules in %s", elapsed(begin)));
             }
 
+            begin = System.nanoTime();
+            logger.info("linking modules");
             deleteDirectories(imageDir);
             linkModules(modules);
-            logger.info("linked modules");
+            logger.info(String.format("linked modules in %s", elapsed(begin)));
 
             generateLauncher();
             logger.info("generated launcher");
@@ -449,7 +481,9 @@ public final class ZpmInstall extends ZpmCommand
                 Path generatedModuleInfo = generatedModuleDir.resolve(MODULE_INFO_JAVA_FILENAME);
                 if (Files.exists(generatedModuleInfo))
                 {
-                    logger.info(String.format("Generated module info for system-only automatic module: %s", module.name));
+                    logger.debug(String.format("Generating module info for system-only automatic module: %s", module.name));
+
+                    long begin = System.nanoTime();
 
                     expandJar(generatedModuleDir, artifactPath);
 
@@ -480,6 +514,9 @@ public final class ZpmInstall extends ZpmCommand
                     extendJar(artifactPath, generatedModulePath, moduleInfoEntry, compiledModuleInfo);
 
                     promotions.put(module, generatedModulePath);
+
+                    logger.info(String.format("Generated module info for system-only automatic module: %s (%s)",
+                        module.name, elapsed(begin)));
                 }
             }
         }
@@ -525,7 +562,11 @@ public final class ZpmInstall extends ZpmCommand
         Files.createDirectories(generatedModulesDir);
 
         Path generatedDelegatePath = generatedModulesDir.resolve(String.format("%s.jar", delegate.name));
+
+        long begin = System.nanoTime();
+        logger.info(String.format("merging %d artifacts into delegate module jar", delegate.paths.size()));
         generateDelegateJar(delegate, generatedDelegatePath);
+        logger.info(String.format("merged delegate module jar in %s", elapsed(begin)));
 
         // Merge the optional dependency tree resolved via Aether into a single validation-only module so
         // jdeps can resolve the delegate's static references to optional third-party libraries (for
@@ -538,7 +579,11 @@ public final class ZpmInstall extends ZpmCommand
         Files.createDirectories(optionalModulesDir);
         String optionalName = String.format("%s.optional", delegate.name);
         Path optionalPath = optionalModulesDir.resolve(String.format("%s.jar", optionalName));
+
+        begin = System.nanoTime();
+        logger.info(String.format("merging %d optional artifacts into validation-only module jar", optional.size()));
         generateDelegateOptional(optionalPath, optional, jarPackages(generatedDelegatePath));
+        logger.info(String.format("merged validation-only module jar in %s", elapsed(begin)));
 
         deleteDirectories(generatedDelegateDir);
 
@@ -548,12 +593,15 @@ public final class ZpmInstall extends ZpmCommand
         boolean strict = !ignoreMissingDependencies;
         if (strict)
         {
+            begin = System.nanoTime();
+            logger.info("running jdeps --generate-module-info for delegate module");
             int result = jdeps.run(
                 System.out,
                 System.err,
                 "--generate-module-info", generatedModulesDir.toString(),
                 "--module-path", optionalModulesDir.toString(),
                 generatedDelegatePath.toString());
+            logger.info(String.format("completed jdeps --generate-module-info in %s", elapsed(begin)));
             strict = result == 0 && Files.exists(generatedModuleInfo);
         }
 
@@ -562,7 +610,11 @@ public final class ZpmInstall extends ZpmCommand
             // jdeps could not resolve every reference against the optional dependency tree (for example
             // offline with an incomplete tree); fall back to generating while ignoring missing
             // dependencies and report what forced the fallback so accidental prunes remain visible
+            begin = System.nanoTime();
+            logger.info("running jdeps --missing-deps for delegate module");
             Set<String> missing = missingDependencies(generatedDelegatePath, optionalModulesDir);
+            logger.info(String.format("completed jdeps --missing-deps in %s", elapsed(begin)));
+
             if (!missing.isEmpty())
             {
                 String details = missing.stream()
@@ -574,12 +626,16 @@ public final class ZpmInstall extends ZpmCommand
                     " generating module info while ignoring them:%n%s", missing.size(), details));
             }
             deleteDirectories(generatedDelegateDir);
+
+            begin = System.nanoTime();
+            logger.info("running jdeps --generate-module-info --ignore-missing-deps for delegate module");
             jdeps.run(
                 System.out,
                 System.err,
                 "--generate-module-info", generatedModulesDir.toString(),
                 "--ignore-missing-deps",
                 generatedDelegatePath.toString());
+            logger.info(String.format("completed jdeps --generate-module-info --ignore-missing-deps in %s", elapsed(begin)));
         }
 
         if (!Files.exists(generatedModuleInfo))
@@ -646,7 +702,12 @@ public final class ZpmInstall extends ZpmCommand
 
         Files.writeString(generatedModuleInfo, moduleInfoContents);
 
+        begin = System.nanoTime();
+        logger.info("expanding delegate module jar");
         expandJar(generatedDelegateDir, generatedDelegatePath);
+        logger.info(String.format("expanded delegate module jar in %s", elapsed(begin)));
+
+        begin = System.nanoTime();
 
         ToolProvider javac = ToolProvider.findFirst("javac").get();
 
@@ -673,6 +734,8 @@ public final class ZpmInstall extends ZpmCommand
         JarEntry moduleInfoEntry = new JarEntry(MODULE_INFO_CLASS_FILENAME);
         moduleInfoEntry.setTime(318240000000L);
         extendJar(generatedDelegatePath, delegatePath, moduleInfoEntry, compiledModuleInfo);
+
+        logger.info(String.format("compiled and packaged delegate module in %s", elapsed(begin)));
     }
 
     private void generateDelegateJar(
@@ -1091,6 +1154,12 @@ public final class ZpmInstall extends ZpmCommand
                 .map(Path::toFile)
                 .forEach(File::delete);
         }
+    }
+
+    private static String elapsed(
+        long begin)
+    {
+        return String.format("%.3fs", (System.nanoTime() - begin) * 1e-9);
     }
 
     private static boolean atLeastVersion(


### PR DESCRIPTION
## Description

`zpm install` emitted no output between `Generated module info for system-only automatic module: ...` and `Generated module info for delegate module`. That window legitimately takes 80–100s on a CI runner, so a stall inside it is indistinguishable from normal progress until the step timeout fires, and there is nothing in the log to bisect with.

This adds phase logging with elapsed time to `ZpmInstall`, so a stalled run shows which phase it entered and never returned from.

**Phases logged in `invoke()`** — entry line, then a completion line with duration:

- dependency resolution (`cache.resolve`, with artifact count)
- module discovery
- `generateSystemOnlyAutomatic`
- `delegateAutomatic`
- `copyNonDelegating`
- `cache.resolveOptional` — previously had no log line at all despite performing network I/O, with the resolved artifact count
- `generateDelegate`
- `generateDelegating`
- `linkModules`

**Inside `generateDelegate`**, split around the expensive steps: the delegate jar merge, the optional validation-only jar merge, each `jdeps` invocation (`--generate-module-info`, and on the fallback path `--missing-deps` and `--generate-module-info --ignore-missing-deps`), the jar expand, and the javac/package step.

**Per-module completion in `generateSystemOnlyAutomatic`.** The `Generated module info for system-only automatic module: %s` line was printed *before* that module's `expandJar`/`javac`/`extendJar`, so the last line a stalled run showed had not finished its work — actively misleading about where execution actually was. It now logs after `extendJar`, with the per-module duration; the pre-work line is retained at `debug` level so a verbose run still names the module currently in flight without adding a second `info` line per module to normal runs.

Log volume is unchanged in shape — still one `info` line per system-only automatic module, plus a bounded number of phase lines. No per-artifact logging was added.

### Sample output

Real `zpm install` run (config with a delegate module, so every phase is exercised):

```
[INFO] reading .../zpm.json
[INFO] reading .../zpm-lock.json
[INFO] resolving dependencies
[INFO] resolved 28 dependencies in 3.736s
[INFO] writing .../zpm-lock.json
[INFO] discovering modules
[INFO] discovered 16 modules in 0.030s
[INFO] generating module info for system-only automatic modules
[INFO] Generated module info for system-only automatic module: org.agrona (0.364s)
[INFO] generated module info for system-only automatic modules in 0.644s
[INFO] delegating automatic modules
[INFO] delegated automatic modules in 0.001s
[INFO] copying non-delegating modules
[INFO] copied non-delegating modules in 0.007s
[INFO] resolving optional dependencies
[INFO] resolved 51 optional dependencies in 4.222s
[INFO] generating delegate module
[INFO] merging 2 artifacts into delegate module jar
[INFO] merged delegate module jar in 0.057s
[INFO] merging 51 optional artifacts into validation-only module jar
[INFO] merged validation-only module jar in 0.535s
[INFO] running jdeps --generate-module-info for delegate module
[INFO] completed jdeps --generate-module-info in 0.093s
[INFO] Generated module info for delegate module
[INFO] expanding delegate module jar
[INFO] expanded delegate module jar in 0.018s
[INFO] compiled and packaged delegate module in 0.086s
[INFO] generated delegate module in 0.794s
[INFO] generating delegating modules
[INFO] generated delegating modules in 0.102s
[INFO] linking modules
[INFO] linked modules in 3.187s
[INFO] generated launcher
```

Same run with `--ignore-missing-dependencies`, which takes the `jdeps` fallback path:

```
[INFO] merged validation-only module jar in 0.588s
[INFO] running jdeps --missing-deps for delegate module
[INFO] completed jdeps --missing-deps in 0.075s
[INFO] running jdeps --generate-module-info --ignore-missing-deps for delegate module
[INFO] completed jdeps --generate-module-info --ignore-missing-deps in 0.073s
[INFO] Generated module info for delegate module
```

### `--exclude-remote-repositories` and `setOffline`

The issue notes that `--exclude-remote-repositories` maps only to `setIgnoreArtifactDescriptorRepositories(excludeRemote)` in `ZpmCache.newRepositorySystemSession` and never calls `setOffline(true)`, so resolution can still contact remote repositories in a build that reads as offline.

**Deliberately not changed here.** Setting `setOffline(true)` is a behaviour change, not a logging change: any build that passes the flag today but still relies on a remote fetch to complete resolution would start failing, and that trade-off deserves its own issue, its own test coverage and its own review — not a drive-by in an observability PR. This change makes the problem visible in the meantime: `resolving optional dependencies` / `resolved N optional dependencies in Xs` shows directly whether a nominally offline build is blocking on the network.

### Verification

- `./mvnw clean install -pl manager` — BUILD SUCCESS, 20 tests pass (including the four `ZpmInstallTest` cases that run a full install)
- `./mvnw checkstyle:check -pl manager` — 0 violations
- Two real `zpm install` runs, output above

Fixes #2343

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYtkmWKuoLRE736KQ7gG6M)_