### PR TITLE
feat(engine): extend VaultHandler SPI with wrap/unwrap KMS operations

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
@@ -21,8 +21,11 @@ import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
 /**
- * Provides access to TLS cryptographic material from an attached vault.
+ * Provides access to cryptographic material from an attached vault, for TLS contexts and
+ * for wrapping and unwrapping named keys.
  * <p>
  * Obtained from {@link VaultContext#attach(VaultConfig)}, a {@code VaultHandler} resolves
  * named key and certificate references from the vault's backing store (e.g., a PKCS#12 file
@@ -119,4 +122,81 @@ public interface VaultHandler
      */
     TrustManagerFactory initTrust(
         KeyStore cacerts);
+
+    /**
+     * Wraps a data encryption key under the named key held by this vault, without the
+     * data encryption key's raw material ever leaving the vault's implementation.
+     * <p>
+     * The result is delivered asynchronously to {@code next}, since resolving the named
+     * key may require a call outside this thread. On success, {@code next} receives the
+     * wrapped bytes; on failure (e.g., the named key could not be resolved), {@code next}
+     * receives a {@code null} buffer and the caller treats the operation as failed. The
+     * reason for a failure is reported separately, through this vault's own diagnostics.
+     * </p>
+     *
+     * @param traceId  the trace identifier correlating this operation with its caller
+     * @param name     the vault-specific name of the key to wrap under
+     * @param dek      the buffer containing the data encryption key to wrap
+     * @param index    the index within {@code dek} at which the data encryption key begins
+     * @param length   the length in bytes of the data encryption key
+     * @param next     invoked with the wrapped bytes on success, or a {@code null} buffer
+     *                 on failure
+     */
+    default void wrap(
+        long traceId,
+        String name,
+        DirectBufferEx dek,
+        int index,
+        int length,
+        BytesConsumer next)
+    {
+        next.accept(null, 0, 0);
+    }
+
+    /**
+     * Unwraps a data encryption key under the named key held by this vault, without the
+     * data encryption key's raw material ever leaving the vault's implementation.
+     * <p>
+     * The result is delivered asynchronously to {@code next}, since resolving the named
+     * key may require a call outside this thread. On success, {@code next} receives the
+     * unwrapped bytes; on failure (e.g., the named key could not be resolved), {@code next}
+     * receives a {@code null} buffer and the caller treats the operation as failed. The
+     * reason for a failure is reported separately, through this vault's own diagnostics.
+     * </p>
+     *
+     * @param traceId  the trace identifier correlating this operation with its caller
+     * @param name     the vault-specific name of the key to unwrap under
+     * @param edek     the buffer containing the wrapped data encryption key
+     * @param index    the index within {@code edek} at which the wrapped data encryption
+     *                 key begins
+     * @param length   the length in bytes of the wrapped data encryption key
+     * @param next     invoked with the unwrapped bytes on success, or a {@code null} buffer
+     *                 on failure
+     */
+    default void unwrap(
+        long traceId,
+        String name,
+        DirectBufferEx edek,
+        int index,
+        int length,
+        BytesConsumer next)
+    {
+        next.accept(null, 0, 0);
+    }
+
+    /**
+     * Receives the result of a {@link #wrap} or {@link #unwrap} operation.
+     * <p>
+     * A {@code null} buffer signals that the operation failed; the reason is reported
+     * separately, through the vault's own diagnostics.
+     * </p>
+     */
+    @FunctionalInterface
+    interface BytesConsumer
+    {
+        void accept(
+            DirectBufferEx buffer,
+            int index,
+            int length);
+    }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/vault/VaultHandler.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 
 /**
  * Provides access to cryptographic material from an attached vault, for TLS contexts and
- * for wrapping and unwrapping named keys.
+ * for wrapping and unwrapping arbitrary byte buffers under a named key.
  * <p>
  * Obtained from {@link VaultContext#attach(VaultConfig)}, a {@code VaultHandler} resolves
  * named key and certificate references from the vault's backing store (e.g., a PKCS#12 file
@@ -124,8 +124,8 @@ public interface VaultHandler
         KeyStore cacerts);
 
     /**
-     * Wraps a data encryption key under the named key held by this vault, without the
-     * data encryption key's raw material ever leaving the vault's implementation.
+     * Wraps a buffer of bytes under the named key held by this vault, without the key's
+     * raw material ever leaving the vault's implementation.
      * <p>
      * The result is delivered asynchronously to {@code next}, since resolving the named
      * key may require a call outside this thread. On success, {@code next} receives the
@@ -135,17 +135,17 @@ public interface VaultHandler
      * </p>
      *
      * @param traceId  the trace identifier correlating this operation with its caller
-     * @param name     the vault-specific name of the key to wrap under
-     * @param dek      the buffer containing the data encryption key to wrap
-     * @param index    the index within {@code dek} at which the data encryption key begins
-     * @param length   the length in bytes of the data encryption key
+     * @param key      the vault-specific name of the key to wrap under
+     * @param bytes    the buffer containing the bytes to wrap
+     * @param index    the index within {@code bytes} at which the bytes to wrap begin
+     * @param length   the length in bytes of the data to wrap
      * @param next     invoked with the wrapped bytes on success, or a {@code null} buffer
      *                 on failure
      */
     default void wrap(
         long traceId,
-        String name,
-        DirectBufferEx dek,
+        String key,
+        DirectBufferEx bytes,
         int index,
         int length,
         BytesConsumer next)
@@ -154,8 +154,8 @@ public interface VaultHandler
     }
 
     /**
-     * Unwraps a data encryption key under the named key held by this vault, without the
-     * data encryption key's raw material ever leaving the vault's implementation.
+     * Unwraps a buffer of previously wrapped bytes under the named key held by this vault,
+     * without the key's raw material ever leaving the vault's implementation.
      * <p>
      * The result is delivered asynchronously to {@code next}, since resolving the named
      * key may require a call outside this thread. On success, {@code next} receives the
@@ -165,18 +165,17 @@ public interface VaultHandler
      * </p>
      *
      * @param traceId  the trace identifier correlating this operation with its caller
-     * @param name     the vault-specific name of the key to unwrap under
-     * @param edek     the buffer containing the wrapped data encryption key
-     * @param index    the index within {@code edek} at which the wrapped data encryption
-     *                 key begins
-     * @param length   the length in bytes of the wrapped data encryption key
+     * @param key      the vault-specific name of the key to unwrap under
+     * @param bytes    the buffer containing the wrapped bytes to unwrap
+     * @param index    the index within {@code bytes} at which the wrapped bytes begin
+     * @param length   the length in bytes of the wrapped data
      * @param next     invoked with the unwrapped bytes on success, or a {@code null} buffer
      *                 on failure
      */
     default void unwrap(
         long traceId,
-        String name,
-        DirectBufferEx edek,
+        String key,
+        DirectBufferEx bytes,
         int index,
         int length,
         BytesConsumer next)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/VaultHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/VaultHandlerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.test.internal.vault;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.security.KeyStore;
+import java.util.List;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.vault.VaultHandler;
+
+public class VaultHandlerTest
+{
+    @Test
+    public void shouldFailWrapWithNoOverride()
+    {
+        VaultHandler handler = new EmptyVaultHandler();
+        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.wrap(1L, "kek", dek, 0, dek.capacity(), captured::accept);
+
+        assertNull(captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(0, captured.length);
+    }
+
+    @Test
+    public void shouldFailUnwrapWithNoOverride()
+    {
+        VaultHandler handler = new EmptyVaultHandler();
+        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.unwrap(1L, "kek", edek, 0, edek.capacity(), captured::accept);
+
+        assertNull(captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(0, captured.length);
+    }
+
+    @Test
+    public void shouldWrapNamedKey()
+    {
+        VaultHandler handler = new NamedKeyVaultHandler("kek");
+        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.wrap(1L, "kek", dek, 0, dek.capacity(), captured::accept);
+
+        assertSame(dek, captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(dek.capacity(), captured.length);
+    }
+
+    @Test
+    public void shouldFailWrapWithUnnamedKey()
+    {
+        VaultHandler handler = new NamedKeyVaultHandler("kek");
+        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.wrap(1L, "unknown", dek, 0, dek.capacity(), captured::accept);
+
+        assertNull(captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(0, captured.length);
+    }
+
+    @Test
+    public void shouldUnwrapNamedKey()
+    {
+        VaultHandler handler = new NamedKeyVaultHandler("kek");
+        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.unwrap(1L, "kek", edek, 0, edek.capacity(), captured::accept);
+
+        assertSame(edek, captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(edek.capacity(), captured.length);
+    }
+
+    @Test
+    public void shouldFailUnwrapWithUnnamedKey()
+    {
+        VaultHandler handler = new NamedKeyVaultHandler("kek");
+        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        CapturedResult captured = new CapturedResult();
+
+        handler.unwrap(1L, "unknown", edek, 0, edek.capacity(), captured::accept);
+
+        assertNull(captured.buffer);
+        assertEquals(0, captured.index);
+        assertEquals(0, captured.length);
+    }
+
+    private static final class CapturedResult
+    {
+        private DirectBufferEx buffer;
+        private int index;
+        private int length;
+
+        private void accept(
+            DirectBufferEx buffer,
+            int index,
+            int length)
+        {
+            this.buffer = buffer;
+            this.index = index;
+            this.length = length;
+        }
+    }
+
+    private static class EmptyVaultHandler implements VaultHandler
+    {
+        @Override
+        public KeyManagerFactory initKeys(
+            List<String> keyRefs)
+        {
+            return null;
+        }
+
+        @Override
+        public KeyManagerFactory initKeys()
+        {
+            return null;
+        }
+
+        @Override
+        public KeyManagerFactory initSigners(
+            List<String> signerRefs)
+        {
+            return null;
+        }
+
+        @Override
+        public KeyManagerFactory initSigners()
+        {
+            return null;
+        }
+
+        @Override
+        public TrustManagerFactory initTrust(
+            List<String> certRefs,
+            KeyStore cacerts)
+        {
+            return null;
+        }
+
+        @Override
+        public TrustManagerFactory initTrust(
+            KeyStore cacerts)
+        {
+            return null;
+        }
+    }
+
+    private static final class NamedKeyVaultHandler extends EmptyVaultHandler
+    {
+        private final String name;
+
+        private NamedKeyVaultHandler(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public void wrap(
+            long traceId,
+            String name,
+            DirectBufferEx dek,
+            int index,
+            int length,
+            BytesConsumer next)
+        {
+            if (this.name.equals(name))
+            {
+                next.accept(dek, index, length);
+            }
+            else
+            {
+                next.accept(null, 0, 0);
+            }
+        }
+
+        @Override
+        public void unwrap(
+            long traceId,
+            String name,
+            DirectBufferEx edek,
+            int index,
+            int length,
+            BytesConsumer next)
+        {
+            if (this.name.equals(name))
+            {
+                next.accept(edek, index, length);
+            }
+            else
+            {
+                next.accept(null, 0, 0);
+            }
+        }
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/VaultHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/vault/VaultHandlerTest.java
@@ -37,10 +37,10 @@ public class VaultHandlerTest
     public void shouldFailWrapWithNoOverride()
     {
         VaultHandler handler = new EmptyVaultHandler();
-        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
         CapturedResult captured = new CapturedResult();
 
-        handler.wrap(1L, "kek", dek, 0, dek.capacity(), captured::accept);
+        handler.wrap(1L, "kek", bytes, 0, bytes.capacity(), captured::accept);
 
         assertNull(captured.buffer);
         assertEquals(0, captured.index);
@@ -51,10 +51,10 @@ public class VaultHandlerTest
     public void shouldFailUnwrapWithNoOverride()
     {
         VaultHandler handler = new EmptyVaultHandler();
-        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
         CapturedResult captured = new CapturedResult();
 
-        handler.unwrap(1L, "kek", edek, 0, edek.capacity(), captured::accept);
+        handler.unwrap(1L, "kek", bytes, 0, bytes.capacity(), captured::accept);
 
         assertNull(captured.buffer);
         assertEquals(0, captured.index);
@@ -62,27 +62,27 @@ public class VaultHandlerTest
     }
 
     @Test
-    public void shouldWrapNamedKey()
+    public void shouldWrapWithNamedKey()
     {
         VaultHandler handler = new NamedKeyVaultHandler("kek");
-        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
         CapturedResult captured = new CapturedResult();
 
-        handler.wrap(1L, "kek", dek, 0, dek.capacity(), captured::accept);
+        handler.wrap(1L, "kek", bytes, 0, bytes.capacity(), captured::accept);
 
-        assertSame(dek, captured.buffer);
+        assertSame(bytes, captured.buffer);
         assertEquals(0, captured.index);
-        assertEquals(dek.capacity(), captured.length);
+        assertEquals(bytes.capacity(), captured.length);
     }
 
     @Test
-    public void shouldFailWrapWithUnnamedKey()
+    public void shouldFailWrapWithUnknownKey()
     {
         VaultHandler handler = new NamedKeyVaultHandler("kek");
-        DirectBufferEx dek = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x01, 0x02, 0x03, 0x04 });
         CapturedResult captured = new CapturedResult();
 
-        handler.wrap(1L, "unknown", dek, 0, dek.capacity(), captured::accept);
+        handler.wrap(1L, "unknown", bytes, 0, bytes.capacity(), captured::accept);
 
         assertNull(captured.buffer);
         assertEquals(0, captured.index);
@@ -90,27 +90,27 @@ public class VaultHandlerTest
     }
 
     @Test
-    public void shouldUnwrapNamedKey()
+    public void shouldUnwrapWithNamedKey()
     {
         VaultHandler handler = new NamedKeyVaultHandler("kek");
-        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
         CapturedResult captured = new CapturedResult();
 
-        handler.unwrap(1L, "kek", edek, 0, edek.capacity(), captured::accept);
+        handler.unwrap(1L, "kek", bytes, 0, bytes.capacity(), captured::accept);
 
-        assertSame(edek, captured.buffer);
+        assertSame(bytes, captured.buffer);
         assertEquals(0, captured.index);
-        assertEquals(edek.capacity(), captured.length);
+        assertEquals(bytes.capacity(), captured.length);
     }
 
     @Test
-    public void shouldFailUnwrapWithUnnamedKey()
+    public void shouldFailUnwrapWithUnknownKey()
     {
         VaultHandler handler = new NamedKeyVaultHandler("kek");
-        DirectBufferEx edek = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
+        DirectBufferEx bytes = new UnsafeBufferEx(new byte[] { 0x05, 0x06, 0x07, 0x08 });
         CapturedResult captured = new CapturedResult();
 
-        handler.unwrap(1L, "unknown", edek, 0, edek.capacity(), captured::accept);
+        handler.unwrap(1L, "unknown", bytes, 0, bytes.capacity(), captured::accept);
 
         assertNull(captured.buffer);
         assertEquals(0, captured.index);
@@ -180,26 +180,26 @@ public class VaultHandlerTest
 
     private static final class NamedKeyVaultHandler extends EmptyVaultHandler
     {
-        private final String name;
+        private final String key;
 
         private NamedKeyVaultHandler(
-            String name)
+            String key)
         {
-            this.name = name;
+            this.key = key;
         }
 
         @Override
         public void wrap(
             long traceId,
-            String name,
-            DirectBufferEx dek,
+            String key,
+            DirectBufferEx bytes,
             int index,
             int length,
             BytesConsumer next)
         {
-            if (this.name.equals(name))
+            if (this.key.equals(key))
             {
-                next.accept(dek, index, length);
+                next.accept(bytes, index, length);
             }
             else
             {
@@ -210,15 +210,15 @@ public class VaultHandlerTest
         @Override
         public void unwrap(
             long traceId,
-            String name,
-            DirectBufferEx edek,
+            String key,
+            DirectBufferEx bytes,
             int index,
             int length,
             BytesConsumer next)
         {
-            if (this.name.equals(name))
+            if (this.key.equals(key))
             {
-                next.accept(edek, index, length);
+                next.accept(bytes, index, length);
             }
             else
             {


### PR DESCRIPTION
## Description

Extends `VaultHandler` — currently TLS-only (`initKeys`, `initSigners`, `initTrust`) — with wrap/unwrap operations against named keys, so a KEK held in an external key manager can wrap and unwrap data encryption keys without its raw key material ever leaving the KMS.

- Adds a `BytesConsumer` functional interface nested inside `VaultHandler` (not placed in `common-agrona`, since nothing else needs the shape yet).
- Adds default `wrap(traceId, name, dek, index, length, next)` / `unwrap(traceId, name, edek, index, length, next)` methods. The default implementations are no-ops that signal failure through the same callback (`next.accept(null, 0, 0)`) rather than never invoking it — a `null` buffer is the "this failed" signal, matching what a real KMS-backed implementation uses for a genuine runtime failure.
- Shaped asynchronously from the start (result delivered via callback, not a return value), since KMS-backed vault implementations make network calls on a reactor-confined thread.
- Diagnostics for *why* an operation failed belong in the vault's own telemetry event, not the callback — unchanged by this PR.
- Existing vault types (`vault-filesystem`, `TestVault`, etc.) are unaffected — no overrides added, so their behavior is unchanged.
- Javadoc stays protocol-neutral per `runtime/engine/AGENTS.md`.

## Testing

Added `VaultHandlerTest`:
- Confirms the null-buffer failure signal fires for both `wrap` and `unwrap` when no override is present.
- Adds a minimal test vault implementation (`NamedKeyVaultHandler`) exercising both the success and failure path of each callback (matched key name vs. unknown key name).

Verified `./mvnw checkstyle:check` and the full `runtime/engine` unit test suite pass.

Fixes #1678


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHWo89NTcBdA3gd5zZajbQ)_