### PR TITLE
feat(common-json,model-json,model-protobuf,model-avro): schema overlay support

### DIFF
--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/OverlayConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/OverlayConfig.java
@@ -18,6 +18,8 @@ import java.util.function.Function;
 
 public class OverlayConfig extends Config
 {
+    public transient long id;
+
     public final String name;
     public final SchemaConfig schema;
 

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfig.java
@@ -23,19 +23,22 @@ public class SchemaConfig extends Config
     public final String subject;
     public final int id;
     public final String record;
+    public final OverlayConfig overlay;
 
     SchemaConfig(
         String strategy,
         String subject,
         String version,
         int id,
-        String record)
+        String record,
+        OverlayConfig overlay)
     {
         this.strategy = strategy;
         this.version = version;
         this.subject = subject;
         this.id = id;
         this.record = record;
+        this.overlay = overlay;
     }
 
     public static <T> SchemaConfigBuilder<T> builder(

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfigAdapter.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfigAdapter.java
@@ -26,6 +26,7 @@ public class SchemaConfigAdapter extends ConfigAdapter<SchemaConfig, JsonObject>
     private static final String VERSION_DEFAULT = "latest";
     private static final String ID_NAME = "id";
     private static final String RECORD_NAME = "record";
+    private static final String OVERLAY_NAME = "overlay";
 
     @Override
     public JsonObject adaptToJson(
@@ -51,6 +52,10 @@ public class SchemaConfigAdapter extends ConfigAdapter<SchemaConfig, JsonObject>
         if (schema.record != null)
         {
             object.add(RECORD_NAME, schema.record);
+        }
+        if (schema.overlay != null)
+        {
+            object.add(OVERLAY_NAME, new OverlayConfigAdapter().adaptToJson(schema.overlay));
         }
         return object.build();
     }
@@ -88,6 +93,11 @@ public class SchemaConfigAdapter extends ConfigAdapter<SchemaConfig, JsonObject>
         if (object.containsKey(RECORD_NAME))
         {
             builder.record(object.getString(RECORD_NAME));
+        }
+
+        if (object.containsKey(OVERLAY_NAME))
+        {
+            builder.overlay(new OverlayConfigAdapter().adaptFromJson(object.getJsonObject(OVERLAY_NAME)));
         }
 
         return builder.build();

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfigBuilder.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/SchemaConfigBuilder.java
@@ -25,6 +25,7 @@ public class SchemaConfigBuilder<T> extends ConfigBuilder<T, SchemaConfigBuilder
     private String subject;
     private int id;
     private String record;
+    private OverlayConfig overlay;
 
     public SchemaConfigBuilder(
         Function<SchemaConfig, T> mapper)
@@ -74,9 +75,21 @@ public class SchemaConfigBuilder<T> extends ConfigBuilder<T, SchemaConfigBuilder
         return this;
     }
 
+    public SchemaConfigBuilder<T> overlay(
+        OverlayConfig overlay)
+    {
+        this.overlay = overlay;
+        return this;
+    }
+
+    public OverlayConfigBuilder<SchemaConfigBuilder<T>> overlay()
+    {
+        return OverlayConfig.builder(this::overlay);
+    }
+
     @Override
     public T build()
     {
-        return mapper.apply(new SchemaConfig(strategy, subject, version, id, record));
+        return mapper.apply(new SchemaConfig(strategy, subject, version, id, record, overlay));
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/SchemaConfigAdapterTest.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/SchemaConfigAdapterTest.java
@@ -67,4 +67,70 @@ public class SchemaConfigAdapterTest
         assertThat(object, not(nullValue()));
         assertThat(object.toString(), equalTo("{\"subject\":\"echo\",\"version\":\"1\"}"));
     }
+
+    @Test
+    public void shouldReadSchemaWithOverlay()
+    {
+        String text =
+            "{" +
+                "\"subject\": \"echo\"," +
+                "\"version\": \"1\"," +
+                "\"overlay\":" +
+                "{" +
+                    "\"my-overlay\":" +
+                    "{" +
+                        "\"subject\": \"echo-overlay\"," +
+                        "\"version\": \"latest\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        JsonObject object = Json.createReader(new StringReader(text)).readObject();
+        SchemaConfig schema = adapter.adaptFromJson(object);
+
+        assertThat(schema, not(nullValue()));
+        assertThat(schema.subject, equalTo("echo"));
+        assertThat(schema.overlay, not(nullValue()));
+        assertThat(schema.overlay.name, equalTo("my-overlay"));
+        assertThat(schema.overlay.schema.subject, equalTo("echo-overlay"));
+        assertThat(schema.overlay.schema.version, equalTo("latest"));
+    }
+
+    @Test
+    public void shouldWriteSchemaWithOverlay()
+    {
+        SchemaConfig schema = SchemaConfig.builder()
+            .subject("echo")
+            .version("1")
+            .overlay()
+                .name("my-overlay")
+                .schema()
+                    .subject("echo-overlay")
+                    .version("latest")
+                    .build()
+                .build()
+            .build();
+
+        JsonObject object = adapter.adaptToJson(schema);
+
+        assertThat(object, not(nullValue()));
+        assertThat(object.toString(), equalTo(
+            "{\"subject\":\"echo\",\"version\":\"1\"," +
+            "\"overlay\":{\"my-overlay\":{\"subject\":\"echo-overlay\",\"version\":\"latest\"}}}"));
+    }
+
+    @Test
+    public void shouldReadSchemaWithoutOverlay()
+    {
+        String text =
+            "{" +
+                "\"subject\": \"echo\"," +
+                "\"version\": \"1\"" +
+            "}";
+
+        JsonObject object = Json.createReader(new StringReader(text)).readObject();
+        SchemaConfig schema = adapter.adaptFromJson(object);
+
+        assertThat(schema.overlay, nullValue());
+    }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlay.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonOverlay.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonPointer;
@@ -28,44 +29,60 @@ import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 
 /**
- * Applies an OpenAPI Overlay Specification (1.0.0) document to a target {@link JsonValue}
- * document, producing the materialized result. Each action's {@code target} JSONPath (see
- * {@link JsonPath}) is re-evaluated against the document as it stands after every preceding
- * action, so later actions observe earlier edits.
+ * Applies an OpenAPI Overlay Specification (1.0.0 or 1.1.0) document to a target
+ * {@link JsonValue} document, producing the materialized result. Each action's {@code target}
+ * JSONPath (see {@link JsonPath}) is re-evaluated against the document as it stands after every
+ * preceding action, so later actions observe earlier edits.
  * <p>
  * For a matched node that is an object, {@code update} is recursively merged into it
- * (existing properties are overwritten, new properties are added). For a matched node that
- * is an array, {@code update} is appended as a new element. For any other matched node
- * (a scalar or {@code null}), {@code update} replaces it outright. A {@code remove} action
- * deletes every matched node from its containing object or array; when a single action
- * matches multiple array elements, removal proceeds from the highest index to the lowest so
- * earlier indices remain valid. A target that matches nothing is a no-op.
+ * (existing properties are overwritten, new properties are added). For a matched node that is
+ * an array: under {@code 1.0.0}, {@code update} is always appended as a single new element;
+ * under {@code 1.1.0}, an {@code update} that is itself an array is concatenated with the
+ * matched array, while any other {@code update} is still appended as a single new element. For
+ * any other matched node (a scalar or {@code null}), {@code update} replaces it outright. A
+ * {@code remove} action deletes every matched node from its containing object or array; when a
+ * single action matches multiple array elements, removal proceeds from the highest index to the
+ * lowest so earlier indices remain valid. A target that matches nothing is a no-op.
  */
 public final class JsonOverlay
 {
+    private static final String VERSION_1_1_0 = "1.1.0";
+    private static final String VERSION_1_0_0 = "1.0.0";
+
+    private final String version;
     private final List<JsonOverlayAction> actions;
 
     private JsonOverlay(
+        String version,
         List<JsonOverlayAction> actions)
     {
+        this.version = version;
         this.actions = actions;
     }
 
     public static JsonOverlay of(
         List<JsonOverlayAction> actions)
     {
+        return of(VERSION_1_0_0, actions);
+    }
+
+    private static JsonOverlay of(
+        String version,
+        List<JsonOverlayAction> actions)
+    {
         if (actions.isEmpty())
         {
             throw new IllegalArgumentException("Overlay must contain at least one action");
         }
-        return new JsonOverlay(new ArrayList<>(actions));
+        return new JsonOverlay(version, new ArrayList<>(actions));
     }
 
     public static JsonOverlay of(
         JsonValue document)
     {
         JsonObject object = document.asJsonObject();
-        if (!object.containsKey("overlay") || object.getString("overlay", "").isEmpty())
+        String version = object.getString("overlay", "");
+        if (!object.containsKey("overlay") || version.isEmpty())
         {
             throw new IllegalArgumentException("Overlay document missing required \"overlay\" version field");
         }
@@ -90,7 +107,7 @@ public final class JsonOverlay
             actions.add(new JsonOverlayAction(target, update, remove));
         }
 
-        return of(actions);
+        return of(version, actions);
     }
 
     public JsonValue apply(
@@ -104,7 +121,7 @@ public final class JsonOverlay
         return result;
     }
 
-    private static JsonStructure applyAction(
+    private JsonStructure applyAction(
         JsonOverlayAction action,
         JsonStructure document)
     {
@@ -132,7 +149,7 @@ public final class JsonOverlay
         return result;
     }
 
-    private static JsonValue merge(
+    private JsonValue merge(
         JsonValue existing,
         JsonValue update)
     {
@@ -151,12 +168,26 @@ public final class JsonOverlay
         }
         else if (existing.getValueType() == JsonValue.ValueType.ARRAY)
         {
-            merged = Json.createArrayBuilder(existing.asJsonArray()).add(update).build();
+            merged = VERSION_1_1_0.equals(version) && update.getValueType() == JsonValue.ValueType.ARRAY
+                ? concat(existing.asJsonArray(), update.asJsonArray())
+                : Json.createArrayBuilder(existing.asJsonArray()).add(update).build();
         }
         else
         {
             merged = update;
         }
         return merged;
+    }
+
+    private static JsonArray concat(
+        JsonArray existing,
+        JsonArray update)
+    {
+        JsonArrayBuilder builder = Json.createArrayBuilder(existing);
+        for (JsonValue item : update)
+        {
+            builder.add(item);
+        }
+        return builder.build();
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPath.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPath.java
@@ -20,6 +20,7 @@ import java.util.function.BiConsumer;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
 /**
@@ -29,9 +30,11 @@ import jakarta.json.JsonValue;
  * Only the subset of JSONPath needed to express OpenAPI Overlay Specification targets is
  * supported: the root selector ({@code $}), dot and bracket member selectors (including
  * single- or double-quoted bracket names for keys containing reserved characters), integer
- * array indices (including negative indices counted from the end), and the wildcard selector
- * ({@code .*} or {@code [*]}) over object values or array elements. Descendant segments,
- * filter expressions, slices and unions are not supported.
+ * array indices (including negative indices counted from the end), the wildcard selector
+ * ({@code .*} or {@code [*]}) over object values or array elements, and an equality-only filter
+ * expression ({@code [?(@.name=='value')]}) selecting array elements whose named property is a
+ * string equal to the quoted literal. Descendant segments, comparisons other than equality, and
+ * slices and unions are not supported.
  */
 public final class JsonPath
 {
@@ -186,6 +189,48 @@ public final class JsonPath
         }
     }
 
+    private static final class FilterSegment implements Segment
+    {
+        private final String name;
+        private final String value;
+
+        private FilterSegment(
+            String name,
+            String value)
+        {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public void match(
+            JsonValue node,
+            BiConsumer<String, JsonValue> emit)
+        {
+            if (node.getValueType() == JsonValue.ValueType.ARRAY)
+            {
+                JsonArray array = node.asJsonArray();
+                for (int i = 0; i < array.size(); i++)
+                {
+                    JsonValue element = array.get(i);
+                    if (element.getValueType() == JsonValue.ValueType.OBJECT && matches(element.asJsonObject()))
+                    {
+                        emit.accept(String.valueOf(i), element);
+                    }
+                }
+            }
+        }
+
+        private boolean matches(
+            JsonObject object)
+        {
+            JsonValue candidate = object.get(name);
+            return candidate != null &&
+                candidate.getValueType() == JsonValue.ValueType.STRING &&
+                ((JsonString) candidate).getString().equals(value);
+        }
+    }
+
     private static final class Parser
     {
         private final String expression;
@@ -236,16 +281,7 @@ public final class JsonPath
             }
             else
             {
-                int start = position;
-                while (position < expression.length() && isNameChar(expression.charAt(position)))
-                {
-                    position++;
-                }
-                if (position == start)
-                {
-                    throw new IllegalArgumentException("Expected property name at " + position + " in: " + expression);
-                }
-                segment = new NameSegment(expression.substring(start, position));
+                segment = new NameSegment(parseName());
             }
             return segment;
         }
@@ -269,6 +305,10 @@ public final class JsonPath
                 position++;
                 segment = new WildcardSegment();
             }
+            else if (c == '?')
+            {
+                segment = parseFilterSegment();
+            }
             else
             {
                 segment = new IndexSegment(parseIndex());
@@ -281,6 +321,48 @@ public final class JsonPath
             position++;
 
             return segment;
+        }
+
+        private Segment parseFilterSegment()
+        {
+            expect('?');
+            expect('(');
+            expect('@');
+            expect('.');
+            String name = parseName();
+            expect('=');
+            expect('=');
+            if (position >= expression.length() || expression.charAt(position) != '\'' && expression.charAt(position) != '"')
+            {
+                throw new IllegalArgumentException("Expected quoted filter value at " + position + " in: " + expression);
+            }
+            String value = parseQuotedName(expression.charAt(position));
+            expect(')');
+            return new FilterSegment(name, value);
+        }
+
+        private String parseName()
+        {
+            int start = position;
+            while (position < expression.length() && isNameChar(expression.charAt(position)))
+            {
+                position++;
+            }
+            if (position == start)
+            {
+                throw new IllegalArgumentException("Expected property name at " + position + " in: " + expression);
+            }
+            return expression.substring(start, position);
+        }
+
+        private void expect(
+            char expected)
+        {
+            if (position >= expression.length() || expression.charAt(position) != expected)
+            {
+                throw new IllegalArgumentException("Expected '" + expected + "' at " + position + " in: " + expression);
+            }
+            position++;
         }
 
         private String parseQuotedName(

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonOverlayTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonOverlayTest.java
@@ -84,6 +84,76 @@ class JsonOverlayTest
     }
 
     @Test
+    void shouldAppendArrayUpdateAsSingleElementUnderOverlay100()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.0.0\",\"actions\":[" +
+                "{\"target\":\"$.tags\",\"update\":[\"c\",\"d\"]}" +
+            "]}");
+        JsonValue document = read("{\"tags\":[\"a\",\"b\"]}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"tags\":[\"a\",\"b\",[\"c\",\"d\"]]}", result.toString());
+    }
+
+    @Test
+    void shouldConcatenateArrayUpdateIntoMatchedArrayUnderOverlay110()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.1.0\",\"actions\":[" +
+                "{\"target\":\"$.tags\",\"update\":[\"c\",\"d\"]}" +
+            "]}");
+        JsonValue document = read("{\"tags\":[\"a\",\"b\"]}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"tags\":[\"a\",\"b\",\"c\",\"d\"]}", result.toString());
+    }
+
+    @Test
+    void shouldAppendScalarUpdateToMatchedArrayUnderOverlay110()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.1.0\",\"actions\":[" +
+                "{\"target\":\"$.tags\",\"update\":\"c\"}" +
+            "]}");
+        JsonValue document = read("{\"tags\":[\"a\",\"b\"]}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"tags\":[\"a\",\"b\",\"c\"]}", result.toString());
+    }
+
+    @Test
+    void shouldAppendObjectUpdateToMatchedArrayUnderOverlay110()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.1.0\",\"actions\":[" +
+                "{\"target\":\"$.items\",\"update\":{\"x\":1}}" +
+            "]}");
+        JsonValue document = read("{\"items\":[\"a\"]}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"items\":[\"a\",{\"x\":1}]}", result.toString());
+    }
+
+    @Test
+    void shouldConcatenateArrayUpdateAtEveryWildcardMatchedArrayUnderOverlay110()
+    {
+        JsonValue overlayDoc = read(
+            "{\"overlay\":\"1.1.0\",\"actions\":[" +
+                "{\"target\":\"$.groups[*]\",\"update\":[\"x\"]}" +
+            "]}");
+        JsonValue document = read("{\"groups\":[[\"a\"],[\"b\"]]}");
+
+        JsonValue result = JsonOverlay.of(overlayDoc).apply(document);
+
+        assertEquals("{\"groups\":[[\"a\",\"x\"],[\"b\",\"x\"]]}", result.toString());
+    }
+
+    @Test
     void shouldApplyUpdateToEveryWildcardMatchedObject()
     {
         JsonValue document = read("{\"paths\":{\"/a\":{\"get\":{}},\"/b\":{\"get\":{}}}}");

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPathTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonPathTest.java
@@ -115,6 +115,80 @@ class JsonPathTest
     }
 
     @Test
+    void shouldMatchArrayElementByFilterEqualityOnName()
+    {
+        assertEquals(List.of("/fields/1"),
+            matches("$.fields[?(@.name=='email')]",
+                "{\"fields\":[{\"name\":\"id\"},{\"name\":\"email\"}]}"));
+    }
+
+    @Test
+    void shouldMatchMultipleArrayElementsByFilterEquality()
+    {
+        assertEquals(List.of("/fields/0", "/fields/2"),
+            matches("$.fields[?(@.name=='email')]",
+                "{\"fields\":[{\"name\":\"email\"},{\"name\":\"id\"},{\"name\":\"email\"}]}"));
+    }
+
+    @Test
+    void shouldMatchFilterWithDoubleQuotedValue()
+    {
+        assertEquals(List.of("/fields/0"),
+            matches("$.fields[?(@.name==\"email\")]", "{\"fields\":[{\"name\":\"email\"}]}"));
+    }
+
+    @Test
+    void shouldNotMatchArrayElementMissingFilteredProperty()
+    {
+        assertEquals(List.of(),
+            matches("$.fields[?(@.name=='email')]", "{\"fields\":[{\"other\":1}]}"));
+    }
+
+    @Test
+    void shouldYieldEmptyListWhenFilterMatchesNothing()
+    {
+        assertEquals(List.of(),
+            matches("$.fields[?(@.name=='missing')]",
+                "{\"fields\":[{\"name\":\"id\"},{\"name\":\"email\"}]}"));
+    }
+
+    @Test
+    void shouldSupportChainedSegmentAfterFilterMatch()
+    {
+        assertEquals(List.of("/fields/1/zilla:tags"),
+            matches("$.fields[?(@.name=='email')]['zilla:tags']",
+                "{\"fields\":[{\"name\":\"id\"},{\"name\":\"email\",\"zilla:tags\":[]}]}"));
+    }
+
+    @Test
+    void shouldRejectFilterMissingEqualityOperator()
+    {
+        assertThrows(IllegalArgumentException.class,
+            () -> JsonPath.compile("$.fields[?(@.name'email')]"));
+    }
+
+    @Test
+    void shouldRejectFilterNotStartingWithAtDot()
+    {
+        assertThrows(IllegalArgumentException.class,
+            () -> JsonPath.compile("$.fields[?(name=='email')]"));
+    }
+
+    @Test
+    void shouldRejectUnterminatedFilterExpression()
+    {
+        assertThrows(IllegalArgumentException.class,
+            () -> JsonPath.compile("$.fields[?(@.name=='email'"));
+    }
+
+    @Test
+    void shouldRejectFilterWithUnquotedValue()
+    {
+        assertThrows(IllegalArgumentException.class,
+            () -> JsonPath.compile("$.fields[?(@.name==email)]"));
+    }
+
+    @Test
     void shouldRejectExpressionNotStartingWithRoot()
     {
         assertThrows(IllegalArgumentException.class, () -> JsonPath.compile("a.b"));

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -63,6 +63,7 @@ import io.aklivity.zilla.config.engine.ModelConfig;
 import io.aklivity.zilla.config.engine.NamespaceConfig;
 import io.aklivity.zilla.config.engine.NamespaceConfigReader;
 import io.aklivity.zilla.config.engine.RouteConfig;
+import io.aklivity.zilla.config.engine.SchemaConfig;
 import io.aklivity.zilla.config.engine.StoreConfig;
 import io.aklivity.zilla.config.engine.TelemetryRefConfig;
 import io.aklivity.zilla.config.engine.VaultConfig;
@@ -444,6 +445,13 @@ public class EngineManager
                         for (CatalogedConfig cataloged : model.cataloged)
                         {
                             cataloged.id = resolver.resolve(cataloged.name);
+                            for (SchemaConfig schema : cataloged.schemas)
+                            {
+                                if (schema.overlay != null)
+                                {
+                                    schema.overlay.id = resolver.resolve(schema.overlay.name);
+                                }
+                            }
                         }
                     }
                 }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
@@ -14,12 +14,19 @@
  */
 package io.aklivity.zilla.runtime.model.avro.internal;
 
+import static io.aklivity.zilla.runtime.engine.catalog.CatalogHandler.NO_SCHEMA_ID;
+
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
+
 import org.agrona.collections.Int2IntHashMap;
-import org.agrona.collections.Int2ObjectCache;
+import org.agrona.collections.Long2ObjectCache;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.OverlayConfig;
 import io.aklivity.zilla.config.engine.SchemaConfig;
 import io.aklivity.zilla.config.engine.ValidateMode;
 import io.aklivity.zilla.config.model.avro.AvroModelConfig;
@@ -27,6 +34,7 @@ import io.aklivity.zilla.runtime.common.avro.Avro;
 import io.aklivity.zilla.runtime.common.avro.AvroKind;
 import io.aklivity.zilla.runtime.common.avro.AvroSchema;
 import io.aklivity.zilla.runtime.common.avro.AvroType;
+import io.aklivity.zilla.runtime.common.json.JsonOverlay;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 
@@ -42,6 +50,9 @@ public abstract class AvroModelHandler
     protected final SchemaConfig catalog;
     protected final CatalogHandler handler;
     protected final String subject;
+    protected final CatalogHandler overlayHandler;
+    protected final String overlaySubject;
+    protected final String overlayVersion;
     protected final String view;
     protected final AvroModelEventContext event;
     // LENIENT per direction: a semantic-validation failure passes through (inert today — no avro semantic
@@ -49,7 +60,7 @@ public abstract class AvroModelHandler
     protected final boolean decodeLenient;
     protected final boolean encodeLenient;
 
-    private final Int2ObjectCache<AvroSchema> schemas;
+    private final Long2ObjectCache<AvroSchema> schemas;
     private final Int2IntHashMap paddings;
     private final int paddingMaxItems;
 
@@ -65,18 +76,44 @@ public abstract class AvroModelHandler
         this.subject = catalog != null && catalog.subject != null
                 ? catalog.subject
                 : options.subject;
+        OverlayConfig overlay = catalog != null ? catalog.overlay : null;
+        this.overlayHandler = overlay != null ? context.supplyCatalog(overlay.id) : null;
+        this.overlaySubject = overlay != null ? overlay.schema.subject : null;
+        this.overlayVersion = overlay != null ? overlay.schema.version : null;
         this.decodeLenient = options.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = options.validate.encode == ValidateMode.LENIENT;
-        this.schemas = new Int2ObjectCache<>(1, 1024, i -> {});
+        this.schemas = new Long2ObjectCache<>(1, 1024, i -> {});
         this.paddings = new Int2IntHashMap(-1);
         this.event = new AvroModelEventContext(context);
         this.paddingMaxItems = config.paddingMaxItems();
     }
 
+    // avoids computeIfAbsent: a capturing lambda argument is allocated fresh on every call, hit or
+    // miss, so this checks the cache directly instead (see ProtobufModelHandler.supplySchema)
     protected final AvroSchema supplySchema(
         int schemaId)
     {
-        return schemas.computeIfAbsent(schemaId, this::resolveSchema);
+        int overlaySchemaId = overlayHandler != null
+            ? overlayHandler.resolve(overlaySubject, overlayVersion)
+            : NO_SCHEMA_ID;
+        long key = cacheKey(schemaId, overlaySchemaId);
+        AvroSchema schema = schemas.get(key);
+        if (schema == null)
+        {
+            schema = resolveSchema(schemaId, overlaySchemaId);
+            if (schema != null)
+            {
+                schemas.put(key, schema);
+            }
+        }
+        return schema;
+    }
+
+    private static long cacheKey(
+        int schemaId,
+        int overlaySchemaId)
+    {
+        return (long) schemaId << 32 | overlaySchemaId & 0xFFFFFFFFL;
     }
 
     protected final int supplyPadding(
@@ -90,15 +127,27 @@ public abstract class AvroModelHandler
     }
 
     private AvroSchema resolveSchema(
-        int schemaId)
+        int schemaId,
+        int overlaySchemaId)
     {
         AvroSchema schema = null;
         String schemaText = handler.resolve(schemaId);
-        if (schemaText != null)
+        String overlayText = overlayHandler != null ? overlayHandler.resolve(overlaySchemaId) : null;
+        if (schemaText != null && (overlayHandler == null || overlayText != null))
         {
-            schema = Avro.schema(schemaText);
+            String resolvedText = overlayText != null ? applyOverlay(schemaText, overlayText) : schemaText;
+            schema = Avro.schema(resolvedText);
         }
         return schema;
+    }
+
+    private static String applyOverlay(
+        String schemaText,
+        String overlayText)
+    {
+        JsonValue document = Json.createReader(new StringReader(schemaText)).readValue();
+        JsonValue overlay = Json.createReader(new StringReader(overlayText)).readValue();
+        return JsonOverlay.of(overlay).apply(document).toString();
     }
 
     private int calculatePadding(

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelOverlayTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelOverlayTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.avro.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.json.JsonValue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.avro.AvroModelConfig;
+import io.aklivity.zilla.runtime.common.avro.AvroField;
+import io.aklivity.zilla.runtime.common.avro.AvroSchema;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+
+public class AvroModelOverlayTest
+{
+    private static final int OVERLAY_SCHEMA_ID_BEFORE = 100;
+    private static final int OVERLAY_SCHEMA_ID_AFTER = 200;
+
+    private static final String SCHEMA = """
+        {
+          "type": "record",
+          "name": "Event",
+          "namespace": "io.aklivity.example",
+          "fields": [
+            { "name": "id", "type": "string" },
+            { "name": "email", "type": "string" }
+          ]
+        }
+        """;
+
+    private static final String OVERLAY_TAGS_EMAIL = """
+        {
+          "overlay": "1.1.0",
+          "actions": [
+            {
+              "target": "$.fields[?(@.name=='email')]",
+              "update": { "zilla:tags": [ "PII" ] }
+            }
+          ]
+        }
+        """;
+
+    private static final String OVERLAY_NOOP = """
+        {
+          "overlay": "1.1.0",
+          "actions": [
+            {
+              "target": "$.fields[?(@.name=='id')]",
+              "update": { "zilla:tags": [ "NONE" ] }
+            }
+          ]
+        }
+        """;
+
+    private EngineContext context;
+    private AvroModelConfiguration config;
+
+    @Before
+    public void init()
+    {
+        config = new AvroModelConfiguration(new Configuration());
+        context = mock(EngineContext.class);
+    }
+
+    @Test
+    public void shouldApplyOverlayBeforeCachingSchema()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(OVERLAY_TAGS_EMAIL, OVERLAY_NOOP);
+        AvroModelHandlerImpl handler = newHandlerWithOverlay(overlay);
+
+        AvroSchema schema = handler.supplySchema(1);
+
+        AvroField email = field(schema, "email");
+        JsonValue tags = email.attribute("zilla:tags");
+        assertEquals("[\"PII\"]", tags.toString());
+    }
+
+    @Test
+    public void shouldNotServeStaleCompiledSchemaWhenNonPinnedOverlayResolvesToNewId()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(OVERLAY_TAGS_EMAIL, OVERLAY_NOOP);
+        AvroModelHandlerImpl handler = newHandlerWithOverlay(overlay);
+
+        // overlay's "latest" reference currently resolves to OVERLAY_SCHEMA_ID_BEFORE, whose overlay
+        // tags "email" with a PII annotation
+        AvroSchema first = handler.supplySchema(1);
+        assertEquals("[\"PII\"]", field(first, "email").attribute("zilla:tags").toString());
+
+        // the overlay catalog entry now resolves "latest" to OVERLAY_SCHEMA_ID_AFTER, an overlay that
+        // doesn't touch "email", with the base schema's own schemaId unchanged -- the cache must not
+        // keep serving the compiled schema from the first, now-stale overlay resolution
+        overlay.advance();
+
+        AvroSchema second = handler.supplySchema(1);
+        assertNull(field(second, "email").attribute("zilla:tags"));
+    }
+
+    private static AvroField field(
+        AvroSchema schema,
+        String name)
+    {
+        return schema.type().fields().stream()
+            .filter(f -> name.equals(f.name()))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private AvroModelHandlerImpl newHandlerWithOverlay(
+        CatalogHandler overlayHandler)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(1)
+                .schema(SCHEMA)
+                .build()
+            .build();
+
+        AvroModelConfig model = AvroModelConfig.builder()
+            .view("json")
+            .catalog()
+                .name("test0")
+                .schema()
+                    .subject("test-value")
+                    .version("latest")
+                    .overlay()
+                        .name("test1")
+                        .schema()
+                            .subject("test-overlay")
+                            .version("latest")
+                            .build()
+                        .build()
+                    .build()
+                .build()
+            .build();
+        model.cataloged.get(0).id = catalog.id;
+        model.cataloged.get(0).schemas.get(0).overlay.id = 10L;
+
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        when(context.supplyCatalog(10L)).thenReturn(overlayHandler);
+
+        return new AvroModelHandlerImpl(config, model, context);
+    }
+
+    private static final class MovingOverlayCatalogHandler implements CatalogHandler
+    {
+        private final String overlayBefore;
+        private final String overlayAfter;
+        private boolean moved;
+
+        private MovingOverlayCatalogHandler(
+            String overlayBefore,
+            String overlayAfter)
+        {
+            this.overlayBefore = overlayBefore;
+            this.overlayAfter = overlayAfter;
+        }
+
+        private void advance()
+        {
+            this.moved = true;
+        }
+
+        @Override
+        public int resolve(
+            String subject,
+            String version)
+        {
+            return moved ? OVERLAY_SCHEMA_ID_AFTER : OVERLAY_SCHEMA_ID_BEFORE;
+        }
+
+        @Override
+        public String resolve(
+            int schemaId)
+        {
+            String resolved = null;
+            if (schemaId == OVERLAY_SCHEMA_ID_BEFORE)
+            {
+                resolved = overlayBefore;
+            }
+            else if (schemaId == OVERLAY_SCHEMA_ID_AFTER)
+            {
+                resolved = overlayAfter;
+            }
+            return resolved;
+        }
+    }
+}

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
@@ -14,9 +14,18 @@
  */
 package io.aklivity.zilla.runtime.model.json.internal;
 
-import org.agrona.collections.Int2ObjectCache;
+import static io.aklivity.zilla.runtime.engine.catalog.CatalogHandler.NO_SCHEMA_ID;
+
+import java.io.StringReader;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+import org.agrona.collections.Long2ObjectCache;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.OverlayConfig;
 import io.aklivity.zilla.config.engine.SchemaConfig;
 import io.aklivity.zilla.config.engine.ValidateMode;
 import io.aklivity.zilla.config.model.json.JsonModelConfig;
@@ -29,12 +38,15 @@ public abstract class JsonModelHandler
     protected final SchemaConfig catalog;
     protected final CatalogHandler handler;
     protected final String subject;
+    protected final CatalogHandler overlayHandler;
+    protected final String overlaySubject;
+    protected final String overlayVersion;
     protected final JsonModelEventContext event;
     // LENIENT per direction: a schema-validation failure on a structurally valid document passes through
     protected final boolean decodeLenient;
     protected final boolean encodeLenient;
 
-    private final Int2ObjectCache<JsonSchema> schemas;
+    private final Long2ObjectCache<JsonSchema> schemas;
 
     public JsonModelHandler(
         JsonModelConfig config,
@@ -46,28 +58,54 @@ public abstract class JsonModelHandler
         this.subject = catalog != null && catalog.subject != null
                 ? catalog.subject
                 : config.subject;
+        OverlayConfig overlay = catalog != null ? catalog.overlay : null;
+        this.overlayHandler = overlay != null ? context.supplyCatalog(overlay.id) : null;
+        this.overlaySubject = overlay != null ? overlay.schema.subject : null;
+        this.overlayVersion = overlay != null ? overlay.schema.version : null;
         this.decodeLenient = config.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = config.validate.encode == ValidateMode.LENIENT;
-        this.schemas = new Int2ObjectCache<>(1, 1024, i -> {});
+        this.schemas = new Long2ObjectCache<>(1, 1024, i -> {});
         this.event = new JsonModelEventContext(context);
     }
 
     protected JsonSchema supplySchema(
         int schemaId)
     {
-        return schemas.computeIfAbsent(schemaId, this::resolveSchema);
+        int overlaySchemaId = overlayHandler != null
+            ? overlayHandler.resolve(overlaySubject, overlayVersion)
+            : NO_SCHEMA_ID;
+        return schemas.computeIfAbsent(cacheKey(schemaId, overlaySchemaId), key -> resolveSchema(schemaId, overlaySchemaId));
+    }
+
+    private static long cacheKey(
+        int schemaId,
+        int overlaySchemaId)
+    {
+        return (long) schemaId << 32 | overlaySchemaId & 0xFFFFFFFFL;
     }
 
     private JsonSchema resolveSchema(
-        int schemaId)
+        int schemaId,
+        int overlaySchemaId)
     {
         JsonSchema schema = null;
         String schemaText = handler.resolve(schemaId);
-        if (schemaText != null)
+        String overlayText = overlayHandler != null ? overlayHandler.resolve(overlaySchemaId) : null;
+        if (schemaText != null && (overlayHandler == null || overlayText != null))
         {
-            schema = JsonSchema.of(schemaText);
+            String resolvedText = overlayText != null ? applyOverlay(schemaText, overlayText) : schemaText;
+            schema = JsonSchema.of(resolvedText);
         }
 
         return schema;
+    }
+
+    private static String applyOverlay(
+        String schemaText,
+        String overlayText)
+    {
+        JsonObject document = Json.createReader(new StringReader(schemaText)).readObject();
+        JsonArray patch = Json.createReader(new StringReader(overlayText)).readArray();
+        return Json.createPatch(patch).apply(document).toString();
     }
 }

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandler.java
@@ -68,13 +68,25 @@ public abstract class JsonModelHandler
         this.event = new JsonModelEventContext(context);
     }
 
+    // avoids computeIfAbsent: a capturing lambda argument is allocated fresh on every call, hit or
+    // miss, so this checks the cache directly instead (see ProtobufModelHandler.supplySchema)
     protected JsonSchema supplySchema(
         int schemaId)
     {
         int overlaySchemaId = overlayHandler != null
             ? overlayHandler.resolve(overlaySubject, overlayVersion)
             : NO_SCHEMA_ID;
-        return schemas.computeIfAbsent(cacheKey(schemaId, overlaySchemaId), key -> resolveSchema(schemaId, overlaySchemaId));
+        long key = cacheKey(schemaId, overlaySchemaId);
+        JsonSchema schema = schemas.get(key);
+        if (schema == null)
+        {
+            schema = resolveSchema(schemaId, overlaySchemaId);
+            if (schema != null)
+            {
+                schemas.put(key, schema);
+            }
+        }
+        return schema;
     }
 
     private static long cacheKey(

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelIT.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelIT.java
@@ -144,4 +144,15 @@ public class JsonModelIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Configuration("value.overlay.yaml")
+    @Specification({
+        "${net}/client.sent.json.overlay.required/client",
+        "${app}/client.sent.json.overlay.required/server"
+    })
+    public void shouldRejectJsonMissingOverlayRequiredProperty() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelOverlayTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelOverlayTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.json.JsonModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+
+public class JsonModelOverlayTest
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+    private static final int OVERLAY_SCHEMA_ID_BEFORE = 100;
+    private static final int OVERLAY_SCHEMA_ID_AFTER = 200;
+
+    private static final String BASE_SCHEMA = "{" +
+        "\"type\":\"object\"," +
+        "\"properties\":{\"id\":{\"type\":\"string\"}}," +
+        "\"required\":[\"id\"]" +
+        "}";
+
+    private static final String PATCH_ADDS_STATUS_REQUIRED =
+        "[{\"op\":\"add\",\"path\":\"/required/-\",\"value\":\"status\"}]";
+
+    private static final String PATCH_NOOP = "[]";
+
+    private EngineContext context;
+
+    @Before
+    public void init()
+    {
+        context = mock(EngineContext.class);
+        MessageConsumer eventWriter = mock(MessageConsumer.class);
+        when(context.clock()).thenReturn(Clock.systemUTC());
+        when(context.supplyEventWriter()).thenReturn(eventWriter);
+    }
+
+    @Test
+    public void shouldApplyOverlayBeforeCompilingSchema()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(PATCH_ADDS_STATUS_REQUIRED, PATCH_NOOP);
+        JsonModelHandlerImpl handler = newHandlerWithOverlay(overlay);
+
+        byte[] missingStatus = "{\"id\":\"1\"}".getBytes(UTF_8);
+
+        assertEquals(ModelStatus.REJECTED, decode(handler, missingStatus).status());
+    }
+
+    @Test
+    public void shouldNotServeStaleCompiledSchemaWhenNonPinnedOverlayResolvesToNewId()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(PATCH_ADDS_STATUS_REQUIRED, PATCH_NOOP);
+        JsonModelHandlerImpl handler = newHandlerWithOverlay(overlay);
+
+        byte[] missingStatus = "{\"id\":\"1\"}".getBytes(UTF_8);
+
+        // overlay's "latest" reference currently resolves to OVERLAY_SCHEMA_ID_BEFORE, whose patch
+        // tightens the base schema to also require "status"
+        assertEquals(ModelStatus.REJECTED, decode(handler, missingStatus).status());
+
+        // the overlay catalog entry now resolves "latest" to OVERLAY_SCHEMA_ID_AFTER, a no-op patch,
+        // with the base schema's own schemaId unchanged -- the cache must not keep serving the
+        // compiled schema from the first, now-stale overlay resolution
+        overlay.advance();
+
+        assertEquals(ModelStatus.COMPLETE, decode(handler, missingStatus).status());
+    }
+
+    private static ModelPipelineResult decode(
+        JsonModelHandlerImpl handler,
+        byte[] in)
+    {
+        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        return pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+    }
+
+    private JsonModelHandlerImpl newHandlerWithOverlay(
+        CatalogHandler overlayHandler)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(9)
+                .schema(BASE_SCHEMA)
+                .build()
+            .build();
+
+        JsonModelConfig model = JsonModelConfig.builder()
+            .catalog()
+                .name("test0")
+                .schema()
+                    .subject("test")
+                    .version("latest")
+                    .overlay()
+                        .name("test1")
+                        .schema()
+                            .subject("test-overlay")
+                            .version("latest")
+                            .build()
+                        .build()
+                    .build()
+                .build()
+            .build();
+        model.cataloged.get(0).id = catalog.id;
+        model.cataloged.get(0).schemas.get(0).overlay.id = 10L;
+
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        when(context.supplyCatalog(10L)).thenReturn(overlayHandler);
+
+        return new JsonModelHandlerImpl(model, context);
+    }
+
+    private static final class MovingOverlayCatalogHandler implements CatalogHandler
+    {
+        private final String patchBefore;
+        private final String patchAfter;
+        private boolean moved;
+
+        private MovingOverlayCatalogHandler(
+            String patchBefore,
+            String patchAfter)
+        {
+            this.patchBefore = patchBefore;
+            this.patchAfter = patchAfter;
+        }
+
+        private void advance()
+        {
+            this.moved = true;
+        }
+
+        @Override
+        public int resolve(
+            String subject,
+            String version)
+        {
+            return moved ? OVERLAY_SCHEMA_ID_AFTER : OVERLAY_SCHEMA_ID_BEFORE;
+        }
+
+        @Override
+        public String resolve(
+            int schemaId)
+        {
+            String resolved = null;
+            if (schemaId == OVERLAY_SCHEMA_ID_BEFORE)
+            {
+                resolved = patchBefore;
+            }
+            else if (schemaId == OVERLAY_SCHEMA_ID_AFTER)
+            {
+                resolved = patchAfter;
+            }
+            return resolved;
+        }
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandler.java
@@ -14,14 +14,21 @@
  */
 package io.aklivity.zilla.runtime.model.protobuf.internal;
 
+import static io.aklivity.zilla.runtime.engine.catalog.CatalogHandler.NO_SCHEMA_ID;
+
+import java.io.StringReader;
 import java.util.Arrays;
+
+import jakarta.json.Json;
+import jakarta.json.JsonValue;
 
 import org.agrona.BitUtil;
 import org.agrona.collections.Int2IntHashMap;
-import org.agrona.collections.Int2ObjectCache;
 import org.agrona.collections.IntArrayList;
+import org.agrona.collections.Long2ObjectCache;
 
 import io.aklivity.zilla.config.engine.CatalogedConfig;
+import io.aklivity.zilla.config.engine.OverlayConfig;
 import io.aklivity.zilla.config.engine.SchemaConfig;
 import io.aklivity.zilla.config.engine.ValidateMode;
 import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
@@ -29,6 +36,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufOverlay;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
@@ -44,6 +52,9 @@ public class ProtobufModelHandler
     protected final SchemaConfig catalog;
     protected final CatalogHandler handler;
     protected final String subject;
+    protected final CatalogHandler overlayHandler;
+    protected final String overlaySubject;
+    protected final String overlayVersion;
     protected final String view;
     // a scratch path buffer, reused (not boxed) across every decode/encode call: IntArrayList backs its
     // elements with a primitive int[] (no per-add Node/Integer allocation, unlike List<Integer>)
@@ -54,7 +65,7 @@ public class ProtobufModelHandler
     protected final boolean decodeLenient;
     protected final boolean encodeLenient;
 
-    private final Int2ObjectCache<ProtobufSchema> schemas;
+    private final Long2ObjectCache<ProtobufSchema> schemas;
     private final Int2IntHashMap paddings;
     // decodedPath()'s reused result buffer: resized only when the path depth actually changes, which is
     // fixed per message shape, so a decode stream settles into zero allocation after its first message
@@ -70,10 +81,14 @@ public class ProtobufModelHandler
         this.subject = catalog != null && catalog.subject != null
                 ? catalog.subject
                 : config.subject;
+        OverlayConfig overlay = catalog != null ? catalog.overlay : null;
+        this.overlayHandler = overlay != null ? context.supplyCatalog(overlay.id) : null;
+        this.overlaySubject = overlay != null ? overlay.schema.subject : null;
+        this.overlayVersion = overlay != null ? overlay.schema.version : null;
         this.view = config.view;
         this.decodeLenient = config.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = config.validate.encode == ValidateMode.LENIENT;
-        this.schemas = new Int2ObjectCache<>(1, 1024, i -> {});
+        this.schemas = new Long2ObjectCache<>(1, 1024, i -> {});
         this.indexes = new IntArrayList();
         this.paddings = new Int2IntHashMap(-1);
         this.event = new ProtobufModelEventContext(context);
@@ -81,22 +96,33 @@ public class ProtobufModelHandler
     }
 
     // called on every decode/encode call, so this checks the cache directly rather than through
-    // computeIfAbsent: a capturing method reference like "this::createSchema" is allocated fresh on every
-    // evaluation of that argument expression, regardless of whether the cache already has an entry, so
-    // computeIfAbsent would pay that cost on every call instead of once per distinct schemaId
+    // computeIfAbsent: a capturing lambda argument is allocated fresh on every evaluation of that
+    // argument expression, regardless of whether the cache already has an entry, so computeIfAbsent
+    // would pay that cost on every call instead of once per distinct (schemaId, overlaySchemaId) pair
     protected ProtobufSchema supplySchema(
         int schemaId)
     {
-        ProtobufSchema schema = schemas.get(schemaId);
+        int overlaySchemaId = overlayHandler != null
+            ? overlayHandler.resolve(overlaySubject, overlayVersion)
+            : NO_SCHEMA_ID;
+        long key = cacheKey(schemaId, overlaySchemaId);
+        ProtobufSchema schema = schemas.get(key);
         if (schema == null)
         {
-            schema = createSchema(schemaId);
+            schema = createSchema(schemaId, overlaySchemaId);
             if (schema != null)
             {
-                schemas.put(schemaId, schema);
+                schemas.put(key, schema);
             }
         }
         return schema;
+    }
+
+    private static long cacheKey(
+        int schemaId,
+        int overlaySchemaId)
+    {
+        return (long) schemaId << 32 | overlaySchemaId & 0xFFFFFFFFL;
     }
 
     protected byte[] encodeIndexes()
@@ -249,14 +275,21 @@ public class ProtobufModelHandler
     }
 
     private ProtobufSchema createSchema(
-        int schemaId)
+        int schemaId,
+        int overlaySchemaId)
     {
         ProtobufSchema schema = null;
 
         String schemaText = handler.resolve(schemaId);
-        if (schemaText != null)
+        String overlayText = overlayHandler != null ? overlayHandler.resolve(overlaySchemaId) : null;
+        if (schemaText != null && (overlayHandler == null || overlayText != null))
         {
             schema = Protobuf.schema(schemaText);
+            if (overlayText != null)
+            {
+                JsonValue overlay = Json.createReader(new StringReader(overlayText)).readValue();
+                schema = ProtobufOverlay.of(overlay).apply(schema);
+            }
         }
         return schema;
     }

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelOverlayTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelOverlayTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+
+public class ProtobufModelOverlayTest
+{
+    private static final int OVERLAY_SCHEMA_ID_BEFORE = 100;
+    private static final int OVERLAY_SCHEMA_ID_AFTER = 200;
+
+    private static final String SCHEMA = """
+        syntax = "proto3";
+        message SimpleMessage
+        {
+          string content = 1;
+        }
+        """;
+
+    private static final String PATCH_TAGS_CONTENT =
+        "[{\"field\":\"SimpleMessage.content\",\"options\":{\"zilla\":{\"tags\":[\"PII\"]}}}]";
+
+    private static final String PATCH_NOOP = "[]";
+
+    private EngineContext context;
+
+    @Before
+    public void init()
+    {
+        context = mock(EngineContext.class);
+    }
+
+    @Test
+    public void shouldApplyOverlayBeforeCachingSchema()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(PATCH_TAGS_CONTENT, PATCH_NOOP);
+        TestHandler handler = newHandlerWithOverlay(overlay);
+
+        ProtobufSchema schema = handler.supplySchema(1);
+
+        assertEquals("{\"zilla\":{\"tags\":[\"PII\"]}}",
+            schema.message("SimpleMessage").field("content").options().toString());
+    }
+
+    @Test
+    public void shouldNotServeStaleCompiledSchemaWhenNonPinnedOverlayResolvesToNewId()
+    {
+        MovingOverlayCatalogHandler overlay = new MovingOverlayCatalogHandler(PATCH_TAGS_CONTENT, PATCH_NOOP);
+        TestHandler handler = newHandlerWithOverlay(overlay);
+
+        // overlay's "latest" reference currently resolves to OVERLAY_SCHEMA_ID_BEFORE, whose patch
+        // tags "content" with a PII annotation
+        ProtobufSchema first = handler.supplySchema(1);
+        assertEquals("{\"zilla\":{\"tags\":[\"PII\"]}}",
+            first.message("SimpleMessage").field("content").options().toString());
+
+        // the overlay catalog entry now resolves "latest" to OVERLAY_SCHEMA_ID_AFTER, a no-op patch,
+        // with the base schema's own schemaId unchanged -- the cache must not keep serving the
+        // compiled schema from the first, now-stale overlay resolution
+        overlay.advance();
+
+        ProtobufSchema second = handler.supplySchema(1);
+        assertEquals("{}", second.message("SimpleMessage").field("content").options().toString());
+    }
+
+    private TestHandler newHandlerWithOverlay(
+        CatalogHandler overlayHandler)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(1)
+                .schema(SCHEMA)
+                .build()
+            .build();
+
+        ProtobufModelConfig model = ProtobufModelConfig.builder()
+            .catalog()
+                .name("test0")
+                .schema()
+                    .subject("test-value")
+                    .version("latest")
+                    .record("SimpleMessage")
+                    .overlay()
+                        .name("test1")
+                        .schema()
+                            .subject("test-overlay")
+                            .version("latest")
+                            .build()
+                        .build()
+                    .build()
+                .build()
+            .build();
+        model.cataloged.get(0).id = catalog.id;
+        model.cataloged.get(0).schemas.get(0).overlay.id = 10L;
+
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        when(context.supplyCatalog(10L)).thenReturn(overlayHandler);
+
+        return new TestHandler(model, context);
+    }
+
+    private static final class TestHandler extends ProtobufModelHandler
+    {
+        private TestHandler(
+            ProtobufModelConfig config,
+            EngineContext context)
+        {
+            super(config, context);
+        }
+    }
+
+    private static final class MovingOverlayCatalogHandler implements CatalogHandler
+    {
+        private final String patchBefore;
+        private final String patchAfter;
+        private boolean moved;
+
+        private MovingOverlayCatalogHandler(
+            String patchBefore,
+            String patchAfter)
+        {
+            this.patchBefore = patchBefore;
+            this.patchAfter = patchAfter;
+        }
+
+        private void advance()
+        {
+            this.moved = true;
+        }
+
+        @Override
+        public int resolve(
+            String subject,
+            String version)
+        {
+            return moved ? OVERLAY_SCHEMA_ID_AFTER : OVERLAY_SCHEMA_ID_BEFORE;
+        }
+
+        @Override
+        public String resolve(
+            int schemaId)
+        {
+            String resolved = null;
+            if (schemaId == OVERLAY_SCHEMA_ID_BEFORE)
+            {
+                resolved = patchBefore;
+            }
+            else if (schemaId == OVERLAY_SCHEMA_ID_AFTER)
+            {
+                resolved = patchAfter;
+            }
+            return resolved;
+        }
+    }
+}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.overlay.invalid.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.overlay.invalid.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      subject: test
+      schema: |
+        {
+          "type": "record",
+          "name": "Event",
+          "namespace": "io.aklivity.example",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            }
+          ]
+        }
+  test1:
+    type: test
+    options:
+      subject: test-overlay
+      schema: |
+        {
+          "overlay": "1.1.0",
+          "actions": []
+        }
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: avro
+        view: json
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+              overlay:
+                overlay0:
+                  version: latest
+    exit: test

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.overlay.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/model.overlay.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      subject: test
+      schema: |
+        {
+          "type": "record",
+          "name": "Event",
+          "namespace": "io.aklivity.example",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "email",
+              "type": "string"
+            }
+          ]
+        }
+  test1:
+    type: test
+    options:
+      subject: test-overlay
+      schema: |
+        {
+          "overlay": "1.1.0",
+          "actions": [
+            {
+              "target": "$.fields[?(@.name=='email')]",
+              "update": {
+                "zilla:tags": [ "PII" ]
+              }
+            }
+          ]
+        }
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: avro
+        view: json
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+              overlay:
+                test1:
+                  subject: test-overlay
+                  version: latest
+    exit: test

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/schema/avro.schema.patch.json
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/schema/avro.schema.patch.json
@@ -93,6 +93,37 @@
                                                 {
                                                     "type": "string",
                                                     "default": "latest"
+                                                },
+                                                "overlay":
+                                                {
+                                                    "title": "Overlay",
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                        {
+                                                            "type": "object",
+                                                            "properties":
+                                                            {
+                                                                "subject":
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                "version":
+                                                                {
+                                                                    "type": "string",
+                                                                    "default": "latest"
+                                                                }
+                                                            },
+                                                            "required":
+                                                            [
+                                                                "subject"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "maxProperties": 1
                                                 }
                                             },
                                             "required":

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/config/SchemaTest.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/config/SchemaTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -40,5 +41,19 @@ public class SchemaTest
         JsonObject config = schema.validate("model.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateCatalogWithOverlay()
+    {
+        JsonObject config = schema.validate("model.overlay.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectCatalogWithInvalidOverlay()
+    {
+        schema.validate("model.overlay.invalid.yaml");
     }
 }

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.overlay.invalid.yaml
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.overlay.invalid.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      subject: test
+      schema: |
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ]
+        }
+  test1:
+    type: test
+    options:
+      subject: test-overlay
+      schema: |
+        {
+          "overlay": "1.1.0",
+          "actions": []
+        }
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: json
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+              overlay:
+                test1:
+                  version: latest
+    exit: test

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.overlay.yaml
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/model.overlay.yaml
@@ -1,0 +1,70 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      subject: test
+      schema: |
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "status"
+          ]
+        }
+  test1:
+    type: test
+    options:
+      subject: test-overlay
+      schema: |
+        {
+          "overlay": "1.1.0",
+          "actions": [
+            {
+              "target": "$.properties.status",
+              "update": {
+                "zilla:tags": [ "PII" ]
+              }
+            }
+          ]
+        }
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: json
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+              overlay:
+                test1:
+                  subject: test-overlay
+                  version: latest
+    exit: test

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/value.overlay.yaml
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/config/value.overlay.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      subject: test
+      schema: |
+        {
+          "type": "object",
+          "properties":
+          {
+            "id": { "type": "string" }
+          },
+          "required": [ "id" ]
+        }
+  test1:
+    type: test
+    options:
+      subject: test-overlay
+      schema: |
+        [
+          { "op": "add", "path": "/required/-", "value": "status" }
+        ]
+bindings:
+  net0:
+    kind: server
+    type: test
+    options:
+      value:
+        model: json
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+              overlay:
+                test1:
+                  subject: test-overlay
+                  version: latest
+    exit: app0

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/schema/json.schema.patch.json
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/schema/json.schema.patch.json
@@ -88,6 +88,37 @@
                                                 {
                                                     "type": "string",
                                                     "default": "latest"
+                                                },
+                                                "overlay":
+                                                {
+                                                    "title": "Overlay",
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                        {
+                                                            "type": "object",
+                                                            "properties":
+                                                            {
+                                                                "subject":
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                "version":
+                                                                {
+                                                                    "type": "string",
+                                                                    "default": "latest"
+                                                                }
+                                                            },
+                                                            "required":
+                                                            [
+                                                                "subject"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "maxProperties": 1
                                                 }
                                             },
                                             "required":

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.overlay.required/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.overlay.required/client.rpt
@@ -1,0 +1,21 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write abort

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.overlay.required/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.overlay.required/server.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read aborted

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.overlay.required/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.overlay.required/client.rpt
@@ -1,0 +1,21 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write "{\"id\":\"123\"}"

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.overlay.required/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/network/client.sent.json.overlay.required/server.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read "{\"id\":\"123\"}"

--- a/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/config/SchemaTest.java
+++ b/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/config/SchemaTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -40,5 +41,19 @@ public class SchemaTest
         JsonObject config = schema.validate("model.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateCatalogWithOverlay()
+    {
+        JsonObject config = schema.validate("model.overlay.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectCatalogWithInvalidOverlay()
+    {
+        schema.validate("model.overlay.invalid.yaml");
     }
 }

--- a/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/streams/ApplicationIT.java
+++ b/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/streams/ApplicationIT.java
@@ -125,4 +125,14 @@ public class ApplicationIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/client.sent.json.overlay.required/client",
+        "${app}/client.sent.json.overlay.required/server"
+    })
+    public void shouldRejectJsonMissingOverlayRequiredProperty() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/streams/NetworkIT.java
+++ b/specs/model-json.spec/src/test/java/io/aklivity/zilla/specs/model/json/streams/NetworkIT.java
@@ -125,4 +125,14 @@ public class NetworkIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${net}/client.sent.json.overlay.required/client",
+        "${net}/client.sent.json.overlay.required/server"
+    })
+    public void shouldForwardJsonMissingOverlayRequiredProperty() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.overlay.invalid.yaml
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.overlay.invalid.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      schema: |
+        syntax = "proto3";
+        message example
+        {
+          string id = 1;
+          string status = 2;
+        }
+  test1:
+    type: test
+    options:
+      schema: |
+        []
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: protobuf
+        view: json
+        catalog:
+          catalog0:
+            - subject: test0
+              version: latest
+              record: example
+              overlay:
+                overlay0:
+                  version: latest
+    exit: test

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.overlay.yaml
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/config/model.overlay.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      schema: |
+        syntax = "proto3";
+        message example
+        {
+          string id = 1;
+          string status = 2;
+        }
+  test1:
+    type: test
+    options:
+      schema: |
+        [
+          { "field": "example.status", "options": { "zilla": { "tags": [ "PII" ] } } }
+        ]
+bindings:
+  test:
+    kind: server
+    type: test
+    options:
+      value:
+        model: protobuf
+        view: json
+        catalog:
+          catalog0:
+            - subject: test0
+              version: latest
+              record: example
+              overlay:
+                overlay0:
+                  subject: test1
+                  version: latest
+    exit: test

--- a/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/schema/protobuf.schema.patch.json
+++ b/specs/model-protobuf.spec/src/main/scripts/io/aklivity/zilla/specs/model/protobuf/schema/protobuf.schema.patch.json
@@ -107,6 +107,37 @@
                                                 "record":
                                                 {
                                                     "type": "string"
+                                                },
+                                                "overlay":
+                                                {
+                                                    "title": "Overlay",
+                                                    "type": "object",
+                                                    "patternProperties":
+                                                    {
+                                                        "^[a-zA-Z]+[a-zA-Z0-9\\._\\-]*$":
+                                                        {
+                                                            "type": "object",
+                                                            "properties":
+                                                            {
+                                                                "subject":
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                "version":
+                                                                {
+                                                                    "type": "string",
+                                                                    "default": "latest"
+                                                                }
+                                                            },
+                                                            "required":
+                                                            [
+                                                                "subject"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "maxProperties": 1
                                                 }
                                             },
                                             "required":

--- a/specs/model-protobuf.spec/src/test/java/io/aklivity/zilla/specs/model/protobuf/config/SchemaTest.java
+++ b/specs/model-protobuf.spec/src/test/java/io/aklivity/zilla/specs/model/protobuf/config/SchemaTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 
 import org.junit.Rule;
@@ -40,5 +41,19 @@ public class SchemaTest
         JsonObject config = schema.validate("model.yaml");
 
         assertThat(config, not(nullValue()));
+    }
+
+    @Test
+    public void shouldValidateCatalogWithOverlay()
+    {
+        JsonObject config = schema.validate("model.overlay.yaml");
+
+        assertThat(config, not(nullValue()));
+    }
+
+    @Test(expected = JsonException.class)
+    public void shouldRejectCatalogWithInvalidOverlay()
+    {
+        schema.validate("model.overlay.invalid.yaml");
     }
 }


### PR DESCRIPTION
## Description

Implements the schema overlay design from #2318: array-merge semantics for OpenAPI Overlay 1.1.0, the JSONPath filter-expression segment it needs, and full `overlay:` wiring for `model: json`, `model: protobuf`, and `model: avro` catalog entries.

**`runtime/common-json`**
- `JsonOverlay.merge()` gains a version-gated branch for array targets: `overlay: "1.0.0"` keeps the existing append-one-element behavior unchanged; `overlay: "1.1.0"` concatenates when `update` is itself an array, per the OpenAPI Overlay 1.1.0 spec text, and still appends for scalar/object updates.
- `JsonPath` gains an equality-only filter-expression segment, `[?(@.name=='value')]`, selecting array elements by a named property's string value — needed so overlay targets can reach Avro's named-array `fields` safely by name instead of by position. Only this narrow predicate is supported, not the full RFC 9535 filter grammar.

**`config/engine.conf`, `runtime/engine`, `specs/model-json.spec`, `runtime/model-json`**
- `SchemaConfig`/`SchemaConfigBuilder`/`SchemaConfigAdapter` gain an `overlay` field, reusing the existing `OverlayConfig`/`OverlayConfigAdapter` type (`{catalogName: {subject, version}}`) rather than introducing a new one.
- `EngineManager` resolves each schema entry's overlay catalog name to an id alongside the existing `cataloged.id` resolution — this is generic across every model, so it covers `model: protobuf` and `model: avro` too with no further engine changes.
- `model-json`'s JSON-schema patch accepts `overlay:` as a sibling of `subject`/`version` inside a catalog entry.
- `JsonModelHandler` fetches the overlay document via the resolved catalog and applies it as an RFC 6902 JSON Patch (`jakarta.json.JsonPatch`) to the fetched JSON Schema document before compiling it. The schema cache is keyed by the packed `(schemaId, overlaySchemaId)` pair (not `schemaId` alone) so a non-pinned overlay reference (`version: latest`) that later resolves to a new id triggers a fresh compile instead of serving a stale one, and a transient overlay-resolution failure fails the whole schema resolution rather than silently falling back to the un-overlaid schema — important since this mechanism exists to tag sensitive fields for downstream policy.

**`specs/model-protobuf.spec`, `runtime/model-protobuf`** (building on #2374/#2279's field- and method-level protobuf options overlay mechanism, `ProtobufOverlay`)
- `overlay:` added as a sibling of `subject`/`version`/`record` in the catalog-entry shape, mirroring `model-json`'s placement.
- `ProtobufModelHandler` fetches the overlay and applies it via `ProtobufOverlay.of(...).apply(schema)` *after* compiling the base schema — protobuf's overlay merges onto the already-built `ProtobufSchema` object graph (`JsonMergePatch` per targeted field/method), unlike JSON's whole-document RFC 6902 patch applied before compiling. Same `(schemaId, overlaySchemaId)` packed-cache-key rule as `model-json`.

**`specs/model-avro.spec`, `runtime/model-avro`**
- `overlay:` added as a sibling of `subject`/`version` in the catalog-entry shape, mirroring `model-json`'s placement (Avro schema entries have no `record` sibling to begin with).
- `AvroModelHandler` fetches the overlay and applies it via `JsonOverlay.of(...).apply(...)` to the raw Avro schema JSON *before* compiling — unlike `model-json`'s RFC 6902 patch, because Avro's `fields` is a JSON array keyed by `name` rather than a JSON object keyed by property name, so a plain JSON Pointer path can't address a field by name; the filter-expression segment above (`$.fields[?(@.name=='email')]`) targets it directly regardless of declaration order. Same `(schemaId, overlaySchemaId)` packed-cache-key rule and explicit get/put `supplySchema` (avoiding a capturing-lambda allocation on every call) as the other two models.

Not in scope here (left for follow-up, per the issue's own breakdown): the catalog-entry-resolution startup validation checks in the issue's §7.

## Test plan

- `JsonOverlayTest`/`JsonPathTest` (`runtime/common-json`): new fixtures for 1.0.0-unchanged/1.1.0-concatenate array merge, and filter-expression match/no-match/malformed-syntax cases.
- `SchemaConfigAdapterTest` (`config/engine.conf`): read/write round-trip for `overlay:` on a schema entry.
- `SchemaTest` (`specs/model-json.spec`, `specs/model-protobuf.spec`, `specs/model-avro.spec`): accept/reject schema-validation fixtures for `overlay:` nested in a catalog entry, for all three models.
- `JsonModelIT`, `NetworkIT`, `ApplicationIT` (`specs/model-json.spec`, `runtime/model-json`): a k3po scenario proving an overlay-tightened schema (adds a required property via RFC 6902 patch) is actually applied against a live engine, both end-to-end and peer-to-peer.
- `JsonModelOverlayTest`, `ProtobufModelOverlayTest`, `AvroModelOverlayTest` (`runtime/model-json`, `runtime/model-protobuf`, `runtime/model-avro`): unit tests proving the overlay is applied before compilation/caching, and that a non-pinned overlay resolving to a new id is not served from a stale cache entry, for all three models.
- JMH benchmarks (`JsonModelDecoderPipelineBM`/`EncoderPipelineBM`, `ProtobufModelDecoderPipelineBM`/`EncoderPipelineBM`, `AvroModelDecoderPipelineBM`/`EncoderPipelineBM`) re-run with `-prof gc` to confirm zero allocation regression from the cache-key/hot-path changes.
- Full `mvn verify` (checkstyle, license, unit tests, k3po ITs, JaCoCo coverage) green on all touched modules.

Fixes #2318
Ref #2279, #2374
