### PR TITLE
feat(common-protobuf): support method- and field-level options overlay

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufConstant.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufConstant.java
@@ -89,8 +89,8 @@ public sealed interface ProtobufConstant
      * custom/extension option's surrounding {@code ( ... )} stripped from its key — that punctuation is
      * only how the {@code .proto} grammar distinguishes an extension reference from a built-in option
      * name, not part of the option's logical (dotted) identity, and a {@link ProtobufOverlay} entry's
-     * {@code options:} bag always addresses that identity unparenthesized (e.g. {@code "zilla.mcp.v1"},
-     * never {@code "(zilla.mcp.v1)"}); stripping it here is what lets the two sides merge onto the same
+     * {@code options:} bag always addresses that identity unparenthesized (e.g. {@code "acme.meta"},
+     * never {@code "(acme.meta)"}); stripping it here is what lets the two sides merge onto the same
      * key rather than coexist as unrelated siblings. A nested {@code MessageValue}'s own field names are
      * never parenthesized, so this is a no-op wherever it doesn't apply. {@code null} converts to an
      * empty object.

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufConstant.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufConstant.java
@@ -16,6 +16,11 @@ package io.aklivity.zilla.runtime.common.protobuf;
 
 import java.util.Map;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
 /**
  * The value of a field option, parsed from the {@code .proto} source text (a text-format literal) rather
  * than resolved against an extension descriptor — no {@code .proto} import declares these custom options,
@@ -57,5 +62,55 @@ public sealed interface ProtobufConstant
      */
     record MessageValue(Map<String, ProtobufConstant> fields) implements ProtobufConstant
     {
+    }
+
+    /**
+     * This constant converted to a {@link JsonValue}, so an inline {@code .proto} source option and a
+     * {@link ProtobufOverlay} entry's {@code options:} bag can be compared and merged in one common
+     * representation. A message-valued constant converts recursively; every other variant maps directly
+     * to its JSON-native equivalent.
+     */
+    default JsonValue toJson()
+    {
+        return switch (this)
+        {
+        case Identifier value -> Json.createValue(value.value());
+        case IntegerValue value -> Json.createValue(value.value());
+        case FloatValue value -> Json.createValue(value.value());
+        case TextValue value -> Json.createValue(value.value());
+        case BooleanValue value -> value.value() ? JsonValue.TRUE : JsonValue.FALSE;
+        case MessageValue value -> toJsonObject(value.fields());
+        };
+    }
+
+    /**
+     * Converts a field's or method's full option map ({@link ProtobufField#option(String)},
+     * {@link ProtobufMethod#option(String)}) to a {@link JsonObject}, one key per option name, with a
+     * custom/extension option's surrounding {@code ( ... )} stripped from its key — that punctuation is
+     * only how the {@code .proto} grammar distinguishes an extension reference from a built-in option
+     * name, not part of the option's logical (dotted) identity, and a {@link ProtobufOverlay} entry's
+     * {@code options:} bag always addresses that identity unparenthesized (e.g. {@code "zilla.mcp.v1"},
+     * never {@code "(zilla.mcp.v1)"}); stripping it here is what lets the two sides merge onto the same
+     * key rather than coexist as unrelated siblings. A nested {@code MessageValue}'s own field names are
+     * never parenthesized, so this is a no-op wherever it doesn't apply. {@code null} converts to an
+     * empty object.
+     */
+    static JsonObject toJsonObject(
+        Map<String, ProtobufConstant> options)
+    {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        if (options != null)
+        {
+            options.forEach((name, value) -> builder.add(unparenthesize(name), value.toJson()));
+        }
+        return builder.build();
+    }
+
+    private static String unparenthesize(
+        String name)
+    {
+        return name.length() >= 2 && name.charAt(0) == '(' && name.charAt(name.length() - 1) == ')'
+            ? name.substring(1, name.length() - 1)
+            : name;
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufField.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufField.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.runtime.common.protobuf;
 import java.util.Map;
 import java.util.Objects;
 
+import jakarta.json.JsonObject;
+
 /**
  * An immutable Protobuf field descriptor: its number, declared {@link ProtobufType}, cardinality,
  * proto3 JSON name, and, for composite fields, the full name of the referenced message or enum.
@@ -35,6 +37,7 @@ public final class ProtobufField
     private final String oneofName;
     private final String defaultValue;
     private final Map<String, ProtobufConstant> options;
+    private final JsonObject overlay;
 
     private ProtobufMessage message;
     private ProtobufEnum enumeration;
@@ -51,7 +54,8 @@ public final class ProtobufField
         String typeName,
         String oneofName,
         String defaultValue,
-        Map<String, ProtobufConstant> options)
+        Map<String, ProtobufConstant> options,
+        JsonObject overlay)
     {
         this.number = number;
         this.name = name;
@@ -65,6 +69,7 @@ public final class ProtobufField
         this.oneofName = oneofName;
         this.defaultValue = defaultValue;
         this.options = options;
+        this.overlay = overlay;
     }
 
     public int number()
@@ -140,6 +145,23 @@ public final class ProtobufField
         String name)
     {
         return options != null ? options.get(name) : null;
+    }
+
+    /**
+     * The effective options for this field as a {@link JsonObject}: the overlay-merged view once a
+     * {@link ProtobufOverlay} has been applied, or the inline {@code .proto} source options converted
+     * to JSON otherwise. Unlike {@link #option(String)}, which always surfaces only the raw inline
+     * value, a consumer that must not care whether an option came from the {@code .proto} source or an
+     * overlay reads this instead.
+     */
+    public JsonObject options()
+    {
+        return overlay != null ? overlay : ProtobufConstant.toJsonObject(options);
+    }
+
+    Map<String, ProtobufConstant> rawOptions()
+    {
+        return options;
     }
 
     public boolean composite()
@@ -226,6 +248,7 @@ public final class ProtobufField
         private String oneofName;
         private String defaultValue;
         private Map<String, ProtobufConstant> options;
+        private JsonObject overlay;
 
         public Builder number(
             int number)
@@ -311,6 +334,13 @@ public final class ProtobufField
             return this;
         }
 
+        public Builder overlay(
+            JsonObject overlay)
+        {
+            this.overlay = overlay;
+            return this;
+        }
+
         public ProtobufField build()
         {
             Objects.requireNonNull(name, "field name");
@@ -318,7 +348,7 @@ public final class ProtobufField
             String resolvedJsonName = jsonName != null ? jsonName : toJsonName(name);
             boolean resolvedPacked = packed != null ? packed : repeated && type.packable();
             return new ProtobufField(number, name, resolvedJsonName, type, repeated, required, resolvedPacked,
-                proto3Optional, typeName, oneofName, defaultValue, options);
+                proto3Optional, typeName, oneofName, defaultValue, options, overlay);
         }
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufMethod.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufMethod.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.json.JsonObject;
+
+/**
+ * An immutable Protobuf {@code rpc} descriptor: its bare name, the full names of its input and output
+ * message types, its streaming cardinality, and any {@code MethodOptions} declared in its {@code .proto}
+ * source's {@code option ...;} statements.
+ */
+public final class ProtobufMethod
+{
+    private final String name;
+    private final String inputType;
+    private final String outputType;
+    private final boolean clientStreaming;
+    private final boolean serverStreaming;
+    private final Map<String, ProtobufConstant> options;
+    private final JsonObject overlay;
+
+    private ProtobufMethod(
+        String name,
+        String inputType,
+        String outputType,
+        boolean clientStreaming,
+        boolean serverStreaming,
+        Map<String, ProtobufConstant> options,
+        JsonObject overlay)
+    {
+        this.name = name;
+        this.inputType = inputType;
+        this.outputType = outputType;
+        this.clientStreaming = clientStreaming;
+        this.serverStreaming = serverStreaming;
+        this.options = options;
+        this.overlay = overlay;
+    }
+
+    public String name()
+    {
+        return name;
+    }
+
+    /**
+     * The full name of this method's request message type, resolved by the proto scoping rules.
+     */
+    public String inputType()
+    {
+        return inputType;
+    }
+
+    /**
+     * The full name of this method's response message type, resolved by the proto scoping rules.
+     */
+    public String outputType()
+    {
+        return outputType;
+    }
+
+    public boolean clientStreaming()
+    {
+        return clientStreaming;
+    }
+
+    public boolean serverStreaming()
+    {
+        return serverStreaming;
+    }
+
+    /**
+     * The value of method option {@code name}, parsed from the {@code .proto} source's {@code rpc { ... }}
+     * body — read from this method's own options only, with no descriptor resolution, so an option need
+     * not be declared by any imported {@code .proto} to be retained. {@code null} when this method
+     * declares no such option.
+     */
+    public ProtobufConstant option(
+        String name)
+    {
+        return options != null ? options.get(name) : null;
+    }
+
+    /**
+     * The effective options for this method as a {@link JsonObject}: the overlay-merged view once a
+     * {@link ProtobufOverlay} has been applied, or the inline {@code .proto} source options converted
+     * to JSON otherwise. Unlike {@link #option(String)}, which always surfaces only the raw inline
+     * value, a consumer that must not care whether an option came from the {@code .proto} source or an
+     * overlay reads this instead.
+     */
+    public JsonObject options()
+    {
+        return overlay != null ? overlay : ProtobufConstant.toJsonObject(options);
+    }
+
+    Map<String, ProtobufConstant> rawOptions()
+    {
+        return options;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private String inputType;
+        private String outputType;
+        private boolean clientStreaming;
+        private boolean serverStreaming;
+        private Map<String, ProtobufConstant> options;
+        private JsonObject overlay;
+
+        public Builder name(
+            String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder inputType(
+            String inputType)
+        {
+            this.inputType = inputType;
+            return this;
+        }
+
+        public Builder outputType(
+            String outputType)
+        {
+            this.outputType = outputType;
+            return this;
+        }
+
+        public Builder clientStreaming(
+            boolean clientStreaming)
+        {
+            this.clientStreaming = clientStreaming;
+            return this;
+        }
+
+        public Builder serverStreaming(
+            boolean serverStreaming)
+        {
+            this.serverStreaming = serverStreaming;
+            return this;
+        }
+
+        public Builder options(
+            Map<String, ProtobufConstant> options)
+        {
+            this.options = options;
+            return this;
+        }
+
+        public Builder overlay(
+            JsonObject overlay)
+        {
+            this.overlay = overlay;
+            return this;
+        }
+
+        public ProtobufMethod build()
+        {
+            Objects.requireNonNull(name, "method name");
+            Objects.requireNonNull(inputType, "method input type");
+            Objects.requireNonNull(outputType, "method output type");
+            return new ProtobufMethod(name, inputType, outputType, clientStreaming, serverStreaming, options, overlay);
+        }
+    }
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlay.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlay.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+
+/**
+ * Resolves a friendly {@code method:}/{@code field:} reference against a {@link ProtobufSchema} and
+ * merges its {@code options:} bag onto the referenced node's existing options, via {@link
+ * jakarta.json.JsonMergePatch}. {@code method:} addresses {@code package.Service/MethodName}, with a
+ * {@code *} wildcard matched anywhere in the string; {@code field:} addresses the exact, non-wildcarded
+ * {@code package.Message.field_name}.
+ * <p>
+ * One {@link ProtobufOverlay} is meant to be reused across many schemas: an entry whose reference does
+ * not resolve against a particular schema is silently skipped for that schema rather than rejected, and
+ * {@link #apply(ProtobufSchema)} returns the identical input instance, unmodified, when nothing in this
+ * overlay matches anything in it. When something does match, only the touched messages/services are
+ * rebuilt — every other message, enum, service, and method is carried into the result by reference,
+ * unmodified and unshared with any other {@link ProtobufSchema} instance.
+ */
+public final class ProtobufOverlay
+{
+    private final List<Entry> entries;
+
+    private ProtobufOverlay(
+        List<Entry> entries)
+    {
+        this.entries = entries;
+    }
+
+    public static ProtobufOverlay of(
+        JsonValue resolved)
+    {
+        JsonArray array = resolved.asJsonArray();
+        List<Entry> entries = new ArrayList<>(array.size());
+        for (JsonValue value : array)
+        {
+            JsonObject object = value.asJsonObject();
+            boolean hasMethod = object.containsKey("method");
+            boolean hasField = object.containsKey("field");
+            if (hasMethod == hasField)
+            {
+                throw new IllegalArgumentException(
+                    "Overlay entry must declare exactly one of \"method\" or \"field\"");
+            }
+            if (!object.containsKey("options"))
+            {
+                throw new IllegalArgumentException("Overlay entry missing required \"options\" field");
+            }
+            JsonObject options = object.getJsonObject("options");
+            entries.add(hasMethod
+                ? new Entry(asPattern(object.getString("method")), null, options)
+                : new Entry(null, object.getString("field"), options));
+        }
+        return new ProtobufOverlay(entries);
+    }
+
+    public ProtobufSchema apply(
+        ProtobufSchema schema)
+    {
+        Map<String, Map<String, JsonObject>> fieldOverlaysByMessage = new LinkedHashMap<>();
+        Map<String, Map<String, JsonObject>> methodOverlaysByService = new LinkedHashMap<>();
+
+        for (Entry entry : entries)
+        {
+            if (entry.method != null)
+            {
+                matchMethod(schema, entry, methodOverlaysByService);
+            }
+            else
+            {
+                matchField(schema, entry, fieldOverlaysByMessage);
+            }
+        }
+
+        ProtobufSchema result = schema;
+        if (!fieldOverlaysByMessage.isEmpty() || !methodOverlaysByService.isEmpty())
+        {
+            result = rebuild(schema, fieldOverlaysByMessage, methodOverlaysByService);
+        }
+        return result;
+    }
+
+    private static void matchMethod(
+        ProtobufSchema schema,
+        Entry entry,
+        Map<String, Map<String, JsonObject>> methodOverlaysByService)
+    {
+        for (ProtobufService service : schema.services())
+        {
+            for (ProtobufMethod method : service.methods())
+            {
+                if (entry.method.matcher(service.name() + "/" + method.name()).matches())
+                {
+                    Map<String, JsonObject> byMethod =
+                        methodOverlaysByService.computeIfAbsent(service.name(), k -> new LinkedHashMap<>());
+                    JsonObject base = byMethod.getOrDefault(method.name(), method.options());
+                    byMethod.put(method.name(), merge(base, entry.options));
+                }
+            }
+        }
+    }
+
+    private static void matchField(
+        ProtobufSchema schema,
+        Entry entry,
+        Map<String, Map<String, JsonObject>> fieldOverlaysByMessage)
+    {
+        int dot = entry.field.lastIndexOf('.');
+        if (dot > 0)
+        {
+            String messageName = entry.field.substring(0, dot);
+            String fieldName = entry.field.substring(dot + 1);
+            ProtobufMessage message = schema.message(messageName);
+            ProtobufField field = message != null ? message.field(fieldName) : null;
+            if (field != null)
+            {
+                Map<String, JsonObject> byField =
+                    fieldOverlaysByMessage.computeIfAbsent(messageName, k -> new LinkedHashMap<>());
+                JsonObject base = byField.getOrDefault(fieldName, field.options());
+                byField.put(fieldName, merge(base, entry.options));
+            }
+        }
+    }
+
+    private static ProtobufSchema rebuild(
+        ProtobufSchema schema,
+        Map<String, Map<String, JsonObject>> fieldOverlaysByMessage,
+        Map<String, Map<String, JsonObject>> methodOverlaysByService)
+    {
+        ProtobufSchema.Builder builder = ProtobufSchema.builder();
+        for (ProtobufEnum enumeration : schema.enumerations())
+        {
+            builder.enumeration(enumeration);
+        }
+        for (ProtobufMessage message : schema.messages())
+        {
+            Map<String, JsonObject> overlaysByField = fieldOverlaysByMessage.get(message.name());
+            if (overlaysByField != null)
+            {
+                builder.message(withOverlay(message, overlaysByField));
+            }
+            else
+            {
+                builder.reuse(message);
+            }
+        }
+        for (ProtobufService service : schema.services())
+        {
+            Map<String, JsonObject> overlaysByMethod = methodOverlaysByService.get(service.name());
+            builder.service(overlaysByMethod != null ? withOverlay(service, overlaysByMethod) : service);
+        }
+        return builder.build();
+    }
+
+    private static ProtobufMessage withOverlay(
+        ProtobufMessage message,
+        Map<String, JsonObject> overlaysByField)
+    {
+        ProtobufMessage.Builder builder = ProtobufMessage.builder(message.name()).mapEntry(message.mapEntry());
+        for (ProtobufField field : message.fields())
+        {
+            builder.field(copyField(field, overlaysByField.get(field.name())));
+        }
+        return builder.build();
+    }
+
+    private static ProtobufField copyField(
+        ProtobufField field,
+        JsonObject overlay)
+    {
+        ProtobufField.Builder builder = ProtobufField.builder()
+            .number(field.number())
+            .name(field.name())
+            .jsonName(field.jsonName())
+            .type(field.type())
+            .repeated(field.repeated())
+            .required(field.required())
+            .packed(field.packed())
+            .proto3Optional(field.proto3Optional())
+            .options(field.rawOptions());
+        if (field.typeName() != null)
+        {
+            builder.typeName(field.typeName());
+        }
+        if (field.oneofName() != null)
+        {
+            builder.oneof(field.oneofName());
+        }
+        if (field.defaultValue() != null)
+        {
+            builder.defaultValue(field.defaultValue());
+        }
+        if (overlay != null)
+        {
+            builder.overlay(overlay);
+        }
+        return builder.build();
+    }
+
+    private static ProtobufService withOverlay(
+        ProtobufService service,
+        Map<String, JsonObject> overlaysByMethod)
+    {
+        ProtobufService.Builder builder = ProtobufService.builder(service.name());
+        for (ProtobufMethod method : service.methods())
+        {
+            JsonObject overlay = overlaysByMethod.get(method.name());
+            builder.method(overlay != null ? copyMethod(method, overlay) : method);
+        }
+        return builder.build();
+    }
+
+    private static ProtobufMethod copyMethod(
+        ProtobufMethod method,
+        JsonObject overlay)
+    {
+        return ProtobufMethod.builder()
+            .name(method.name())
+            .inputType(method.inputType())
+            .outputType(method.outputType())
+            .clientStreaming(method.clientStreaming())
+            .serverStreaming(method.serverStreaming())
+            .options(method.rawOptions())
+            .overlay(overlay)
+            .build();
+    }
+
+    private static JsonObject merge(
+        JsonObject existing,
+        JsonObject patch)
+    {
+        return Json.createMergePatch(patch).apply(existing).asJsonObject();
+    }
+
+    private static Pattern asPattern(
+        String wildcard)
+    {
+        return Pattern.compile(wildcard.replace(".", "\\.").replace("*", ".*"));
+    }
+
+    private static final class Entry
+    {
+        private final Pattern method;
+        private final String field;
+        private final JsonObject options;
+
+        private Entry(
+            Pattern method,
+            String field,
+            JsonObject options)
+        {
+            this.method = method;
+            this.field = field;
+            this.options = options;
+        }
+    }
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
@@ -16,6 +16,7 @@ package io.aklivity.zilla.runtime.common.protobuf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ public final class ProtobufSchema
 {
     private final Map<String, ProtobufMessage> messages;
     private final Map<String, ProtobufEnum> enums;
+    private final Map<String, ProtobufService> services;
     private final Map<String, int[]> indexesByRecord;
     private final Map<IndexPath, ProtobufMessage> messageByIndexes;
     // a single mutable key reused for every lookup, so resolving a message by its decoded index path
@@ -45,10 +47,12 @@ public final class ProtobufSchema
     private ProtobufSchema(
         Map<String, ProtobufMessage> messages,
         Map<String, ProtobufEnum> enums,
+        Map<String, ProtobufService> services,
         List<ProtobufMessage> ordered)
     {
         this.messages = messages;
         this.enums = enums;
+        this.services = services;
         this.indexesByRecord = new LinkedHashMap<>();
         this.messageByIndexes = new LinkedHashMap<>();
         this.lookupPath = new IndexPath(null);
@@ -186,6 +190,30 @@ public final class ProtobufSchema
         return enums.get(name);
     }
 
+    public ProtobufService service(
+        String name)
+    {
+        return services.get(name);
+    }
+
+    public Collection<ProtobufService> services()
+    {
+        return services.values();
+    }
+
+    // package-private: only used internally by ProtobufOverlay's schema rebuild, which must deep-copy
+    // every field to avoid mutating a shared ProtobufField's resolve() link (see Builder#build below) —
+    // no external consumer needs to enumerate every message/enum in a schema today
+    Collection<ProtobufMessage> messages()
+    {
+        return messages.values();
+    }
+
+    Collection<ProtobufEnum> enumerations()
+    {
+        return enums.values();
+    }
+
     public ProtobufMessage resolveMessage(
         ProtobufField field)
     {
@@ -248,15 +276,35 @@ public final class ProtobufSchema
     public static final class Builder
     {
         private final Map<String, ProtobufMessage> messages;
+        private final List<ProtobufMessage> toRelink;
         private final Map<String, ProtobufEnum> enums;
+        private final Map<String, ProtobufService> services;
 
         private Builder()
         {
             this.messages = new LinkedHashMap<>();
+            this.toRelink = new ArrayList<>();
             this.enums = new LinkedHashMap<>();
+            this.services = new LinkedHashMap<>();
         }
 
         public Builder message(
+            ProtobufMessage message)
+        {
+            messages.put(message.name(), message);
+            toRelink.add(message);
+            return this;
+        }
+
+        /**
+         * Adds {@code message} to the schema being resolved without re-linking its fields'
+         * {@link ProtobufField#message()}/{@link ProtobufField#enumeration()} — for a message reused
+         * verbatim from a schema already built (e.g. by {@link ProtobufOverlay}), whose fields are
+         * already correctly linked and must not be re-resolved, since {@link ProtobufField#resolve}
+         * mutates the field in place and those fields may still be shared with the schema {@code
+         * message} was reused from.
+         */
+        Builder reuse(
             ProtobufMessage message)
         {
             messages.put(message.name(), message);
@@ -270,11 +318,19 @@ public final class ProtobufSchema
             return this;
         }
 
+        public Builder service(
+            ProtobufService service)
+        {
+            services.put(service.name(), service);
+            return this;
+        }
+
         public ProtobufSchema build()
         {
             Map<String, ProtobufMessage> resolvedMessages = Map.copyOf(messages);
             Map<String, ProtobufEnum> resolvedEnums = Map.copyOf(enums);
-            for (ProtobufMessage message : resolvedMessages.values())
+            Map<String, ProtobufService> resolvedServices = Map.copyOf(services);
+            for (ProtobufMessage message : toRelink)
             {
                 for (ProtobufField field : message.fields())
                 {
@@ -288,7 +344,7 @@ public final class ProtobufSchema
                     }
                 }
             }
-            return new ProtobufSchema(resolvedMessages, resolvedEnums, new ArrayList<>(messages.values()));
+            return new ProtobufSchema(resolvedMessages, resolvedEnums, resolvedServices, new ArrayList<>(messages.values()));
         }
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufService.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An immutable Protobuf {@code service} descriptor: its full name and the {@link ProtobufMethod}s it
+ * declares, keyed by their bare {@code rpc} name.
+ */
+public final class ProtobufService
+{
+    private final String name;
+    private final Map<String, ProtobufMethod> methods;
+
+    private ProtobufService(
+        String name,
+        Map<String, ProtobufMethod> methods)
+    {
+        this.name = name;
+        this.methods = methods;
+    }
+
+    public String name()
+    {
+        return name;
+    }
+
+    public Collection<ProtobufMethod> methods()
+    {
+        return methods.values();
+    }
+
+    public ProtobufMethod method(
+        String name)
+    {
+        return methods.get(name);
+    }
+
+    public static Builder builder(
+        String name)
+    {
+        return new Builder(name);
+    }
+
+    public static final class Builder
+    {
+        private final String name;
+        private final Map<String, ProtobufMethod> methods;
+
+        private Builder(
+            String name)
+        {
+            this.name = name;
+            this.methods = new LinkedHashMap<>();
+        }
+
+        public Builder method(
+            ProtobufMethod method)
+        {
+            methods.put(method.name(), method);
+            return this;
+        }
+
+        public ProtobufService build()
+        {
+            return new ProtobufService(name, methods);
+        }
+    }
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
@@ -36,7 +36,9 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnum;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufMethod;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufService;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
 import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf2BaseListener;
 import io.aklivity.zilla.runtime.common.protobuf.internal.parser.Protobuf2Lexer;
@@ -140,7 +142,45 @@ public final class ProtobufSourceCompiler
             }
             schema.message(builder.build());
         }
+        for (DraftService service : draft.services)
+        {
+            ProtobufService.Builder builder = ProtobufService.builder(service.fullName);
+            for (DraftMethod method : service.methods)
+            {
+                builder.method(linkMethod(method, names));
+            }
+            schema.service(builder.build());
+        }
         return schema.build();
+    }
+
+    private ProtobufMethod linkMethod(
+        DraftMethod method,
+        Set<String> names)
+    {
+        String inputType = resolveTypeName(method.inputTypeToken, method.scope, names);
+        if (inputType == null)
+        {
+            throw new ProtobufException("unresolved type " + method.inputTypeToken);
+        }
+        String outputType = resolveTypeName(method.outputTypeToken, method.scope, names);
+        if (outputType == null)
+        {
+            throw new ProtobufException("unresolved type " + method.outputTypeToken);
+        }
+
+        ProtobufMethod.Builder builder = ProtobufMethod.builder()
+            .name(method.name)
+            .inputType(inputType)
+            .outputType(outputType)
+            .clientStreaming(method.clientStreaming)
+            .serverStreaming(method.serverStreaming);
+        if (method.options != null)
+        {
+            builder.options(method.options);
+        }
+
+        return builder.build();
     }
 
     private ProtobufField linkField(
@@ -256,6 +296,7 @@ public final class ProtobufSourceCompiler
         private final boolean proto3;
         private final List<DraftMessage> messages;
         private final List<DraftEnum> enums;
+        private final List<DraftService> services;
         private final Set<String> enumNames;
         private String packageName;
 
@@ -265,6 +306,7 @@ public final class ProtobufSourceCompiler
             this.proto3 = proto3;
             this.messages = new ArrayList<>();
             this.enums = new ArrayList<>();
+            this.services = new ArrayList<>();
             this.enumNames = new LinkedHashSet<>();
             this.packageName = "";
         }
@@ -318,12 +360,37 @@ public final class ProtobufSourceCompiler
         private Map<String, ProtobufConstant> options;
     }
 
+    private static final class DraftService
+    {
+        private final String fullName;
+        private final List<DraftMethod> methods;
+
+        private DraftService(
+            String fullName)
+        {
+            this.fullName = fullName;
+            this.methods = new ArrayList<>();
+        }
+    }
+
+    private static final class DraftMethod
+    {
+        private String name;
+        private String scope;
+        private String inputTypeToken;
+        private String outputTypeToken;
+        private boolean clientStreaming;
+        private boolean serverStreaming;
+        private Map<String, ProtobufConstant> options;
+    }
+
     private static final class Assembler
     {
         private final Draft draft;
         private final Deque<String> scope;
         private final Deque<DraftMessage> messages;
         private String oneof;
+        private DraftService service;
 
         private Assembler(
             Draft draft)
@@ -432,6 +499,25 @@ public final class ProtobufSourceCompiler
         private boolean inMessage()
         {
             return !messages.isEmpty();
+        }
+
+        private void enterService(
+            String name)
+        {
+            service = new DraftService(qualify(name));
+            draft.services.add(service);
+        }
+
+        private void exitService()
+        {
+            service = null;
+        }
+
+        private void addMethod(
+            DraftMethod method)
+        {
+            method.scope = currentScope();
+            service.methods.add(method);
         }
     }
 
@@ -546,6 +632,48 @@ public final class ProtobufSourceCompiler
                 }
             }
             helper.addEnum(ctx.enumName().getText(), valueNames, valueNumbers);
+        }
+
+        @Override
+        public void enterServiceDef(
+            Protobuf3Parser.ServiceDefContext ctx)
+        {
+            helper.enterService(ctx.serviceName().getText());
+        }
+
+        @Override
+        public void exitServiceDef(
+            Protobuf3Parser.ServiceDefContext ctx)
+        {
+            helper.exitService();
+        }
+
+        @Override
+        public void enterRpc(
+            Protobuf3Parser.RpcContext ctx)
+        {
+            DraftMethod method = new DraftMethod();
+            method.name = ctx.rpcName().getText();
+            method.inputTypeToken = ctx.messageType(0).getText();
+            method.outputTypeToken = ctx.messageType(1).getText();
+            method.clientStreaming = ctx.clientStreaming != null;
+            method.serverStreaming = ctx.serverStreaming != null;
+            applyMethodOptions(method, ctx.optionStatement());
+            helper.addMethod(method);
+        }
+
+        private void applyMethodOptions(
+            DraftMethod method,
+            List<Protobuf3Parser.OptionStatementContext> statements)
+        {
+            if (!statements.isEmpty())
+            {
+                method.options = new LinkedHashMap<>();
+                for (Protobuf3Parser.OptionStatementContext option : statements)
+                {
+                    method.options.put(option.optionName().getText(), toConstant(option.constant()));
+                }
+            }
         }
 
         private void applyOptions(
@@ -744,6 +872,48 @@ public final class ProtobufSourceCompiler
                 }
             }
             helper.addEnum(ctx.enumName().getText(), valueNames, valueNumbers);
+        }
+
+        @Override
+        public void enterServiceDef(
+            Protobuf2Parser.ServiceDefContext ctx)
+        {
+            helper.enterService(ctx.serviceName().getText());
+        }
+
+        @Override
+        public void exitServiceDef(
+            Protobuf2Parser.ServiceDefContext ctx)
+        {
+            helper.exitService();
+        }
+
+        @Override
+        public void enterRpc(
+            Protobuf2Parser.RpcContext ctx)
+        {
+            DraftMethod method = new DraftMethod();
+            method.name = ctx.rpcName().getText();
+            method.inputTypeToken = ctx.messageType(0).getText();
+            method.outputTypeToken = ctx.messageType(1).getText();
+            method.clientStreaming = ctx.clientStreaming != null;
+            method.serverStreaming = ctx.serverStreaming != null;
+            applyMethodOptions(method, ctx.optionStatement());
+            helper.addMethod(method);
+        }
+
+        private void applyMethodOptions(
+            DraftMethod method,
+            List<Protobuf2Parser.OptionStatementContext> statements)
+        {
+            if (!statements.isEmpty())
+            {
+                method.options = new LinkedHashMap<>();
+                for (Protobuf2Parser.OptionStatementContext option : statements)
+                {
+                    method.options.put(option.optionName().getText(), toConstant(option.constant()));
+                }
+            }
         }
 
         private void applyOptions(

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
@@ -37,7 +37,7 @@ class ProtobufOverlayTest
         "message Other { string email = 1; string name = 2; }\n" +
         "service Greeter {\n" +
         "  rpc SayHello (Req) returns (Res) {\n" +
-        "    option (zilla.mcp.v1) = { title: \"Say Hello\" };\n" +
+        "    option (acme.doc) = { title: \"Say Hello\" };\n" +
         "  }\n" +
         "  rpc StreamHello (Req) returns (Res);\n" +
         "}\n" +
@@ -52,12 +52,12 @@ class ProtobufOverlayTest
         ProtobufSchema schema = Protobuf.schema(PROTO);
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
             "[{\"method\":\"test.Greeter/SayHello\"," +
-                "\"options\":{\"zilla.mcp.v1\":{\"annotations\":{\"readOnlyHint\":true}}}}]"));
+                "\"options\":{\"acme.doc\":{\"tags\":[\"public\"]}}}]"));
 
         ProtobufSchema result = overlay.apply(schema);
 
         assertEquals(
-            "{\"zilla.mcp.v1\":{\"title\":\"Say Hello\",\"annotations\":{\"readOnlyHint\":true}}}",
+            "{\"acme.doc\":{\"title\":\"Say Hello\",\"tags\":[\"public\"]}}",
             result.service("test.Greeter").method("SayHello").options().toString());
     }
 
@@ -66,11 +66,11 @@ class ProtobufOverlayTest
     {
         ProtobufSchema schema = Protobuf.schema(PROTO);
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
-            "[{\"field\":\"test.Other.email\",\"options\":{\"zilla\":{\"tags\":[\"EMAIL\"]}}}]"));
+            "[{\"field\":\"test.Other.email\",\"options\":{\"acme\":{\"tags\":[\"EMAIL\"]}}}]"));
 
         ProtobufSchema result = overlay.apply(schema);
 
-        assertEquals("{\"zilla\":{\"tags\":[\"EMAIL\"]}}",
+        assertEquals("{\"acme\":{\"tags\":[\"EMAIL\"]}}",
             result.message("test.Other").field("email").options().toString());
         assertEquals("{}", result.message("test.Other").field("name").options().toString());
     }
@@ -80,12 +80,12 @@ class ProtobufOverlayTest
     {
         ProtobufSchema schema = Protobuf.schema(PROTO);
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
-            "[{\"method\":\"test.Other1/*\",\"options\":{\"zilla\":{\"tagged\":true}}}]"));
+            "[{\"method\":\"test.Other1/*\",\"options\":{\"acme\":{\"tagged\":true}}}]"));
 
         ProtobufSchema result = overlay.apply(schema);
 
-        assertEquals("{\"zilla\":{\"tagged\":true}}", result.service("test.Other1").method("First").options().toString());
-        assertEquals("{\"zilla\":{\"tagged\":true}}", result.service("test.Other1").method("Second").options().toString());
+        assertEquals("{\"acme\":{\"tagged\":true}}", result.service("test.Other1").method("First").options().toString());
+        assertEquals("{\"acme\":{\"tagged\":true}}", result.service("test.Other1").method("Second").options().toString());
     }
 
     @Test
@@ -93,13 +93,13 @@ class ProtobufOverlayTest
     {
         ProtobufSchema schema = Protobuf.schema(PROTO);
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
-            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"title\":\"Overridden\"}}}," +
-                "{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"description\":\"desc\"}}}]"));
+            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"acme.doc\":{\"title\":\"Overridden\"}}}," +
+                "{\"method\":\"test.Greeter/SayHello\",\"options\":{\"acme.doc\":{\"description\":\"desc\"}}}]"));
 
         ProtobufSchema result = overlay.apply(schema);
 
         assertEquals(
-            "{\"zilla.mcp.v1\":{\"title\":\"Overridden\",\"description\":\"desc\"}}",
+            "{\"acme.doc\":{\"title\":\"Overridden\",\"description\":\"desc\"}}",
             result.service("test.Greeter").method("SayHello").options().toString());
     }
 
@@ -123,7 +123,7 @@ class ProtobufOverlayTest
         ProtobufMessage untouchedMessage = schema.message("test.Req");
         ProtobufService untouchedService = schema.service("test.Other1");
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
-            "[{\"field\":\"test.Other.email\",\"options\":{\"zilla\":{\"tags\":[\"EMAIL\"]}}}]"));
+            "[{\"field\":\"test.Other.email\",\"options\":{\"acme\":{\"tags\":[\"EMAIL\"]}}}]"));
 
         ProtobufSchema result = overlay.apply(schema);
 
@@ -140,12 +140,12 @@ class ProtobufOverlayTest
             "package other;\n" +
             "message M { string v = 1; }\n");
         ProtobufOverlay overlay = ProtobufOverlay.of(read(
-            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"title\":\"X\"}}}]"));
+            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"acme.doc\":{\"title\":\"X\"}}}]"));
 
         ProtobufSchema matchedResult = overlay.apply(matching);
         ProtobufSchema unmatchedResult = overlay.apply(nonMatching);
 
-        assertEquals("{\"zilla.mcp.v1\":{\"title\":\"X\"}}",
+        assertEquals("{\"acme.doc\":{\"title\":\"X\"}}",
             matchedResult.service("test.Greeter").method("SayHello").options().toString());
         assertSame(nonMatching, unmatchedResult);
     }
@@ -181,9 +181,9 @@ class ProtobufOverlayTest
         ProtobufSchema schema = Protobuf.schema(PROTO);
 
         assertEquals("{\"title\":\"Say Hello\"}",
-            schema.service("test.Greeter").method("SayHello").option("(zilla.mcp.v1)").toJson().toString());
-        assertTrue(schema.service("test.Greeter").method("SayHello").options().containsKey("zilla.mcp.v1"));
-        assertNull(schema.service("test.Greeter").method("StreamHello").option("(zilla.mcp.v1)"));
+            schema.service("test.Greeter").method("SayHello").option("(acme.doc)").toJson().toString());
+        assertTrue(schema.service("test.Greeter").method("SayHello").options().containsKey("acme.doc"));
+        assertNull(schema.service("test.Greeter").method("StreamHello").option("(acme.doc)"));
     }
 
     private static JsonValue read(

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+
+import org.junit.jupiter.api.Test;
+
+class ProtobufOverlayTest
+{
+    private static final String PROTO =
+        "syntax = \"proto3\";\n" +
+        "package test;\n" +
+        "message Req { string id = 1; }\n" +
+        "message Res { string id = 1; }\n" +
+        "message Other { string email = 1; string name = 2; }\n" +
+        "service Greeter {\n" +
+        "  rpc SayHello (Req) returns (Res) {\n" +
+        "    option (zilla.mcp.v1) = { title: \"Say Hello\" };\n" +
+        "  }\n" +
+        "  rpc StreamHello (Req) returns (Res);\n" +
+        "}\n" +
+        "service Other1 {\n" +
+        "  rpc First (Req) returns (Res);\n" +
+        "  rpc Second (Req) returns (Res);\n" +
+        "}\n";
+
+    @Test
+    void shouldMergeOptionsOntoMatchedMethod()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"method\":\"test.Greeter/SayHello\"," +
+                "\"options\":{\"zilla.mcp.v1\":{\"annotations\":{\"readOnlyHint\":true}}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertEquals(
+            "{\"zilla.mcp.v1\":{\"title\":\"Say Hello\",\"annotations\":{\"readOnlyHint\":true}}}",
+            result.service("test.Greeter").method("SayHello").options().toString());
+    }
+
+    @Test
+    void shouldMergeOptionsOntoMatchedFieldExactReference()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"field\":\"test.Other.email\",\"options\":{\"zilla\":{\"tags\":[\"EMAIL\"]}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertEquals("{\"zilla\":{\"tags\":[\"EMAIL\"]}}",
+            result.message("test.Other").field("email").options().toString());
+        assertEquals("{}", result.message("test.Other").field("name").options().toString());
+    }
+
+    @Test
+    void shouldMatchMethodWildcardAcrossMultipleRpcs()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"method\":\"test.Other1/*\",\"options\":{\"zilla\":{\"tagged\":true}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertEquals("{\"zilla\":{\"tagged\":true}}", result.service("test.Other1").method("First").options().toString());
+        assertEquals("{\"zilla\":{\"tagged\":true}}", result.service("test.Other1").method("Second").options().toString());
+    }
+
+    @Test
+    void shouldApplyLaterEntryOnTopOfEarlierForSameMethod()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"title\":\"Overridden\"}}}," +
+                "{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"description\":\"desc\"}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertEquals(
+            "{\"zilla.mcp.v1\":{\"title\":\"Overridden\",\"description\":\"desc\"}}",
+            result.service("test.Greeter").method("SayHello").options().toString());
+    }
+
+    @Test
+    void shouldReturnSameSchemaInstanceWhenNothingMatches()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"method\":\"test.Missing/Method\",\"options\":{\"a\":1}}," +
+                "{\"field\":\"test.Missing.field\",\"options\":{\"a\":1}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertSame(schema, result);
+    }
+
+    @Test
+    void shouldLeaveUntouchedMessageAndServiceUnchangedByReference()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+        ProtobufMessage untouchedMessage = schema.message("test.Req");
+        ProtobufService untouchedService = schema.service("test.Other1");
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"field\":\"test.Other.email\",\"options\":{\"zilla\":{\"tags\":[\"EMAIL\"]}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertSame(untouchedMessage, result.message("test.Req"));
+        assertSame(untouchedService, result.service("test.Other1"));
+    }
+
+    @Test
+    void shouldReuseOneOverlayAcrossMultipleSchemas()
+    {
+        ProtobufSchema matching = Protobuf.schema(PROTO);
+        ProtobufSchema nonMatching = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "package other;\n" +
+            "message M { string v = 1; }\n");
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"method\":\"test.Greeter/SayHello\",\"options\":{\"zilla.mcp.v1\":{\"title\":\"X\"}}}]"));
+
+        ProtobufSchema matchedResult = overlay.apply(matching);
+        ProtobufSchema unmatchedResult = overlay.apply(nonMatching);
+
+        assertEquals("{\"zilla.mcp.v1\":{\"title\":\"X\"}}",
+            matchedResult.service("test.Greeter").method("SayHello").options().toString());
+        assertSame(nonMatching, unmatchedResult);
+    }
+
+    @Test
+    void shouldRejectEntryWithNeitherMethodNorField()
+    {
+        JsonValue document = read("[{\"options\":{\"a\":1}}]");
+
+        assertThrows(IllegalArgumentException.class, () -> ProtobufOverlay.of(document));
+    }
+
+    @Test
+    void shouldRejectEntryWithBothMethodAndField()
+    {
+        JsonValue document = read(
+            "[{\"method\":\"test.Greeter/SayHello\",\"field\":\"test.Other.email\",\"options\":{\"a\":1}}]");
+
+        assertThrows(IllegalArgumentException.class, () -> ProtobufOverlay.of(document));
+    }
+
+    @Test
+    void shouldRejectEntryMissingOptions()
+    {
+        JsonValue document = read("[{\"method\":\"test.Greeter/SayHello\"}]");
+
+        assertThrows(IllegalArgumentException.class, () -> ProtobufOverlay.of(document));
+    }
+
+    @Test
+    void shouldExposeInlineOptionsWhenNoOverlayApplied()
+    {
+        ProtobufSchema schema = Protobuf.schema(PROTO);
+
+        assertEquals("{\"title\":\"Say Hello\"}",
+            schema.service("test.Greeter").method("SayHello").option("(zilla.mcp.v1)").toJson().toString());
+        assertTrue(schema.service("test.Greeter").method("SayHello").options().containsKey("zilla.mcp.v1"));
+        assertNull(schema.service("test.Greeter").method("StreamHello").option("(zilla.mcp.v1)"));
+    }
+
+    private static JsonValue read(
+        String text)
+    {
+        return Json.createReader(new StringReader(text)).readValue();
+    }
+}

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
@@ -236,6 +236,75 @@ public class ProtobufSourceCompilerTest
     }
 
     @Test
+    public void shouldCompileProto3ServiceAndRpc()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "package test;\n" +
+            "message Req { string id = 1; }\n" +
+            "message Res { string id = 1; }\n" +
+            "service Greeter {\n" +
+            "  rpc SayHello (Req) returns (Res);\n" +
+            "  rpc StreamHello (stream Req) returns (stream Res);\n" +
+            "}\n");
+
+        ProtobufService service = schema.service("test.Greeter");
+        assertNotNull(service);
+        assertEquals("test.Greeter", service.name());
+        assertEquals(2, service.methods().size());
+
+        ProtobufMethod sayHello = service.method("SayHello");
+        assertEquals("test.Req", sayHello.inputType());
+        assertEquals("test.Res", sayHello.outputType());
+        assertFalse(sayHello.clientStreaming());
+        assertFalse(sayHello.serverStreaming());
+
+        ProtobufMethod streamHello = service.method("StreamHello");
+        assertTrue(streamHello.clientStreaming());
+        assertTrue(streamHello.serverStreaming());
+
+        assertNull(schema.service("test.Missing"));
+    }
+
+    @Test
+    public void shouldExposeCustomMethodOptionsInProto3()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "package test;\n" +
+            "message Req { string id = 1; }\n" +
+            "message Res { string id = 1; }\n" +
+            "service Greeter {\n" +
+            "  rpc SayHello (Req) returns (Res) {\n" +
+            "    option (acme.kind) = \"A\";\n" +
+            "    option deprecated = true;\n" +
+            "  }\n" +
+            "}\n");
+
+        ProtobufMethod sayHello = schema.service("test.Greeter").method("SayHello");
+        assertEquals(new ProtobufConstant.TextValue("A"), sayHello.option("(acme.kind)"));
+        assertEquals(new ProtobufConstant.BooleanValue(true), sayHello.option("deprecated"));
+        assertNull(sayHello.option("(acme.missing)"));
+    }
+
+    @Test
+    public void shouldCompileProto2ServiceAndRpc()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto2\";\n" +
+            "package test;\n" +
+            "message Req { required string id = 1; }\n" +
+            "message Res { required string id = 1; }\n" +
+            "service Greeter {\n" +
+            "  rpc SayHello (Req) returns (Res);\n" +
+            "}\n");
+
+        ProtobufMethod sayHello = schema.service("test.Greeter").method("SayHello");
+        assertEquals("test.Req", sayHello.inputType());
+        assertEquals("test.Res", sayHello.outputType());
+    }
+
+    @Test
     public void shouldDeriveJsonNameForSnakeCaseField()
     {
         ProtobufSchema schema = Protobuf.schema(


### PR DESCRIPTION
## Description

Adds `ProtobufService`/`ProtobufMethod` (service/rpc parsing — previously parsed by the grammar but silently dropped by `ProtobufSourceCompiler`'s listeners, with no model type at all) and `ProtobufOverlay`, which resolves a `method:`/`field:` friendly reference against a `ProtobufSchema` and merges an `options:` bag onto the referenced node via `jakarta.json.JsonMergePatch`:

- `method:` addresses `package.Service/MethodName`, with a `*` wildcard matched anywhere in the string (mirroring, not depending on, `binding-grpc`'s `GrpcConditionMatcher` wildcard-to-regex transform — `common-protobuf` can't depend on `binding-grpc`).
- `field:` addresses the exact, non-wildcarded `package.Message.field_name`.
- The merge uses `jakarta.json.Json.createMergePatch(...)`, already implemented and tested in `common-json` (`JsonProviderImpl`/`JsonValues.mergePatch`) and reachable via the public `jakarta.json` facade — no new dependency needed.

`ProtobufConstant` gains `toJson()`/`toJsonObject()` to bridge the ANTLR-sourced option constants into `jakarta.json`, normalizing a parenthesized custom/extension option reference (`"(zilla.mcp.v1)"`) to its bare dotted name (`"zilla.mcp.v1"`) — that punctuation is only how the `.proto` grammar distinguishes an extension reference from a built-in option name, and an overlay's `options:` bag always addresses the bare name, so without normalizing, an inline option and an overlay entry for "the same" option would merge as unrelated sibling keys instead of colliding on one.

**Reuse across schemas.** One `ProtobufOverlay` is meant to be applied to many different schemas, most of which won't contain what a given entry addresses: `apply(schema)` returns the identical input instance, unmodified, when nothing matches. When something does match, only the touched messages/services are rebuilt — everything else is carried through by reference, unshared with any other `ProtobufSchema` instance. This required a new `ProtobufSchema.Builder.reuse(...)`, distinct from the existing `message(...)`: `ProtobufField.resolve()` mutates the field's cached `.message()`/`.enumeration()` link in place during the relink pass, so an "unchanged" message added via the ordinary `message(...)` path would still have its shared field objects silently re-relinked (and thus mutated) by a second `build()` call — corrupting the original schema's own view through those same shared objects. `reuse(...)` adds a message for lookup without re-running the relink pass over it, since it's already correctly linked from the schema it came from. `ProtobufMethod`/`ProtobufService` have no such mutable state, so untouched methods inside a rebuilt service are simply passed through unchanged with no copy at all.

**Scope**, matching the issue's own boundaries and cross-referenced follow-up work:
- Only the ANTLR/text-source path (`ProtobufSourceCompiler`) gets service/rpc modeling and the overlay mechanism — `ProtobufSchemaCompiler` (binary `FileDescriptorSet` path) has zero production callers today and is left untouched.
- `field:` is exact-reference only, no wildcard — bulk field selection by pattern is `named:`'s job (#2302), not this mechanism's.
- No `CatalogHandler`/config-schema/`model-protobuf`/`binding-mcp-grpc` wiring — this issue owns reference resolution and the options merge only, per #2280's own "module placement" note. Wiring this into `model: protobuf`'s `overlay:` catalog entry is #2318; wiring it into `binding-mcp-grpc`'s `zilla.mcp.v1` tool annotations is #2280.

Fixes #2279

## Test plan

- [x] `ProtobufSourceCompilerTest` extended with service/rpc parsing (proto2 + proto3), streaming flags, and method-option capture
- [x] New `ProtobufOverlayTest`: exact method match, wildcard match across multiple rpcs, exact field match, later-entry-wins merge precedence, no-op (identical instance returned) when nothing matches, untouched messages/services reused by reference (`assertSame`), one overlay reused across two schemas (matching + non-matching), malformed entry rejection (neither/both of `method`/`field`, missing `options`)
- [x] `./mvnw test -pl runtime/common-protobuf` — 212/212 passing (full module, no regressions)
- [x] `./mvnw checkstyle:check -pl runtime/common-protobuf` — 0 violations
- [x] `./mvnw test jacoco:check -pl runtime/common-protobuf` — coverage requirements met (90% instruction, 0 missed classes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZYtsEXoSX13cn1R5s1Ztb)_