### PR TITLE
fix(binding-mcp): preserve per-request elicitation timeout across proxy relay

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -233,6 +233,8 @@ abstract class McpProxyItemFactory implements BindingHandler
                 }
                 else if (executeCache != null)
                 {
+                    final long timeout = timeout(beginEx);
+
                     newStream = new McpExecuteToolServer(
                         binding,
                         lifecycle,
@@ -242,7 +244,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                         initialId,
                         affinity,
                         authorization,
-                        timeout(beginEx))::onExecuteToolMessage;
+                        timeout)::onExecuteToolMessage;
                 }
                 else
                 {

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -241,7 +241,8 @@ abstract class McpProxyItemFactory implements BindingHandler
                         routedId,
                         initialId,
                         affinity,
-                        authorization)::onExecuteToolMessage;
+                        authorization,
+                        timeout(beginEx))::onExecuteToolMessage;
                 }
                 else
                 {
@@ -250,6 +251,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                     {
                         final String identifier = route.strip(beginEx);
                         final int contentLength = contentLength(beginEx);
+                        final long timeout = timeout(beginEx);
                         final String prefix = route.prefix(beginEx);
 
                         newStream = new McpServer(
@@ -264,6 +266,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                             authorization,
                             identifier,
                             contentLength,
+                            timeout,
                             prefix)::onServerMessage;
                     }
                 }
@@ -425,7 +428,8 @@ abstract class McpProxyItemFactory implements BindingHandler
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength);
+        int contentLength,
+        long timeout);
 
     protected abstract void injectReplyBeginEx(
         McpBeginExFW.Builder builder,
@@ -436,6 +440,9 @@ abstract class McpProxyItemFactory implements BindingHandler
         McpBeginExFW beginEx);
 
     protected abstract int contentLength(
+        McpBeginExFW beginEx);
+
+    protected abstract long timeout(
         McpBeginExFW beginEx);
 
     private final class McpServer
@@ -451,6 +458,7 @@ abstract class McpProxyItemFactory implements BindingHandler
         private final long authorization;
         private final String identifier;
         private final int contentLength;
+        private final long timeout;
         private final String prefix;
         private boolean prefixStripped;
         private ExpandableDirectByteBufferEx prefixCarryBuffer;
@@ -486,6 +494,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             long authorization,
             String identifier,
             int contentLength,
+            long timeout,
             String prefix)
         {
             this.binding = binding;
@@ -499,6 +508,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             this.authorization = authorization;
             this.identifier = identifier;
             this.contentLength = contentLength;
+            this.timeout = timeout;
             this.prefix = prefix;
             this.toolSchemaId = kind == McpBeginExFW.KIND_TOOLS_CALL && binding.validatesTools()
                 ? binding.toolSchemaId(prefix + identifier)
@@ -1739,6 +1749,7 @@ abstract class McpProxyItemFactory implements BindingHandler
         private final long replyId;
         private final long affinity;
         private final long authorization;
+        private final long timeout;
         private final McpExecuteToolCallScanner scanner;
         // survives the async gap between registering for the delegate's upstream lifecycle to settle
         // and that settlement actually happening -- unlike the factory's shared, per-worker scratch
@@ -1772,7 +1783,8 @@ abstract class McpProxyItemFactory implements BindingHandler
             long routedId,
             long initialId,
             long affinity,
-            long authorization)
+            long authorization,
+            long timeout)
         {
             this.binding = binding;
             this.lifecycle = lifecycle;
@@ -1783,6 +1795,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.affinity = affinity;
             this.authorization = authorization;
+            this.timeout = timeout;
             this.scanner = new McpExecuteToolCallScanner();
         }
 
@@ -2058,6 +2071,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                 authorization,
                 identifier,
                 prefix.length() + bodyLength,
+                timeout,
                 prefix);
 
             driveDelegateBegin(traceId);
@@ -2329,7 +2343,8 @@ abstract class McpProxyItemFactory implements BindingHandler
                 final McpBeginExFW beginEx = mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
-                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier, server.contentLength - server.prefix.length()))
+                    .inject(b -> injectInitialBeginEx(b, sid, server.identifier,
+                        server.contentLength - server.prefix.length(), server.timeout))
                     .build();
 
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsGetFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyPromptsGetFactory.java
@@ -36,9 +36,10 @@ final class McpProxyPromptsGetFactory extends McpProxyItemFactory
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength)
+        int contentLength,
+        long timeout)
     {
-        builder.promptsGet(p -> p.sessionId(sessionId).name(identifier).contentLength(contentLength));
+        builder.promptsGet(p -> p.sessionId(sessionId).name(identifier).contentLength(contentLength).timeout(timeout));
     }
 
     @Override
@@ -62,5 +63,12 @@ final class McpProxyPromptsGetFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.promptsGet().contentLength();
+    }
+
+    @Override
+    protected long timeout(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.promptsGet().timeout();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesReadFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesReadFactory.java
@@ -36,9 +36,10 @@ final class McpProxyResourcesReadFactory extends McpProxyItemFactory
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength)
+        int contentLength,
+        long timeout)
     {
-        builder.resourcesRead(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength));
+        builder.resourcesRead(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength).timeout(timeout));
     }
 
     @Override
@@ -62,5 +63,12 @@ final class McpProxyResourcesReadFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.resourcesRead().contentLength();
+    }
+
+    @Override
+    protected long timeout(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.resourcesRead().timeout();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesSubscribeFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesSubscribeFactory.java
@@ -36,9 +36,10 @@ final class McpProxyResourcesSubscribeFactory extends McpProxyItemFactory
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength)
+        int contentLength,
+        long timeout)
     {
-        builder.resourcesSubscribe(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength));
+        builder.resourcesSubscribe(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength).timeout(timeout));
     }
 
     @Override
@@ -62,5 +63,12 @@ final class McpProxyResourcesSubscribeFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.resourcesSubscribe().contentLength();
+    }
+
+    @Override
+    protected long timeout(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.resourcesSubscribe().timeout();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesUnsubscribeFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyResourcesUnsubscribeFactory.java
@@ -36,9 +36,10 @@ final class McpProxyResourcesUnsubscribeFactory extends McpProxyItemFactory
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength)
+        int contentLength,
+        long timeout)
     {
-        builder.resourcesUnsubscribe(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength));
+        builder.resourcesUnsubscribe(r -> r.sessionId(sessionId).uri(identifier).contentLength(contentLength).timeout(timeout));
     }
 
     @Override
@@ -62,5 +63,12 @@ final class McpProxyResourcesUnsubscribeFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.resourcesUnsubscribe().contentLength();
+    }
+
+    @Override
+    protected long timeout(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.resourcesUnsubscribe().timeout();
     }
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsCallFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyToolsCallFactory.java
@@ -36,9 +36,10 @@ final class McpProxyToolsCallFactory extends McpProxyItemFactory
         McpBeginExFW.Builder builder,
         String sessionId,
         String identifier,
-        int contentLength)
+        int contentLength,
+        long timeout)
     {
-        builder.toolsCall(t -> t.sessionId(sessionId).name(identifier).contentLength(contentLength));
+        builder.toolsCall(t -> t.sessionId(sessionId).name(identifier).contentLength(contentLength).timeout(timeout));
     }
 
     @Override
@@ -62,5 +63,12 @@ final class McpProxyToolsCallFactory extends McpProxyItemFactory
         McpBeginExFW beginEx)
     {
         return beginEx.toolsCall().contentLength();
+    }
+
+    @Override
+    protected long timeout(
+        McpBeginExFW beginEx)
+    {
+        return beginEx.toolsCall().timeout();
     }
 }


### PR DESCRIPTION
## Description

`McpProxyItemFactory` (and its `tools/call`, `prompts/get`, `resources/read`, `resources/subscribe`, `resources/unsubscribe` subclasses) replays a client's original request onto the south exit binding after the proxy's lifecycle handshake settles. That replay built the new `BeginEx` without carrying forward the original request's `timeout` field.

`McpClientFactory` reads this per-request `timeout` to decide whether to hold a guard `CHALLENGE` open (`timeout > 0`, via `Signaler.signalAt`) or reset+abort the stream immediately (`timeout <= 0`). Because the proxy always dropped the value to 0 on relay, any south exit route guarded with an elicitation-based reauthorization (e.g. `guard-oauth`'s DCR + authorization-code flow) would abort immediately after issuing the `CHALLENGE`, before the client had any chance to act on the elicitation URL — regardless of what timeout the client actually requested.

Fix: thread `timeout` through `injectInitialBeginEx` and a new `timeout(beginEx)` accessor on each of the five affected factories, so the south relay preserves the caller's requested value.

Found and reproduced while verifying `aklivity/zilla-plus`'s MCP proxy DCR example (`examples/mcp.proxy`) end-to-end against a live Keycloak instance — the `everything_connect` toolkit's `elicitation/create` (mode:url) → held-open `tools/call` → `notifications/elicitation/complete` chain aborted immediately instead of staying open for the interactive login. Independently confirmed on real CI in `aklivity/zilla-plus#1134` (job `testing (mcp.proxy)`, against the published `zilla:2.1.1` release).

Note: `McpProxyListFactory` (backing `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`) has the same structural gap — `McpClientFactory` reads `.timeout()` uniformly for those kinds too, but `injectInitialBeginEx` there has no `timeout` parameter at all. Left out of this PR since it wasn't part of the reproduced bug (list requests aren't typically guarded); tracked as a likely follow-up.

Fixes # (issue)

## Test plan

- [x] Confirmed the bug reproduces end-to-end via `zilla-plus`'s `examples/mcp.proxy` DCR scenario, and via real CI on `zilla-plus#1134`
- [x] `./mvnw install -pl runtime/binding-mcp -am` compiles clean
- [ ] Regression k3po coverage for the timeout-preservation behavior — the existing `application/tools.call.elicit.timeout.proxied` scenario (`McpProxyIT#shouldCallToolElicitTimeoutProxied`) exercises the same lifecycle-then-replay path but never asserts a nonzero `.timeout(...)` on either side, so it doesn't catch this regression (verified: passes identically before and after this fix). Follow-up: extend that scenario's `client.rpt`/`server.rpt` (and the sibling scenarios for `prompts.get`, `resources.read`, `resources.subscribe`, `resources.unsubscribe`) to set and assert a nonzero timeout across the relay.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9YgtMNWpwmS5uhaw3KNzz)_