### PR TITLE
feat(engine): add per-message authorization to ModelPipeline.transform

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModel.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModel.java
@@ -26,10 +26,10 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
  * Per-stream driver around a decode {@link ModelPipeline} for the http binding.
  * <p>
  * Scalar metadata (header, path and query values) is transformed whole-value via the
- * {@link #transform(long, long, DirectBufferEx, int, int)} overload: the value is driven through the
+ * {@link #transform(long, long, long, DirectBufferEx, int, int)} overload: the value is driven through the
  * pipeline and the produced (possibly changed) bytes are exposed via {@link #buffer} / {@link #produced}
  * for the caller to substitute downstream, or {@code -1} signals the model rejected it. Streaming content
- * is transformed via {@link #transform(long, long, int, DirectBufferEx, int, int, int)}: each fragment is
+ * is transformed via {@link #transform(long, long, long, int, DirectBufferEx, int, int, int)}: each fragment is
  * driven through the pipeline and the produced bytes are exposed for the caller to forward downstream.
  * </p>
  */
@@ -71,6 +71,7 @@ public final class HttpModel
     public int transform(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit)
@@ -90,7 +91,7 @@ public final class HttpModel
             boolean done = false;
             while (!done)
             {
-                final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+                final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
                     data, srcAt, limit, scratch, total, scratch.capacity());
                 final ModelStatus status = result.status();
 
@@ -123,13 +124,14 @@ public final class HttpModel
     public int transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
         int srcLimit,
         int dstMax)
     {
-        final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+        final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
             src, srcIndex, srcLimit, scratch, 0, dstMax);
         final ModelStatus status = result.status();
 

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -5130,7 +5130,8 @@ public final class HttpClientFactory implements HttpStreamFactory
                 final int responseNoAck = (int)(responseSeq - responseAck);
                 final int window = Math.max(responseMax - responseNoAck - responsePad, 0);
                 final int dstMax = Math.min(window, modelBuffer.capacity());
-                final int consumed = content.transform(traceId, routedId, flags, buffer, offset, limit, dstMax);
+                final int consumed =
+                    content.transform(traceId, routedId, authorization, flags, buffer, offset, limit, dstMax);
 
                 if (consumed < 0)
                 {
@@ -5393,7 +5394,8 @@ public final class HttpClientFactory implements HttpStreamFactory
                         final HttpModel model = response.headers.get(name);
                         if (model != null && model != HttpModel.NONE)
                         {
-                            final int produced = model.transform(traceId, routedId, value.value(), 0, value.length());
+                            final int produced =
+                                model.transform(traceId, routedId, requestAuth, value.value(), 0, value.length());
                             if (produced < 0)
                             {
                                 modelValid.value = false;

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -2367,7 +2367,8 @@ public final class HttpServerFactory implements HttpStreamFactory
         {
             final HttpExchange exchange = new HttpExchange(originId, routedId, requestId, affinity,
                 authorization, traceId, policy, origin, requestType);
-            final HttpBeginExFW transformedBeginEx = transformRequestBeginEx(traceId, routedId, beginEx, requestType);
+            final HttpBeginExFW transformedBeginEx =
+                transformRequestBeginEx(traceId, routedId, authorization, beginEx, requestType);
             boolean headersValid = transformedBeginEx != null;
             if (headersValid)
             {
@@ -2961,7 +2962,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 else
                 {
                     final int dstMax = Math.min(window, modelBuffer.capacity());
-                    final int consumed = content.transform(traceId, routedId, flags & FLAG_COM,
+                    final int consumed = content.transform(traceId, routedId, sessionId, flags & FLAG_COM,
                         buffer, offset, limit, dstMax);
 
                     if (consumed < 0)
@@ -3421,6 +3422,7 @@ public final class HttpServerFactory implements HttpStreamFactory
     private HttpBeginExFW transformRequestBeginEx(
         long traceId,
         long routedId,
+        long authorization,
         HttpBeginExFW beginEx,
         HttpRequestType requestType)
     {
@@ -3444,7 +3446,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                     final String16FW value = header.value();
                     if (HEADER_PATH.equals(name))
                     {
-                        final String path = transformPath(traceId, routedId, value.asString(), requestType);
+                        final String path =
+                            transformPath(traceId, routedId, authorization, value.asString(), requestType);
                         if (path == null)
                         {
                             modelValid.value = false;
@@ -3459,7 +3462,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                         final HttpModel model = requestType.headers.get(name);
                         if (model != null && model != HttpModel.NONE)
                         {
-                            final int produced = model.transform(traceId, routedId, value.value(), 0, value.length());
+                            final int produced =
+                                model.transform(traceId, routedId, authorization, value.value(), 0, value.length());
                             if (produced < 0)
                             {
                                 modelValid.value = false;
@@ -3485,6 +3489,7 @@ public final class HttpServerFactory implements HttpStreamFactory
     private String transformPath(
         long traceId,
         long routedId,
+        long authorization,
         String path,
         HttpRequestType requestType)
     {
@@ -3502,7 +3507,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 if (start >= 0)
                 {
                     final int end = pathMatcher.end(entry.getKey());
-                    final String produced = transformValue(traceId, routedId, model, path, start, end);
+                    final String produced = transformValue(traceId, routedId, authorization, model, path, start, end);
                     valid = produced != null;
                     if (!valid)
                     {
@@ -3524,7 +3529,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 {
                     final int start = queryMatcher.start(2);
                     final int end = queryMatcher.end(2);
-                    final String produced = transformValue(traceId, routedId, model, path, start, end);
+                    final String produced = transformValue(traceId, routedId, authorization, model, path, start, end);
                     valid = produced != null;
                     if (valid)
                     {
@@ -3555,13 +3560,14 @@ public final class HttpServerFactory implements HttpStreamFactory
     private String transformValue(
         long traceId,
         long routedId,
+        long authorization,
         HttpModel model,
         String value,
         int start,
         int end)
     {
         final int length = modelValueBuffer.putStringWithoutLengthUtf8(0, value.substring(start, end));
-        final int produced = model.transform(traceId, routedId, modelValueBuffer, 0, length);
+        final int produced = model.transform(traceId, routedId, authorization, modelValueBuffer, 0, length);
         return produced < 0 ? null : model.buffer().getStringWithoutLengthUtf8(0, produced);
     }
 
@@ -5341,7 +5347,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                                 streamId, exchangeAuth, traceId, policy, origin, contentLength, requestType);
 
                             final HttpBeginExFW transformedBeginEx =
-                                transformRequestBeginEx(traceId, routedId, beginEx, requestType);
+                                transformRequestBeginEx(traceId, routedId, exchangeAuth, beginEx, requestType);
                             boolean headersValid = transformedBeginEx != null;
                             if (headersValid)
                             {
@@ -6150,7 +6156,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                 {
                     final int window = Math.max(Math.min(initialWindow() - requestPad, remaining.value), 0);
                     final int dstMax = Math.min(window, modelBuffer.capacity());
-                    final int consumed = content.transform(traceId, routedId, flags, buffer, 0, remaining.value, dstMax);
+                    final int consumed =
+                        content.transform(traceId, routedId, sessionId, flags, buffer, 0, remaining.value, dstMax);
 
                     if (consumed < 0)
                     {

--- a/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModelTest.java
+++ b/runtime/binding-http/src/test/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModelTest.java
@@ -40,7 +40,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(5, produced);
         assertValue(model, produced, "hello");
@@ -51,7 +51,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        assertEquals(-1, model.transform(0L, 0L, value("nope"), 0, 4));
+        assertEquals(-1, model.transform(0L, 0L, 0L, value("nope"), 0, 4));
     }
 
     @Test
@@ -59,7 +59,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5, 8), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(8, produced);
         assertValue(model, 5, "hello");
@@ -70,7 +70,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5, 3), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(3, produced);
         assertValue(model, produced, "hel");
@@ -87,7 +87,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int consumed = model.transform(0L, 0L, FLAGS_COMPLETE, value("hello"), 0, 5, 256);
+        int consumed = model.transform(0L, 0L, 0L, FLAGS_COMPLETE, value("hello"), 0, 5, 256);
 
         assertEquals(5, consumed);
         assertEquals(5, model.produced());
@@ -99,7 +99,7 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int consumed = model.transform(0L, 0L, FLAGS_COMPLETE, value("nope"), 0, 4, 256);
+        int consumed = model.transform(0L, 0L, 0L, FLAGS_COMPLETE, value("nope"), 0, 4, 256);
 
         assertEquals(-1, consumed);
     }
@@ -109,12 +109,12 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(10), new UnsafeBufferEx(new byte[256]));
 
-        int consumed1 = model.transform(0L, 0L, FLAGS_INIT, value("hello"), 0, 5, 256);
+        int consumed1 = model.transform(0L, 0L, 0L, FLAGS_INIT, value("hello"), 0, 5, 256);
         assertEquals(5, consumed1);
         assertEquals(5, model.produced());
         assertOutput(model, "hello");
 
-        int consumed2 = model.transform(0L, 0L, FLAGS_FIN, value("world"), 0, 5, 256);
+        int consumed2 = model.transform(0L, 0L, 0L, FLAGS_FIN, value("world"), 0, 5, 256);
         assertEquals(5, consumed2);
         assertEquals(5, model.produced());
         assertOutput(model, "world");
@@ -125,12 +125,12 @@ public class HttpModelTest
     {
         HttpModel model = HttpModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int consumed1 = model.transform(0L, 0L, FLAGS_COMPLETE, value("hello"), 0, 5, 2);
+        int consumed1 = model.transform(0L, 0L, 0L, FLAGS_COMPLETE, value("hello"), 0, 5, 2);
         assertEquals(2, consumed1);
         assertEquals(2, model.produced());
         assertOutput(model, "he");
 
-        int consumed2 = model.transform(0L, 0L, FLAGS_FIN, value("hello"), 2, 5, 256);
+        int consumed2 = model.transform(0L, 0L, 0L, FLAGS_FIN, value("hello"), 2, 5, 256);
         assertEquals(3, consumed2);
         assertEquals(3, model.produced());
         assertOutput(model, "llo");

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
@@ -78,6 +78,7 @@ public final class KafkaCacheModel
     public int transform(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit,
@@ -98,7 +99,7 @@ public final class KafkaCacheModel
             boolean done = false;
             while (!done)
             {
-                final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+                final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
                     data, srcAt, limit, scratch, 0, scratch.capacity());
                 final ModelStatus status = result.status();
                 final int produced = result.produced();

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -353,6 +353,7 @@ public final class KafkaCachePartition
         EngineContext context,
         long traceId,
         long bindingId,
+        long authorization,
         long offset,
         MutableInteger entryMark,
         MutableInteger valueMark,
@@ -368,17 +369,18 @@ public final class KafkaCachePartition
         boolean verbose)
     {
         final int valueLength = value != null ? value.sizeof() : -1;
-        writeEntryStart(context, traceId, bindingId, offset, entryMark, valueMark, timestamp, timestampType, producerId, key,
-            valueLength, null, entryFlags, deltaType, value, pipeline, verbose);
+        writeEntryStart(context, traceId, bindingId, authorization, offset, entryMark, valueMark, timestamp, timestampType,
+            producerId, key, valueLength, null, entryFlags, deltaType, value, pipeline, verbose);
         writeEntryContinue(value);
-        writeEntryFinish(headers, deltaType, context, traceId, bindingId, FLAGS_COMPLETE, offset, entryMark, valueMark,
-            pipeline, verbose);
+        writeEntryFinish(headers, deltaType, context, traceId, bindingId, authorization, FLAGS_COMPLETE, offset, entryMark,
+            valueMark, pipeline, verbose);
     }
 
     public void writeEntryStart(
         EngineContext context,
         long traceId,
         long bindingId,
+        long authorization,
         long offset,
         MutableInteger entryMark,
         MutableInteger valueMark,
@@ -475,7 +477,7 @@ public final class KafkaCachePartition
             entrySink.begin(null);
 
             OctetsFW value = key.value();
-            int transformed = pipeline.transformKey(traceId, bindingId,
+            int transformed = pipeline.transformKey(traceId, bindingId, authorization,
                     value.buffer(), value.offset(), value.limit(), writeKey, entrySink);
 
             if (transformed == -1)
@@ -556,6 +558,7 @@ public final class KafkaCachePartition
         EngineContext context,
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         long offset,
         MutableInteger entryMark,
@@ -606,7 +609,7 @@ public final class KafkaCachePartition
             {
                 entrySink.begin(trailersRW.wrap(trailersRW.buffer(), 0, trailersRW.maxLimit()));
 
-                int transformed = pipeline.transformValue(traceId, bindingId, logFile.buffer(),
+                int transformed = pipeline.transformValue(traceId, bindingId, authorization, logFile.buffer(),
                     valueMark.value, valueMark.value + valueLength, consumeTransformed, entrySink);
                 if (transformed == -1)
                 {
@@ -704,6 +707,7 @@ public final class KafkaCachePartition
     public int writeProduceEntryStart(
         long traceId,
         long bindingId,
+        long authorization,
         long offset,
         Node head,
         MutableInteger entryMark,
@@ -798,7 +802,7 @@ public final class KafkaCachePartition
                     logFile.appendBytes(buffer, index, length);
                 };
 
-                transformed = transformKey.transform(traceId, bindingId,
+                transformed = transformKey.transform(traceId, bindingId, authorization,
                     value.buffer(), value.offset(), value.limit(), writeKey);
 
                 if (transformed == -1)
@@ -834,6 +838,7 @@ public final class KafkaCachePartition
     public int writeProduceEntryContinue(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         Node head,
         MutableInteger entryMark,
@@ -872,7 +877,7 @@ public final class KafkaCachePartition
                 final int valueLength = valueLimit.value - valueMark.value;
                 if ((flags & FLAGS_FIN) != 0x00)
                 {
-                    transformed = transformValue.transform(traceId, bindingId, logFile.buffer(),
+                    transformed = transformValue.transform(traceId, bindingId, authorization, logFile.buffer(),
                         valueMark.value, valueMark.value + valueLength, consumeTransformed);
                 }
             }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipeline.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipeline.java
@@ -180,50 +180,54 @@ public final class KafkaPipeline
      * Drives the key through its model, selecting the key lane for the transform chain. A stage may append
      * to the key lane while this runs; appending to any other lane is not supported.
      *
-     * @param traceId    the trace identifier for diagnostics
-     * @param bindingId  the binding identifier
-     * @param data       the buffer holding the untransformed key
-     * @param index      the offset of the key
-     * @param limit      the offset just past the key
-     * @param next       receives the transformed key bytes
-     * @param sink       the terminal each lane's content is written through
+     * @param traceId       the trace identifier for diagnostics
+     * @param bindingId     the binding identifier
+     * @param authorization the authorization in effect for the message being transformed
+     * @param data          the buffer holding the untransformed key
+     * @param index         the offset of the key
+     * @param limit         the offset just past the key
+     * @param next          receives the transformed key bytes
+     * @param sink          the terminal each lane's content is written through
      * @return the transformed key length, or {@code -1} if the key was rejected
      */
     public int transformKey(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit,
         KafkaCacheModel.Output next,
         KafkaSink sink)
     {
-        return drive(key, KafkaEvent.SWITCH_KEY, traceId, bindingId, data, index, limit, next, sink);
+        return drive(key, KafkaEvent.SWITCH_KEY, traceId, bindingId, authorization, data, index, limit, next, sink);
     }
 
     /**
      * Drives the value through its model, selecting the value lane for the transform chain. A stage may
      * append to the headers lane while this runs; appending to the key lane is not supported.
      *
-     * @param traceId    the trace identifier for diagnostics
-     * @param bindingId  the binding identifier
-     * @param data       the buffer holding the untransformed value
-     * @param index      the offset of the value
-     * @param limit      the offset just past the value
-     * @param next       receives the transformed value bytes
-     * @param sink       the terminal each lane's content is written through
+     * @param traceId       the trace identifier for diagnostics
+     * @param bindingId     the binding identifier
+     * @param authorization the authorization in effect for the message being transformed
+     * @param data          the buffer holding the untransformed value
+     * @param index         the offset of the value
+     * @param limit         the offset just past the value
+     * @param next          receives the transformed value bytes
+     * @param sink          the terminal each lane's content is written through
      * @return the transformed value length, or {@code -1} if the value was rejected
      */
     public int transformValue(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit,
         KafkaCacheModel.Output next,
         KafkaSink sink)
     {
-        return drive(value, KafkaEvent.SWITCH_VALUE, traceId, bindingId, data, index, limit, next, sink);
+        return drive(value, KafkaEvent.SWITCH_VALUE, traceId, bindingId, authorization, data, index, limit, next, sink);
     }
 
     /**
@@ -257,6 +261,7 @@ public final class KafkaPipeline
         KafkaEvent lane,
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit,
@@ -266,7 +271,7 @@ public final class KafkaPipeline
         this.sink = guard.begin(lane, sink);
         transform.reset();
 
-        final int transformed = model.transform(traceId, bindingId, data, index, limit, next);
+        final int transformed = model.transform(traceId, bindingId, authorization, data, index, limit, next);
 
         this.sink = ANNOUNCE;
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -718,7 +718,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     assert partitionOffset >= 0 && partitionOffset >= nextOffset
                         : String.format("%d >= 0 && %d >= %d", partitionOffset, partitionOffset, nextOffset);
 
-                    if (partition.writeProduceEntryStart(traceId, routedId, partitionOffset, stream.segment,
+                    if (partition.writeProduceEntryStart(traceId, routedId, authorization, partitionOffset, stream.segment,
                         stream.entryMark, stream.valueMark, stream.valueLimit, timestamp, stream.initialId,
                         producerId, producerEpoch, sequence, ackMode, key, valueLength,
                         headers, trailersSizeMax, valueFragment, transformKey, transformValue) == -1)
@@ -737,7 +737,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
 
             if (valueFragment != null && error == NO_ERROR)
             {
-                if (partition.writeProduceEntryContinue(traceId, routedId, flags, stream.segment,
+                if (partition.writeProduceEntryContinue(traceId, routedId, authorization, flags, stream.segment,
                         stream.entryMark, stream.valueMark, stream.valueLimit,
                         valueFragment, transformValue) == -1)
                 {
@@ -798,10 +798,10 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                 assert partitionOffset >= 0 && partitionOffset >= nextOffset
                     : String.format("%d >= 0 && %d >= %d", partitionOffset, partitionOffset, nextOffset);
 
-                partition.writeProduceEntryStart(traceId, routedId, partitionOffset, stream.segment, stream.entryMark,
-                    stream.valueMark, stream.valueLimit, now().toEpochMilli(), stream.initialId, PRODUCE_FLUSH_PRODUCER_ID,
-                    PRODUCE_FLUSH_PRODUCER_EPOCH, PRODUCE_FLUSH_SEQUENCE, KafkaAckMode.LEADER_ONLY, EMPTY_KEY,
-                    0, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, transformKey, transformValue);
+                partition.writeProduceEntryStart(traceId, routedId, authorization, partitionOffset, stream.segment,
+                    stream.entryMark, stream.valueMark, stream.valueLimit, now().toEpochMilli(), stream.initialId,
+                    PRODUCE_FLUSH_PRODUCER_ID, PRODUCE_FLUSH_PRODUCER_EPOCH, PRODUCE_FLUSH_SEQUENCE, KafkaAckMode.LEADER_ONLY,
+                    EMPTY_KEY, 0, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, transformKey, transformValue);
                 stream.partitionOffset = partitionOffset;
                 partitionOffset++;
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -102,6 +102,10 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
 
     private static final int ERROR_NOT_LEADER_FOR_PARTITION = 6;
 
+    // populating the cache from the topic itself, ahead of any consumer's authorized read, carries no
+    // per-consumer authorization to thread through the model pipeline
+    private static final long NO_AUTHORIZATION = 0L;
+
     private static final DirectBufferEx EMPTY_BUFFER = new UnsafeBufferEx();
     private static final OctetsFW EMPTY_OCTETS = new OctetsFW().wrap(EMPTY_BUFFER, 0, 0);
     private static final Consumer<OctetsFW.Builder> EMPTY_EXTENSION = ex -> {};
@@ -819,8 +823,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                     entryFlags |= CACHE_ENTRY_FLAGS_ABORTED;
                 }
 
-                partition.writeEntry(context, traceId, routedId, partitionOffset, entryMark, valueMark, timestamp, AUTHORITATIVE,
-                    producerId, EMPTY_KEY, EMPTY_HEADERS, EMPTY_OCTETS,
+                partition.writeEntry(context, traceId, routedId, NO_AUTHORIZATION, partitionOffset, entryMark, valueMark,
+                    timestamp, AUTHORITATIVE, producerId, EMPTY_KEY, EMPTY_HEADERS, EMPTY_OCTETS,
                     entryFlags, KafkaDeltaType.NONE, pipeline, verbose);
 
                 if (result == KafkaTransactionResult.ABORT)
@@ -926,7 +930,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 final int entryFlags =
                     ((flags & FLAGS_SKIP) != 0x00 ? CACHE_ENTRY_FLAGS_ABORTED : 0x00) |
                     (timestampType == AUTHORITATIVE ? CACHE_ENTRY_FLAGS_AUTHORITATIVE : 0x00);
-                partition.writeEntryStart(context, traceId, routedId, partitionOffset, entryMark, valueMark,
+                partition.writeEntryStart(context, traceId, routedId, NO_AUTHORIZATION, partitionOffset, entryMark, valueMark,
                     timestamp, timestampType, producerId, key, valueLength, findAncestor, entryFlags, deltaType, valueFragment,
                     pipeline, verbose);
             }
@@ -952,8 +956,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                 assert partitionId == partition.id();
                 assert partitionOffset >= this.partitionOffset;
 
-                partition.writeEntryFinish(headers, deltaType, context, traceId, routedId, flags, partitionOffset,
-                    entryMark, valueMark, pipeline, verbose);
+                partition.writeEntryFinish(headers, deltaType, context, traceId, routedId, NO_AUTHORIZATION, flags,
+                    partitionOffset, entryMark, valueMark, pipeline, verbose);
 
                 this.partitionOffset = partitionOffset;
                 this.stableOffset = stableOffset;

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
@@ -53,7 +53,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
 
         assertEquals(5, produced);
         assertOutput("hello");
@@ -64,7 +64,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("nope"), 0, 4, sink);
+        int produced = model.transform(0L, 0L, 0L, value("nope"), 0, 4, sink);
 
         assertEquals(-1, produced);
     }
@@ -74,7 +74,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5, 8), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
 
         assertEquals(8, produced);
         assertEquals(8, outputLength.value);
@@ -88,7 +88,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5, 3), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
 
         assertEquals(3, produced);
         assertOutput("hel");
@@ -99,7 +99,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[2]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
 
         assertEquals(5, produced);
         assertOutput("hello");
@@ -110,7 +110,7 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.encoder(handler(3), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("abc"), 0, 3, sink);
+        int produced = model.transform(0L, 0L, 0L, value("abc"), 0, 3, sink);
 
         assertEquals(3, produced);
         assertOutput("abc");
@@ -119,7 +119,7 @@ public class KafkaCacheModelTest
     @Test
     public void shouldForwardWhenNone()
     {
-        int produced = KafkaCacheModel.NONE.transform(0L, 0L, value("passthrough"), 0, 11, sink);
+        int produced = KafkaCacheModel.NONE.transform(0L, 0L, 0L, value("passthrough"), 0, 11, sink);
 
         assertEquals(11, produced);
         assertOutput("passthrough");
@@ -141,7 +141,7 @@ public class KafkaCacheModelTest
         KafkaCacheModel model = new KafkaCacheModel(rejectingHandler("$.id").supplyDecoder(),
             new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
 
         assertEquals(-1, produced);
     }
@@ -159,11 +159,11 @@ public class KafkaCacheModelTest
     {
         KafkaCacheModel model = KafkaCacheModel.decoder(handler(5), ModelTransform.NONE, new UnsafeBufferEx(new byte[256]));
 
-        model.transform(0L, 0L, value("hello"), 0, 5, sink);
+        model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
         model.reset();
         outputLength.value = 0;
 
-        int produced = model.transform(0L, 0L, value("world"), 0, 5, sink);
+        int produced = model.transform(0L, 0L, 0L, value("world"), 0, 5, sink);
 
         assertEquals(5, produced);
         assertOutput("world");
@@ -238,6 +238,7 @@ public class KafkaCacheModelTest
         public ModelPipelineResult transform(
             long traceId,
             long bindingId,
+            long authorization,
             int flags,
             DirectBufferEx src,
             int srcIndex,
@@ -246,7 +247,7 @@ public class KafkaCacheModelTest
             int dstIndex,
             int dstLimit)
         {
-            bridge.start();
+            bridge.start(authorization);
             bridge.field(path, src, srcIndex, srcLimit - srcIndex);
             return result.set(ModelStatus.REJECTED, 0, 0);
         }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -224,7 +224,7 @@ public class KafkaCachePartitionTest
 
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, handler(5), null, scratch);
 
-        partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, pipeline, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
@@ -251,7 +251,7 @@ public class KafkaCachePartitionTest
 
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, handler(99), null, scratch);
 
-        partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, pipeline, false);
 
         int flags = head.segment().logFile().readInt(entryMark.value + KafkaCacheEntryFW.FIELD_OFFSET_FLAGS);
@@ -278,7 +278,7 @@ public class KafkaCachePartitionTest
         KafkaPipeline pipeline = KafkaPipeline.decoder(extractingHandler("$.key"), extractingHandler("$.region"),
             transforms, scratch);
 
-        partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, pipeline, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
@@ -316,7 +316,7 @@ public class KafkaCachePartitionTest
         KafkaPipeline pipeline = KafkaPipeline.decoder(
             fieldsHandler("$.tenant", "tenantA", "$.id", "id42", "$.zone", "euw1"), null, transforms, scratch);
 
-        partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+        partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, pipeline, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
@@ -358,7 +358,7 @@ public class KafkaCachePartitionTest
         Array32FW<KafkaHeaderFW> headers = noHeaders(buffer, key.limit());
         OctetsFW value = value(buffer, headers.limit(), valueText);
 
-        partition.writeEntry(null, 1L, 1L, offset, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+        partition.writeEntry(null, 1L, 1L, 0L, offset, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
             key, headers, value, 0x00, KafkaDeltaType.NONE, pipeline, false);
 
         KafkaCacheEntryFW entry = head.segment().logFile().readBytes(entryMark.value, entryRO::wrap);
@@ -477,6 +477,7 @@ public class KafkaCachePartitionTest
         public ModelPipelineResult transform(
             long traceId,
             long bindingId,
+            long authorization,
             int flags,
             DirectBufferEx src,
             int srcIndex,
@@ -488,7 +489,7 @@ public class KafkaCachePartitionTest
             final int srcLength = srcLimit - srcIndex;
             dst.putBytes(dstIndex, src, srcIndex, srcLength);
 
-            bridge.start();
+            bridge.start(authorization);
             for (int index = 0; index < pathsAndValues.length; index += 2)
             {
                 final String text = pathsAndValues[index + 1];
@@ -560,13 +561,13 @@ public class KafkaCachePartitionTest
             Node head10 = partition.append(10L);
             KafkaCacheSegment head10s = head10.segment();
 
-            partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
                 key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaPipeline.NONE, false);
 
             long keyHash = partition.computeKeyHash(key);
             KafkaCacheEntryFW ancestor = head10.findAndMarkAncestor(key, keyHash, 11L, ancestorRO);
 
-            partition.writeEntry(null, 1L, 1L, 12L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            partition.writeEntry(null, 1L, 1L, 0L, 12L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
                 key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaPipeline.NONE, false);
 
             Node head15 = partition.append(15L);
@@ -616,13 +617,13 @@ public class KafkaCachePartitionTest
             KafkaCachePartition partition = new KafkaCachePartition(location, config, "cache", "test", 0, 65536, long[]::new);
             Node head10 = partition.append(10L);
 
-            partition.writeEntry(null, 1L, 1L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            partition.writeEntry(null, 1L, 1L, 0L, 11L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
                 key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaPipeline.NONE, false);
 
             long keyHash = partition.computeKeyHash(key);
             KafkaCacheEntryFW ancestor = head10.findAndMarkAncestor(key, keyHash, 11L, ancestorRO);
 
-            partition.writeEntry(null, 1L, 1L, 12L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
+            partition.writeEntry(null, 1L, 1L, 0L, 12L, entryMark, valueMark, 0L, KafkaTimestampType.ADVISORY, -1L,
                 key, headers, value, 0x00, KafkaDeltaType.NONE, KafkaPipeline.NONE, false);
 
             Node head15 = partition.append(15L);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipelineTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipelineTest.java
@@ -67,7 +67,7 @@ public class KafkaPipelineTest
         KafkaTopicTransformsType transforms = new KafkaTopicTransformsType("$.id", emptyList());
         KafkaPipeline pipeline = KafkaPipeline.decoder(handler("$.id", "id0"), null, transforms, scratch);
 
-        int transformed = pipeline.transformKey(0L, 0L, message("key0"), 0, 4, sink, recorder);
+        int transformed = pipeline.transformKey(0L, 0L, 0L, message("key0"), 0, 4, sink, recorder);
 
         assertEquals(4, transformed);
         assertEquals("key0", output.toString());
@@ -85,7 +85,7 @@ public class KafkaPipelineTest
             singletonList(new KafkaTopicHeaderType("region", "$.region")));
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, handler("$.region", "east"), transforms, scratch);
 
-        int transformed = pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        int transformed = pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
 
         assertEquals(7, transformed);
         assertEquals("payload", output.toString());
@@ -100,7 +100,7 @@ public class KafkaPipelineTest
         KafkaPipeline pipeline = KafkaPipeline.decoder(null,
             handler("$.region", "east", "$.status", "ok"), transforms, scratch);
 
-        pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
 
         // the headers land in the order the fields are encountered, not the order they are configured in
         assertEquals(asList(
@@ -119,7 +119,7 @@ public class KafkaPipelineTest
         KafkaPipeline pipeline = KafkaPipeline.stagedDecoder(handler("$.id", "id0"), null,
             new KafkaExtractTransform(KafkaEvent.SWITCH_KEY, KafkaEvent.SWITCH_HEADERS, "$.id", "id"), scratch);
 
-        pipeline.transformKey(0L, 0L, message("key0"), 0, 4, sink, recorder);
+        pipeline.transformKey(0L, 0L, 0L, message("key0"), 0, 4, sink, recorder);
     }
 
     @Test(expected = AssertionError.class)
@@ -128,7 +128,7 @@ public class KafkaPipelineTest
         KafkaPipeline pipeline = KafkaPipeline.stagedDecoder(handler("$.id", "id0"), null,
             new KafkaExtractTransform(KafkaEvent.SWITCH_KEY, KafkaEvent.SWITCH_VALUE, "$.id", "id"), scratch);
 
-        pipeline.transformKey(0L, 0L, message("key0"), 0, 4, sink, recorder);
+        pipeline.transformKey(0L, 0L, 0L, message("key0"), 0, 4, sink, recorder);
     }
 
     @Test(expected = AssertionError.class)
@@ -137,7 +137,7 @@ public class KafkaPipelineTest
         KafkaPipeline pipeline = KafkaPipeline.stagedDecoder(null, handler("$.region", "east"),
             new KafkaExtractTransform(KafkaEvent.SWITCH_VALUE, KafkaEvent.SWITCH_KEY, "$.region", "region"), scratch);
 
-        pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
     }
 
     @Test(expected = AssertionError.class)
@@ -146,7 +146,7 @@ public class KafkaPipelineTest
         KafkaPipeline pipeline = KafkaPipeline.stagedDecoder(null, handler("$.region", "east"),
             new AppendingOnSwitch(), scratch);
 
-        pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class KafkaPipelineTest
     {
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, handler("$.region", "east"), null, scratch);
 
-        int transformed = pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        int transformed = pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
 
         assertEquals(7, transformed);
         assertEquals(emptyList(), events);
@@ -177,7 +177,7 @@ public class KafkaPipelineTest
         assertFalse(KafkaPipeline.NONE.transformsValue());
         assertEquals(0, KafkaPipeline.NONE.padding(message("x"), 0, 1));
 
-        int transformed = KafkaPipeline.NONE.transformValue(0L, 0L, message("passthrough"), 0, 11, sink, recorder);
+        int transformed = KafkaPipeline.NONE.transformValue(0L, 0L, 0L, message("passthrough"), 0, 11, sink, recorder);
 
         assertEquals(11, transformed);
         assertEquals("passthrough", output.toString());
@@ -202,7 +202,7 @@ public class KafkaPipelineTest
             singletonList(new KafkaTopicHeaderType("region", "$.region")));
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, rejectingHandler("$.region"), transforms, scratch);
 
-        int transformed = pipeline.transformValue(0L, 0L, message("payload"), 0, 7, sink, recorder);
+        int transformed = pipeline.transformValue(0L, 0L, 0L, message("payload"), 0, 7, sink, recorder);
 
         assertEquals(-1, transformed);
     }
@@ -214,11 +214,11 @@ public class KafkaPipelineTest
             singletonList(new KafkaTopicHeaderType("region", "$.region")));
         KafkaPipeline pipeline = KafkaPipeline.decoder(null, handler("$.region", "east"), transforms, scratch);
 
-        pipeline.transformValue(0L, 0L, message("first"), 0, 5, sink, recorder);
+        pipeline.transformValue(0L, 0L, 0L, message("first"), 0, 5, sink, recorder);
         pipeline.reset();
         events.clear();
 
-        pipeline.transformValue(0L, 0L, message("second"), 0, 6, sink, recorder);
+        pipeline.transformValue(0L, 0L, 0L, message("second"), 0, 6, sink, recorder);
 
         assertEquals(asList("SWITCH_HEADERS", "FIELD(region=east)", "SWITCH_VALUE", "FIELD($.region=east)"), events);
     }
@@ -326,6 +326,7 @@ public class KafkaPipelineTest
         public ModelPipelineResult transform(
             long traceId,
             long bindingId,
+            long authorization,
             int flags,
             DirectBufferEx src,
             int srcIndex,
@@ -336,7 +337,7 @@ public class KafkaPipelineTest
         {
             final int srcLength = srcLimit - srcIndex;
 
-            bridge.start();
+            bridge.start(authorization);
             for (int index = 0; index < pathsAndValues.length; index += 2)
             {
                 final byte[] value = pathsAndValues[index + 1].getBytes(UTF_8);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaAvroPipelineBM.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaAvroPipelineBM.java
@@ -168,8 +168,8 @@ public class KafkaAvroPipelineBM
     {
         pipeline.reset();
         final int transformed = key
-            ? pipeline.transformKey(0L, 0L, data, 0, length, next, sink)
-            : pipeline.transformValue(0L, 0L, data, 0, length, next, sink);
+            ? pipeline.transformKey(0L, 0L, 0L, data, 0, length, next, sink)
+            : pipeline.transformValue(0L, 0L, 0L, data, 0, length, next, sink);
         return checksum + transformed;
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaJsonPipelineBM.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaJsonPipelineBM.java
@@ -163,8 +163,8 @@ public class KafkaJsonPipelineBM
     {
         pipeline.reset();
         final int transformed = key
-            ? pipeline.transformKey(0L, 0L, data, 0, length, next, sink)
-            : pipeline.transformValue(0L, 0L, data, 0, length, next, sink);
+            ? pipeline.transformKey(0L, 0L, 0L, data, 0, length, next, sink)
+            : pipeline.transformValue(0L, 0L, 0L, data, 0, length, next, sink);
         return checksum + transformed;
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaPipelineBM.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaPipelineBM.java
@@ -142,8 +142,8 @@ public class KafkaPipelineBM
     {
         pipeline.reset();
         final int transformed = key
-            ? pipeline.transformKey(0L, 0L, data, 0, length, next, sink)
-            : pipeline.transformValue(0L, 0L, data, 0, length, next, sink);
+            ? pipeline.transformKey(0L, 0L, 0L, data, 0, length, next, sink)
+            : pipeline.transformValue(0L, 0L, 0L, data, 0, length, next, sink);
         return checksum + transformed;
     }
 
@@ -189,6 +189,7 @@ public class KafkaPipelineBM
         public ModelPipelineResult transform(
             long traceId,
             long bindingId,
+            long authorization,
             int flags,
             DirectBufferEx src,
             int srcIndex,
@@ -199,7 +200,7 @@ public class KafkaPipelineBM
         {
             final int srcLength = srcLimit - srcIndex;
 
-            bridge.start();
+            bridge.start(authorization);
             for (int index = 0; index < pathsAndValues.length; index += 2)
             {
                 final byte[] value = pathsAndValues[index + 1].getBytes(UTF_8);

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaProtobufPipelineBM.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaProtobufPipelineBM.java
@@ -158,8 +158,8 @@ public class KafkaProtobufPipelineBM
     {
         pipeline.reset();
         final int transformed = key
-            ? pipeline.transformKey(0L, 0L, data, 0, length, next, sink)
-            : pipeline.transformValue(0L, 0L, data, 0, length, next, sink);
+            ? pipeline.transformKey(0L, 0L, 0L, data, 0, length, next, sink)
+            : pipeline.transformValue(0L, 0L, 0L, data, 0, length, next, sink);
         return checksum + transformed;
     }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -219,6 +219,7 @@ public final class McpBindingConfig
         int schemaId,
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit)
@@ -235,7 +236,7 @@ public final class McpBindingConfig
             boolean done = false;
             while (!done)
             {
-                final ModelPipelineResult result = decoder.transform(traceId, bindingId, flags,
+                final ModelPipelineResult result = decoder.transform(traceId, bindingId, authorization, flags,
                     data, srcAt, limit, scratch, produced, scratch.capacity());
                 final ModelStatus status = result.status();
                 if (status == ModelStatus.REJECTED)
@@ -312,6 +313,7 @@ public final class McpBindingConfig
         int schemaId,
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx params,
         int index,
         int limit)
@@ -321,7 +323,7 @@ public final class McpBindingConfig
         if (arguments != null)
         {
             final int length = argsScratch.putStringWithoutLengthUtf8(0, arguments);
-            valid = validateToolArgs(schemaId, traceId, bindingId, argsScratch, 0, length);
+            valid = validateToolArgs(schemaId, traceId, bindingId, authorization, argsScratch, 0, length);
         }
         return valid;
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -735,7 +735,7 @@ abstract class McpProxyItemFactory implements BindingHandler
             long traceId)
         {
             final boolean valid =
-                binding.validateToolCall(toolSchemaId, traceId, routedId, argsBuffer, 0, argsProgress);
+                binding.validateToolCall(toolSchemaId, traceId, routedId, authorization, argsBuffer, 0, argsProgress);
             if (valid)
             {
                 client.doClientData(traceId, 0L, DATA_FLAG_COMPLETE, argsProgress,

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModel.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModel.java
@@ -26,7 +26,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
  * Per-stream driver around a decode {@link ModelPipeline} for the mqtt binding.
  * <p>
  * A publish payload or user-property value is transformed whole-value via
- * {@link #transform(long, long, DirectBufferEx, int, int)}: the value is driven through the pipeline and the
+ * {@link #transform(long, long, long, DirectBufferEx, int, int)}: the value is driven through the pipeline and the
  * produced (possibly changed) bytes are exposed via {@link #buffer} for the caller to forward downstream, or
  * {@code -1} signals the model rejected it.
  * </p>
@@ -77,6 +77,7 @@ public final class MqttModel
     public int transform(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit)
@@ -87,7 +88,7 @@ public final class MqttModel
         boolean done = false;
         while (!done)
         {
-            final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+            final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
                 data, srcAt, limit, scratch, total, scratch.capacity());
             final ModelStatus status = result.status();
 
@@ -119,6 +120,7 @@ public final class MqttModel
     public boolean validate(
         long traceId,
         long bindingId,
+        long authorization,
         boolean first,
         boolean last,
         DirectBufferEx data,
@@ -135,7 +137,7 @@ public final class MqttModel
             flags |= FLAGS_FIN;
         }
 
-        final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+        final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
             data, index, limit, scratch, 0, scratch.capacity());
         final ModelStatus status = result.status();
         final boolean valid = status != ModelStatus.REJECTED;

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -1441,7 +1441,8 @@ public final class MqttServerFactory implements MqttStreamFactory
 
             final MqttPublishHelper mqttPublishHelper = this.mqttPublishHelper.reset();
 
-            reasonCode = mqttPublishHelper.decodeV5(traceId, server, topicName, properties, typeAndFlags, qos, packetId);
+            reasonCode = mqttPublishHelper.decodeV5(traceId, authorization, server, topicName, properties, typeAndFlags,
+                qos, packetId);
 
             if (reasonCode == SUCCESS)
             {
@@ -1554,7 +1555,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                     else
                     {
                         final int produced =
-                            model.transform(traceId, publisher.routedId, buffer, offset, offset + sourceBytes);
+                            model.transform(traceId, publisher.routedId, authorization, buffer, offset, offset + sourceBytes);
                         if (produced < 0)
                         {
                             reasonCode = PAYLOAD_FORMAT_INVALID;
@@ -1603,7 +1604,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                     final boolean first = !server.publishPayloadValidating;
                     final boolean last = sizeClaimed == server.decodeablePublishPayloadBytes;
                     server.publishPayloadValidating = !last;
-                    if (!model.validate(traceId, publisher.routedId, first, last,
+                    if (!model.validate(traceId, publisher.routedId, authorization, first, last,
                             payloadBuffer, payloadOffset, payloadOffset + sizeClaimed))
                     {
                         reasonCode = PAYLOAD_FORMAT_INVALID;
@@ -7535,6 +7536,7 @@ public final class MqttServerFactory implements MqttStreamFactory
 
         private int decodeV5(
             long traceId,
+            long authorization,
             MqttServer server,
             String16FW topicName,
             MqttPropertiesFW properties,
@@ -7638,7 +7640,8 @@ public final class MqttServerFactory implements MqttStreamFactory
                             MqttModel.decoder(config != null ? supplyModel.apply(config) : null, modelBuffer);
                         if (model.active())
                         {
-                            final int produced = model.transform(traceId, server.routedId, userPropertyValue.buffer(),
+                            final int produced = model.transform(traceId, server.routedId, authorization,
+                                userPropertyValue.buffer(),
                                 userPropertyValue.offset() + BitUtil.SIZE_OF_SHORT, userPropertyValue.limit());
                             if (produced < 0)
                             {

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModelTest.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModelTest.java
@@ -38,7 +38,7 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertTrue(model.active());
         assertEquals(5, produced);
@@ -50,7 +50,7 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        assertEquals(-1, model.transform(0L, 0L, value("nope"), 0, 4));
+        assertEquals(-1, model.transform(0L, 0L, 0L, value("nope"), 0, 4));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5, 8), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(8, produced);
         assertValue(model, 5, "hello");
@@ -69,7 +69,7 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5, 3), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(3, produced);
         assertValue(model, produced, "hel");
@@ -113,8 +113,8 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        assertTrue(model.validate(0L, 0L, true, false, value("hello"), 0, 3));
-        assertTrue(model.validate(0L, 0L, false, true, value("hello"), 3, 5));
+        assertTrue(model.validate(0L, 0L, 0L, true, false, value("hello"), 0, 3));
+        assertTrue(model.validate(0L, 0L, 0L, false, true, value("hello"), 3, 5));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class MqttModelTest
     {
         MqttModel model = MqttModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        assertFalse(model.validate(0L, 0L, true, true, value("nope"), 0, 4));
+        assertFalse(model.validate(0L, 0L, 0L, true, true, value("nope"), 0, 4));
     }
 
     private static TestModelHandler handler(

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModel.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModel.java
@@ -25,7 +25,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 /**
  * Per-stream driver around a decode {@link ModelPipeline} for the sse binding.
  * <p>
- * An event payload is transformed whole-value via {@link #transform(long, long, DirectBufferEx, int, int)}: the
+ * An event payload is transformed whole-value via {@link #transform(long, long, long, DirectBufferEx, int, int)}: the
  * value is driven through the pipeline and the produced (possibly changed) bytes are exposed via
  * {@link #buffer} for the caller to encode downstream, or {@code -1} signals the model rejected it.
  * </p>
@@ -71,6 +71,7 @@ public final class SseModel
     public int transform(
         long traceId,
         long bindingId,
+        long authorization,
         DirectBufferEx data,
         int index,
         int limit)
@@ -81,7 +82,7 @@ public final class SseModel
         boolean done = false;
         while (!done)
         {
-            final ModelPipelineResult result = pipeline.transform(traceId, bindingId, flags,
+            final ModelPipelineResult result = pipeline.transform(traceId, bindingId, authorization, flags,
                 data, srcAt, limit, scratch, total, scratch.capacity());
             final ModelStatus status = result.status();
 

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/stream/SseServerFactory.java
@@ -1132,7 +1132,7 @@ public final class SseServerFactory implements SseStreamFactory
                     }
                     else if (payload != null)
                     {
-                        final int produced = contentType.transform(traceId, routedId,
+                        final int produced = contentType.transform(traceId, routedId, authorization,
                             payload.buffer(), payload.offset(), payload.limit());
                         content = produced < 0 ? null : contentRO.wrap(contentType.buffer(), 0, produced);
                         encode = content != null;

--- a/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModelTest.java
+++ b/runtime/binding-sse/src/test/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModelTest.java
@@ -38,7 +38,7 @@ public class SseModelTest
     {
         SseModel model = SseModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertTrue(model.active());
         assertEquals(5, produced);
@@ -50,7 +50,7 @@ public class SseModelTest
     {
         SseModel model = SseModel.decoder(handler(5), new UnsafeBufferEx(new byte[256]));
 
-        assertEquals(-1, model.transform(0L, 0L, value("nope"), 0, 4));
+        assertEquals(-1, model.transform(0L, 0L, 0L, value("nope"), 0, 4));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SseModelTest
     {
         SseModel model = SseModel.decoder(handler(5, 8), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(8, produced);
         assertValue(model, 5, "hello");
@@ -69,7 +69,7 @@ public class SseModelTest
     {
         SseModel model = SseModel.decoder(handler(5, 3), new UnsafeBufferEx(new byte[256]));
 
-        int produced = model.transform(0L, 0L, value("hello"), 0, 5);
+        int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5);
 
         assertEquals(3, produced);
         assertValue(model, produced, "hel");

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
@@ -27,6 +27,18 @@ package io.aklivity.zilla.runtime.engine.model;
 public interface ModelController
 {
     /**
+     * Returns the authorization in effect for the message currently being transformed.
+     * <p>
+     * A mediating stage may override this to scope the authorization further for a nested composition; a
+     * non-mediating stage passes {@code control} through, so this reflects the authorization the pipeline
+     * received for the current message unless some stage along the way has narrowed it.
+     * </p>
+     *
+     * @return the authorization in effect for the current message
+     */
+    long authorization();
+
+    /**
      * Signals that the current value must be rejected, supplying the diagnostic the adapter reports.
      * <p>
      * A stage raising this also returns {@link ModelStatus#REJECTED}; the diagnostic is what distinguishes

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFieldBridge.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelFieldBridge.java
@@ -48,9 +48,13 @@ public final class ModelFieldBridge
 
     /**
      * Delivers {@link ModelEvent#START_VALUE}, opening the field run for one value.
+     *
+     * @param authorization  the authorization in effect for the value being opened
      */
-    public void start()
+    public void start(
+        long authorization)
     {
+        control.authorization = authorization;
         value.wrap(null, null, 0, 0);
         transform.transform(control, value, ModelEvent.START_VALUE, discard);
     }
@@ -137,6 +141,14 @@ public final class ModelFieldBridge
     // observation-only: there is no output left to reject into by the time a field is delivered here
     private static final class Control implements ModelController
     {
+        private long authorization;
+
+        @Override
+        public long authorization()
+        {
+            return authorization;
+        }
+
         @Override
         public void reject(
             String diagnostic)

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelPipeline.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelPipeline.java
@@ -45,20 +45,22 @@ public interface ModelPipeline
      * Transforms input from {@code src[srcIndex..srcLimit)} into {@code dst[dstIndex..dstLimit)} and
      * reports progress.
      *
-     * @param traceId    the trace identifier for diagnostics
-     * @param bindingId  the binding identifier
-     * @param flags      the per-fragment stream flags
-     * @param src        the source buffer
-     * @param srcIndex   the offset of the input in {@code src}
-     * @param srcLimit   the offset just past the input in {@code src}
-     * @param dst        the destination buffer
-     * @param dstIndex   the offset to write output at in {@code dst}
-     * @param dstLimit   the offset just past the available output in {@code dst}
+     * @param traceId       the trace identifier for diagnostics
+     * @param bindingId     the binding identifier
+     * @param authorization the authorization in effect for the message being transformed
+     * @param flags         the per-fragment stream flags
+     * @param src           the source buffer
+     * @param srcIndex      the offset of the input in {@code src}
+     * @param srcLimit      the offset just past the input in {@code src}
+     * @param dst           the destination buffer
+     * @param dstIndex      the offset to write output at in {@code dst}
+     * @param dstLimit      the offset just past the available output in {@code dst}
      * @return the reused {@link ModelPipelineResult} describing the outcome, consumed, and produced bytes
      */
     ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelTransformTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelTransformTest.java
@@ -33,7 +33,20 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ModelTransformTest
 {
-    private static final ModelController NO_CONTROL = diagnostic -> {};
+    private static final ModelController NO_CONTROL = new ModelController()
+    {
+        @Override
+        public long authorization()
+        {
+            return 0L;
+        }
+
+        @Override
+        public void reject(
+            String diagnostic)
+        {
+        }
+    };
 
     @Test
     public void shouldForwardEveryFieldWhenNone()
@@ -164,12 +177,44 @@ public class ModelTransformTest
         ModelFieldBridge bridge = new ModelFieldBridge(transform);
         DirectBufferEx value = new UnsafeBufferEx("one".getBytes(UTF_8));
 
-        bridge.start();
+        bridge.start(0L);
         bridge.field("$.id", value, 0, value.capacity());
         bridge.end();
 
         assertEquals(List.of("START_VALUE", "$.id=one", "END_VALUE"), transform.events);
         assertEquals(1, transform.flushes);
+    }
+
+    @Test
+    public void shouldExposeAuthorizationToBridgedTransform()
+    {
+        Recording transform = new Recording();
+        ModelFieldBridge bridge = new ModelFieldBridge(transform);
+        DirectBufferEx value = new UnsafeBufferEx("one".getBytes(UTF_8));
+
+        bridge.start(0x0102L);
+        bridge.field("$.id", value, 0, value.capacity());
+        bridge.end();
+
+        assertEquals(List.of(0x0102L, 0x0102L, 0x0102L), transform.authorizations);
+    }
+
+    @Test
+    public void shouldObserveChangedAuthorizationOnNextValue()
+    {
+        Recording transform = new Recording();
+        ModelFieldBridge bridge = new ModelFieldBridge(transform);
+        DirectBufferEx value = new UnsafeBufferEx("one".getBytes(UTF_8));
+
+        bridge.start(0x0102L);
+        bridge.field("$.id", value, 0, value.capacity());
+        bridge.end();
+
+        bridge.start(0x0304L);
+        bridge.field("$.id", value, 0, value.capacity());
+        bridge.end();
+
+        assertEquals(List.of(0x0102L, 0x0102L, 0x0102L, 0x0304L, 0x0304L, 0x0304L), transform.authorizations);
     }
 
     private static String text(
@@ -349,6 +394,7 @@ public class ModelTransformTest
     private static final class Recording implements ModelTransform
     {
         private final List<String> events = new ArrayList<>();
+        private final List<Long> authorizations = new ArrayList<>();
 
         private int flushes;
 
@@ -360,6 +406,7 @@ public class ModelTransformTest
             ModelSink sink)
         {
             events.add(event == ModelEvent.FIELD ? source.getPath() + "=" + text(source) : event.name());
+            authorizations.add(control.authorization());
             return sink.transform(control, source, event);
         }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -886,6 +886,7 @@ final class TestBindingFactory implements BindingHandler
         {
             long sequence = data.sequence();
             long traceId = data.traceId();
+            long authorization = data.authorization();
             int reserved = data.reserved();
             int flags = data.flags();
             OctetsFW payload = data.payload();
@@ -893,7 +894,7 @@ final class TestBindingFactory implements BindingHandler
             initialSeq = sequence + reserved;
 
             if (valuePipeline != null &&
-                transform(traceId, payload.buffer(), payload.offset(), payload.limit()) < 0)
+                transform(traceId, authorization, payload.buffer(), payload.offset(), payload.limit()) < 0)
             {
                 target.doInitialAbort(traceId);
             }
@@ -905,6 +906,7 @@ final class TestBindingFactory implements BindingHandler
 
         private int transform(
             long traceId,
+            long authorization,
             DirectBufferEx data,
             int index,
             int limit)
@@ -915,7 +917,7 @@ final class TestBindingFactory implements BindingHandler
             boolean done = false;
             while (!done)
             {
-                final ModelPipelineResult result = valuePipeline.transform(traceId, routedId, flags,
+                final ModelPipelineResult result = valuePipeline.transform(traceId, routedId, authorization, flags,
                         data, srcAt, limit, modelBuffer, total, modelBuffer.capacity());
                 final ModelStatus status = result.status();
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandlerTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.config.engine.ValidateConfig;
@@ -28,9 +31,13 @@ import io.aklivity.zilla.config.engine.test.internal.model.config.TestModelConfi
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelSink;
+import io.aklivity.zilla.runtime.engine.model.ModelSource;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 
@@ -49,7 +56,7 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3, 4};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -64,7 +71,7 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -77,7 +84,7 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -98,13 +105,13 @@ public class TestModelHandlerTest
 
         ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult decoded = decoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
         ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult encoded = encoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, encodeDst, 0, encodeDst.capacity());
         assertEquals(ModelStatus.REJECTED, encoded.status());
     }
@@ -118,13 +125,13 @@ public class TestModelHandlerTest
         MutableDirectBufferEx src = new UnsafeBufferEx(bytes);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[4]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             src, 0, bytes.length, dst, 0, 2);
         assertEquals(ModelStatus.OVERFLOW, first.status());
         assertEquals(2, first.consumed());
 
         int progress = first.consumed();
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             src, progress, bytes.length, dst, progress, bytes.length);
         assertEquals(ModelStatus.COMPLETE, second.status());
     }
@@ -136,7 +143,7 @@ public class TestModelHandlerTest
 
         byte[] head = {1, 2};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.UNDERFLOW, result.status());
@@ -150,7 +157,7 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3, 4};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[0]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, 0);
 
         assertEquals(ModelStatus.OVERFLOW, result.status());
@@ -174,13 +181,59 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3, 4};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         pipeline.reset();
 
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, result.status());
+    }
+
+    @Test
+    public void shouldObserveAuthorizationReceivedByPipeline()
+    {
+        TestModelConfig config = TestModelConfig.builder()
+            .length(4)
+            .field("$.a")
+            .build();
+        ModelHandler handler = new TestModelContext(context).supplyHandler(config);
+
+        List<Long> observed = new ArrayList<>();
+        ModelTransform transform = new ModelTransform()
+        {
+            @Override
+            public ModelStatus transform(
+                ModelController control,
+                ModelSource source,
+                ModelEvent event,
+                ModelSink sink)
+            {
+                observed.add(control.authorization());
+                return sink.transform(control, source, event);
+            }
+
+            @Override
+            public boolean identity()
+            {
+                return true;
+            }
+        };
+        ModelPipeline pipeline = handler.supplyDecoder(transform);
+
+        byte[] bytes = {1, 2, 3, 4};
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
+        pipeline.transform(0L, 0L, 0x0102L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
+        pipeline.reset();
+        int firstValueEvents = observed.size();
+
+        pipeline.transform(0L, 0L, 0x0304L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
+
+        assertFalse(observed.isEmpty());
+        assertTrue(observed.subList(0, firstValueEvents).stream().allMatch(a -> a == 0x0102L));
+        assertTrue(observed.subList(firstValueEvents, observed.size()).stream().allMatch(a -> a == 0x0304L));
     }
 
     @Test

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
@@ -71,6 +71,7 @@ final class TestModelPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
@@ -115,7 +116,7 @@ final class TestModelPipeline implements ModelPipeline
             consumed = available;
             produced = transformLength;
             status = ModelStatus.COMPLETE;
-            visitExtracted();
+            visitExtracted(authorization);
         }
         else
         {
@@ -133,7 +134,7 @@ final class TestModelPipeline implements ModelPipeline
                 status = ModelStatus.COMPLETE;
                 if (lengthValid)
                 {
-                    visitExtracted();
+                    visitExtracted(authorization);
                 }
             }
             else
@@ -156,11 +157,12 @@ final class TestModelPipeline implements ModelPipeline
         processed = 0;
     }
 
-    private void visitExtracted()
+    private void visitExtracted(
+        long authorization)
     {
         if (bridge != null)
         {
-            bridge.start();
+            bridge.start(authorization);
             for (int i = 0; i < fields.size(); i++)
             {
                 bridge.field("$." + fields.get(i), extractedValue, 0, extractedValue.capacity());

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -66,6 +66,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
@@ -74,6 +75,11 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         int dstIndex,
         int dstLimit)
     {
+        if (adapter instanceof AvroModelTransform mediating)
+        {
+            mediating.authorization(authorization);
+        }
+
         int srcLength = srcLimit - srcIndex;
         int dstLength = dstLimit - dstIndex;
         int prefix = 0;

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
@@ -61,6 +61,7 @@ final class AvroModelEncoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
@@ -69,6 +70,11 @@ final class AvroModelEncoderPipeline implements ModelPipeline
         int dstIndex,
         int dstLimit)
     {
+        if (adapter instanceof AvroModelTransform mediating)
+        {
+            mediating.authorization(authorization);
+        }
+
         int srcLength = srcLimit - srcIndex;
         int dstLength = dstLimit - dstIndex;
         int prefix = 0;

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransform.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransform.java
@@ -192,6 +192,14 @@ final class AvroModelTransform implements AvroTransform
         return transform.identity();
     }
 
+    // stored on the shared Control so every transform.transform(...) call this adapter drives during the
+    // current message sees the authorization the owning pipeline received for it
+    void authorization(
+        long authorization)
+    {
+        control.authorization = authorization;
+    }
+
     // observing mode: track as a side-effect before forwarding — the downstream consumes a length-delimited
     // value off the source as it writes it, so the bytes must be captured while the source still exposes them
     private Status observe(
@@ -515,7 +523,14 @@ final class AvroModelTransform implements AvroTransform
 
     private static final class Control implements ModelController
     {
+        private long authorization;
         private String diagnostic;
+
+        @Override
+        public long authorization()
+        {
+            return authorization;
+        }
 
         @Override
         public void reject(

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -110,20 +110,20 @@ public class AvroModelDecoderPipelineTest
         ByteArrayOutputStream outA = new ByteArrayOutputStream();
 
         // stream A: first fragment, incomplete -> UNDERFLOW
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
         drain(dst, ra1.produced(), outA);
 
         // stream B: a whole value fed in the middle of A — would corrupt A if state were shared
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
         assertEquals(JSON, text(dst, rb.produced()));
 
         // stream A: finish, prepending A's unconsumed remainder (the caller's decode-slot residue)
         byte[] a2 = concat(a1, ra1.consumed(), a2tail);
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
         drain(dst, ra2.produced(), outA);
@@ -140,7 +140,7 @@ public class AvroModelDecoderPipelineTest
         ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -167,7 +167,7 @@ public class AvroModelDecoderPipelineTest
             0x02
         };
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(scalars), 0, scalars.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -197,7 +197,7 @@ public class AvroModelDecoderPipelineTest
         assertFalse(pipeline.identity());
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertTrue(pipeline.identity());
@@ -210,7 +210,7 @@ public class AvroModelDecoderPipelineTest
         ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertFalse(pipeline.identity());

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipelineTest.java
@@ -89,14 +89,14 @@ public class AvroModelEncoderPipelineTest
         ByteArrayOutputStream outA = new ByteArrayOutputStream();
 
         // stream A: first fragment, incomplete -> UNDERFLOW
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
         drain(dst, ra1.produced(), outA);
 
         // stream B: a whole value fed in the middle of A — would corrupt A if state were shared
         byte[] bIn = JSON.getBytes(UTF_8);
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bIn), 0, bIn.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
         byte[] outB = new byte[rb.produced()];
@@ -105,7 +105,7 @@ public class AvroModelEncoderPipelineTest
 
         // stream A: finish, prepending A's unconsumed remainder (the caller's decode-slot residue)
         byte[] a2 = concat(a1, ra1.consumed(), a2tail);
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
         drain(dst, ra2.produced(), outA);
@@ -125,7 +125,7 @@ public class AvroModelEncoderPipelineTest
         // throw a JsonParsingException; the parser boundary must translate it to a clean REJECTED, not crash
         byte[] in = {0x0a, 0x02, 0x69, 0x64};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
@@ -289,7 +289,7 @@ public class AvroModelTransformTest
         ModelPipeline pipeline = handler.supplyDecoder(new Rejecting("$.status"));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -302,7 +302,7 @@ public class AvroModelTransformTest
         ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.id", "replaced"));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertFalse(pipeline.identity());
@@ -315,7 +315,7 @@ public class AvroModelTransformTest
         ModelPipeline pipeline = handler.supplyDecoder(new Observing());
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
 
         assertTrue(pipeline.identity());
@@ -329,7 +329,7 @@ public class AvroModelTransformTest
 
         byte[] json = "{\"id\":\"id0\",\"status\":\"positive\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(json), 0, json.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -352,7 +352,7 @@ public class AvroModelTransformTest
         ModelStatus status = ModelStatus.OK;
         for (int rounds = 0; rounds < 64 && status != ModelStatus.COMPLETE && status != ModelStatus.REJECTED; rounds++)
         {
-            ModelPipelineResult result = pipeline.transform(0L, 0L, flags,
+            ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, flags,
                 new UnsafeBufferEx(avro), srcAt, avro.length, dst, 0, dst.capacity());
             status = result.status();
             if (result.produced() > 0)
@@ -373,7 +373,7 @@ public class AvroModelTransformTest
         byte[] avro)
     {
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[512]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(avro), 0, avro.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelDecoderPipelineBM.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelDecoderPipelineBM.java
@@ -110,7 +110,7 @@ public class AvroModelDecoderPipelineBM
     private int decode(
         ModelPipeline pipeline)
     {
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             src, 0, AVRO.length, dst, 0, dst.capacity());
         return result.produced();
     }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelEncoderPipelineBM.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelEncoderPipelineBM.java
@@ -103,7 +103,7 @@ public class AvroModelEncoderPipelineBM
     @Benchmark
     public int encodeFromJson()
     {
-        ModelPipelineResult result = fromJson.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = fromJson.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             jsonSrc, 0, JSON.length, dst, 0, dst.capacity());
         return result.produced();
     }
@@ -111,7 +111,7 @@ public class AvroModelEncoderPipelineBM
     @Benchmark
     public int encodeIdentity()
     {
-        ModelPipelineResult result = identity.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = identity.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             avroSrc, 0, AVRO.length, dst, 0, dst.capacity());
         return result.produced();
     }

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelPipeline.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelPipeline.java
@@ -50,6 +50,7 @@ final class CoreModelPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelPipelineTest.java
@@ -56,7 +56,7 @@ public class BooleanModelPipelineTest
 
         byte[] bytes = {0x00};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[8]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -71,7 +71,7 @@ public class BooleanModelPipelineTest
 
         byte[] bytes = {0x01, 0x00};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[8]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelLenientTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelLenientTest.java
@@ -68,7 +68,7 @@ public class CoreModelLenientTest
 
         byte[] bytes = "12x".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -83,7 +83,7 @@ public class CoreModelLenientTest
 
         byte[] bytes = "12x".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -100,13 +100,13 @@ public class CoreModelLenientTest
 
         ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult decoded = decoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
         ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult encoded = encoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, encodeDst, 0, encodeDst.capacity());
         assertEquals(ModelStatus.REJECTED, encoded.status());
     }
@@ -122,7 +122,7 @@ public class CoreModelLenientTest
 
         byte[] bytes = "hello".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -137,7 +137,7 @@ public class CoreModelLenientTest
 
         byte[] bytes = "hello".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelPipelineTest.java
@@ -58,7 +58,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "+10.1119998321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -73,7 +73,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "-.11190092111111112".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -87,7 +87,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "-.11.19987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -101,7 +101,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "99.9987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -119,7 +119,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "99.9987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -137,7 +137,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "10.0".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -151,7 +151,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "25".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -165,7 +165,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = {-64, 0, 0, 0, 0, 0, 0, 0};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -180,7 +180,7 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "Invalid Double".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -197,15 +197,15 @@ public class DoubleModelPipelineTest
         byte[] tail = {-120, 23, -78, 63};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, 0x00,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, 0x00,
             new UnsafeBufferEx(mid), 0, mid.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, second.status());
 
-        ModelPipelineResult third = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult third = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length + mid.length, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, third.status());
     }
@@ -221,15 +221,15 @@ public class DoubleModelPipelineTest
         byte[] tail = {42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, 0x00,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, 0x00,
             new UnsafeBufferEx(mid), 0, mid.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, second.status());
 
-        ModelPipelineResult third = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult third = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length + mid.length, dst.capacity());
         assertEquals(ModelStatus.REJECTED, third.status());
     }
@@ -242,11 +242,11 @@ public class DoubleModelPipelineTest
 
         byte[] bytes = "4.2".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         pipeline.reset();
 
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, result.status());
     }

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelPipelineTest.java
@@ -58,7 +58,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "+10.1119f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -73,7 +73,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "-.1119f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -87,7 +87,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "-.11.19f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -101,7 +101,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "99.99f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -119,7 +119,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "99.99f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -137,7 +137,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "10.0".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -151,7 +151,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "25".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -165,7 +165,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = {62, -128, 5, 8};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -180,7 +180,7 @@ public class FloatModelPipelineTest
 
         byte[] bytes = "Invalid Float".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -196,11 +196,11 @@ public class FloatModelPipelineTest
         byte[] tail = {5, 8};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, second.status());
     }

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelPipelineTest.java
@@ -58,7 +58,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = "+8449999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -72,7 +72,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = "-125".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -90,7 +90,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -108,7 +108,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -122,7 +122,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = {0, 0, 0, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -137,7 +137,7 @@ public class Int32ModelPipelineTest
 
         byte[] bytes = "Test value".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -153,11 +153,11 @@ public class Int32ModelPipelineTest
         byte[] tail = {0, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.REJECTED, second.status());
     }
@@ -172,12 +172,12 @@ public class Int32ModelPipelineTest
         byte[] tail = {0x00, 0x2a};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
         assertEquals(head.length, first.consumed());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, second.status());
         assertEquals(tail.length, second.consumed());

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelPipelineTest.java
@@ -58,7 +58,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "+8449999L".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -73,7 +73,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "-125".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -87,7 +87,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "8449999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -105,7 +105,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -123,7 +123,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -137,7 +137,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = {0, 0, 0, 0, 0, 0, 0, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -152,7 +152,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = {-1, -1, -1, -1, -1, -1, -1, -32};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -166,7 +166,7 @@ public class Int64ModelPipelineTest
 
         byte[] bytes = "Test value!".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());
@@ -182,11 +182,11 @@ public class Int64ModelPipelineTest
         byte[] tail = {0, 0, 1, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, head.length, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, second.status());
     }

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelPipelineTest.java
@@ -61,7 +61,7 @@ public class StringModelPipelineTest
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[bytes.length]);
 
         // first call: only 5 bytes of room -> OVERFLOW, 5 consumed/produced
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             src, 0, bytes.length, dst, 0, 5);
         assertEquals(ModelStatus.OVERFLOW, first.status());
         assertEquals(5, first.consumed());
@@ -69,7 +69,7 @@ public class StringModelPipelineTest
 
         // re-call advancing the source by what was consumed, INIT cleared per the driver contract
         int progress = first.consumed();
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             src, progress, bytes.length, dst, progress, bytes.length);
         assertEquals(ModelStatus.COMPLETE, second.status());
         assertEquals(bytes.length - progress, second.consumed());
@@ -85,7 +85,7 @@ public class StringModelPipelineTest
 
         byte[] bytes = "Valid String".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[0]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, 0);
 
         assertEquals(ModelStatus.OVERFLOW, result.status());
@@ -106,15 +106,15 @@ public class StringModelPipelineTest
         byte[] whole = "Other Value".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
 
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
 
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(whole), 0, whole.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
 
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
     }
@@ -127,11 +127,11 @@ public class StringModelPipelineTest
 
         byte[] bytes = "abc".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         pipeline.reset();
 
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, result.status());
         assertEquals(bytes.length, result.produced());
@@ -148,11 +148,11 @@ public class StringModelPipelineTest
         byte[] tail = "€".getBytes(java.nio.charset.StandardCharsets.UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
-        ModelPipelineResult first = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult first = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, first.status());
 
-        ModelPipelineResult second = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult second = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(tail), 0, tail.length, dst, first.produced(), dst.capacity());
         assertEquals(ModelStatus.COMPLETE, second.status());
     }

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -73,6 +73,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
@@ -124,7 +125,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
             // under LENIENT the value still completes (original bytes passed through) and the event still fired
             if (status == ModelStatus.COMPLETE && extractor != null)
             {
-                visitExtracted();
+                visitExtracted(authorization);
             }
         }
         return result.set(status, consumed, produced);
@@ -156,9 +157,10 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         diagnostic = null;
     }
 
-    private void visitExtracted()
+    private void visitExtracted(
+        long authorization)
     {
-        bridge.start();
+        bridge.start(authorization);
         for (int i = 0; i < extractor.captured(); i++)
         {
             bridge.field(extractor.path(i), extractor.value(i), 0, extractor.length(i));

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
@@ -63,6 +63,7 @@ final class JsonModelEncoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -100,20 +100,20 @@ public class JsonModelDecoderPipelineTest
         ByteArrayOutputStream outA = new ByteArrayOutputStream();
 
         // stream A: first fragment, incomplete -> UNDERFLOW
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
         drain(dst, ra1.produced(), outA);
 
         // stream B: a whole value fed in the middle of A — would corrupt A if state were shared
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bWhole), 0, bWhole.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
         assertEquals("{\"id\":\"B\",\"status\":\"NO\"}", text(dst, rb.produced()));
 
         // stream A: finish, prepending A's unconsumed remainder (the caller's decode-slot residue)
         byte[] a2 = concat(a1, ra1.consumed(), a2tail);
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
         drain(dst, ra2.produced(), outA);
@@ -130,7 +130,7 @@ public class JsonModelDecoderPipelineTest
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -148,7 +148,7 @@ public class JsonModelDecoderPipelineTest
         // "id" holds a 3-byte BMP char (中) and a 2-byte char (é); "status" holds a surrogate-pair emoji (😀)
         byte[] in = "{\"id\":\"中é\",\"status\":\"😀\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -166,7 +166,7 @@ public class JsonModelDecoderPipelineTest
         // \uD800 is an unpaired high surrogate; String.getBytes(UTF_8) replaces it with '?' (0x3F)
         byte[] in = "{\"id\":\"a\\uD800b\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -188,7 +188,7 @@ public class JsonModelDecoderPipelineTest
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[512]);
 
         // window 1: everything up to (not including) the value
-        ModelPipelineResult r1 = pipeline.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult r1 = pipeline.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(head), 0, head.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, r1.status());
 
@@ -197,7 +197,7 @@ public class JsonModelDecoderPipelineTest
         byte[] remainder1 = concat(head, r1.consumed(), new byte[0]);
         byte[] valueChunk1 = ("\"" + note.substring(0, 20)).getBytes(UTF_8);
         byte[] window2 = concat(remainder1, 0, valueChunk1);
-        ModelPipelineResult r2 = pipeline.transform(0L, 0L, FLAGS_NONE,
+        ModelPipelineResult r2 = pipeline.transform(0L, 0L, 0L, FLAGS_NONE,
             new UnsafeBufferEx(window2), 0, window2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, r2.status());
 
@@ -205,7 +205,7 @@ public class JsonModelDecoderPipelineTest
         byte[] remainder2 = concat(window2, r2.consumed(), new byte[0]);
         byte[] tail = (note.substring(20) + "\"}").getBytes(UTF_8);
         byte[] window3 = concat(remainder2, 0, tail);
-        ModelPipelineResult r3 = pipeline.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult r3 = pipeline.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(window3), 0, window3.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, r3.status());
@@ -232,7 +232,7 @@ public class JsonModelDecoderPipelineTest
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertTrue(pipeline.identity());

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelLenientTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelLenientTest.java
@@ -79,13 +79,13 @@ public class JsonModelLenientTest
 
         ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult decoded = decoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
         ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult encoded = encoder.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, encodeDst, 0, encodeDst.capacity());
         assertEquals(ModelStatus.REJECTED, encoded.status());
     }
@@ -98,7 +98,7 @@ public class JsonModelLenientTest
 
         byte[] in = "{\"id\":\"abc\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
@@ -118,7 +118,7 @@ public class JsonModelDecoderPipelineBM
     private int run(
         ModelPipeline pipeline)
     {
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             validBuffer, 0, validLength, dst, 0, dst.capacity());
         return result.produced();
     }

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
@@ -123,7 +123,7 @@ public class JsonModelEncoderPipelineBM
         UnsafeBufferEx buffer,
         int length)
     {
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             buffer, 0, length, dst, 0, dst.capacity());
         return result.produced();
     }

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -68,6 +68,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,
@@ -116,7 +117,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
             produced = proto.produced();
             if (status == ModelStatus.COMPLETE && extractor != null)
             {
-                visitExtracted();
+                visitExtracted(authorization);
             }
             else if (status == ModelStatus.REJECTED)
             {
@@ -152,9 +153,10 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         diagnostic = null;
     }
 
-    private void visitExtracted()
+    private void visitExtracted(
+        long authorization)
     {
-        bridge.start();
+        bridge.start(authorization);
         for (int i = 0; i < extractor.captured(); i++)
         {
             bridge.field(extractor.path(i), extractor.value(i), 0, extractor.length(i));

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
@@ -58,6 +58,7 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
     public ModelPipelineResult transform(
         long traceId,
         long bindingId,
+        long authorization,
         int flags,
         DirectBufferEx src,
         int srcIndex,

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
@@ -114,13 +114,13 @@ public class ProtobufModelDecoderPipelineTest
         ByteArrayOutputStream outA = new ByteArrayOutputStream();
 
         // stream A: first fragment, incomplete -> UNDERFLOW
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
         drain(dst, ra1.produced(), outA);
 
         // stream B: a whole value fed in the middle of A — would corrupt A if state were shared
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(WIRE), 0, WIRE.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
         byte[] outB = new byte[rb.produced()];
@@ -129,7 +129,7 @@ public class ProtobufModelDecoderPipelineTest
 
         // stream A: finish, prepending A's unconsumed remainder (the caller's decode-slot residue)
         byte[] a2 = concat(a1, ra1.consumed(), a2tail);
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
         drain(dst, ra2.produced(), outA);
@@ -146,7 +146,7 @@ public class ProtobufModelDecoderPipelineTest
         ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(WIRE), 0, WIRE.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -188,7 +188,7 @@ public class ProtobufModelDecoderPipelineTest
             117, 109, 109, 121, 32, 115, 116, 114, 105, 110, 103, 74, 5, 1, 2, 3, 4, 5, 80, -78, -110, 4, 101, 57,
             48, 0, 0, 105, 21, -51, 91, 7, 0, 0, 0, 0, 112, -28, -92, 8, 120, -30, -94, -13, -83, 7};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(wire), 0, wire.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.COMPLETE, result.status());
@@ -231,7 +231,7 @@ public class ProtobufModelDecoderPipelineTest
         int guard = 0;
         do
         {
-            result = pipeline.transform(0L, 0L, flags, new UnsafeBufferEx(wire), 0, p, dst, 0, dst.capacity());
+            result = pipeline.transform(0L, 0L, 0L, flags, new UnsafeBufferEx(wire), 0, p, dst, 0, dst.capacity());
             drain(dst, result.produced(), out);
             flags = FLAGS_FIN;
             guard++;
@@ -252,7 +252,7 @@ public class ProtobufModelDecoderPipelineTest
         assertFalse(pipeline.identity());
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(WIRE), 0, WIRE.length, dst, 0, dst.capacity());
 
         assertTrue(pipeline.identity());
@@ -265,7 +265,7 @@ public class ProtobufModelDecoderPipelineTest
         ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(WIRE), 0, WIRE.length, dst, 0, dst.capacity());
 
         assertFalse(pipeline.identity());

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipelineTest.java
@@ -82,14 +82,14 @@ public class ProtobufModelEncoderPipelineTest
         ByteArrayOutputStream outA = new ByteArrayOutputStream();
 
         // stream A: first fragment, incomplete -> UNDERFLOW
-        ModelPipelineResult ra1 = a.transform(0L, 0L, FLAGS_INIT,
+        ModelPipelineResult ra1 = a.transform(0L, 0L, 0L, FLAGS_INIT,
             new UnsafeBufferEx(a1), 0, a1.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.UNDERFLOW, ra1.status());
         drain(dst, ra1.produced(), outA);
 
         // stream B: a whole value fed in the middle of A — would corrupt A if state were shared
         byte[] bIn = JSON.getBytes(UTF_8);
-        ModelPipelineResult rb = b.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult rb = b.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bIn), 0, bIn.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, rb.status());
         byte[] outB = new byte[rb.produced()];
@@ -98,7 +98,7 @@ public class ProtobufModelEncoderPipelineTest
 
         // stream A: finish, prepending A's unconsumed remainder (the caller's decode-slot residue)
         byte[] a2 = concat(a1, ra1.consumed(), a2tail);
-        ModelPipelineResult ra2 = a.transform(0L, 0L, FLAGS_FIN,
+        ModelPipelineResult ra2 = a.transform(0L, 0L, 0L, FLAGS_FIN,
             new UnsafeBufferEx(a2), 0, a2.length, dst, 0, dst.capacity());
         assertEquals(ModelStatus.COMPLETE, ra2.status());
         drain(dst, ra2.produced(), outA);
@@ -123,7 +123,7 @@ public class ProtobufModelEncoderPipelineTest
         int guard = 0;
         do
         {
-            result = pipeline.transform(0L, 0L, flags, new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+            result = pipeline.transform(0L, 0L, 0L, flags, new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
             drain(dst, result.produced(), out);
             flags = FLAGS_FIN;
             guard++;
@@ -147,7 +147,7 @@ public class ProtobufModelEncoderPipelineTest
 
         byte[] in = JSON.getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
 
         assertEquals(ModelStatus.REJECTED, result.status());

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
@@ -104,7 +104,7 @@ public class ProtobufModelDecoderPipelineBM
         ModelPipeline pipeline)
     {
         pipeline.reset();
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             inputBuffer, 0, WIRE.length, outputBuffer, 0, outputBuffer.capacity());
         return result.produced();
     }

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
@@ -89,7 +89,7 @@ public class ProtobufModelEncoderPipelineBM
     public int encodeToWire()
     {
         pipeline.reset();
-        ModelPipelineResult result = pipeline.transform(0L, 0L, FLAGS_COMPLETE,
+        ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             inputBuffer, 0, JSON.length, outputBuffer, 0, outputBuffer.capacity());
         return result.produced();
     }


### PR DESCRIPTION
## Description

Adds `long authorization` to `ModelPipeline.transform(...)`, positioned beside `traceId`/`bindingId` where per-operation authorization already sits throughout the engine, and a matching `ModelController.authorization()` read accessor so a per-field `ModelTransform` stage can read the authorization in effect for the message it is processing, rather than a snapshot taken when the stream opened. Guards expire and reauthorize mid-stream, and Kafka consume streams are long-lived, so a stale stream-open snapshot is a reachable authorization bug in normal operation.

Threads the new parameter through every `ModelPipeline` implementation (`model-core`, `model-json`, `model-protobuf`, `model-avro`, engine's `TestModelPipeline`) and every call site (`binding-sse`, `binding-http`, `binding-mqtt`, `binding-mcp`, and `binding-kafka`'s cache read/write paths). `ModelFieldBridge.start(...)` and `AvroModelTransform` gain the plumbing needed to expose the value to a wired `ModelTransform` via `ModelController.authorization()`.

The Kafka fetch-from-broker cache-population path has no per-consumer authorization to thread — it populates the shared cache from the topic itself, ahead of any consumer's authorized read — so it passes a documented `NO_AUTHORIZATION` constant; the produce path threads the producing client's actual authorization.

This is the widest change in the "Data Privacy Protection" epic (zilla-platform#383) — it touches Apache-licensed `engine`, every model implementation, and every binding that uses a model — split out of #1680 because of that scope. Consumers of this channel (#1689 and its produce-path equivalent) will read `control.authorization()` from within a `ModelTransform` stage.

Adds unit coverage for authorization threading through `TestModelPipeline`, a changed authorization value observed on the next `transform()` call, and a `ModelTransform` stage reading `control.authorization()` via `ModelFieldBridge`.

Fixes #2310

## Test plan

- [x] `./mvnw checkstyle:check` — 0 violations across every touched module
- [x] `./mvnw test` for every touched module (engine, model-core/json/protobuf/avro, binding-sse/http/mqtt/mcp/kafka) — all green
- [x] Full repo `./mvnw install` (including the Docker image build) — green


---
_Generated by [Claude Code](https://claude.ai/code/session_014EoZdsAEjwf7oLcpi1rS3j)_