### PR TITLE
test(engine): let TestBindingFactory model guard session acquire+release

### DIFF
--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestAuthorizationConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestAuthorizationConfig.java
@@ -25,13 +25,14 @@ public final class TestAuthorizationConfig
     public final String expectIdentity;
     public final String expectCredentials;
     public final Map<String, String> attributes;
+    public final boolean releaseOnEnd;
 
     public TestAuthorizationConfig(
         String name,
         String credentials,
         Map<String, String> attributes)
     {
-        this(name, credentials, null, null, null, null, attributes);
+        this(name, credentials, null, null, null, null, attributes, false);
     }
 
     public TestAuthorizationConfig(
@@ -43,6 +44,19 @@ public final class TestAuthorizationConfig
         String expectCredentials,
         Map<String, String> attributes)
     {
+        this(name, credentials, callback, callbackParams, expectIdentity, expectCredentials, attributes, false);
+    }
+
+    public TestAuthorizationConfig(
+        String name,
+        String credentials,
+        String callback,
+        Map<String, String> callbackParams,
+        String expectIdentity,
+        String expectCredentials,
+        Map<String, String> attributes,
+        boolean releaseOnEnd)
+    {
         this.name = name;
         this.credentials = credentials;
         this.callback = callback;
@@ -50,5 +64,6 @@ public final class TestAuthorizationConfig
         this.expectIdentity = expectIdentity;
         this.expectCredentials = expectCredentials;
         this.attributes = attributes;
+        this.releaseOnEnd = releaseOnEnd;
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigAdapter.java
@@ -51,6 +51,7 @@ public final class TestBindingOptionsConfigAdapter implements JsonbAdapter<Optio
     private static final String EXPECT_IDENTITY_NAME = "expectIdentity";
     private static final String EXPECT_CREDENTIALS_NAME = "expectCredentials";
     private static final String ATTRIBUTES_NAME = "attributes";
+    private static final String RELEASE_ON_END_NAME = "releaseOnEnd";
     private static final String EVENTS_NAME = "events";
     private static final String TIMESTAMP_NAME = "timestamp";
     private static final String MESSAGE_NAME = "message";
@@ -200,7 +201,14 @@ public final class TestBindingOptionsConfigAdapter implements JsonbAdapter<Optio
         {
             JsonObjectBuilder credentials = Json.createObjectBuilder();
             TestAuthorizationConfig authorization = testOptions.authorization;
-            credentials.add(CREDENTIALS_NAME, authorization.credentials);
+            if (authorization.credentials != null)
+            {
+                credentials.add(CREDENTIALS_NAME, authorization.credentials);
+            }
+            if (authorization.releaseOnEnd)
+            {
+                credentials.add(RELEASE_ON_END_NAME, authorization.releaseOnEnd);
+            }
             if (authorization.callback != null)
             {
                 credentials.add(CALLBACK_NAME, authorization.callback);
@@ -367,9 +375,13 @@ public final class TestBindingOptionsConfigAdapter implements JsonbAdapter<Optio
                 if (name != null)
                 {
                     JsonObject guard = authorization.getJsonObject(name);
-                    if (guard.containsKey(CREDENTIALS_NAME))
+                    if (guard.containsKey(CREDENTIALS_NAME) ||
+                        guard.containsKey(EXPECT_IDENTITY_NAME) ||
+                        guard.containsKey(EXPECT_CREDENTIALS_NAME))
                     {
-                        String credentials = guard.getString(CREDENTIALS_NAME);
+                        String credentials = guard.containsKey(CREDENTIALS_NAME)
+                            ? guard.getString(CREDENTIALS_NAME) : null;
+                        boolean releaseOnEnd = guard.getBoolean(RELEASE_ON_END_NAME, false);
                         String callback = guard.containsKey(CALLBACK_NAME) ? guard.getString(CALLBACK_NAME) : null;
                         Map<String, String> callbackParams = null;
                         if (guard.containsKey(CALLBACK_PARAMS_NAME))
@@ -390,7 +402,7 @@ public final class TestBindingOptionsConfigAdapter implements JsonbAdapter<Optio
                                 .forEach((key, value) -> attributes.put(key, ((JsonString) value).getString()));
                         }
                         testOptions.authorization(name, credentials, callback, callbackParams,
-                            expectIdentity, expectCredentials, attributes);
+                            expectIdentity, expectCredentials, attributes, releaseOnEnd);
                     }
                 }
             }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/binding/config/TestBindingOptionsConfigBuilder.java
@@ -117,6 +117,21 @@ public final class TestBindingOptionsConfigBuilder<T> extends ConfigBuilder<T, T
         return this;
     }
 
+    public TestBindingOptionsConfigBuilder<T> authorization(
+        String name,
+        String credentials,
+        String callback,
+        Map<String, String> callbackParams,
+        String expectIdentity,
+        String expectCredentials,
+        Map<String, String> attributes,
+        boolean releaseOnEnd)
+    {
+        this.authorization = new TestAuthorizationConfig(
+            name, credentials, callback, callbackParams, expectIdentity, expectCredentials, attributes, releaseOnEnd);
+        return this;
+    }
+
     public TestBindingOptionsConfigBuilder<T> event(
         long timestamp,
         String message)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/internal/EngineIT.java
@@ -200,4 +200,14 @@ public class EngineIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("server.release.on.end.yaml")
+    @Specification({
+        "${net}/client.write.close/client",
+        "${app}/client.write.close/server"})
+    public void shouldReleaseGuardSessionOnClientSentWriteClose() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.test.internal.binding;
 
 import static io.aklivity.zilla.config.engine.test.internal.binding.config.TestBindingOptionsConfigAdapter.DEFAULT_ASSERTION_SCHEMA;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NEEDS_PREAUTHORIZE;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
 import static java.util.Collections.emptyList;
@@ -77,6 +78,7 @@ final class TestBindingFactory implements BindingHandler
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
+    private static final List<String> EMPTY_ROLES = emptyList();
 
     private final BeginFW beginRO = new BeginFW();
     private final BeginFW.Builder beginRW = new BeginFW.Builder();
@@ -120,6 +122,7 @@ final class TestBindingFactory implements BindingHandler
     private String expectIdentity;
     private String expectCredentials;
     private Map<String, String> attributes;
+    private boolean releaseOnEnd;
     private List<Event> events;
     private int eventIndex;
     private VaultHandler vault;
@@ -181,6 +184,7 @@ final class TestBindingFactory implements BindingHandler
                 this.expectIdentity = options.authorization.expectIdentity;
                 this.expectCredentials = options.authorization.expectCredentials;
                 this.attributes = options.authorization.attributes;
+                this.releaseOnEnd = options.authorization.releaseOnEnd;
             }
 
             this.events = options.events;
@@ -352,7 +356,7 @@ final class TestBindingFactory implements BindingHandler
             long traceId,
             long authorization)
         {
-            if (guard == null)
+            if (guard == null || credentials == null)
             {
                 onAuthorized(traceId, authorization);
             }
@@ -501,7 +505,7 @@ final class TestBindingFactory implements BindingHandler
         {
             long traceId = begin.traceId();
 
-            doAuthorize(traceId, authorization);
+            doAuthorize(traceId, begin.authorization());
 
             if (target == null)
             {
@@ -945,7 +949,12 @@ final class TestBindingFactory implements BindingHandler
         {
             long traceId = end.traceId();
 
-            target.doInitialEnd(traceId);
+            releaseSession();
+
+            if (verifyReleased(traceId))
+            {
+                target.doInitialEnd(traceId);
+            }
         }
 
         private void onInitialAbort(
@@ -953,7 +962,34 @@ final class TestBindingFactory implements BindingHandler
         {
             long traceId = abort.traceId();
 
-            target.doInitialAbort(traceId);
+            releaseSession();
+
+            if (verifyReleased(traceId))
+            {
+                target.doInitialAbort(traceId);
+            }
+        }
+
+        private void releaseSession()
+        {
+            if (releaseOnEnd && guard != null && credentials != null && (authorization & MASK_AUTHORIZED) != 0)
+            {
+                guard.deauthorize(authorization);
+            }
+        }
+
+        private boolean verifyReleased(
+            long traceId)
+        {
+            boolean verified = true;
+
+            if (releaseOnEnd && guard != null && guard.verify(authorization, EMPTY_ROLES))
+            {
+                doInitialReset(traceId);
+                verified = false;
+            }
+
+            return verified;
         }
 
         private void onInitialFlush(

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.release.on.end.yaml
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/config/server.release.on.end.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+guards:
+    test0:
+        type: test
+        options:
+            credentials: TOKEN
+bindings:
+    net0:
+        type: test
+        kind: server
+        options:
+            authorization:
+                test0:
+                    credentials: TOKEN
+                    releaseOnEnd: true
+        exit: app0

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/binding/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/binding/test.schema.patch.json
@@ -206,6 +206,10 @@
                                                         }
                                                     },
                                                     "additionalProperties": false
+                                                },
+                                                "releaseOnEnd":
+                                                {
+                                                    "type": "boolean"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Why

`GuardHandler.reauthorize` acquires a session; `deauthorize` releases it. Whether a binding that acquires a session is obliged to release it, and how a test would prove that a binding does, isn't something the engine's test infrastructure currently supports:

- `TestBindingFactory` (the `type: test` binding used across the test suite) already resolves a guard session via `reauthorize` on its own accepted stream when `options.authorization.<guard>.credentials` is configured, but never calls `deauthorize` — so it isn't a correct example of the acquire+release contract, and no k3po IT anywhere exercises a binding actually releasing a session it acquired.
- Guard-derived values (`identity`, `attribute`, `credentials`) are only compared against `zilla.yaml`-declared expectations once, at `BEGIN` — there's no way to observe, from the wire, whether a session is still valid *after* a stream that carried it has closed.

This makes it hard to write a k3po IT for any binding's guard-session lifecycle (acquire correctly, release correctly on end/abort/reset) — the kind of coverage `runtime/AGENTS.md` calls for ("every state transition... belongs in a k3po IT... run against a live `EngineRule`").

## What changed

Added an opt-in `releaseOnEnd` flag under `options.authorization.<guard>` in the `type: test` binding:

- When this binding resolved its own session (`credentials` configured) and `releaseOnEnd` is set, it now calls `guard.deauthorize(...)` on its own initial `END`/`ABORT` — a correct, minimal acquire+release reference.
- Whenever `releaseOnEnd` is set, it re-checks `guard.verify(authorization, [])` after processing `END`/`ABORT` and resets the stream if the session is unexpectedly still valid — turning "was this session actually released" into an observable pass/fail signal a k3po script can assert against, rather than something only visible by reaching into engine internals.
- The `options.authorization.<guard>` block can now also be configured *without* `credentials` — in that case the binding skips its own `reauthorize` call and uses the incoming `BEGIN`'s authorization value as-is. This lets a `type: test` binding positioned *downstream* of another authorizing binding observe the session id that binding propagated, rather than minting an unrelated one of its own — the shape needed to prove a stream handler released a session another component acquired.

Both new branches are unreachable by any existing configuration (nothing sets `releaseOnEnd`, and no existing config configures a guard without `credentials`), so existing behavior is unchanged. `identity`/`attribute` on `TestGuardHandler` are deliberately left as-is — making them session-validity-aware to serve this same purpose was tried and reverted after it broke over 20 existing ITs across several modules that rely on their current unconditional-return behavior as a static value fixture; `guard.verify(...)` already correctly reflects session validity without touching that surface.

Adds `server.release.on.end.yaml` and an `EngineIT` method (`shouldReleaseGuardSessionOnClientSentWriteClose`) reusing the existing `client.write.close` scripts against it. Confirmed non-vacuous: temporarily removing the `deauthorize` call makes the new test fail.

## Testing

`./mvnw clean verify -pl config/engine.conf,runtime/engine,specs/engine.spec`: green (16/16 `EngineIT` tests, checkstyle clean, JaCoCo met). Also spot-checked `runtime/guard-x509`'s `X509IT` (an existing IT that uses the self-acquire `credentials`+`expectIdentity`/`attributes` pattern this PR touches) — unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG11tAQFQKFnyrqoJ6e7Ee)_