### PR TITLE
fix(manager): bound the transfer timeouts when resolving dependencies

### DIFF
--- a/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
+++ b/manager/src/main/java/io/aklivity/zilla/manager/internal/commands/install/cache/ZpmCache.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.manager.internal.commands.install.cache;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
+import static org.eclipse.aether.ConfigurationProperties.CONNECT_TIMEOUT;
+import static org.eclipse.aether.ConfigurationProperties.REQUEST_TIMEOUT;
 import static org.eclipse.aether.util.graph.transformer.ConflictResolver.CONFIG_PROP_VERBOSE;
 
 import java.nio.file.Path;
@@ -79,6 +81,14 @@ public final class ZpmCache
     // acquired within the 30s timeout (observed with both the default "file-lock" factory
     // and the in-JVM "rwlock-local" factory). Disable locking with the "noop" factory.
     private static final String CONFIG_PROP_NAMED_LOCK_FACTORY = "aether.syncContext.named.factory";
+
+    // maven-resolver defaults REQUEST_TIMEOUT to 1800000ms, so a transfer that connects and
+    // then stalls waits half an hour before failing. Resolution is otherwise seconds long,
+    // so that reads as a deadlock and outlives most CI step budgets: one observed install
+    // sat in resolveOptional for 19 minutes with no output before the job was killed. Bound
+    // both so a stuck transfer fails while there is still budget left to report it.
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+    private static final int REQUEST_TIMEOUT_MS = 60000;
 
     private final RepositorySystem repositorySystem;
 
@@ -289,6 +299,8 @@ public final class ZpmCache
                 .setTransferListener(new ZpmConsoleTransferListener())
                 .setConfigProperty(CONFIG_PROP_VERBOSE, "true")
                 .setConfigProperty(CONFIG_PROP_NAMED_LOCK_FACTORY, "noop")
+                .setConfigProperty(CONNECT_TIMEOUT, CONNECT_TIMEOUT_MS)
+                .setConfigProperty(REQUEST_TIMEOUT, REQUEST_TIMEOUT_MS)
                 .setIgnoreArtifactDescriptorRepositories(excludeRemote)
                 .build();
     }


### PR DESCRIPTION
## Description

Follow-up to #2343 / #2346. The phase logging added there localized a `zpm install` stall that had
taken four runs to chase, and this fixes what it found.

`maven-resolver` 2.0.3 defaults:

```
DEFAULT_CONNECT_TIMEOUT  = 30000     (30s)
DEFAULT_REQUEST_TIMEOUT  = 1800000   (30 minutes)
```

So a transfer that connects and then stalls waits **half an hour** before failing. Every other phase
of an install finishes in seconds, which makes that indistinguishable from a deadlock, and it
outlives most CI step budgets. With the new logging in place, an install showed:

```
resolved 924 dependencies in 4.644s
discovering modules
discovered 308 modules in 0.661s
generating module info for system-only automatic modules
  ... 9 modules, each 0.017s - 0.460s ...
generated module info for system-only automatic modules in 3.994s
delegating automatic modules
delegated automatic modules in 0.002s
copying non-delegating modules
copied non-delegating modules in 0.064s
resolving optional dependencies
  <-- 19 minutes, no output, then the job was killed
```

Nothing was deadlocked and nothing was slow on disk — it was one unbounded read inside
`resolveOptional`. Worth noting this corrects the guess in #2343 that the silent window was
I/O-bound jar work: that work is the 3.994s line above.

This bounds connect to 10s and request to 60s. `REQUEST_TIMEOUT` is a per-read socket timeout rather
than a whole-transfer budget, so 60s stays generous for a large artifact on a slow link while turning
a stuck read into a failure that still leaves budget to report which phase it died in.

## What I tried first, and why it is not here

The obvious fix looked like honoring `--exclude-remote-repositories` properly. It maps only to
`setIgnoreArtifactDescriptorRepositories(excludeRemote)`, which drops the repositories an artifact
descriptor declares for itself while still contacting the configured ones — so resolution reaches the
network in a build whose flags read as offline. `resolveOptional` also already tolerates artifacts it
cannot resolve, so going offline looked safe.

`setOffline(excludeRemote)` breaks three existing tests:

```
RepositoryOfflineException: Cannot access (file:///root/.m2/repository) in offline mode
and the artifact io.aklivity.zilla:engine:jar has not been downloaded from it before
```

Aether treats offline as *no repository access at all*, which disables `file://` repositories too —
nothing to do with the network, and the install tests configure exactly that. So `setOffline` is the
wrong lever. Making the flag mean what its name says would require filtering non-`file` repositories,
which is a behaviour change worth its own discussion rather than a drive-by; I have left it alone.
Flagging it here so the next person does not spend the same time on it.

## Trade-off worth a reviewer's attention

The optional, validation-only tree resolves leniently — unresolvable artifacts are tolerated so the
install continues. That means a timed-out optional artifact is now skipped quietly, where before it
hung. Better failure mode, but not a free one: the validation-only jar could silently miss artifacts
and weaken what `jdeps` can check. If that matters, the lenient path should probably log what it
dropped, which I have not done here.

## Testing

`./mvnw clean install -pl manager` green: 20/20 tests pass, including `ZpmInstallTest`, which drives
a real install end to end and exercises the changed session construction. Checkstyle clean.

**No new test, deliberately.** A faithful regression test needs a remote that accepts a connection and
then never responds, then asserts resolution fails inside a bound. I did not add one because it would
be timing- and environment-dependent: the timeout that fires depends on whether the connect or the
read stalls, Aether may retry, and any HTTP-intercepting proxy in the build environment changes the
behaviour entirely. A test that passes locally and flakes in CI seemed worse than none, but I am happy
to add one if you would rather have it — say which shape you want and I will.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8qDfygNWTeejdmm9PfsnS)_