### PR TITLE
fix(config): remove unused jakarta.json.bind dependency from openapi/asyncapi bindings

### DIFF
--- a/config/binding-asyncapi.conf/pom.xml
+++ b/config/binding-asyncapi.conf/pom.xml
@@ -45,10 +45,6 @@
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.json.bind</groupId>
-      <artifactId>jakarta.json.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <scope>test</scope>

--- a/config/binding-asyncapi.conf/src/main/moditect/module-info.java
+++ b/config/binding-asyncapi.conf/src/main/moditect/module-info.java
@@ -15,7 +15,6 @@
 module io.aklivity.zilla.config.binding.asyncapi
 {
     requires jakarta.json;
-    requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
 
     exports io.aklivity.zilla.config.binding.asyncapi;

--- a/config/binding-openapi-asyncapi.conf/pom.xml
+++ b/config/binding-openapi-asyncapi.conf/pom.xml
@@ -45,10 +45,6 @@
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.json.bind</groupId>
-      <artifactId>jakarta.json.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <scope>test</scope>

--- a/config/binding-openapi-asyncapi.conf/src/main/moditect/module-info.java
+++ b/config/binding-openapi-asyncapi.conf/src/main/moditect/module-info.java
@@ -15,7 +15,6 @@
 module io.aklivity.zilla.config.binding.openapi.asyncapi
 {
     requires jakarta.json;
-    requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
 
     exports io.aklivity.zilla.config.binding.openapi.asyncapi;

--- a/config/binding-openapi.conf/pom.xml
+++ b/config/binding-openapi.conf/pom.xml
@@ -45,10 +45,6 @@
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.json.bind</groupId>
-      <artifactId>jakarta.json.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
       <scope>test</scope>

--- a/config/binding-openapi.conf/src/main/moditect/module-info.java
+++ b/config/binding-openapi.conf/src/main/moditect/module-info.java
@@ -15,7 +15,6 @@
 module io.aklivity.zilla.config.binding.openapi
 {
     requires jakarta.json;
-    requires jakarta.json.bind;
     requires io.aklivity.zilla.config.engine;
 
     exports io.aklivity.zilla.config.binding.openapi;


### PR DESCRIPTION
## Description

`binding-openapi.conf`, `binding-asyncapi.conf`, and `binding-openapi-asyncapi.conf` each declared a `jakarta.json.bind-api` Maven dependency and `requires jakarta.json.bind;` in `module-info.java`, but no main-source file in any of the three modules imports `jakarta.json.bind.*` — only `jakarta.json.*` (JSON-P) is used directly. The `jakarta.json.bind` types (`Jsonb`, `JsonbBuilder`, `JsonbConfig`) are used only in test sources, where they remain available transitively via `engine.conf`'s compile-scope dependency on `jakarta.json.bind-api`.

For each of the three modules:
- Removed the `jakarta.json.bind-api` dependency from `pom.xml`
- Removed `requires jakarta.json.bind;` from `module-info.java`

Verified with `./mvnw clean install -pl config/binding-openapi.conf,config/binding-asyncapi.conf,config/binding-openapi-asyncapi.conf` (checkstyle, license headers, jacoco coverage, notice check, unit tests, moditect module descriptor) — all pass, confirming this is a no-op for compilation as expected.

Fixes #2372


---
_Generated by [Claude Code](https://claude.ai/code/session_01SwkXJYfggxJ8dQnCoo54xX)_