### PR TITLE
fix(model-avro,binding-kafka): reserve enough Kafka cache capacity for values that expand during decode

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartition.java
@@ -596,11 +596,23 @@ public final class KafkaCachePartition
                 final int convertedValueLimit = convertedLengthAt + SIZE_OF_INT + convertedLength;
                 final int convertedPadding = convertedFile.readInt(convertedValueLimit);
 
-                assert convertedPadding - length >= 0;
-
-                convertedFile.writeInt(convertedLengthAt, convertedLength + length);
-                convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
-                convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
+                if (convertedPadding < length)
+                {
+                    logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
+                    if (verbose)
+                    {
+                        System.out.printf("%s:%s %s: Skipping message on topic %s, partition %d, offset %d: " +
+                            "transformed value exceeded reserved capacity\n",
+                            System.currentTimeMillis(), context.supplyNamespace(bindingId),
+                            context.supplyLocalName(bindingId), topic, id, offset);
+                    }
+                }
+                else
+                {
+                    convertedFile.writeInt(convertedLengthAt, convertedLength + length);
+                    convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
+                    convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
+                }
             };
 
             int entryFlags = logFile.readInt(entryMark.value + FIELD_OFFSET_FLAGS);
@@ -867,11 +879,16 @@ public final class KafkaCachePartition
                     final int convertedValueLimit = convertedLengthAt + SIZE_OF_INT + convertedLength;
                     final int convertedPadding = convertedFile.readInt(convertedValueLimit);
 
-                    assert convertedPadding - length >= 0;
-
-                    convertedFile.writeInt(convertedLengthAt, convertedLength + length);
-                    convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
-                    convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
+                    if (convertedPadding < length)
+                    {
+                        logFile.writeInt(entryMark.value + FIELD_OFFSET_FLAGS, CACHE_ENTRY_FLAGS_ABORTED);
+                    }
+                    else
+                    {
+                        convertedFile.writeInt(convertedLengthAt, convertedLength + length);
+                        convertedFile.writeBytes(convertedValueLimit, buffer, index, length);
+                        convertedFile.writeInt(convertedValueLimit + length, convertedPadding - length);
+                    }
                 };
 
                 final int valueLength = valueLimit.value - valueMark.value;

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.model.avro.ext;
 
+import io.aklivity.zilla.runtime.common.avro.AvroSchema;
 import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 
 /**
@@ -31,4 +32,19 @@ public interface AvroModelExtHandler
      */
     AvroTransformable transform(
         AvroTransformable stream);
+
+    /**
+     * Returns the maximum number of additional bytes this extension's transform may add to a decoded
+     * value of {@code schema}, beyond what the untransformed value would occupy — for example, a
+     * substitute value whose length does not derive from the original field's length. A caller sizing a
+     * buffer to hold the transformed output adds this to its own estimate.
+     *
+     * @param schema  the resolved schema
+     * @return the additional byte count (0 if this extension's transform never expands a value)
+     */
+    default int padding(
+        AvroSchema schema)
+    {
+        return 0;
+    }
 }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
@@ -62,6 +62,7 @@ public abstract class AvroModelHandler
 
     private final Long2ObjectCache<AvroSchema> schemas;
     private final Int2IntHashMap paddings;
+    private final Int2IntHashMap extPaddings;
     private final int paddingMaxItems;
 
     protected AvroModelHandler(
@@ -84,6 +85,7 @@ public abstract class AvroModelHandler
         this.encodeLenient = options.validate.encode == ValidateMode.LENIENT;
         this.schemas = new Long2ObjectCache<>(1, 1024, i -> {});
         this.paddings = new Int2IntHashMap(-1);
+        this.extPaddings = new Int2IntHashMap(-1);
         this.event = new AvroModelEventContext(context);
         this.paddingMaxItems = config.paddingMaxItems();
     }
@@ -124,6 +126,20 @@ public abstract class AvroModelHandler
             AvroSchema schema = supplySchema(id);
             return calculatePadding(schema != null ? schema.type() : null);
         });
+    }
+
+    protected final int supplyExtPadding(
+        int schemaId)
+    {
+        return extPaddings.computeIfAbsent(schemaId, id -> extPadding(supplySchema(id)));
+    }
+
+    // overridden by AvroModelHandlerImpl to sum the padding contributed by each installed model extension;
+    // the base (encoder) handler never installs extensions, so this stays 0 there
+    protected int extPadding(
+        AvroSchema schema)
+    {
+        return 0;
     }
 
     private AvroSchema resolveSchema(

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -83,10 +83,26 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         int index,
         int length)
     {
-        int padding = handler.decodePadding(data, index, length);
+        int schemaId = resolveSchemaId(data, index, length);
+        int padding = handler.decodePadding(data, index, length) + supplyExtPadding(schemaId);
         if (VIEW_JSON.equals(view))
         {
-            padding += supplyPadding(resolveSchemaId(data, index, length));
+            padding += supplyPadding(schemaId);
+        }
+        return padding;
+    }
+
+    @Override
+    protected int extPadding(
+        AvroSchema schema)
+    {
+        int padding = 0;
+        if (schema != null)
+        {
+            for (AvroModelExtContext ext : exts)
+            {
+                padding += ext.supplyHandler(schema, options).padding(schema);
+            }
         }
         return padding;
     }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.avro.ext;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
+
+public class AvroModelExtHandlerTest
+{
+    @Test
+    public void shouldReportNoPaddingByDefault()
+    {
+        AvroModelExtHandler handler = new AvroModelExtHandler()
+        {
+            @Override
+            public AvroTransformable transform(
+                AvroTransformable stream)
+            {
+                return stream;
+            }
+        };
+
+        assertEquals(0, handler.padding(null));
+    }
+}

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -36,6 +36,8 @@ import io.aklivity.zilla.config.model.avro.AvroModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroSchema;
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
@@ -47,6 +49,8 @@ import io.aklivity.zilla.runtime.engine.model.ModelSource;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtContext;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
 
 public class AvroModelDecoderPipelineTest
 {
@@ -190,6 +194,20 @@ public class AvroModelDecoderPipelineTest
     }
 
     @Test
+    public void shouldIncludeExtensionPaddingContribution()
+    {
+        AvroModelHandlerImpl baseline = newHandler(SCHEMA, "json", List.of());
+        AvroModelHandlerImpl extended = newHandler(SCHEMA, "json", List.of(expandingExt(64)));
+
+        int basePadding = baseline.supplyDecoder(ModelTransform.NONE)
+            .padding(new UnsafeBufferEx(AVRO), 0, AVRO.length);
+        int extPadding = extended.supplyDecoder(ModelTransform.NONE)
+            .padding(new UnsafeBufferEx(AVRO), 0, AVRO.length);
+
+        assertEquals(basePadding + 64, extPadding);
+    }
+
+    @Test
     public void shouldReportIdentityWhenNoView()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, null);
@@ -226,6 +244,14 @@ public class AvroModelDecoderPipelineTest
         String schema,
         String view)
     {
+        return newHandler(schema, view, List.of());
+    }
+
+    private AvroModelHandlerImpl newHandler(
+        String schema,
+        String view,
+        List<AvroModelExtContext> exts)
+    {
         TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
             .namespace("test")
             .name("test0")
@@ -247,7 +273,28 @@ public class AvroModelDecoderPipelineTest
                 .build()
             .build();
         when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
-        return new AvroModelHandlerImpl(config, model, context, List.of());
+        return new AvroModelHandlerImpl(config, model, context, exts);
+    }
+
+    private static AvroModelExtContext expandingExt(
+        int padding)
+    {
+        return (schema, config) -> new AvroModelExtHandler()
+        {
+            @Override
+            public AvroTransformable transform(
+                AvroTransformable stream)
+            {
+                return stream;
+            }
+
+            @Override
+            public int padding(
+                AvroSchema schema)
+            {
+                return padding;
+            }
+        };
     }
 
     private static byte[] concat(


### PR DESCRIPTION
## Description

`AvroModelExtHandler` (the SPI a model extension plugs into the `avro` model's decoder pipeline with) had no way to declare that its transform can expand a decoded value beyond the untransformed input's length. The Kafka local cache's converted-value (JSON view) capacity reservation in `KafkaCachePartition` relied solely on schema-shape padding (JSON syntax overhead — field names, punctuation), so an installed extension whose substitute value is longer than the original field silently overran the reserved region. The only guard was `assert convertedPadding - length >= 0`, compiled out in production, so the overflow corrupted the mmap'd converted-value file and surfaced later as an unrelated `IndexOutOfBoundsException` on a subsequent read.

This surfaced from a value-expanding extension — one whose substitute value's length doesn't derive from the original field's length (e.g. a fixed-length replacement) — long enough to exceed the reserved capacity for a short original field, crashing a live engine on fetch.

### Changes

- `AvroModelExtHandler`: add a default `padding(AvroSchema schema)` method (returns `0`), so an extension that can expand a value overrides it to declare the maximum additional bytes.
- `AvroModelHandler`/`AvroModelHandlerImpl`: sum every installed extension's `padding(schema)` contribution into the decode padding estimate (`decodePadding`), cached per schema id alongside the existing JSON-syntax padding.
- `KafkaCachePartition`: replace the disabled `assert convertedPadding - length >= 0` in both the fetch-path (`writeEntryFinish`) and produce-path (`writeProduceEntryContinue`) converted-value writers with a real runtime bounds check. On violation, the cache entry is marked `CACHE_ENTRY_FLAGS_ABORTED` (the same mechanism already used for invalid-key entries) instead of writing past the reserved capacity, so a mis-declaring extension degrades to a skipped entry rather than corrupting the cache file.

### Test plan

- [x] New unit test `AvroModelDecoderPipelineTest.shouldIncludeExtensionPaddingContribution`, confirmed failing to compile against the prior `AvroModelExtHandler` (no such method to override), then green after implementing
- [x] New unit test `AvroModelExtHandlerTest.shouldReportNoPaddingByDefault`, covering the new default method
- [x] `./mvnw clean verify -pl runtime/model-avro` — 34 unit tests + 6 k3po ITs, checkstyle, license headers, JaCoCo coverage all pass
- [x] `./mvnw clean verify -pl runtime/binding-kafka` — 395 k3po ITs pass, no regressions
- [x] Verified live: rebuilt a downstream image consuming this branch's `AvroModelExtHandler.padding()` override for a value-expanding extension, ran an end-to-end `docker compose` scenario that previously crashed the engine on fetch — now returns a stable result across repeated fetches with no engine errors

Fixes #1681

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3