### PR TITLE
test(model-protobuf): add JMH benchmarks, fix allocations they found

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
@@ -36,7 +36,11 @@ public final class ProtobufSchema
     private final Map<String, ProtobufMessage> messages;
     private final Map<String, ProtobufEnum> enums;
     private final Map<String, int[]> indexesByRecord;
-    private final Map<String, ProtobufMessage> messageByIndexes;
+    private final Map<IndexPath, ProtobufMessage> messageByIndexes;
+    // a single mutable key reused for every lookup, so resolving a message by its decoded index path
+    // never materializes a String (or any other per-call object) as a map key; index() below is the only
+    // place that puts an (immutable, build-time-only) IndexPath into the map
+    private final IndexPath lookupPath;
 
     private ProtobufSchema(
         Map<String, ProtobufMessage> messages,
@@ -47,6 +51,7 @@ public final class ProtobufSchema
         this.enums = enums;
         this.indexesByRecord = new LinkedHashMap<>();
         this.messageByIndexes = new LinkedHashMap<>();
+        this.lookupPath = new IndexPath(null);
         index(ordered);
     }
 
@@ -71,7 +76,7 @@ public final class ProtobufSchema
     public ProtobufMessage messageByIndexes(
         int[] indexes)
     {
-        return indexes != null ? messageByIndexes.get(Arrays.toString(indexes)) : null;
+        return indexes != null ? messageByIndexes.get(lookupPath.wrap(indexes)) : null;
     }
 
     private void index(
@@ -127,8 +132,45 @@ public final class ProtobufSchema
             String simplePath = simplePrefix.isEmpty() ? simpleName : simplePrefix + "." + simpleName;
             indexesByRecord.put(message.name(), path);
             indexesByRecord.put(simplePath, path);
-            messageByIndexes.put(Arrays.toString(path), message);
+            // path is a fresh array owned by this node (never mutated after this point, and never handed
+            // to a caller by reference — messageIndexes(String) below always returns a defensive clone),
+            // so the key can wrap it directly with no extra copy
+            messageByIndexes.put(new IndexPath(path), message);
             index(childrenOf.getOrDefault(message.name(), List.of()), path, simplePath, childrenOf);
+        }
+    }
+
+    // a Map key over int[] content: equals/hashCode compare array contents rather than identity, exactly
+    // as Arrays.toString(indexes) achieved via a String key, but with a mutable variant (wrap) reused as a
+    // scratch lookup key so resolving a message by its decoded index path allocates nothing
+    private static final class IndexPath
+    {
+        private int[] value;
+
+        private IndexPath(
+            int[] value)
+        {
+            this.value = value;
+        }
+
+        private IndexPath wrap(
+            int[] value)
+        {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Arrays.hashCode(value);
+        }
+
+        @Override
+        public boolean equals(
+            Object obj)
+        {
+            return obj instanceof IndexPath && Arrays.equals(value, ((IndexPath) obj).value);
         }
     }
 

--- a/runtime/model-protobuf/README.md
+++ b/runtime/model-protobuf/README.md
@@ -1,0 +1,37 @@
+# model-protobuf
+
+The `protobuf` model: validates and transcodes Kafka message values against a Protobuf schema
+resolved from a configured catalog, composing `common-protobuf` for the wire side and
+`common-json` for the protobuf &lt;-&gt; JSON view.
+
+## Run performance benchmarks
+
+`model-protobuf` depends on `engine` as a `provided`-scope dependency (the engine is supplied by
+the runtime host, not bundled), so the decode/encode pipeline benchmarks run over the module's
+resolved **test** classpath rather than a single self-contained jar.
+
+Compile the module and resolve its test classpath from this directory:
+
+```sh
+../../mvnw test-compile -pl runtime/model-protobuf
+../../mvnw dependency:build-classpath -pl runtime/model-protobuf -DincludeScope=test \
+  -Dmdep.outputFile=/tmp/model-protobuf-cp.txt -q
+```
+
+Run the decode and encode pipeline benchmarks with GC allocation profiling:
+
+```sh
+CP="target/classes:target/test-classes:$(cat /tmp/model-protobuf-cp.txt)"
+java --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED -cp "$CP" \
+  org.openjdk.jmh.Main '.*Protobuf.*BM.*' -prof gc
+```
+
+For a quick smoke run while iterating, reduce the warmup and measurement time:
+
+```sh
+java --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED -cp "$CP" \
+  org.openjdk.jmh.Main '.*Protobuf.*BM.*' -prof gc -wi 1 -i 1 -r 200ms -w 200ms -f 1
+```
+
+The `--add-opens` option is required on recent JDKs when Agrona accesses
+`jdk.internal.misc.Unsafe`.

--- a/runtime/model-protobuf/pom.xml
+++ b/runtime/model-protobuf/pom.xml
@@ -85,6 +85,21 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.biboudis</groupId>
+      <artifactId>jmh-profilers</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -157,6 +172,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
       <plugin>
@@ -183,6 +209,39 @@
               </limits>
             </rule>
           </rules>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.gatling</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>org.agrona:agrona</include>
+              <include>org.openjdk.jmh:jmh-core</include>
+              <include>net.sf.jopt-simple:jopt-simple</include>
+              <include>org.apache.commons:commons-math3</include>
+              <include>commons-cli:commons-cli</include>
+              <include>com.github.biboudis:jmh-profilers</include>
+              <include>io.aklivity.zilla:model-protobuf.conf</include>
+              <include>io.aklivity.zilla:engine.conf</include>
+              <include>io.aklivity.zilla:engine</include>
+              <include>io.aklivity.zilla:common-feature</include>
+              <include>io.aklivity.zilla:common-agrona</include>
+              <include>io.aklivity.zilla:common-yaml</include>
+              <include>io.aklivity.zilla:common-protobuf</include>
+              <include>io.aklivity.zilla:common-lang</include>
+              <include>io.aklivity.zilla:common-json</include>
+              <include>org.antlr:antlr4-runtime</include>
+              <include>jakarta.json:jakarta.json-api</include>
+              <include>jakarta.json.bind:jakarta.json.bind-api</include>
+              <include>org.eclipse:yasson</include>
+              <include>org.mockito:mockito-core</include>
+              <include>net.bytebuddy:byte-buddy</include>
+              <include>net.bytebuddy:byte-buddy-agent</include>
+              <include>org.objenesis:objenesis</include>
+            </includes>
+          </artifactSet>
         </configuration>
       </plugin>
       <plugin>

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufExtractor.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufExtractor.java
@@ -37,38 +37,45 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
 // legacy converter.
 final class ProtobufExtractor implements ProtobufTransform
 {
+    // every distinct field name ever seen on this extractor, keyed by name and never shrunk: a Field's
+    // name/path/value buffer are all allocated exactly once (see supplyField) and reused across every
+    // later message that has a field of that name, however many messages that extractor lives across
     private final List<Field> fields;
+    // fields captured for the in-flight message, in encounter order; cleared (not reallocated) on reset()
+    private final List<Field> captured;
 
-    private int captured;
     private int depth;
     private Field current;
 
     ProtobufExtractor()
     {
         this.fields = new ArrayList<>();
+        this.captured = new ArrayList<>();
     }
 
     int captured()
     {
-        return captured;
+        return captured.size();
     }
 
-    String name(
+    // pre-joined "$." + name, computed once per distinct field name (see supplyField) rather than on
+    // every capture, so a caller building a JSON pointer path never pays a per-call concatenation
+    String path(
         int index)
     {
-        return fields.get(index).name;
+        return captured.get(index).path;
     }
 
     int length(
         int index)
     {
-        return fields.get(index).length;
+        return captured.get(index).length;
     }
 
     DirectBufferEx value(
         int index)
     {
-        return fields.get(index).value;
+        return captured.get(index).value;
     }
 
     @Override
@@ -86,7 +93,7 @@ final class ProtobufExtractor implements ProtobufTransform
     public void reset()
     {
         depth = 0;
-        captured = 0;
+        captured.clear();
         current = null;
     }
 
@@ -117,6 +124,12 @@ final class ProtobufExtractor implements ProtobufTransform
             if (current != null)
             {
                 current.length = 0;
+                // a repeated top-level field re-observed within the same message overwrites its value in
+                // place rather than appearing twice in capture order (matches supplyField's Field reuse)
+                if (!captured.contains(current))
+                {
+                    captured.add(current);
+                }
             }
             break;
         case VALUE:
@@ -191,11 +204,14 @@ final class ProtobufExtractor implements ProtobufTransform
         }
     }
 
+    // searches every field name ever seen on this extractor (not just this message's), so a name that
+    // recurs across messages — the common case, since the same schema shapes every message on a stream —
+    // reuses its Field (and thus its name/path Strings) instead of reallocating them every call
     private Field supplyField(
         String name)
     {
         Field result = null;
-        for (int i = 0; result == null && i < captured; i++)
+        for (int i = 0; result == null && i < fields.size(); i++)
         {
             if (fields.get(i).name.equals(name))
             {
@@ -204,13 +220,10 @@ final class ProtobufExtractor implements ProtobufTransform
         }
         if (result == null)
         {
-            if (captured == fields.size())
-            {
-                fields.add(new Field());
-            }
-            result = fields.get(captured);
+            result = new Field();
             result.name = name;
-            captured++;
+            result.path = "$." + name;
+            fields.add(result);
         }
         return result;
     }
@@ -220,6 +233,7 @@ final class ProtobufExtractor implements ProtobufTransform
         private final MutableDirectBufferEx value;
 
         private String name;
+        private String path;
         private int length;
 
         private Field()

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -157,7 +157,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         bridge.start();
         for (int i = 0; i < extractor.captured(); i++)
         {
-            bridge.field("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            bridge.field(extractor.path(i), extractor.value(i), 0, extractor.length(i));
         }
         bridge.end();
     }

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -162,12 +162,21 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         bridge.end();
     }
 
+    // called on every message (not just once per messageName), so this checks the cache directly rather
+    // than through computeIfAbsent: that would evaluate the capturing "name -> ..." lambda as an argument
+    // on every call regardless of whether the map already has an entry, allocating it for nothing on the
+    // (overwhelmingly common) cache-hit path
     private ProtobufPipeline supplyPipeline(
         int schemaId,
         String messageName)
     {
-        return pipelines.computeIfAbsent(messageName,
-            name -> handler.newPipeline(schemaId, handler.decodeLenient, name, extractor, this::onRejected));
+        ProtobufPipeline pipeline = pipelines.get(messageName);
+        if (pipeline == null)
+        {
+            pipeline = handler.newPipeline(schemaId, handler.decodeLenient, messageName, extractor, this::onRejected);
+            pipelines.put(messageName, pipeline);
+        }
+        return pipeline;
     }
 
     private void onRejected(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
@@ -166,12 +166,21 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
         prefixAt += length;
     }
 
+    // called on every message (not just once per messageName), so this checks the cache directly rather
+    // than through computeIfAbsent: that would evaluate the capturing "name -> ..." lambda as an argument
+    // on every call regardless of whether the map already has an entry, allocating it for nothing on the
+    // (overwhelmingly common) cache-hit path
     private ProtobufPipeline supplyPipeline(
         int schemaId,
         String messageName)
     {
-        return pipelines.computeIfAbsent(messageName,
-            name -> handler.newPipeline(schemaId, handler.encodeLenient, name, this::onRejected));
+        ProtobufPipeline pipeline = pipelines.get(messageName);
+        if (pipeline == null)
+        {
+            pipeline = handler.newPipeline(schemaId, handler.encodeLenient, messageName, this::onRejected);
+            pipelines.put(messageName, pipeline);
+        }
+        return pipeline;
     }
 
     private void onRejected(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
@@ -15,12 +15,11 @@
 package io.aklivity.zilla.runtime.model.protobuf.internal;
 
 import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.agrona.BitUtil;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.Int2ObjectCache;
+import org.agrona.collections.IntArrayList;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.SchemaConfig;
@@ -46,7 +45,9 @@ public class ProtobufModelHandler
     protected final CatalogHandler handler;
     protected final String subject;
     protected final String view;
-    protected final List<Integer> indexes;
+    // a scratch path buffer, reused (not boxed) across every decode/encode call: IntArrayList backs its
+    // elements with a primitive int[] (no per-add Node/Integer allocation, unlike List<Integer>)
+    protected final IntArrayList indexes;
     protected final ProtobufModelEventContext event;
     // LENIENT per direction: a semantic-validation failure passes through (inert today — no protobuf
     // semantic validation stage throws yet, so the wired branch is unreached)
@@ -55,6 +56,9 @@ public class ProtobufModelHandler
 
     private final Int2ObjectCache<ProtobufSchema> schemas;
     private final Int2IntHashMap paddings;
+    // decodedPath()'s reused result buffer: resized only when the path depth actually changes, which is
+    // fixed per message shape, so a decode stream settles into zero allocation after its first message
+    private int[] pathScratch;
 
     protected ProtobufModelHandler(
         ProtobufModelConfig config,
@@ -70,9 +74,10 @@ public class ProtobufModelHandler
         this.decodeLenient = config.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = config.validate.encode == ValidateMode.LENIENT;
         this.schemas = new Int2ObjectCache<>(1, 1024, i -> {});
-        this.indexes = new LinkedList<>();
+        this.indexes = new IntArrayList();
         this.paddings = new Int2IntHashMap(-1);
         this.event = new ProtobufModelEventContext(context);
+        this.pathScratch = new int[0];
     }
 
     protected ProtobufSchema supplySchema(
@@ -90,7 +95,7 @@ public class ProtobufModelHandler
         int index = 0;
         for (int i = 0; i < size; i++)
         {
-            int entry = this.indexes.get(i);
+            int entry = this.indexes.getInt(i);
             int value = (entry << 1) ^ (entry >> 31);
             while ((value & ~0x7F) != 0)
             {
@@ -114,11 +119,11 @@ public class ProtobufModelHandler
         progress += BitUtil.SIZE_OF_BYTE;
         if (encodedLength == 0)
         {
-            indexes.add(encodedLength);
+            indexes.addInt(encodedLength);
         }
         for (int i = 0; i < encodedLength; i++)
         {
-            indexes.add(decodeIndex(data.getByte(index + progress)));
+            indexes.addInt(decodeIndex(data.getByte(index + progress)));
             progress += BitUtil.SIZE_OF_BYTE;
         }
         return progress;
@@ -126,22 +131,26 @@ public class ProtobufModelHandler
 
     protected int[] decodedPath()
     {
-        int[] path = new int[indexes.size()];
-        for (int i = 0; i < indexes.size(); i++)
+        int size = indexes.size();
+        if (pathScratch.length != size)
         {
-            path[i] = indexes.get(i);
+            pathScratch = new int[size];
         }
-        return path;
+        for (int i = 0; i < size; i++)
+        {
+            pathScratch[i] = indexes.getInt(i);
+        }
+        return pathScratch;
     }
 
     protected void encodeIndexes(
         int[] path)
     {
         indexes.clear();
-        indexes.add(path.length);
+        indexes.addInt(path.length);
         for (int entry : path)
         {
-            indexes.add(entry);
+            indexes.addInt(entry);
         }
     }
 

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
@@ -80,10 +80,23 @@ public class ProtobufModelHandler
         this.pathScratch = new int[0];
     }
 
+    // called on every decode/encode call, so this checks the cache directly rather than through
+    // computeIfAbsent: a capturing method reference like "this::createSchema" is allocated fresh on every
+    // evaluation of that argument expression, regardless of whether the cache already has an entry, so
+    // computeIfAbsent would pay that cost on every call instead of once per distinct schemaId
     protected ProtobufSchema supplySchema(
         int schemaId)
     {
-        return schemas.computeIfAbsent(schemaId, this::createSchema);
+        ProtobufSchema schema = schemas.get(schemaId);
+        if (schema == null)
+        {
+            schema = createSchema(schemaId);
+            if (schema != null)
+            {
+                schemas.put(schemaId, schema);
+            }
+        }
+        return schema;
     }
 
     protected byte[] encodeIndexes()
@@ -154,16 +167,30 @@ public class ProtobufModelHandler
         }
     }
 
+    // avoids computeIfAbsent for the same reason as supplySchema above: a capturing method reference
+    // argument is allocated on every call, not just on a cache miss
     protected int supplyIndexPadding(
         int schemaId)
     {
-        return paddings.computeIfAbsent(schemaId, this::calculateIndexPadding);
+        int padding = paddings.get(schemaId);
+        if (padding == paddings.missingValue())
+        {
+            padding = calculateIndexPadding(schemaId);
+            paddings.put(schemaId, padding);
+        }
+        return padding;
     }
 
     protected int supplyJsonFormatPadding(
         int schemaId)
     {
-        return paddings.computeIfAbsent(schemaId, this::calculateJsonFormatPadding);
+        int padding = paddings.get(schemaId);
+        if (padding == paddings.missingValue())
+        {
+            padding = calculateJsonFormatPadding(schemaId);
+            paddings.put(schemaId, padding);
+        }
+        return padding;
     }
 
     private int decodeIndex(

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.agrona.collections.Int2ObjectCache;
+
 import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
@@ -50,6 +52,10 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         (traceId, bindingId, schemaId, data, index, length, next) -> 0;
 
     private final Map<String, Object> jsonConfig;
+    // the encode-side message-index path is fixed per schemaId (catalog.record never changes at runtime),
+    // so resolving it is cached exactly like supplySchema/supplyIndexPadding rather than re-derived (and
+    // defensively re-cloned by ProtobufSchema.messageIndexes) on every encode call
+    private final Int2ObjectCache<int[]> messagePaths;
 
     public ProtobufModelHandlerImpl(
         ProtobufModelConfig config,
@@ -59,6 +65,7 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         this.jsonConfig = new HashMap<>();
         jsonConfig.put(ProtobufJson.FIELD_NAMES, ProtobufJson.FieldNames.PROTO);
         jsonConfig.put(ProtobufJson.INCLUDE_DEFAULTS, Boolean.TRUE);
+        this.messagePaths = new Int2ObjectCache<>(1, 1024, i -> {});
     }
 
     @Override
@@ -145,6 +152,12 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
     int[] messagePath(
         int schemaId)
     {
+        return messagePaths.computeIfAbsent(schemaId, this::resolveMessagePath);
+    }
+
+    private int[] resolveMessagePath(
+        int schemaId)
+    {
         ProtobufSchema schema = supplySchema(schemaId);
         return schema != null && catalog.record != null ? schema.messageIndexes(catalog.record) : null;
     }
@@ -177,7 +190,7 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
     {
         encodeIndexes(path);
         byte[] framing;
-        if (indexes.size() == 2 && indexes.get(0) == 1 && indexes.get(1) == 0)
+        if (indexes.size() == 2 && indexes.getInt(0) == 1 && indexes.getInt(1) == 0)
         {
             framing = ZERO_INDEX;
         }

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -149,10 +149,21 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         return schema != null ? schema.messageByIndexes(decodedPath()) : null;
     }
 
+    // avoids computeIfAbsent for the same reason as ProtobufModelHandler.supplySchema: a capturing method
+    // reference argument is allocated on every call, not just on a cache miss
     int[] messagePath(
         int schemaId)
     {
-        return messagePaths.computeIfAbsent(schemaId, this::resolveMessagePath);
+        int[] path = messagePaths.get(schemaId);
+        if (path == null)
+        {
+            path = resolveMessagePath(schemaId);
+            if (path != null)
+            {
+                messagePaths.put(schemaId, path);
+            }
+        }
+        return path;
     }
 
     private int[] resolveMessagePath(

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal.bench;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.protobuf.internal.ProtobufModelHandlerImpl;
+
+/**
+ * Drives {@code ProtobufModelDecoderPipeline} (via {@code ProtobufModelHandlerImpl.supplyDecoder}) over
+ * a fully-buffered wire message, comparing the wire-to-wire canonical pass against the wire-to-JSON
+ * view. Run with {@code -prof gc} to compare allocation per op between the two decode targets.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class ProtobufModelDecoderPipelineBM
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String SCHEMA = """
+                                            syntax = "proto3";
+                                            package io.aklivity.examples.clients.proto;
+                                            message SimpleMessage {
+                                                string content = 1;
+                                                optional string date_time = 2;
+                                            }
+                                            """;
+
+    // message index 0, then content="OK" (field 1) and date_time="01012024" (field 2)
+    private static final byte[] WIRE =
+        {0x00, 0x0a, 0x02, 0x4f, 0x4b, 0x12, 0x08, 0x30, 0x31, 0x30, 0x31, 0x32, 0x30, 0x32, 0x34};
+
+    private final MutableDirectBufferEx outputBuffer = new UnsafeBufferEx(new byte[1024]);
+    private final UnsafeBufferEx inputBuffer = new UnsafeBufferEx(WIRE);
+
+    private ModelPipeline wirePipeline;
+    private ModelPipeline jsonPipeline;
+
+    @Setup(Level.Trial)
+    public void init()
+    {
+        wirePipeline = newHandler(null).supplyDecoder(ModelTransform.NONE);
+        jsonPipeline = newHandler("json").supplyDecoder(ModelTransform.NONE);
+    }
+
+    @Benchmark
+    public int decodeToWire()
+    {
+        return run(wirePipeline);
+    }
+
+    @Benchmark
+    public int decodeToJson()
+    {
+        return run(jsonPipeline);
+    }
+
+    private int run(
+        ModelPipeline pipeline)
+    {
+        pipeline.reset();
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            inputBuffer, 0, WIRE.length, outputBuffer, 0, outputBuffer.capacity());
+        return result.produced();
+    }
+
+    private static ProtobufModelHandlerImpl newHandler(
+        String view)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(1)
+                .schema(SCHEMA)
+                .build()
+            .build();
+        var builder = ProtobufModelConfig.builder();
+        if (view != null)
+        {
+            builder.view(view);
+        }
+        ProtobufModelConfig model = builder
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .version("latest")
+                    .subject("test-value")
+                    .build()
+                .build()
+            .build();
+        EngineContext context = mock(EngineContext.class);
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new ProtobufModelHandlerImpl(model, context);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(ProtobufModelDecoderPipelineBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal.bench;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.protobuf.internal.ProtobufModelHandlerImpl;
+
+/**
+ * Drives {@code ProtobufModelEncoderPipeline} (via {@code ProtobufModelHandlerImpl.supplyEncoder}) over
+ * a fully-buffered JSON message, encoding it to protobuf wire bytes. Run with {@code -prof gc} to
+ * measure allocation per op for the JSON-to-wire hot path.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class ProtobufModelEncoderPipelineBM
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String SCHEMA = """
+                                            syntax = "proto3";
+                                            package io.aklivity.examples.clients.proto;
+                                            message SimpleMessage {
+                                                string content = 1;
+                                                optional string date_time = 2;
+                                            }
+                                            """;
+
+    private static final byte[] JSON = "{\"content\":\"OK\",\"date_time\":\"01012024\"}".getBytes(UTF_8);
+
+    private final MutableDirectBufferEx outputBuffer = new UnsafeBufferEx(new byte[1024]);
+    private final UnsafeBufferEx inputBuffer = new UnsafeBufferEx(JSON);
+
+    private ModelPipeline pipeline;
+
+    @Setup(Level.Trial)
+    public void init()
+    {
+        pipeline = newHandler().supplyEncoder(ModelTransform.NONE);
+    }
+
+    @Benchmark
+    public int encodeToWire()
+    {
+        pipeline.reset();
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            inputBuffer, 0, JSON.length, outputBuffer, 0, outputBuffer.capacity());
+        return result.produced();
+    }
+
+    private static ProtobufModelHandlerImpl newHandler()
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(1)
+                .schema(SCHEMA)
+                .build()
+            .build();
+        ProtobufModelConfig model = ProtobufModelConfig.builder()
+            .view("json")
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .version("latest")
+                    .subject("test-value")
+                    .record("SimpleMessage")
+                    .build()
+                .build()
+            .build();
+        EngineContext context = mock(EngineContext.class);
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new ProtobufModelHandlerImpl(model, context);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(ProtobufModelEncoderPipelineBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Description

Adds JMH microbenchmark coverage for `model-protobuf`, matching the benchmark setup already present in `common-json`, `common-avro`, and `common-protobuf` (`src/test/java/.../bench/`, jmh-core/jmh-generator-annprocess/jmh-profilers test deps, maven-shade-plugin `-shaded-tests.jar` packaging), plus a new `README.md` documenting how to run them (this module previously had none).

- `ProtobufModelDecoderPipelineBM` — drives `ProtobufModelHandlerImpl.supplyDecoder` over a fully-buffered protobuf wire message, comparing the wire-to-wire canonical pass against the wire-to-JSON view.
- `ProtobufModelEncoderPipelineBM` — drives `ProtobufModelHandlerImpl.supplyEncoder` over a fully-buffered JSON message, encoding it to protobuf wire bytes.

Both benchmarks exercise the real decode/encode pipelines the same way `ProtobufModelDecoderPipelineTest` / `ProtobufModelEncoderPipelineTest` do (catalog-backed schema resolution via the engine's `type: test` catalog, `ModelTransform.NONE`), rather than a synthetic shortcut.

`model-protobuf` depends on `engine` as `provided` scope (unlike the `common-*` modules the benchmark pattern was copied from), so the shaded test jar alone can't resolve `EngineContext`/`ModelPipeline` at runtime. The README documents the working run command using the module's resolved **test** classpath (`dependency:build-classpath -DincludeScope=test` + `java -cp ... org.openjdk.jmh.Main`), per the house convention in `runtime/AGENTS.md`'s Benchmarks section. The pom's jmh/shade wiring still mirrors `common-protobuf`'s pattern as closely as that dependency shape allows.

### Allocation fixes found via the above

Running the new benchmarks under `-prof gc` (per the model-json JMH work in #2353, used here as a template) turned up real, fixable allocation sources in the decode/encode hot path — one of them one layer down, in `common-protobuf`'s schema resolution, not just in `model-protobuf` itself.

**Round 1 — data-structure allocations:**

- **`common-protobuf`** — `ProtobufSchema.messageByIndexes(int[])` keyed its lookup map by `Arrays.toString(indexes)`, materializing a `String` (and its backing `StringBuilder`/`char[]`) on every decode *and* encode call. Replaced with a `Map` keyed by array content (`IndexPath`, comparing via `Arrays.equals`/`Arrays.hashCode`) and a single mutable instance reused as a scratch lookup key — this was the dominant cost.
- **`model-protobuf`** — `ProtobufModelHandler`'s message-index scratch list was a boxed `LinkedList<Integer>` (a `Node` plus autoboxing per element on every decode/encode call); replaced with Agrona's `IntArrayList` (`addInt`/`getInt`, primitive-backed). `decodedPath()` allocated a fresh `int[]` every decode call; now reuses a scratch buffer resized only when the path depth actually changes (fixed per message shape).
- **`model-protobuf`** — `ProtobufModelHandlerImpl.messagePath(schemaId)` re-derived and re-cloned the encode-side message-index path (`ProtobufSchema.messageIndexes` defensively clones) on every encode call instead of caching it once per `schemaId`, the same way `supplySchema`/`supplyIndexPadding` already do.
- **`model-protobuf`** — `ProtobufExtractor`'s field-name dedup search was bounded by a per-message counter that reset every message, so it never actually matched a previously-seen name across messages — the same bug class #2353 found in `JsonExtractor`. Fixed the search to check every name ever seen, and pre-joins `"$."+name` once per distinct field instead of concatenating it on every capture in `ProtobufModelDecoderPipeline.visitExtracted()`. Not exercised by the two benchmarks below (they use `ModelTransform.NONE`), but covered by the existing `shouldExtractField`/`shouldExtractScalarFields` unit tests.

**Round 2 — a `computeIfAbsent` capturing-lambda gotcha:** round 1 dropped allocation from 152-176 B/op to a uniform, non-scaling 24 B/op across all three benchmarks. JFR allocation-sample profiling (`jdk.ObjectAllocationSample`, stack traces attached) traced this to `Map.computeIfAbsent`/`Int2ObjectCache.computeIfAbsent`/`Int2IntHashMap.computeIfAbsent` calls on the hot path (`supplyPipeline`, `supplySchema`, `supplyIndexPadding`, `supplyJsonFormatPadding`, `messagePath`): each passes a capturing lambda or method reference (`name -> ...`, `this::createSchema`) as an argument, and Java allocates that lambda object on *every evaluation of the expression* — regardless of whether the map already has the entry cached. A hot path that's a cache hit >99% of the time was still paying a real allocation on every single call. Replaced each with a manual get-then-put-if-absent check (preserving computeIfAbsent's exact semantics, including never caching a null result) so the lambda/method-reference is only evaluated on an actual cache miss.

### Results (`gc.alloc.rate.norm` under `-prof gc`, `-wi 5 -i 5 -f 1`)

| Benchmark | Before | After round 1 | After round 2 |
|---|---|---|---|
| `ProtobufModelDecoderPipelineBM.decodeToWire` | 152.003 B/op | 24.002 B/op | 0.002 B/op |
| `ProtobufModelDecoderPipelineBM.decodeToJson` | 152.008 B/op | 24.006 B/op | 0.006 B/op |
| `ProtobufModelEncoderPipelineBM.encodeToWire` | 176.009 B/op | 24.007 B/op | 0.006 B/op |

All three benchmarks now sit within noise of fully garbage-free, matching the ~0 B/op bar `common-protobuf`'s own `ProtobufJsonPipelineBM` sets for this layer. Throughput improved alongside the allocation drop (roughly 35-55% higher after round 1, comparable or better after round 2).

### Testing

- `common-protobuf`: all 188 tests passing, including `ProtobufSchemaIndexTest` (exercises `messageIndexes`/`messageByIndexes` directly) and the `ProtobufBinaryConformanceTest` corpus.
- `model-protobuf`: all 21 tests passing.
- `checkstyle:check` clean on both modules.
- Both benchmarks re-run successfully after each round of fixes with `-prof gc -wi 5 -i 5 -f 1`, producing the numbers above.

Fixes # (N/A — authorized directly by repo owner to close a benchmark-coverage gap; no tracking issue)