### PR TITLE
fix(engine,binding-mqtt,binding-kafka,binding-mcp): release guard sessions on connection end

### DIFF
--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfig.java
@@ -32,6 +32,7 @@ public final class TestGuardOptionsConfig extends OptionsConfig
     public final Map<String, String> attributes;
     public final String preauthorize;
     public final boolean deferAcquire;
+    public final int maxSessions;
 
     public static TestGuardOptionsConfigBuilder<TestGuardOptionsConfig> builder()
     {
@@ -52,7 +53,8 @@ public final class TestGuardOptionsConfig extends OptionsConfig
         List<String> roles,
         Map<String, String> attributes,
         String preauthorize,
-        boolean deferAcquire)
+        boolean deferAcquire,
+        int maxSessions)
     {
         this.credentials = credentials;
         this.lifetime = Objects.requireNonNull(lifetime);
@@ -62,5 +64,6 @@ public final class TestGuardOptionsConfig extends OptionsConfig
         this.attributes = attributes;
         this.preauthorize = preauthorize;
         this.deferAcquire = deferAcquire;
+        this.maxSessions = maxSessions;
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfigAdapter.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfigAdapter.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.config.engine.test.internal.guard.config;
 
 import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_CHALLENGE_NEVER;
 import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_LIFETIME_FOREVER;
+import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_MAX_SESSIONS_UNLIMITED;
 
 import java.time.Duration;
 
@@ -39,6 +40,7 @@ public final class TestGuardOptionsConfigAdapter implements JsonbAdapter<Options
     private static final String PREAUTHORIZE_NAME = "preauthorize";
     private static final String ACQUIRE_NAME = "acquire";
     private static final String ACQUIRE_DEFERRED = "deferred";
+    private static final String MAX_SESSIONS_NAME = "max-sessions";
 
     @Override
     public JsonObject adaptToJson(
@@ -91,6 +93,11 @@ public final class TestGuardOptionsConfigAdapter implements JsonbAdapter<Options
         if (testOptions.deferAcquire)
         {
             object.add(ACQUIRE_NAME, ACQUIRE_DEFERRED);
+        }
+
+        if (testOptions.maxSessions != DEFAULT_MAX_SESSIONS_UNLIMITED)
+        {
+            object.add(MAX_SESSIONS_NAME, testOptions.maxSessions);
         }
 
         return object.build();
@@ -146,6 +153,11 @@ public final class TestGuardOptionsConfigAdapter implements JsonbAdapter<Options
             if (object.containsKey(ACQUIRE_NAME))
             {
                 testOptions.deferAcquire(ACQUIRE_DEFERRED.equals(object.getString(ACQUIRE_NAME)));
+            }
+
+            if (object.containsKey(MAX_SESSIONS_NAME))
+            {
+                testOptions.maxSessions(object.getInt(MAX_SESSIONS_NAME));
             }
         }
 

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/guard/config/TestGuardOptionsConfigBuilder.java
@@ -31,6 +31,7 @@ public final class TestGuardOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
     public static final String DEFAULT_IDENTITY = "test";
     public static final Duration DEFAULT_CHALLENGE_NEVER = Duration.ofMillis(0L);
     public static final Duration DEFAULT_LIFETIME_FOREVER = Duration.ofMillis(Long.MAX_VALUE);
+    public static final int DEFAULT_MAX_SESSIONS_UNLIMITED = Integer.MAX_VALUE;
 
     private final Function<OptionsConfig, T> mapper;
 
@@ -42,6 +43,7 @@ public final class TestGuardOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
     private Map<String, String> attributes;
     private String preauthorize;
     private boolean deferAcquire;
+    private Integer maxSessions;
 
     TestGuardOptionsConfigBuilder(
         Function<OptionsConfig, T> mapper)
@@ -121,6 +123,13 @@ public final class TestGuardOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
         return this;
     }
 
+    public TestGuardOptionsConfigBuilder<T> maxSessions(
+        int maxSessions)
+    {
+        this.maxSessions = maxSessions;
+        return this;
+    }
+
     @Override
     public T build()
     {
@@ -132,6 +141,7 @@ public final class TestGuardOptionsConfigBuilder<T> extends ConfigBuilder<T, Tes
             roles,
             attributes,
             preauthorize,
-            deferAcquire));
+            deferAcquire,
+            Optional.ofNullable(maxSessions).orElse(DEFAULT_MAX_SESSIONS_UNLIMITED)));
     }
 }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientAlterConfigsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientAlterConfigsFactory.java
@@ -1159,6 +1159,8 @@ public final class KafkaClientAlterConfigsFactory extends KafkaClientSaslHandsha
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbort(
@@ -1173,6 +1175,8 @@ public final class KafkaClientAlterConfigsFactory extends KafkaClientSaslHandsha
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkReset(
@@ -1186,6 +1190,8 @@ public final class KafkaClientAlterConfigsFactory extends KafkaClientSaslHandsha
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientApiFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientApiFactory.java
@@ -21,6 +21,7 @@ import static io.aklivity.zilla.runtime.engine.budget.BudgetDebitor.NO_DEBITOR_I
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -1138,6 +1139,7 @@ public final class KafkaClientApiFactory implements BindingHandler
         private boolean saslResolved;
         private int saslMechanismsRemaining;
         private long guardSession;
+        private boolean guardSessionOwned;
 
         private BudgetDebitor initialDeb;
         private KafkaApiClientDecoder decoder;
@@ -1343,6 +1345,7 @@ public final class KafkaClientApiFactory implements BindingHandler
             final String resolved = guard.credentials(authorization);
             final boolean authorized = resolved != null;
             guardSession = authorized ? authorization : guard.reauthorize(traceId, routedId, initialId, null);
+            guardSessionOwned = !authorized;
 
             if (!authorized && (guardSession & MASK_AUTHORIZED) == 0L)
             {
@@ -1890,6 +1893,8 @@ public final class KafkaClientApiFactory implements BindingHandler
 
             cleanupEncodeSlot();
             cleanupBudget();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetAbort(
@@ -1905,6 +1910,8 @@ public final class KafkaClientApiFactory implements BindingHandler
 
             cleanupEncodeSlot();
             cleanupBudget();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetReset(
@@ -1919,6 +1926,18 @@ public final class KafkaClientApiFactory implements BindingHandler
             }
 
             cleanupDecodeSlot();
+
+            deauthorizeGuardSession();
+        }
+
+        private void deauthorizeGuardSession()
+        {
+            if (guardSessionOwned && (guardSession & MASK_AUTHORIZED) != 0)
+            {
+                guard.deauthorize(guardSession);
+                guardSession = NOT_AUTHORIZED;
+                guardSessionOwned = false;
+            }
         }
 
         private void doNetWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientConnectionPool.java
@@ -1374,6 +1374,8 @@ public final class KafkaClientConnectionPool extends KafkaClientSaslHandshaker
             }
 
             cleanupBudgetCreditorIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doConnectionAbort(
@@ -1388,6 +1390,8 @@ public final class KafkaClientConnectionPool extends KafkaClientSaslHandshaker
             }
 
             cleanupBudgetCreditorIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doConnectionSignalNow(
@@ -1436,6 +1440,8 @@ public final class KafkaClientConnectionPool extends KafkaClientSaslHandshaker
 
                 state = KafkaState.closedReply(state);
             }
+
+            deauthorizeGuardSession();
         }
 
         private void doConnectionWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientCreateTopicsFactory.java
@@ -1231,6 +1231,8 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbort(
@@ -1245,6 +1247,8 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkReset(
@@ -1258,6 +1262,8 @@ public final class KafkaClientCreateTopicsFactory extends KafkaClientSaslHandsha
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDeleteTopicsFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDeleteTopicsFactory.java
@@ -1160,6 +1160,8 @@ public final class KafkaClientDeleteTopicsFactory extends KafkaClientSaslHandsha
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbort(
@@ -1174,6 +1176,8 @@ public final class KafkaClientDeleteTopicsFactory extends KafkaClientSaslHandsha
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkReset(
@@ -1187,6 +1191,8 @@ public final class KafkaClientDeleteTopicsFactory extends KafkaClientSaslHandsha
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeClusterFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeClusterFactory.java
@@ -1162,6 +1162,8 @@ public final class KafkaClientDescribeClusterFactory extends KafkaClientSaslHand
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbort(
@@ -1176,6 +1178,8 @@ public final class KafkaClientDescribeClusterFactory extends KafkaClientSaslHand
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkReset(
@@ -1189,6 +1193,8 @@ public final class KafkaClientDescribeClusterFactory extends KafkaClientSaslHand
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientDescribeFactory.java
@@ -1303,6 +1303,8 @@ public final class KafkaClientDescribeFactory extends KafkaClientSaslHandshaker 
 
                 doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                         traceId, authorization, EMPTY_EXTENSION);
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkAbortIfNecessary(
@@ -1317,6 +1319,8 @@ public final class KafkaClientDescribeFactory extends KafkaClientSaslHandshaker 
 
                 cleanupEncodeSlotIfNecessary();
                 cleanupBudgetIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkResetIfNecessary(
@@ -1330,6 +1334,8 @@ public final class KafkaClientDescribeFactory extends KafkaClientSaslHandshaker 
                 }
 
                 cleanupDecodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientFetchFactory.java
@@ -2541,6 +2541,8 @@ public final class KafkaClientFetchFactory extends KafkaClientSaslHandshaker imp
                         traceId, authorization, EMPTY_OCTETS);
 
                 cleanupEncodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkAbortIfNecessary(
@@ -2554,6 +2556,8 @@ public final class KafkaClientFetchFactory extends KafkaClientSaslHandshaker imp
                 }
 
                 cleanupEncodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkResetIfNecessary(
@@ -2567,6 +2571,8 @@ public final class KafkaClientFetchFactory extends KafkaClientSaslHandshaker imp
                 }
 
                 cleanupDecodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientGroupFactory.java
@@ -2154,6 +2154,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -2169,6 +2171,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -2183,6 +2187,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(
@@ -2921,6 +2927,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -2936,6 +2944,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -2950,6 +2960,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(
@@ -3684,6 +3696,7 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
 
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -3700,6 +3713,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -3714,6 +3729,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(
@@ -4639,6 +4656,7 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
 
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -4657,6 +4675,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         @Override
@@ -4671,6 +4691,8 @@ public final class KafkaClientGroupFactory extends KafkaClientSaslHandshaker imp
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientInitProducerIdFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientInitProducerIdFactory.java
@@ -1127,6 +1127,8 @@ public final class KafkaClientInitProducerIdFactory extends KafkaClientSaslHands
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbortIfNecessary(
@@ -1141,6 +1143,8 @@ public final class KafkaClientInitProducerIdFactory extends KafkaClientSaslHands
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkResetIfNecessary(
@@ -1154,6 +1158,8 @@ public final class KafkaClientInitProducerIdFactory extends KafkaClientSaslHands
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientMetaFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientMetaFactory.java
@@ -1469,6 +1469,8 @@ public final class KafkaClientMetaFactory extends KafkaClientSaslHandshaker impl
 
                 cleanupEncodeSlotIfNecessary();
                 cleanupBudgetIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkAbortIfNecessary(
@@ -1484,6 +1486,8 @@ public final class KafkaClientMetaFactory extends KafkaClientSaslHandshaker impl
 
                 cleanupEncodeSlotIfNecessary();
                 cleanupBudgetIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkResetIfNecessary(
@@ -1497,6 +1501,8 @@ public final class KafkaClientMetaFactory extends KafkaClientSaslHandshaker impl
                 }
 
                 cleanupDecodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetCommitFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetCommitFactory.java
@@ -1276,6 +1276,8 @@ public final class KafkaClientOffsetCommitFactory extends KafkaClientSaslHandsha
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbortIfNecessary(
@@ -1290,6 +1292,8 @@ public final class KafkaClientOffsetCommitFactory extends KafkaClientSaslHandsha
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkResetIfNecessary(
@@ -1303,6 +1307,8 @@ public final class KafkaClientOffsetCommitFactory extends KafkaClientSaslHandsha
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientOffsetFetchFactory.java
@@ -1379,6 +1379,8 @@ public final class KafkaClientOffsetFetchFactory extends KafkaClientSaslHandshak
 
             doEnd(network, originId, routedId, initialId, initialSeq, initialAck, initialMax,
                 traceId, authorization, EMPTY_EXTENSION);
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbortIfNecessary(
@@ -1393,6 +1395,8 @@ public final class KafkaClientOffsetFetchFactory extends KafkaClientSaslHandshak
 
             cleanupEncodeSlotIfNecessary();
             cleanupBudgetIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkResetIfNecessary(
@@ -1406,6 +1410,8 @@ public final class KafkaClientOffsetFetchFactory extends KafkaClientSaslHandshak
             }
 
             cleanupDecodeSlotIfNecessary();
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientProduceFactory.java
@@ -1611,6 +1611,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
                         traceId, authorization, EMPTY_EXTENSION);
 
                 cleanupEncodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkAbortIfNecessary(
@@ -1624,6 +1626,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
                 }
 
                 cleanupEncodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkResetIfNecessary(
@@ -1637,6 +1641,8 @@ public final class KafkaClientProduceFactory extends KafkaClientSaslHandshaker i
                 }
 
                 cleanupDecodeSlotIfNecessary();
+
+                deauthorizeGuardSession();
             }
 
             private void doNetworkWindow(

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaClientSaslHandshaker.java
@@ -16,6 +16,8 @@
 package io.aklivity.zilla.runtime.binding.kafka.internal.stream;
 
 import static io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguration.KAFKA_CLIENT_ID_DEFAULT;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -172,6 +174,7 @@ public abstract class KafkaClientSaslHandshaker
         private LongLongConsumer encodeSaslAuthenticate;
         private KafkaSaslClientDecoder decodeSaslAuthenticate;
         private long guardSession;
+        private boolean guardSessionOwned;
         private final GuardHandler guard;
 
         protected long saslAuthorization;
@@ -206,6 +209,16 @@ public abstract class KafkaClientSaslHandshaker
             this.replyId = supplyReplyId.applyAsLong(initialId);
         }
 
+        protected final void deauthorizeGuardSession()
+        {
+            if (guardSessionOwned && (guardSession & MASK_AUTHORIZED) != 0)
+            {
+                guard.deauthorize(guardSession);
+                guardSession = NOT_AUTHORIZED;
+                guardSessionOwned = false;
+            }
+        }
+
         protected final void doEncodeSaslHandshakeRequest(
             long traceId,
             long budgetId)
@@ -214,9 +227,16 @@ public abstract class KafkaClientSaslHandshaker
                 (CREDENTIALS_TEMPLATE.equals(sasl.token) || CREDENTIALS_TEMPLATE.equals(sasl.password)))
             {
                 final String resolved = guard.credentials(saslAuthorization);
-                guardSession = resolved != null
-                        ? saslAuthorization
-                        : guard.reauthorize(traceId, routedId, initialId, null);
+                if (resolved != null)
+                {
+                    guardSession = saslAuthorization;
+                    guardSessionOwned = false;
+                }
+                else
+                {
+                    guardSession = guard.reauthorize(traceId, routedId, initialId, null);
+                    guardSessionOwned = true;
+                }
             }
 
             final MutableDirectBufferEx encodeBuffer = writeBuffer;

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterSaslIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/DescribeClusterSaslIT.java
@@ -37,7 +37,7 @@ public class DescribeClusterSaslIT
         .addScriptRoot("app", "io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster")
         .addScriptRoot("net", "io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
 
     private final EngineRule engine = new EngineRule()
         .directory("target/zilla-itests")
@@ -67,6 +67,16 @@ public class DescribeClusterSaslIT
     @Configure(name = KAFKA_CLIENT_SASL_SCRAM_NONCE_NAME,
             value = "io.aklivity.zilla.runtime.binding.kafka.internal.stream.DescribeClusterSaslIT::supplyNonce")
     public void shouldDescribeClusterBrokerInfoWithSaslScram() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.options.sasl.plain.max.sessions.yaml")
+    @Specification({
+        "${app}/cluster.brokers.info.twice/client",
+        "${net}/cluster.brokers.info.sasl.plain.twice/server"})
+    public void shouldReleaseGuardSessionAfterEachConnectionWithSaslPlain() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpAuthorizationResult.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpAuthorizationResult.java
@@ -18,6 +18,7 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBearerErro
 
 public record McpAuthorizationResult(
     long authorization,
-    McpBearerError error)
+    McpBearerError error,
+    boolean owned)
 {
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -844,7 +844,7 @@ public final class McpBindingConfig
         HttpBeginExFW httpBeginEx,
         String path)
     {
-        McpAuthorizationResult result = new McpAuthorizationResult(authorization, null);
+        McpAuthorizationResult result = new McpAuthorizationResult(authorization, null, false);
         if (guard != null && !isAuthCallbackPath(path))
         {
             final String authorizationHeader = Optional.ofNullable(httpBeginEx.headers()
@@ -870,10 +870,10 @@ public final class McpBindingConfig
                     : GuardHandler.NOT_AUTHORIZED;
 
                 result = (sessionAuth & GuardHandler.MASK_AUTHORIZED) != 0L
-                    ? new McpAuthorizationResult(sessionAuth, null)
+                    ? new McpAuthorizationResult(sessionAuth, null, true)
                     : new McpAuthorizationResult(authorization, credentials == null
                         ? McpBearerError.INVALID_REQUEST
-                        : McpBearerError.INVALID_TOKEN);
+                        : McpBearerError.INVALID_TOKEN, false);
             }
         }
         return result;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1668,6 +1668,7 @@ public final class McpClientFactory implements McpStreamFactory
 
         protected HttpStream http;
         protected String credentials;
+        protected long guardSessionId = GuardHandler.NOT_AUTHORIZED;
         protected int clientCapabilities;
         protected String authCallback;
         protected int serverCapabilities = SERVER_CAPABILITIES;
@@ -1912,6 +1913,16 @@ public final class McpClientFactory implements McpStreamFactory
 
         abstract McpBindingConfig binding();
 
+        final void deauthorizeGuardSession()
+        {
+            final GuardHandler guard = binding().guard;
+            if (guard != null && (guardSessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
+            {
+                guard.deauthorize(guardSessionId);
+                guardSessionId = GuardHandler.NOT_AUTHORIZED;
+            }
+        }
+
         boolean proceedWithRequest(
             long traceId,
             long authorization,
@@ -1934,6 +1945,7 @@ public final class McpClientFactory implements McpStreamFactory
                     if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
                     {
                         credentials = guard.credentials(sessionId);
+                        guardSessionId = sessionId;
                     }
                 }
             }
@@ -2691,6 +2703,9 @@ public final class McpClientFactory implements McpStreamFactory
         {
             if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
+                deauthorizeGuardSession();
+                guardSessionId = sessionId;
+
                 final McpFlushExFW flushEx = mcpFlushExRW
                     .wrap(extBuffer, 0, extBuffer.capacity())
                     .typeId(mcpTypeId)
@@ -2863,6 +2878,7 @@ public final class McpClientFactory implements McpStreamFactory
         {
             if (sessions.remove(sessionId) != null)
             {
+                deauthorizeGuardSession();
                 cancelKeepalive();
 
                 if (sse != null)
@@ -3048,6 +3064,7 @@ public final class McpClientFactory implements McpStreamFactory
             if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
                 credentials = guard.credentials(sessionId);
+                guardSessionId = sessionId;
                 return true;
             }
 
@@ -3337,6 +3354,7 @@ public final class McpClientFactory implements McpStreamFactory
             if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
                 credentials = session.binding.guard.credentials(sessionId);
+                guardSessionId = sessionId;
                 emitElicitComplete(elicitTraceId, elicitAuthorization);
 
                 http.doEncodeRequestBegin(elicitTraceId, elicitAuthorization);
@@ -3476,6 +3494,7 @@ public final class McpClientFactory implements McpStreamFactory
         {
             if (session.unregister(requestId))
             {
+                deauthorizeGuardSession();
                 new HttpNotifyCancelled(this).doNetBegin(traceId, authorization);
             }
         }
@@ -3487,6 +3506,7 @@ public final class McpClientFactory implements McpStreamFactory
         {
             if (McpState.closed(state))
             {
+                deauthorizeGuardSession();
                 session.unregister(requestId);
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -20,6 +20,7 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_RESOURCES_SUBSCRIBE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
 import static java.lang.Integer.toUnsignedLong;
 
 import java.net.URLDecoder;
@@ -407,6 +408,11 @@ public final class McpServerFactory implements McpStreamFactory
 
             if (sessionId != null && !isSessionIdAligned(routedId, sessionId))
             {
+                if (authResult.owned())
+                {
+                    binding.guard.deauthorize(resolvedAuthorization);
+                }
+
                 newStream = new McpRedirectHandler(
                     sender,
                     originId,
@@ -446,6 +452,7 @@ public final class McpServerFactory implements McpStreamFactory
                         routedId,
                         initialId,
                         resolvedAuthorization,
+                        authResult.owned(),
                         resolvedId,
                         binding,
                         session,
@@ -1463,7 +1470,10 @@ public final class McpServerFactory implements McpStreamFactory
         private final long initialId;
         private final long replyId;
         private final long authorization;
+        private final boolean guardSessionOwned;
         private final long resolvedId;
+
+        private boolean guardSessionDeauthorized;
 
         private McpLifecycleStream session;
 
@@ -1519,6 +1529,7 @@ public final class McpServerFactory implements McpStreamFactory
             long routedId,
             long initialId,
             long authorization,
+            boolean guardSessionOwned,
             long resolvedId,
             McpBindingConfig binding,
             McpLifecycleStream session,
@@ -1533,6 +1544,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.authorization = authorization;
+            this.guardSessionOwned = guardSessionOwned;
             this.resolvedId = resolvedId;
             this.binding = binding;
             this.session = session;
@@ -1928,6 +1940,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
+            deauthorizeGuardSession();
         }
 
         private void doNetAbort(
@@ -1942,6 +1955,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
+            deauthorizeGuardSession();
         }
 
         private void doNetWindow(
@@ -1973,6 +1987,18 @@ public final class McpServerFactory implements McpStreamFactory
                 state = McpState.closedInitial(state);
                 doReset(net, originId, routedId, initialId,
                     initialSeq, initialAck, initialMax, traceId, authorization, extension);
+            }
+
+            deauthorizeGuardSession();
+        }
+
+        private void deauthorizeGuardSession()
+        {
+            if (!guardSessionDeauthorized &&
+                guardSessionOwned && binding.guard != null && (authorization & MASK_AUTHORIZED) != 0L)
+            {
+                guardSessionDeauthorized = true;
+                binding.guard.deauthorize(authorization);
             }
         }
 

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -24,7 +24,10 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTes
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SESSION_ID_NAME;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.McpConfigurationTest.MCP_SSE_KEEPALIVE_INTERVAL_NAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
+
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +40,7 @@ import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
+import io.aklivity.zilla.runtime.engine.test.internal.guard.TestGuardHandler;
 
 public class McpServerIT
 {
@@ -149,6 +153,28 @@ public class McpServerIT
     public void shouldInitializeLifecycleWithGuardedBearer() throws Exception
     {
         k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.guarded.max.sessions.yaml")
+    @Specification({
+        "${net}/lifecycle.initialize.guarded.reauthorize.after.close/client",
+        "${app}/lifecycle.initialize.guarded.reauthorize.after.close/server"})
+    public void shouldReauthorizeGuardedBearerAfterClose() throws Exception
+    {
+        CountDownLatch deauthorized = new CountDownLatch(1);
+        TestGuardHandler.onDeauthorized = deauthorized::countDown;
+        try
+        {
+            k3po.start();
+            assertTrue(deauthorized.await(5, SECONDS));
+            k3po.notifyBarrier("SESSION_RELEASED");
+            k3po.finish();
+        }
+        finally
+        {
+            TestGuardHandler.onDeauthorized = null;
+        }
     }
 
     @Test

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -67,6 +67,8 @@ import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttP
 import static io.aklivity.zilla.runtime.binding.mqtt.internal.types.stream.MqttPublishDataExFW.Builder.DEFAULT_FORMAT;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.concurrent.Signaler.NO_CANCEL_ID;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
+import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -2620,6 +2622,7 @@ public final class MqttServerFactory implements MqttStreamFactory
 
         private int state;
         private long sessionId;
+        private long guardSessionId = NOT_AUTHORIZED;
         private int decodableRemainingBytes;
         private final Int2ObjectHashMap<MqttSubscribeStream> qos1Subscribes;
         private final Int2ObjectHashMap<MqttSubscribeStream> qos2Subscribes;
@@ -3091,6 +3094,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                     if (credentialsMatch != null)
                     {
                         sessionAuth = guard.reauthorize(traceId, routedId, initialId, credentialsMatch);
+                        guardSessionId = sessionAuth;
                     }
                 }
 
@@ -4514,6 +4518,8 @@ public final class MqttServerFactory implements MqttStreamFactory
                 doEnd(network, originId, routedId, replyId, encodeSeq, encodeAck, encodeMax,
                     traceId, authorization, EMPTY_OCTETS);
             }
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkAbort(
@@ -4529,6 +4535,8 @@ public final class MqttServerFactory implements MqttStreamFactory
                 doAbort(network, originId, routedId, replyId, encodeSeq, encodeAck, encodeMax,
                     traceId, authorization, EMPTY_OCTETS);
             }
+
+            deauthorizeGuardSession();
         }
 
         private void doNetworkReset(
@@ -4543,6 +4551,17 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                 doReset(network, originId, routedId, initialId, decodeSeq, decodeAck, decodeMax,
                     traceId, authorization, EMPTY_OCTETS);
+            }
+
+            deauthorizeGuardSession();
+        }
+
+        private void deauthorizeGuardSession()
+        {
+            if (guard != null && (guardSessionId & MASK_AUTHORIZED) != 0)
+            {
+                guard.deauthorize(guardSessionId);
+                guardSessionId = NOT_AUTHORIZED;
             }
         }
 

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/ConnectionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/ConnectionIT.java
@@ -504,4 +504,14 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("server.credentials.username.max.sessions.yaml")
+    @Specification({
+        "${net}/connect.username.reauthorize.after.disconnect/client",
+        "${app}/connect.username.reauthorize.after.disconnect/server"})
+    public void shouldReauthorizeUsernameAfterDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/guard/GuardHandler.java
@@ -79,6 +79,13 @@ public interface GuardHandler
      *       to obtain a URL for the user to visit</li>
      * </ul>
      * </p>
+     * <p>
+     * <b>A positive session id obliges the caller to release it.</b> The caller must invoke
+     * {@link #deauthorize} exactly once with that session id, when the stream or connection
+     * that acquired it ends — whether it closes cleanly, is aborted, or is reset. Neither
+     * {@link #NOT_AUTHORIZED} nor {@link #NEEDS_PREAUTHORIZE} creates a session, so neither
+     * requires a matching {@link #deauthorize} call.
+     * </p>
      *
      * @param traceId    the trace identifier for diagnostics
      * @param bindingId  the binding identifier requesting authorization
@@ -119,6 +126,12 @@ public interface GuardHandler
      * results to the correct stream — typically by issuing a {@code Signaler}
      * signal — without per-call lambda capture.
      * </p>
+     * <p>
+     * The same release obligation as the synchronous overload applies to a positive
+     * session id delivered to {@code completion}: the caller must invoke
+     * {@link #deauthorize} exactly once with that session id, when the stream or
+     * connection that acquired it ends.
+     * </p>
      *
      * @param traceId      the trace identifier for diagnostics
      * @param bindingId    the binding identifier requesting authorization
@@ -137,6 +150,14 @@ public interface GuardHandler
 
     /**
      * Invalidates and releases the given session.
+     * <p>
+     * Every positive session id returned by {@link #reauthorize} must be released with
+     * exactly one matching call to this method, once the stream or connection that
+     * acquired it ends — whether it closes cleanly, is aborted, or is reset. A guard is
+     * entitled to retain per-session state (e.g. identity, attributes, credentials,
+     * expiry) for as long as a session remains unreleased, so an acquiring caller that
+     * never releases causes that state to accumulate for the life of the process.
+     * </p>
      *
      * @param sessionId  the session identifier to deauthorize
      */

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/guard/TestGuardHandler.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.engine.test.internal.guard;
 import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_CHALLENGE_NEVER;
 import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_IDENTITY;
 import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_LIFETIME_FOREVER;
+import static io.aklivity.zilla.config.engine.test.internal.guard.config.TestGuardOptionsConfigBuilder.DEFAULT_MAX_SESSIONS_UNLIMITED;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +40,10 @@ public final class TestGuardHandler implements GuardHandler
     private static final String REDIRECT_URI_PLACEHOLDER = "replace.me";
     private static final Pattern REDIRECT_URI_PARAM_PATTERN = Pattern.compile("redirect_uri=[^&]*");
 
+    // observability hook for tests that need to synchronize on an actual release,
+    // e.g. before opening a second guarded connection constrained by max-sessions
+    public static volatile Runnable onDeauthorized;
+
     private final String credentials;
     private final Duration challenge;
     private final Duration lifetime;
@@ -47,6 +52,7 @@ public final class TestGuardHandler implements GuardHandler
     private final Map<String, String> attributes;
     private final String preauthorize;
     private final boolean deferAcquire;
+    private final int maxSessions;
     private final Consumer<Runnable> dispatcher;
 
     private final Long2LongHashMap sessions;
@@ -64,6 +70,7 @@ public final class TestGuardHandler implements GuardHandler
         this.roles = config.options != null ? config.options.roles : null;
         this.preauthorize = config.options != null ? config.options.preauthorize : null;
         this.deferAcquire = config.options != null && config.options.deferAcquire;
+        this.maxSessions = config.options != null ? config.options.maxSessions : DEFAULT_MAX_SESSIONS_UNLIMITED;
         this.sessions = new Long2LongHashMap(-1L);
         this.nextSessionId = new MutableLong(1L);
         this.attributes = config.options != null ? config.options.attributes : null;
@@ -78,7 +85,13 @@ public final class TestGuardHandler implements GuardHandler
     {
         long sessionId = NOT_AUTHORIZED;
 
-        if (deferAcquire)
+        if (deferAcquire && credentials == null)
+        {
+            // no out-of-band credentials supplied and nothing to await turn-taking on
+            // synchronously -- same shortcut the async completion path takes
+            sessionId = createSession();
+        }
+        else if (deferAcquire)
         {
             sessionId = NOT_AUTHORIZED;
         }
@@ -157,12 +170,18 @@ public final class TestGuardHandler implements GuardHandler
 
     private long createSession()
     {
-        long expiresAt = DEFAULT_LIFETIME_FOREVER.equals(lifetime)
-                ? EXPIRES_NEVER
-                : Instant.now().toEpochMilli() + lifetime.toMillis();
+        long sessionId = NOT_AUTHORIZED;
 
-        long sessionId = nextSessionId.value++;
-        sessions.put(sessionId, expiresAt);
+        if (sessions.size() < maxSessions)
+        {
+            long expiresAt = DEFAULT_LIFETIME_FOREVER.equals(lifetime)
+                    ? EXPIRES_NEVER
+                    : Instant.now().toEpochMilli() + lifetime.toMillis();
+
+            sessionId = nextSessionId.value++;
+            sessions.put(sessionId, expiresAt);
+        }
+
         return sessionId;
     }
 
@@ -171,6 +190,12 @@ public final class TestGuardHandler implements GuardHandler
         long sessionId)
     {
         sessions.remove(sessionId);
+
+        final Runnable notify = onDeauthorized;
+        if (notify != null)
+        {
+            notify.run();
+        }
     }
 
     @Override

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.plain.max.sessions.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/client.options.sasl.plain.max.sessions.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+guards:
+  guard0:
+    type: test
+    options:
+      credentials: password
+      identity: username
+      acquire: deferred
+      max-sessions: 1
+bindings:
+  app0:
+    type: kafka
+    kind: client
+    options:
+      servers:
+        - localhost:9092
+      authorization:
+        guard0:
+          credentials:
+            mechanism: plain
+            username: "{identity}"
+            password: "{credentials}"
+    routes:
+      - exit: net0

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info.twice/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info.twice/client.rpt
@@ -1,0 +1,94 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .request()
+                                 .describeCluster()
+                                    .includeAuthorizedOperations("false")
+                                 .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                               .typeId(zilla:id("kafka"))
+                               .response()
+                                 .describeCluster()
+                                    .throttle(0)
+                                    .error(0)
+                                    .clusterId("cluster-0")
+                                    .controllerId(0)
+                                    .broker()
+                                       .brokerId(1)
+                                       .host("broker1.example.com")
+                                       .port(9092)
+                                       .build()
+                                    .broker()
+                                       .brokerId(2)
+                                       .host("broker2.example.com")
+                                       .port(9092)
+                                       .build()
+                                   .authorizedOperations(0)
+                                   .build()
+                                .build()}
+
+write close
+read closed
+
+connect await CONNECTION_1_CLOSED
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .request()
+                                 .describeCluster()
+                                    .includeAuthorizedOperations("false")
+                                 .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                               .typeId(zilla:id("kafka"))
+                               .response()
+                                 .describeCluster()
+                                    .throttle(0)
+                                    .error(0)
+                                    .clusterId("cluster-0")
+                                    .controllerId(0)
+                                    .broker()
+                                       .brokerId(1)
+                                       .host("broker1.example.com")
+                                       .port(9092)
+                                       .build()
+                                    .broker()
+                                       .brokerId(2)
+                                       .host("broker2.example.com")
+                                       .port(9092)
+                                       .build()
+                                   .authorizedOperations(0)
+                                   .build()
+                                .build()}
+
+write close
+read closed

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info.twice/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/describe.cluster/cluster.brokers.info.twice/server.rpt
@@ -1,0 +1,99 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                               .typeId(zilla:id("kafka"))
+                               .request()
+                                 .describeCluster()
+                                    .includeAuthorizedOperations("false")
+                                 .build()
+                               .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .response()
+                                 .describeCluster()
+                                    .throttle(0)
+                                    .error(0)
+                                    .clusterId("cluster-0")
+                                    .controllerId(0)
+                                    .broker()
+                                       .brokerId(1)
+                                       .host("broker1.example.com")
+                                       .port(9092)
+                                       .build()
+                                    .broker()
+                                       .brokerId(2)
+                                       .host("broker2.example.com")
+                                       .port(9092)
+                                       .build()
+                                   .authorizedOperations(0)
+                                   .build()
+                                .build()}
+write flush
+
+read closed
+write close
+
+write notify CONNECTION_1_CLOSED
+
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                               .typeId(zilla:id("kafka"))
+                               .request()
+                                 .describeCluster()
+                                    .includeAuthorizedOperations("false")
+                                 .build()
+                               .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .response()
+                                 .describeCluster()
+                                    .throttle(0)
+                                    .error(0)
+                                    .clusterId("cluster-0")
+                                    .controllerId(0)
+                                    .broker()
+                                       .brokerId(1)
+                                       .host("broker1.example.com")
+                                       .port(9092)
+                                       .build()
+                                    .broker()
+                                       .brokerId(2)
+                                       .host("broker2.example.com")
+                                       .port(9092)
+                                       .build()
+                                   .authorizedOperations(0)
+                                   .build()
+                                .build()}
+write flush
+
+read closed
+write close

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain.twice/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain.twice/client.rpt
@@ -1,0 +1,160 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property networkConnectWindow 8192
+
+property newRequestId1 ${kafka:newRequestId()}
+property newRequestId2 ${kafka:newRequestId()}
+
+connect "zilla://streams/net0"
+  option zilla:window ${networkConnectWindow}
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write 22                                # size
+      17s                               # sasl.handshake
+      1s                                # v1
+      ${newRequestId1}
+      5s "zilla"                        # client id
+      5s "PLAIN"                        # mechanism
+
+read 17                                 # size
+     ${newRequestId1}
+     0s                                 # no error
+     1                                  # mechanisms
+       5s "PLAIN"                         # PLAIN
+
+write 37                                # size
+      36s                               # sasl.authenticate
+      1s                                # v1
+      ${newRequestId1}
+      5s "zilla"                        # client id
+      18
+      [0x00] "username"                 # authentication bytes
+      [0x00] "password"
+
+read 20                                 # size
+     ${newRequestId1}
+     0s                                 # no error
+     -1
+     -1s                                # authentication bytes
+     0L                                 # session lifetime
+
+write 18                                # size
+      60s                               # describe cluster
+      0s                                # v0
+      ${newRequestId1}
+      5s "zilla"                        # client id
+      [0x00]                            # tagged fields
+      [0x00]                            # include cluster authorized ops
+      [0x00]                            # tagged fields
+
+read  92                                 # size
+      (int:newRequestId1)
+      [0x00]                             # tagged fields
+      0                                  # throttle time ms
+      0s                                 # error code
+      [0x00]                             # error message
+      [0x0a] "cluster-0"                 # cluster id
+      0                                  # controller id
+      [0x03]                             # brokers
+        1                                # broker id
+        [0x14] "broker1.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+        2                                # broker id
+        [0x14] "broker2.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+      0                                  # cluster authorized operations
+      [0x00]                             # tagged fields
+
+write abort
+read aborted
+
+connect "zilla://streams/net0"
+  option zilla:window ${networkConnectWindow}
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write 22                                # size
+      17s                               # sasl.handshake
+      1s                                # v1
+      ${newRequestId2}
+      5s "zilla"                        # client id
+      5s "PLAIN"                        # mechanism
+
+read 17                                 # size
+     ${newRequestId2}
+     0s                                 # no error
+     1                                  # mechanisms
+       5s "PLAIN"                         # PLAIN
+
+write 37                                # size
+      36s                               # sasl.authenticate
+      1s                                # v1
+      ${newRequestId2}
+      5s "zilla"                        # client id
+      18
+      [0x00] "username"                 # authentication bytes
+      [0x00] "password"
+
+read 20                                 # size
+     ${newRequestId2}
+     0s                                 # no error
+     -1
+     -1s                                # authentication bytes
+     0L                                 # session lifetime
+
+write 18                                # size
+      60s                               # describe cluster
+      0s                                # v0
+      ${newRequestId2}
+      5s "zilla"                        # client id
+      [0x00]                            # tagged fields
+      [0x00]                            # include cluster authorized ops
+      [0x00]                            # tagged fields
+
+read  92                                 # size
+      (int:newRequestId2)
+      [0x00]                             # tagged fields
+      0                                  # throttle time ms
+      0s                                 # error code
+      [0x00]                             # error message
+      [0x0a] "cluster-0"                 # cluster id
+      0                                  # controller id
+      [0x03]                             # brokers
+        1                                # broker id
+        [0x14] "broker1.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+        2                                # broker id
+        [0x14] "broker2.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+      0                                  # cluster authorized operations
+      [0x00]                             # tagged fields
+
+write abort
+read aborted

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain.twice/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/network/describe.cluster.v0.sasl.handshake.v1/cluster.brokers.info.sasl.plain.twice/server.rpt
@@ -1,0 +1,159 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property networkAcceptWindow 8192
+
+accept "zilla://streams/net0"
+  option zilla:window ${networkAcceptWindow}
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+
+connected
+
+read 22                                 # size
+     17s                                # sasl.handshake
+     1s                                 # v1
+     (int:requestId1)
+      5s "zilla"                        # client id
+      5s "PLAIN"                        # mechanism
+
+write 17                                # size
+      ${requestId1}
+      0s                                # no error
+      1                                 # mechanisms
+        5s "PLAIN"                        # PLAIN
+
+read 37                                 # size
+     36s                                # sasl.authenticate
+     1s                                 # v1
+     (int:requestId1)
+     5s "zilla"                        # client id
+     18
+     [0x00] "username"                  # authentication bytes
+     [0x00] "password"
+
+write 20                                # size
+      ${requestId1}
+      0s                                # no error
+      -1
+      -1s                               # authentication bytes
+      0L                                # session lifetime
+
+read  18                                # size
+      60s                               # describe cluster
+      0s                                # v0
+      (int:newRequestId1)
+      5s "zilla"                        # client id
+      [0x00]                            # tagged fields
+      [0x00]                            # include cluster authorized ops
+      [0x00]                            # tagged fields
+
+write 92                                 # size
+      ${newRequestId1}
+      [0x00]                             # tagged fields
+      0                                  # throttle time ms
+      0s                                 # error code
+      [0x00]                             # error message
+      [0x0a] "cluster-0"                 # cluster id
+      0                                  # controller id
+      [0x03]                             # brokers
+        1                                # broker id
+        [0x14] "broker1.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+        2                                # broker id
+        [0x14] "broker2.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+      0                                  # cluster authorized operations
+      [0x00]                             # tagged fields
+
+read aborted
+write abort
+
+write notify CONNECTION_1_CLOSED
+
+accepted
+
+connected
+
+read 22                                 # size
+     17s                                # sasl.handshake
+     1s                                 # v1
+     (int:requestId2)
+      5s "zilla"                        # client id
+      5s "PLAIN"                        # mechanism
+
+write 17                                # size
+      ${requestId2}
+      0s                                # no error
+      1                                 # mechanisms
+        5s "PLAIN"                        # PLAIN
+
+read 37                                 # size
+     36s                                # sasl.authenticate
+     1s                                 # v1
+     (int:requestId2)
+     5s "zilla"                        # client id
+     18
+     [0x00] "username"                  # authentication bytes
+     [0x00] "password"
+
+write 20                                # size
+      ${requestId2}
+      0s                                # no error
+      -1
+      -1s                               # authentication bytes
+      0L                                # session lifetime
+
+read  18                                # size
+      60s                               # describe cluster
+      0s                                # v0
+      (int:newRequestId2)
+      5s "zilla"                        # client id
+      [0x00]                            # tagged fields
+      [0x00]                            # include cluster authorized ops
+      [0x00]                            # tagged fields
+
+write 92                                 # size
+      ${newRequestId2}
+      [0x00]                             # tagged fields
+      0                                  # throttle time ms
+      0s                                 # error code
+      [0x00]                             # error message
+      [0x0a] "cluster-0"                 # cluster id
+      0                                  # controller id
+      [0x03]                             # brokers
+        1                                # broker id
+        [0x14] "broker1.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+        2                                # broker id
+        [0x14] "broker2.example.com"     # host
+        9092                             # port
+        [0x00]                           # rack
+        [0x00]                           # tagged fields
+      0                                  # cluster authorized operations
+      [0x00]                             # tagged fields
+
+read aborted
+
+write abort

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeClusterIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/DescribeClusterIT.java
@@ -45,4 +45,13 @@ public class DescribeClusterIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/cluster.brokers.info.twice/client",
+        "${app}/cluster.brokers.info.twice/server"})
+    public void shouldDescribeClusterBrokerInfoTwice() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterSaslIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/network/DescribeClusterSaslIT.java
@@ -55,4 +55,13 @@ public class DescribeClusterSaslIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${net}/cluster.brokers.info.sasl.plain.twice/client",
+        "${net}/cluster.brokers.info.sasl.plain.twice/server"})
+    public void shouldDescribeClusterBrokerInfoTwiceWithSaslPlain() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/server.guarded.max.sessions.yaml
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/config/server.guarded.max.sessions.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+guards:
+  test0:
+    type: test
+    options:
+      credentials: "test-token"
+      max-sessions: 1
+bindings:
+  net0:
+    type: mcp
+    kind: server
+    options:
+      authorization:
+        test0:
+          credentials: "Bearer {credentials}"
+    exit: app0

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.guarded.reauthorize.after.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.guarded.reauthorize.after.close/server.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+       option zilla:authorization 1L
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-1")
+                               .build()
+                           .build()}
+write flush
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+       option zilla:authorization 2L
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("session-2")
+                               .build()
+                           .build()}
+write flush

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.guarded.reauthorize.after.close/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.guarded.reauthorize.after.close/client.rpt
@@ -1,0 +1,76 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("authorization", "Bearer test-token")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed
+
+connect await SESSION_RELEASED "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "POST")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("content-type", "application/json")
+                            .header("accept", "application/json, text/event-stream")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("authorization", "Bearer test-token")
+                            .build()}
+
+connected
+
+write '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+write close
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":status", "200")
+                           .header("content-type", "application/json")
+                           .header("mcp-session-id", "transport-1")
+                           .build()}
+
+read '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.guarded.reauthorize.after.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.initialize.guarded.reauthorize.after.close/server.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("authorization", "Bearer test-token")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+write notify SESSION_RELEASED
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("authorization", "Bearer test-token")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "transport-1")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -137,6 +137,15 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.initialize.guarded.reauthorize.after.close/client",
+        "${net}/lifecycle.initialize.guarded.reauthorize.after.close/server"})
+    public void shouldReauthorizeGuardedBearerAfterClose() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/tools.call.reject.bearer/client",
         "${net}/tools.call.reject.bearer/server"})
     public void shouldRejectToolsCallOnUpstreamBearerChallenge() throws Exception

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.username.max.sessions.yaml
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/config/server.credentials.username.max.sessions.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+stores:
+  test0:
+    type: test
+guards:
+  test0:
+    type: test
+    options:
+      credentials: TOKEN
+      lifetime: PT5S
+      challenge: PT5S
+      max-sessions: 1
+bindings:
+  net0:
+    type: mqtt
+    kind: server
+    options:
+      store: test0
+      authorization:
+        test0:
+          credentials:
+            connect:
+              username: Bearer {credentials}
+    routes:
+      - exit: app0
+        guarded:
+          test0: []

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.username.reauthorize.after.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/connect.username.reauthorize.after.disconnect/server.rpt
@@ -1,0 +1,47 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+        option zilla:authorization 2L
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("CLEAN_START")
+                                .clientId("client2")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("client2")
+                                .build()
+                              .build()}
+
+connected
+
+write zilla:data.empty
+write flush

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.reauthorize.after.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.reauthorize.after.disconnect/client.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x26]                   # CONNECT
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x82]                        # flags = username, clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x05]                        # properties
+      [0x27] 33792                  # maximum packet size = 33792
+      [0x00 0x06] "client"          # client id
+      [0x00 0x0c] "Bearer TOKEN"    # username
+
+write abort
+read aborted
+read notify FIRST_ABORTED
+
+connect await FIRST_ABORTED "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x27]                   # CONNECT
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x82]                        # flags = username, clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x05]                        # properties
+      [0x27] 33792                  # maximum packet size = 33792
+      [0x00 0x07] "client2"         # client id
+      [0x00 0x0c] "Bearer TOKEN"    # username
+
+read  [0x20 0x03]                   # CONNACK
+      [0x00]                        # flags = none
+      [0x00]                        # reason code -- succeeds only if the first
+                                     # guard session was released on disconnect
+      [0x00]                        # properties = none
+
+write [0xe0 0x02]                   # DISCONNECT
+      [0x00]                        # normal disconnect
+      [0x00]                        # properties = none
+
+write close
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.reauthorize.after.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/connect.username.reauthorize.after.disconnect/server.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0x26]                   # CONNECT
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x82]                        # flags = username, clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x05]                        # properties
+      [0x27] 33792                  # maximum packet size = 33792
+      [0x00 0x06] "client"          # client id
+      [0x00 0x0c] "Bearer TOKEN"    # username
+
+read aborted
+write abort
+
+accepted
+connected
+
+read  [0x10 0x27]                   # CONNECT
+      [0x00 0x04] "MQTT"            # protocol name
+      [0x05]                        # protocol version
+      [0x82]                        # flags = username, clean start
+      [0x00 0x3c]                   # keep alive = 60s
+      [0x05]                        # properties
+      [0x27] 33792                  # maximum packet size = 33792
+      [0x00 0x07] "client2"         # client id
+      [0x00 0x0c] "Bearer TOKEN"    # username
+
+write [0x20 0x03]                   # CONNACK
+      [0x00]                        # flags = none
+      [0x00]                        # reason code
+      [0x00]                        # properties
+
+read  [0xe0 0x02]                   # DISCONNECT
+      [0x00]                        # normal disconnect
+      [0x00]                        # properties = none
+
+read closed
+write close

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ConnectionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/ConnectionIT.java
@@ -472,4 +472,13 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${net}/connect.username.reauthorize.after.disconnect/client",
+        "${net}/connect.username.reauthorize.after.disconnect/server"})
+    public void shouldReauthorizeUsernameAfterDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/guard/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/guard/test.schema.patch.json
@@ -78,6 +78,11 @@
                             {
                                 "enum": [ "immediate", "deferred" ],
                                 "default": "immediate"
+                            },
+                            "max-sessions":
+                            {
+                                "type": "integer",
+                                "minimum": 0
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
## Description

`GuardHandler.reauthorize()` acquires a guard session that must be released via `GuardHandler.deauthorize()` when the acquiring stream/connection ends — cleanly, aborted, or reset. Previously only `binding-http` did this. `binding-mqtt`, `binding-kafka`, and `binding-mcp` never called `deauthorize`, causing unbounded growth of guard-held session state (identity, attributes, credentials) for long-running gateways.

Changes:

- **`GuardHandler` SPI**: javadoc on `reauthorize()`/`deauthorize()` now states plainly that a session acquired via `reauthorize()` must be released via `deauthorize()` when the acquiring stream ends.
- **`TestGuardHandler`** (engine test double): added a `max-sessions` option that caps concurrent sessions, so a test can prove release actually happened (a second session can only be acquired if the first was released), rather than only exercising the guard's own `deauthorize()` in isolation.
- **`binding-mqtt`**: `MqttServerFactory` now tracks the guard session acquired during CONNECT username/password authorization and releases it from `doNetworkEnd`/`doNetworkAbort`/`doNetworkReset`, so the session is released however the connection ends.
- **`binding-kafka`**: `KafkaClientSaslHandshaker` (shared base for all Kafka client stream factories) now tracks whether a guard session was acquired by this client (as opposed to a borrowed/pass-through authorization it doesn't own) and releases it on connection end; wired into all 13 `KafkaClient*Factory` classes plus the reconnecting `KafkaApiClient`.
- **`binding-mcp`**: both `McpServerFactory` (HTTP bearer auth) and `McpClientFactory` (elicitation reauthorization) now release guard sessions they acquire, again distinguishing owned sessions from borrowed ones. Also fixed a session-redirect path where a freshly-acquired session was dropped without release when the request redirected to a different session owner.

Each binding has a new k3po test (spec-level peer test + runtime engine-driven test) that configures `max-sessions: 1` and reconnects, proving the second connection can only succeed if the first connection's guard session was actually released.

Fixes #2355.

## Test plan

- [x] `./mvnw -pl runtime/binding-mqtt -am clean verify` — 350 tests, 0 failures
- [x] `./mvnw -pl runtime/binding-kafka -am clean verify` — full module, 0 failures
- [x] `./mvnw -pl runtime/binding-mcp -am clean verify` — full module, 0 failures
- [x] `./mvnw checkstyle:check` across all touched modules
- [x] Full repo `./mvnw install -DskipITs` (193 modules) — all touched modules green; only unrelated failure is `cloud/docker-image` (no Docker daemon in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEfdHRfZBpjrsx9j1pAjQ)_