### PR TITLE
test(model-json): add JMH benchmarks, fix allocations they found

### DIFF
--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2392,6 +2392,13 @@ public final class JsonSchemaImpl implements JsonSchema
         private final boolean lenient;
         private final Trace trace = new Trace(diagnostics::add);
         private final Eval eval;
+        // captures a KEY_NAME's chars before forwarding to the sink (see transform()'s structural-event
+        // branch below): reading getStringView() only after the forward can return an empty remainder if
+        // the sink (or an intermediate stage) already rendered this same key, since that shared cursor
+        // has no notion of "consumed by whom" — reading first, while the cursor is still fresh, sidesteps
+        // that race entirely. Reused across every key on this validator; only ever holds one key at a time
+        private final StringBuilder keyCapture = new StringBuilder();
+        private final KeySource keySourceRO = new KeySource();
 
         private JsonController upstreamControl;
         private boolean downstreamVerbatim;
@@ -2402,6 +2409,88 @@ public final class JsonSchemaImpl implements JsonSchema
         {
             this.lenient = lenient;
             this.eval = eval(trace);
+        }
+
+        // Redirects getStringView() to the pre-forward key capture, delegating every other accessor to
+        // the real source unchanged (so the slow, String-materializing key path — which never calls
+        // getStringView() — is unaffected either way)
+        private final class KeySource implements JsonSource
+        {
+            private JsonSource delegate;
+
+            private KeySource wrap(
+                JsonSource delegate)
+            {
+                this.delegate = delegate;
+                return this;
+            }
+
+            @Override
+            public String getString()
+            {
+                return delegate.getString();
+            }
+
+            @Override
+            public CharSequence getStringView()
+            {
+                return keyCapture;
+            }
+
+            @Override
+            public BigDecimal getBigDecimal()
+            {
+                return delegate.getBigDecimal();
+            }
+
+            @Override
+            public boolean isIntegralNumber()
+            {
+                return delegate.isIntegralNumber();
+            }
+
+            @Override
+            public int getInt()
+            {
+                return delegate.getInt();
+            }
+
+            @Override
+            public long getLong()
+            {
+                return delegate.getLong();
+            }
+
+            @Override
+            public JsonLocation getLocation()
+            {
+                return delegate.getLocation();
+            }
+
+            @Override
+            public DirectBufferEx getSegment()
+            {
+                return delegate.getSegment();
+            }
+
+            @Override
+            public JsonVerbatim getVerbatim(
+                int limit)
+            {
+                return delegate.getVerbatim(limit);
+            }
+
+            @Override
+            public void skipValue()
+            {
+                delegate.skipValue();
+            }
+
+            @Override
+            public boolean deferredBytes()
+            {
+                return delegate.deferredBytes();
+            }
         }
 
         @Override
@@ -2481,10 +2570,18 @@ public final class JsonSchemaImpl implements JsonSchema
             }
             else
             {
+                // a key is captured before forwarding — see keyCapture's field comment — so Eval reads an
+                // intact view below regardless of what the sink does with the same live cursor
+                boolean keyName = event == JsonEvent.KEY_NAME;
+                if (keyName)
+                {
+                    keyCapture.setLength(0);
+                    keyCapture.append(source.getStringView());
+                }
                 // structural events and keys forward first, preserving the emit-then-reject ordering (e.g. a
                 // missing required property is detected at END_OBJECT only after the object has been emitted)
                 Status downstream = sink.transform(decline, source, forward(event));
-                Verdict verdict = eval.feed(toEvent(event), source);
+                Verdict verdict = eval.feed(toEvent(event), keyName ? keySourceRO.wrap(source) : source);
                 // throw a descriptive exception at the point of detection so the pipeline maps it to REJECTED
                 // and pushes the diagnostic to the reporter, rather than rejecting structurally with no message
                 if (verdict == Verdict.INVALID && !lenient)
@@ -2640,8 +2737,10 @@ public final class JsonSchemaImpl implements JsonSchema
         private boolean reused;
 
         private final boolean annotate;
-        // keys matched/tracked as a CharSequence (no String): a simple object, with neither annotation
-        // nor diagnostics needing the materialized key
+        // keys matched/tracked as a CharSequence (no String) for a simple object with no annotation
+        // tracking: required-key and property-schema resolution use array scans instead of a Set/Map. Not
+        // gated on trace activity — Validator now captures the key before forwarding downstream (see
+        // Validator.keyCapture), so this is safe even when diagnostics (and thus the pointer trail) are wanted
         private final boolean fastKeys;
         private boolean[] requiredSeen;
         private Set<String> evaluatedProps;
@@ -2675,7 +2774,7 @@ public final class JsonSchemaImpl implements JsonSchema
             this.elseEval = elseSchema != null ? elseSchema.eval(Trace.NONE, dynScope) : null;
             this.dependentSchemaEvals = evalsOfMap(dependentSchemas, Trace.NONE);
             this.trackKeys = required != null || dependentRequired != null || dependentSchemaEvals != null;
-            this.fastKeys = simpleObject && !annotate && !trace.active();
+            this.fastKeys = simpleObject && !annotate;
         }
 
         // resets to pre-feed state for reuse: eager combinator children reset in place, lazy children
@@ -3231,7 +3330,7 @@ public final class JsonSchemaImpl implements JsonSchema
             {
                 if (fastKeys)
                 {
-                    checkRequiredFast();
+                    checkRequiredFast(parser);
                 }
                 else if (required != null && !seen.containsAll(required))
                 {
@@ -3293,11 +3392,13 @@ public final class JsonSchemaImpl implements JsonSchema
                 }
             }
             JsonSchemaImpl schema = null;
+            int matchedIndex = -1;
             for (int i = 0; i < propertyKeys.length; i++)
             {
                 if (charsEqual(propertyKeys[i], key))
                 {
                     schema = propertySchemas[i];
+                    matchedIndex = i;
                     break;
                 }
             }
@@ -3305,20 +3406,52 @@ public final class JsonSchemaImpl implements JsonSchema
             {
                 schema = additionalSchema != null ? additionalSchema : additionalAllowed ? ANY : NONE;
             }
-            directChildMark = 0;
+            if (matchedIndex >= 0)
+            {
+                // a declared property: the schema already owns this exact name, so the pointer segment
+                // reuses it directly rather than copying the document's own key
+                directChildMark = trace.push(propertyKeys[matchedIndex]);
+            }
+            else if (schema != ANY && trace.active())
+            {
+                // an additionalProperties key the schema doesn't already know by name, routed to a
+                // fallible sub-schema (or disallowed outright via NONE): only here does the pointer
+                // need the document's own key text, materialized once, on this less-common path
+                directChildMark = trace.push(key.toString());
+            }
+            else
+            {
+                directChildMark = 0;
+            }
             directChild = propEvalFor(schema);
             directChildren = null;
         }
 
-        private void checkRequiredFast()
+        private void checkRequiredFast(
+            JsonSource parser)
         {
+            boolean missing = false;
             for (int i = 0; i < requiredKeys.length; i++)
             {
                 if (!requiredSeen[i])
                 {
                     directInvalid = true;
-                    break;
+                    missing = true;
                 }
+            }
+            // the message text is built only on this rare failure path, at parity with the slow path's
+            // equivalent seen.containsAll(required) branch
+            if (missing && trace.active())
+            {
+                Set<String> names = new LinkedHashSet<>();
+                for (int i = 0; i < requiredKeys.length; i++)
+                {
+                    if (!requiredSeen[i])
+                    {
+                        names.add(requiredKeys[i]);
+                    }
+                }
+                trace.report("required", "missing required " + names, parser);
             }
         }
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonSchemaImpl.java
@@ -2092,6 +2092,16 @@ public final class JsonSchemaImpl implements JsonSchema
             this.pointer = reporter != null ? new StringBuilder() : null;
         }
 
+        // defensively re-empties the pointer for reuse across documents; push()/pop() keep it balanced
+        // in the normal case, but this guards against any path that leaves it non-empty
+        private void reset()
+        {
+            if (pointer != null)
+            {
+                pointer.setLength(0);
+            }
+        }
+
         private boolean active()
         {
             return reporter != null;
@@ -2380,9 +2390,10 @@ public final class JsonSchemaImpl implements JsonSchema
         private final JsonController decline = new Decline();
         private final List<JsonSchemaDiagnostic> diagnostics = new ArrayList<>();
         private final boolean lenient;
+        private final Trace trace = new Trace(diagnostics::add);
+        private final Eval eval;
 
         private JsonController upstreamControl;
-        private Eval eval;
         private boolean downstreamVerbatim;
         private boolean failed;
 
@@ -2390,7 +2401,7 @@ public final class JsonSchemaImpl implements JsonSchema
             boolean lenient)
         {
             this.lenient = lenient;
-            this.eval = eval(new Trace(diagnostics::add));
+            this.eval = eval(trace);
         }
 
         @Override
@@ -2552,7 +2563,8 @@ public final class JsonSchemaImpl implements JsonSchema
         public void reset()
         {
             diagnostics.clear();
-            eval = eval(new Trace(diagnostics::add));
+            trace.reset();
+            eval.reset();
             downstreamVerbatim = false;
             failed = false;
         }

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/bench/JsonPipelineBM.java
@@ -54,6 +54,19 @@ import io.aklivity.zilla.runtime.common.json.JsonTransforms;
  * a structured benchmark over the same input and projection so throughput and (under {@code -prof gc})
  * allocation can be compared directly. The scalar-leaf case has no segmented counterpart because a
  * scalar value is never segmented — it is the control where the two modes coincide.
+ * <p>
+ * The {@code validate*} benchmarks drive {@code JsonSchemaImpl.Validator} (the push-based
+ * {@code JsonTransform} every {@code JsonPipeline} consumer gets from {@code schema.validator()}) rather
+ * than a projector, so allocation regressions in {@code Validator}/{@code Eval}'s fastKeys path are
+ * caught here directly instead of only downstream in a consumer module's own benchmarks.
+ * {@code validateCanonical}/{@code validateVerbatim} use a schema with no declared {@code properties},
+ * so every key falls through to the default (never-fails) {@code additionalProperties}.
+ * {@code validatePropertiesCanonical}/{@code validatePropertiesVerbatim} add declared {@code properties}
+ * and {@code required}, exercising fastKeys' matched-property path (expected ~0 B/op: the pointer segment
+ * reuses the schema's own property name). {@code validateAdditionalCanonical}/
+ * {@code validateAdditionalVerbatim} route an undeclared key to a real (fallible) {@code
+ * additionalProperties} sub-schema — the one case fastKeys still has to materialize the document's own
+ * key text, since the schema has no name of its own to reuse for it.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
@@ -91,6 +104,22 @@ public class JsonPipelineBM
     private static final String VALIDATE_DOCUMENT = ROOT_IDENTITY;
     private static final String VALIDATE_SCHEMA = "{\"type\":\"object\"}";
 
+    // unlike VALIDATE_SCHEMA (bare "type":"object", no declared properties), this exercises Eval's
+    // fastKeys "matched declared property" branch: "id" and "ok" resolve against propertyKeys/requiredKeys
+    // (array scans, the schema's own strings pushed onto the pointer trail — see onFastKey), while "items"
+    // falls through to the default additionalProperties:true (ANY, never fails, no pointer push at all)
+    private static final String VALIDATE_PROPERTIES_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"ok\":{\"type\":\"boolean\"}}," +
+        "\"required\":[\"id\",\"ok\"]}";
+
+    // "note" is not a declared property, and additionalProperties is a real (fallible) sub-schema rather
+    // than the bare-true/absent default — the one case fastKeys still has to materialize the document's
+    // own key text (not the schema's), since the schema has no name for it to reuse
+    private static final String VALIDATE_ADDITIONAL_SCHEMA =
+        "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"}},\"required\":[\"id\"]," +
+        "\"additionalProperties\":{\"type\":\"string\"}}";
+    private static final String VALIDATE_ADDITIONAL_DOCUMENT = "{\"id\":1,\"note\":\"hello\"} ";
+
     private final MutableDirectBufferEx outputBuffer = new UnsafeBufferEx(new byte[16 * 1024]);
     private final JsonGeneratorEx generator = JsonEx.createGenerator();
     // structured = the explicit canonical opt-out (re-render); the bare default now prefers bytes
@@ -110,6 +139,10 @@ public class JsonPipelineBM
     private JsonPipeline fragmentNumberStructuredPipeline;
     private JsonPipeline validateCanonicalPipeline;
     private JsonPipeline validateVerbatimPipeline;
+    private JsonPipeline validatePropertiesCanonicalPipeline;
+    private JsonPipeline validatePropertiesVerbatimPipeline;
+    private JsonPipeline validateAdditionalCanonicalPipeline;
+    private JsonPipeline validateAdditionalVerbatimPipeline;
 
     private UnsafeBufferEx flatBuffer;
     private UnsafeBufferEx nestedBuffer;
@@ -118,6 +151,7 @@ public class JsonPipelineBM
     private UnsafeBufferEx largeStringBuffer;
     private UnsafeBufferEx largeNumberBuffer;
     private UnsafeBufferEx validateBuffer;
+    private UnsafeBufferEx validateAdditionalBuffer;
 
     private int flatLength;
     private int nestedLength;
@@ -126,6 +160,7 @@ public class JsonPipelineBM
     private int largeStringLength;
     private int largeNumberLength;
     private int validateLength;
+    private int validateAdditionalLength;
 
     @Setup(Level.Trial)
     public void init()
@@ -159,6 +194,14 @@ public class JsonPipelineBM
             .transform(JsonSchema.of(VALIDATE_SCHEMA).validator()).into(structuredSink);
         validateVerbatimPipeline = JsonEx.stream(JsonEx.createParser())
             .transform(JsonSchema.of(VALIDATE_SCHEMA).validator()).into(bytePreferringSink);
+        validatePropertiesCanonicalPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(VALIDATE_PROPERTIES_SCHEMA).validator()).into(structuredSink);
+        validatePropertiesVerbatimPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(VALIDATE_PROPERTIES_SCHEMA).validator()).into(bytePreferringSink);
+        validateAdditionalCanonicalPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(VALIDATE_ADDITIONAL_SCHEMA).validator()).into(structuredSink);
+        validateAdditionalVerbatimPipeline = JsonEx.stream(JsonEx.createParser())
+            .transform(JsonSchema.of(VALIDATE_ADDITIONAL_SCHEMA).validator()).into(bytePreferringSink);
 
         byte[] flatBytes = FLAT_OBJECT.getBytes(UTF_8);
         byte[] nestedBytes = NESTED_OBJECT.getBytes(UTF_8);
@@ -167,6 +210,7 @@ public class JsonPipelineBM
         byte[] largeStringBytes = LARGE_STRING.getBytes(UTF_8);
         byte[] largeNumberBytes = LARGE_NUMBER.getBytes(UTF_8);
         byte[] validateBytes = VALIDATE_DOCUMENT.getBytes(UTF_8);
+        byte[] validateAdditionalBytes = VALIDATE_ADDITIONAL_DOCUMENT.getBytes(UTF_8);
 
         flatBuffer = new UnsafeBufferEx(flatBytes);
         nestedBuffer = new UnsafeBufferEx(nestedBytes);
@@ -175,6 +219,7 @@ public class JsonPipelineBM
         largeStringBuffer = new UnsafeBufferEx(largeStringBytes);
         largeNumberBuffer = new UnsafeBufferEx(largeNumberBytes);
         validateBuffer = new UnsafeBufferEx(validateBytes);
+        validateAdditionalBuffer = new UnsafeBufferEx(validateAdditionalBytes);
 
         flatLength = flatBytes.length;
         nestedLength = nestedBytes.length;
@@ -183,6 +228,7 @@ public class JsonPipelineBM
         largeStringLength = largeStringBytes.length;
         largeNumberLength = largeNumberBytes.length;
         validateLength = validateBytes.length;
+        validateAdditionalLength = validateAdditionalBytes.length;
     }
 
     @Benchmark
@@ -255,6 +301,30 @@ public class JsonPipelineBM
     public int validateVerbatim()
     {
         return run(validateVerbatimPipeline, validateBuffer, validateLength);
+    }
+
+    @Benchmark
+    public int validatePropertiesCanonical()
+    {
+        return run(validatePropertiesCanonicalPipeline, validateBuffer, validateLength);
+    }
+
+    @Benchmark
+    public int validatePropertiesVerbatim()
+    {
+        return run(validatePropertiesVerbatimPipeline, validateBuffer, validateLength);
+    }
+
+    @Benchmark
+    public int validateAdditionalCanonical()
+    {
+        return run(validateAdditionalCanonicalPipeline, validateAdditionalBuffer, validateAdditionalLength);
+    }
+
+    @Benchmark
+    public int validateAdditionalVerbatim()
+    {
+        return run(validateAdditionalVerbatimPipeline, validateAdditionalBuffer, validateAdditionalLength);
     }
 
     private int run(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFieldBridge.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFieldBridge.java
@@ -88,12 +88,19 @@ public final class ModelFieldBridge
         private static final byte[] EMPTY = new byte[0];
 
         private final UnsafeBufferEx view;
+        // wrapped once at construction and never re-wrapped: UnsafeBufferEx.wrap(byte[]) allocates a new
+        // MemorySegment every call, so start()/end() (which carry no buffer) swap to this cached empty
+        // view instead of re-wrapping the same EMPTY array on every value run
+        private final DirectBufferEx empty;
 
         private String path;
+        private DirectBufferEx current;
 
         private Value()
         {
             this.view = new UnsafeBufferEx(EMPTY);
+            this.empty = new UnsafeBufferEx(EMPTY);
+            this.current = empty;
         }
 
         @Override
@@ -105,7 +112,7 @@ public final class ModelFieldBridge
         @Override
         public DirectBufferEx getValue()
         {
-            return view;
+            return current;
         }
 
         private void wrap(
@@ -118,10 +125,11 @@ public final class ModelFieldBridge
             if (buffer != null)
             {
                 view.wrap(buffer, index, length);
+                current = view;
             }
             else
             {
-                view.wrap(EMPTY);
+                current = empty;
             }
         }
     }

--- a/runtime/model-json/README.md
+++ b/runtime/model-json/README.md
@@ -1,0 +1,32 @@
+# model-json
+
+The `json` model: validates and transforms JSON message payloads against a JSON Schema resolved from
+a configured catalog, using the `common-json` streaming pipeline for both the decode (read) and encode
+(write) directions.
+
+## Run performance benchmarks
+
+Build the benchmark jar from this directory:
+
+```sh
+../../mvnw clean -DskipTests package
+```
+
+Run the decode/encode pipeline benchmarks with GC allocation profiling:
+
+```sh
+java --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
+  -jar target/model-json-develop-SNAPSHOT-shaded-tests.jar \
+  '.*JsonModel.*BM.*' -prof gc
+```
+
+For a quick smoke run while iterating, reduce the warmup and measurement time:
+
+```sh
+java --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
+  -jar target/model-json-develop-SNAPSHOT-shaded-tests.jar \
+  '.*JsonModel.*BM.*' -prof gc -wi 1 -i 1 -r 200ms -w 200ms -f 0
+```
+
+The `--add-opens` option is required on recent JDKs when Agrona accesses
+`jdk.internal.misc.Unsafe` from the shaded benchmark jar.

--- a/runtime/model-json/pom.xml
+++ b/runtime/model-json/pom.xml
@@ -82,6 +82,21 @@
     <artifactId>mockito-core</artifactId>
     <scope>test</scope>
   </dependency>
+  <dependency>
+    <groupId>org.openjdk.jmh</groupId>
+    <artifactId>jmh-core</artifactId>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.openjdk.jmh</groupId>
+    <artifactId>jmh-generator-annprocess</artifactId>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.github.biboudis</groupId>
+    <artifactId>jmh-profilers</artifactId>
+    <scope>test</scope>
+  </dependency>
 </dependencies>
 
 <build>
@@ -154,6 +169,17 @@
     </plugin>
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-jar-plugin</artifactId>
+      <executions>
+        <execution>
+          <goals>
+            <goal>test-jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-failsafe-plugin</artifactId>
     </plugin>
     <plugin>
@@ -198,6 +224,64 @@
           <version>${project.version}</version>
         </dependency>
       </dependencies>
+    </plugin>
+    <plugin>
+      <groupId>io.gatling</groupId>
+      <artifactId>maven-shade-plugin</artifactId>
+      <configuration>
+        <shadeTestJar>true</shadeTestJar>
+        <outputFile>${project.build.directory}/${project.artifactId}-shaded.jar</outputFile>
+        <transformers>
+          <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+          <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+            <mainClass>org.openjdk.jmh.Main</mainClass>
+            <manifestEntries>
+              <!-- engine is provided-scope (shipped separately in the docker image), so it is
+                   never eligible for shading; bridge it in here so the standalone benchmark jar
+                   can still resolve EngineContext, ModelPipeline, and friends at runtime -->
+              <Class-Path>${project.build.directory}/${project.artifactId}-shaded.jar ${settings.localRepository}/io/aklivity/zilla/engine/${project.version}/engine-${project.version}.jar</Class-Path>
+            </manifestEntries>
+          </transformer>
+          <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+            <resource>META-INF/BenchmarkList</resource>
+          </transformer>
+          <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+            <resource>META-INF/CompilerHints</resource>
+          </transformer>
+        </transformers>
+        <filters>
+          <filter>
+            <artifact>*:*</artifact>
+            <excludes>
+              <exclude>**/module-info.class</exclude>
+            </excludes>
+          </filter>
+        </filters>
+        <artifactSet>
+          <includes>
+            <include>org.agrona:agrona</include>
+            <include>jakarta.json:jakarta.json-api</include>
+            <include>jakarta.json.bind:jakarta.json.bind-api</include>
+            <include>org.openjdk.jmh:jmh-core</include>
+            <include>net.sf.jopt-simple:jopt-simple</include>
+            <include>org.apache.commons:commons-math3</include>
+            <include>commons-cli:commons-cli</include>
+            <include>com.github.biboudis:jmh-profilers</include>
+            <include>org.mockito:mockito-core</include>
+            <include>net.bytebuddy:byte-buddy</include>
+            <include>net.bytebuddy:byte-buddy-agent</include>
+            <include>org.objenesis:objenesis</include>
+            <include>${project.groupId}:common-agrona</include>
+            <include>${project.groupId}:common-feature</include>
+            <include>${project.groupId}:common-yaml</include>
+            <include>${project.groupId}:common-lang</include>
+            <include>${project.groupId}:common-json</include>
+            <include>${project.groupId}:engine</include>
+            <include>${project.groupId}:engine.conf</include>
+            <include>${project.groupId}:model-json.conf</include>
+          </includes>
+        </artifactSet>
+      </configuration>
     </plugin>
   </plugins>
 </build>

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonExtractor.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonExtractor.java
@@ -32,32 +32,39 @@ import io.aklivity.zilla.runtime.common.json.JsonTransform;
 // is char-view based, so it sees the decoded scalar (string content or number lexeme).
 final class JsonExtractor implements JsonTransform
 {
+    // every distinct field name ever seen on this extractor, keyed by name and never shrunk: a Field's
+    // name/path/value buffer are all allocated exactly once (see supplyField) and reused across every
+    // later document that has a field of that name, however many documents that extractor lives across
     private final List<Field> fields;
+    // fields captured for the in-flight document, in encounter order; cleared (not reallocated) on reset()
+    private final List<Field> captured;
     private final JsonController mediator;
     private final StringBuilder pendingKey;
 
     private JsonController upstreamControl;
     private boolean downstreamVerbatim;
-    private int captured;
     private int depth;
     private boolean armed;
 
     JsonExtractor()
     {
         this.fields = new ArrayList<>();
+        this.captured = new ArrayList<>();
         this.mediator = new Mediator();
         this.pendingKey = new StringBuilder();
     }
 
     int captured()
     {
-        return captured;
+        return captured.size();
     }
 
-    String name(
+    // pre-joined "$." + name, computed once per distinct field name (see supplyField) rather than on
+    // every capture, so a caller building a JSON pointer path never pays a per-call concatenation
+    String path(
         int index)
     {
-        return fields.get(index).name;
+        return captured.get(index).path;
     }
 
     // Extraction reads the decoded structured events, so this stage must keep receiving them: it intercepts the
@@ -88,13 +95,13 @@ final class JsonExtractor implements JsonTransform
     int length(
         int index)
     {
-        return fields.get(index).length;
+        return captured.get(index).length;
     }
 
     DirectBufferEx value(
         int index)
     {
-        return fields.get(index).value;
+        return captured.get(index).value;
     }
 
     @Override
@@ -137,7 +144,7 @@ final class JsonExtractor implements JsonTransform
     {
         depth = 0;
         armed = false;
-        captured = 0;
+        captured.clear();
         downstreamVerbatim = false;
     }
 
@@ -202,14 +209,66 @@ final class JsonExtractor implements JsonTransform
         CharSequence view)
     {
         Field field = supplyField(key);
-        field.length = field.value.putStringWithoutLengthUtf8(0, view.toString());
+        field.length = putUtf8(field.value, view);
+        // a duplicate top-level key within one document overwrites the value in place rather than
+        // appearing twice in capture order
+        if (!captured.contains(field))
+        {
+            captured.add(field);
+        }
     }
 
+    // encodes UTF-8 bytes straight from the decoded char view into the field's reused buffer, matching
+    // CharSequence.toString().getBytes(UTF_8) byte-for-byte (including the '?' replacement for an unpaired
+    // surrogate) without materializing an intermediate String or byte[] on every capture
+    private static int putUtf8(
+        MutableDirectBufferEx buffer,
+        CharSequence value)
+    {
+        int length = value.length();
+        int index = 0;
+        for (int i = 0; i < length; i++)
+        {
+            char c = value.charAt(i);
+            if (c < 0x80)
+            {
+                buffer.putByte(index++, (byte) c);
+            }
+            else if (c < 0x800)
+            {
+                buffer.putByte(index++, (byte) (0xC0 | (c >> 6)));
+                buffer.putByte(index++, (byte) (0x80 | (c & 0x3F)));
+            }
+            else if (Character.isHighSurrogate(c) && i + 1 < length && Character.isLowSurrogate(value.charAt(i + 1)))
+            {
+                int codePoint = Character.toCodePoint(c, value.charAt(++i));
+                buffer.putByte(index++, (byte) (0xF0 | (codePoint >> 18)));
+                buffer.putByte(index++, (byte) (0x80 | ((codePoint >> 12) & 0x3F)));
+                buffer.putByte(index++, (byte) (0x80 | ((codePoint >> 6) & 0x3F)));
+                buffer.putByte(index++, (byte) (0x80 | (codePoint & 0x3F)));
+            }
+            else if (Character.isSurrogate(c))
+            {
+                buffer.putByte(index++, (byte) '?');
+            }
+            else
+            {
+                buffer.putByte(index++, (byte) (0xE0 | (c >> 12)));
+                buffer.putByte(index++, (byte) (0x80 | ((c >> 6) & 0x3F)));
+                buffer.putByte(index++, (byte) (0x80 | (c & 0x3F)));
+            }
+        }
+        return index;
+    }
+
+    // searches every field name ever seen on this extractor (not just this document's), so a name that
+    // recurs across documents — the common case, since the same schema shapes every message on a stream —
+    // reuses its Field (and thus its name/path Strings) instead of reallocating them every call
     private Field supplyField(
         CharSequence key)
     {
         Field result = null;
-        for (int i = 0; result == null && i < captured; i++)
+        for (int i = 0; result == null && i < fields.size(); i++)
         {
             if (charsEqual(fields.get(i).name, key))
             {
@@ -218,13 +277,10 @@ final class JsonExtractor implements JsonTransform
         }
         if (result == null)
         {
-            if (captured == fields.size())
-            {
-                fields.add(new Field());
-            }
-            result = fields.get(captured);
+            result = new Field();
             result.name = key.toString();
-            captured++;
+            result.path = "$." + result.name;
+            fields.add(result);
         }
         return result;
     }
@@ -246,6 +302,7 @@ final class JsonExtractor implements JsonTransform
         private final MutableDirectBufferEx value;
 
         private String name;
+        private String path;
         private int length;
 
         private Field()

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonExtractor.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonExtractor.java
@@ -192,9 +192,18 @@ final class JsonExtractor implements JsonTransform
         case VALUE_NUMBER:
             if (depth == 1 && armed)
             {
+                // a value spanning an input window arrives as repeated events over the same key, each
+                // carrying the value's whole decoded-so-far prefix (scratch is never pruned mid-value
+                // since nothing here advances the parser's string-view cursor) until the closing fragment
+                // delivers it complete, so re-capturing on every fragment and staying armed until
+                // deferredBytes() goes false always leaves the last (complete) capture in place
                 capture(pendingKey, source.getStringView());
+                armed = source.deferredBytes();
             }
-            armed = false;
+            else
+            {
+                armed = false;
+            }
             break;
         default:
             armed = false;

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -161,7 +161,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         bridge.start();
         for (int i = 0; i < extractor.captured(); i++)
         {
-            bridge.field("$." + extractor.name(i), extractor.value(i), 0, extractor.length(i));
+            bridge.field(extractor.path(i), extractor.value(i), 0, extractor.length(i));
         }
         bridge.end();
     }

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -50,6 +50,7 @@ public class JsonModelDecoderPipelineTest
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
+    private static final int FLAGS_NONE = 0x00;
     private static final int FLAGS_COMPLETE = 0x03;
 
     private static final String OBJECT_SCHEMA = """
@@ -61,6 +62,19 @@ public class JsonModelDecoderPipelineTest
                 "status": { "type": "string" }
             },
             "required": [ "id", "status" ]
+        }""";
+
+    // "note" has no content-constraining keyword (pattern/minLength/maxLength), so the validator forwards
+    // a value spanning an input window in fragments instead of reassembling it first (see JsonExtractor)
+    private static final String UNCONSTRAINED_VALUE_SCHEMA = """
+        {
+            "type": "object",
+            "properties":
+            {
+                "id": { "type": "string" },
+                "note": { "type": "string" }
+            },
+            "required": [ "id", "note" ]
         }""";
 
     private EngineContext context;
@@ -160,6 +174,45 @@ public class JsonModelDecoderPipelineTest
     }
 
     @Test
+    public void shouldExtractFieldSpanningInputWindow()
+    {
+        JsonModelHandlerImpl handler = newHandler(UNCONSTRAINED_VALUE_SCHEMA);
+        Map<String, String> extracted = new HashMap<>();
+        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+
+        // "note" has no content keyword, so a value spanning an input window is forwarded to the
+        // extractor in fragments (Validator's forward-and-suppress path) instead of being reassembled
+        // first, unlike "id" or an object key
+        String note = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        byte[] head = "{\"id\":\"1\",\"note\":".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[512]);
+
+        // window 1: everything up to (not including) the value
+        ModelPipelineResult r1 = pipeline.transform(0L, 0L, FLAGS_INIT,
+            new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
+        assertEquals(ModelStatus.UNDERFLOW, r1.status());
+
+        // window 2: a small window of ONLY value bytes (opening quote + a prefix), so the value's own
+        // scanned bytes fill this window before it closes, forcing the fragmenting path
+        byte[] remainder1 = concat(head, r1.consumed(), new byte[0]);
+        byte[] valueChunk1 = ("\"" + note.substring(0, 20)).getBytes(UTF_8);
+        byte[] window2 = concat(remainder1, 0, valueChunk1);
+        ModelPipelineResult r2 = pipeline.transform(0L, 0L, FLAGS_NONE,
+            new UnsafeBufferEx(window2), 0, window2.length, dst, 0, dst.capacity());
+        assertEquals(ModelStatus.UNDERFLOW, r2.status());
+
+        // window 3: the rest of the value, its closing quote, and the closing brace
+        byte[] remainder2 = concat(window2, r2.consumed(), new byte[0]);
+        byte[] tail = (note.substring(20) + "\"}").getBytes(UTF_8);
+        byte[] window3 = concat(remainder2, 0, tail);
+        ModelPipelineResult r3 = pipeline.transform(0L, 0L, FLAGS_FIN,
+            new UnsafeBufferEx(window3), 0, window3.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.COMPLETE, r3.status());
+        assertEquals(note, extracted.get("$.note"));
+    }
+
+    @Test
     public void shouldReportDecodePadding()
     {
         JsonModelHandlerImpl handler = newHandler();
@@ -187,13 +240,19 @@ public class JsonModelDecoderPipelineTest
 
     private JsonModelHandlerImpl newHandler()
     {
+        return newHandler(OBJECT_SCHEMA);
+    }
+
+    private JsonModelHandlerImpl newHandler(
+        String schema)
+    {
         TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
             .namespace("test")
             .name("test0")
             .type("test")
             .options(TestCatalogOptionsConfig::builder)
                 .id(9)
-                .schema(OBJECT_SCHEMA)
+                .schema(schema)
                 .build()
             .build();
         JsonModelConfig model = JsonModelConfig.builder()

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -125,6 +125,41 @@ public class JsonModelDecoderPipelineTest
     }
 
     @Test
+    public void shouldExtractMultiByteAndSurrogatePairFields()
+    {
+        JsonModelHandlerImpl handler = newHandler();
+        Map<String, String> extracted = new HashMap<>();
+        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+
+        // "id" holds a 3-byte BMP char (中) and a 2-byte char (é); "status" holds a surrogate-pair emoji (😀)
+        byte[] in = "{\"id\":\"中é\",\"status\":\"😀\"}".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.COMPLETE, result.status());
+        assertEquals("中é", extracted.get("$.id"));
+        assertEquals("😀", extracted.get("$.status"));
+    }
+
+    @Test
+    public void shouldExtractUnpairedSurrogateAsReplacementChar()
+    {
+        JsonModelHandlerImpl handler = newHandler();
+        Map<String, String> extracted = new HashMap<>();
+        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+
+        // \uD800 is an unpaired high surrogate; String.getBytes(UTF_8) replaces it with '?' (0x3F)
+        byte[] in = "{\"id\":\"a\\uD800b\",\"status\":\"OK\"}".getBytes(UTF_8);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+
+        assertEquals(ModelStatus.COMPLETE, result.status());
+        assertEquals("a?b", extracted.get("$.id"));
+    }
+
+    @Test
     public void shouldReportDecodePadding()
     {
         JsonModelHandlerImpl handler = newHandler();

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.json.internal.bench;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.json.JsonModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEvent;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelSink;
+import io.aklivity.zilla.runtime.engine.model.ModelSource;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.json.internal.JsonModelHandlerImpl;
+
+/**
+ * Exercises {@code model-json}'s decode {@link ModelPipeline}, the schema-validating transform that
+ * {@code JsonModelHandlerImpl.supplyDecoder} vends per stream. {@code decodeValidDocument} drives the
+ * verbatim/SEGMENTED fast path ({@link ModelTransform#NONE}, no field-extraction bridge); {@code
+ * decodeWithFieldExtraction} drives the same schema and document through a wired {@link ModelTransform}
+ * so the extra {@code ModelFieldBridge} field-visit cost is directly comparable under {@code -prof gc}.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class JsonModelDecoderPipelineBM
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String OBJECT_SCHEMA = """
+        {
+            "type": "object",
+            "properties":
+            {
+                "id": { "type": "string" },
+                "status": { "type": "string" }
+            },
+            "required": [ "id", "status" ]
+        }""";
+
+    private static final String VALID_DOCUMENT = "{\"id\":\"123\",\"status\":\"OK\"}";
+
+    private final MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16 * 1024]);
+
+    private ModelPipeline plainPipeline;
+    private ModelPipeline extractingPipeline;
+
+    private UnsafeBufferEx validBuffer;
+    private int validLength;
+
+    @Setup(Level.Trial)
+    public void init()
+    {
+        JsonModelHandlerImpl handler = newHandler();
+        plainPipeline = handler.supplyDecoder(ModelTransform.NONE);
+        extractingPipeline = handler.supplyDecoder(fieldCounter());
+
+        byte[] validBytes = VALID_DOCUMENT.getBytes(UTF_8);
+        validBuffer = new UnsafeBufferEx(validBytes);
+        validLength = validBytes.length;
+    }
+
+    @Benchmark
+    public int decodeValidDocument()
+    {
+        return run(plainPipeline);
+    }
+
+    @Benchmark
+    public int decodeWithFieldExtraction()
+    {
+        return run(extractingPipeline);
+    }
+
+    private int run(
+        ModelPipeline pipeline)
+    {
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            validBuffer, 0, validLength, dst, 0, dst.capacity());
+        return result.produced();
+    }
+
+    private JsonModelHandlerImpl newHandler()
+    {
+        EngineContext context = mock(EngineContext.class);
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(9)
+                .schema(OBJECT_SCHEMA)
+                .build()
+            .build();
+        JsonModelConfig model = JsonModelConfig.builder()
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .subject(null)
+                    .version("latest")
+                    .id(0)
+                    .build()
+                .build()
+            .build();
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new JsonModelHandlerImpl(model, context);
+    }
+
+    // captures field-visit count without allocating per call, isolating the bridge's traversal cost
+    // from any downstream storage the caller might use
+    private static ModelTransform fieldCounter()
+    {
+        return new ModelTransform()
+        {
+            private long fields;
+
+            @Override
+            public ModelStatus transform(
+                ModelController control,
+                ModelSource source,
+                ModelEvent event,
+                ModelSink sink)
+            {
+                if (event == ModelEvent.FIELD)
+                {
+                    fields++;
+                }
+                return sink.transform(control, source, event);
+            }
+
+            @Override
+            public boolean identity()
+            {
+                return true;
+            }
+        };
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(JsonModelDecoderPipelineBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.json.internal.bench;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.json.JsonModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.json.internal.JsonModelHandlerImpl;
+
+/**
+ * Exercises {@code model-json}'s encode {@link ModelPipeline}, the schema-validating transform that
+ * {@code JsonModelHandlerImpl.supplyEncoder} vends per stream: catalog framing prefix on the first
+ * fragment, then the common-json transform into the destination. {@code encodeSmallDocument} and
+ * {@code encodeLargeDocument} drive the same schema over a short and a long value respectively, so the
+ * effect of document size on throughput and allocation (under {@code -prof gc}) is directly comparable.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@Fork(3)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+@OutputTimeUnit(SECONDS)
+public class JsonModelEncoderPipelineBM
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String OBJECT_SCHEMA = """
+        {
+            "type": "object",
+            "properties":
+            {
+                "id": { "type": "string" },
+                "status": { "type": "string" }
+            },
+            "required": [ "id", "status" ]
+        }""";
+
+    private static final String SMALL_DOCUMENT = "{\"id\":\"123\",\"status\":\"OK\"}";
+
+    private static final String LARGE_DOCUMENT =
+        "{\"id\":\"123\",\"status\":\"OK\",\"payload\":\"" + "x".repeat(2048) + "\"}";
+
+    private final MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32 * 1024]);
+
+    private ModelPipeline pipeline;
+
+    private UnsafeBufferEx smallBuffer;
+    private UnsafeBufferEx largeBuffer;
+    private int smallLength;
+    private int largeLength;
+
+    @Setup(Level.Trial)
+    public void init()
+    {
+        JsonModelHandlerImpl handler = newHandler();
+        pipeline = handler.supplyEncoder(ModelTransform.NONE);
+
+        byte[] smallBytes = SMALL_DOCUMENT.getBytes(UTF_8);
+        byte[] largeBytes = LARGE_DOCUMENT.getBytes(UTF_8);
+        smallBuffer = new UnsafeBufferEx(smallBytes);
+        largeBuffer = new UnsafeBufferEx(largeBytes);
+        smallLength = smallBytes.length;
+        largeLength = largeBytes.length;
+    }
+
+    @Benchmark
+    public int encodeSmallDocument()
+    {
+        return run(smallBuffer, smallLength);
+    }
+
+    @Benchmark
+    public int encodeLargeDocument()
+    {
+        return run(largeBuffer, largeLength);
+    }
+
+    private int run(
+        UnsafeBufferEx buffer,
+        int length)
+    {
+        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+            buffer, 0, length, dst, 0, dst.capacity());
+        return result.produced();
+    }
+
+    private JsonModelHandlerImpl newHandler()
+    {
+        EngineContext context = mock(EngineContext.class);
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(9)
+                .schema(OBJECT_SCHEMA)
+                .build()
+            .build();
+        JsonModelConfig model = JsonModelConfig.builder()
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .subject(null)
+                    .version("latest")
+                    .id(9)
+                    .build()
+                .build()
+            .build();
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(mock(MessageConsumer.class));
+        return new JsonModelHandlerImpl(model, context);
+    }
+
+    public static void main(
+        String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+            .include(JsonModelEncoderPipelineBM.class.getSimpleName())
+            .addProfiler("gc")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Description

Adds JMH microbenchmark coverage for `model-json`, closing the gap called out against the existing `common-json` / `common-avro` / `common-protobuf` / `common-yaml` benchmark setups (none of which existed for `model-json` before this change). Running those benchmarks under `-prof gc` then turned up several real, fixable allocation sources in the decode/encode hot path — three of them one layer down, in `common-json`'s schema validator, not just in `model-json` itself.

### Benchmarks added

- `runtime/model-json/src/test/java/.../internal/bench/JsonModelDecoderPipelineBM.java` — `decodeValidDocument` (verbatim fast path, `ModelTransform.NONE`) vs `decodeWithFieldExtraction` (a wired `ModelTransform`), so the field-visit/bridge cost is directly comparable under `-prof gc`.
- `runtime/model-json/src/test/java/.../internal/bench/JsonModelEncoderPipelineBM.java` — `encodeSmallDocument` vs `encodeLargeDocument`, so the effect of document size on throughput/allocation is comparable.
- `runtime/model-json/pom.xml` / `README.md` — the shaded-tests jar setup and run instructions needed to execute the above standalone (mirrors `common-json`'s).
- `runtime/common-json/src/test/java/.../bench/JsonPipelineBM.java` — two new benchmark pairs (`validatePropertiesCanonical`/`Verbatim`, `validateAdditionalCanonical`/`Verbatim`) added alongside the existing `validateCanonical`/`validateVerbatim`, specifically to exercise the `Validator`/`Eval` code paths the fixes below touch, directly in the module where that code lives rather than only indirectly via `model-json`'s benchmarks.

### Allocation fixes found via the above

- **`common-json`** — `JsonSchemaImpl.Validator.reset()` rebuilt its entire `Eval` tree from scratch on every message instead of reusing the in-place `Eval.reset()` that already existed for exactly this purpose. This was the dominant cost, roughly 80% of total allocation across every benchmark.
- **`engine`** — `ModelFieldBridge.Value` re-wrapped a constant empty `byte[]` on every `start()`/`end()` call; `UnsafeBufferEx.wrap(byte[])` allocates a new `MemorySegment` per call, so this now wraps the empty array once and reuses it via reference-swap.
- **`model-json`** — `JsonExtractor`'s field-name dedup search was bounded by a per-document counter that resets every message, so it never actually matched against a previously-seen name — every captured field's name was reallocated on *every* call, not once per distinct name as intended. Also replaced its value-side `String`+`byte[]` materialization with a direct `CharSequence`-to-buffer UTF-8 encoder.
- **`common-json`** — `Eval`'s `fastKeys` optimization (array-scan key matching, no `String`/`HashSet` per key) was gated on an inactive diagnostics trace, so it never applied to `Validator` — diagnostics are always wanted there. Enabling it unconditionally surfaced a real bug: `onFastKey` reads a key via `getStringView()`, whose cursor is shared with whatever renders the same event downstream, and `Validator` forwards to the sink *before* validating (by design, for emit-then-reject ordering) — so a downstream stage could already have exhausted that cursor by the time `onFastKey` read it. Fixed by having `Validator` capture the key into a reused buffer *before* forwarding, while the cursor is still fresh, and feeding `Eval` a small decorator source for that one read. With a reliable read restored, a matched declared property now reuses the schema's own name (no allocation); only an unmatched, fallible `additionalProperties` key still needs the document's own text.

### Results (`gc.alloc.rate.norm` under `-prof gc`)

| Benchmark | Before | After |
|---|---|---|
| `JsonPipelineBM.validateCanonical`/`validateVerbatim` | 144.03 B/op | 0.025 B/op |
| `model-json` `decodeValidDocument` | 984.01 B/op | 0.010 B/op |
| `model-json` `decodeWithFieldExtraction` | 1544.02 B/op | 80.01 B/op (a separate, bounded, documented residual — see below) |
| `model-json` `encodeSmallDocument` | 984.01 B/op | 0.010 B/op |
| `model-json` `encodeLargeDocument` | 1240.13 B/op | 0.104 B/op |
| `JsonPipelineBM.validatePropertiesCanonical`/`Verbatim` (new) | — | 0.027 B/op |
| `JsonPipelineBM.validateAdditionalCanonical`/`Verbatim` (new) | — | 48.01 B/op (expected: the one case that still copies the document's key) |

The remaining 80 B/op in `decodeWithFieldExtraction` is `ExpandableDirectByteBufferEx.segment()` recomputing a `MemorySegment` on every `.wrap()` call in `JsonExtractor`'s field-value buffer — a deliberate lazy-recompute (the buffer can grow, which would invalidate a cached segment), not a bug, left as a documented, bounded cost.

### Testing

- Full `common-json` suite: 4923 tests passing, including the 4373-case `JsonSchemaConformanceTest` and the two tests that caught a real regression on the first (reverted) attempt at the `fastKeys` fix.
- `model-json` and `engine` (`ModelFieldBridge`) suites passing.
- New `JsonModelDecoderPipelineTest` coverage for the hand-rolled UTF-8 encoder: multi-byte characters, surrogate pairs, and unpaired-surrogate replacement, matching `String.getBytes(UTF_8)` byte-for-byte.
- `checkstyle:check` (0 violations), `license:check`.

Fixes # (issue)