### PR TITLE
docs(engine): drop in-tree-consumer example from SPI PR neutrality rule

### DIFF
--- a/runtime/engine/AGENTS.md
+++ b/runtime/engine/AGENTS.md
@@ -27,10 +27,11 @@ Two conventions to follow when adding to or modifying them:
   (`Set.of()`, `List.of()`) return cached singletons, the project convention
   is `null` so callers learn one rule across the SPI rather than mixing styles.
 
-PR descriptions for engine SPI changes follow the same neutrality — describe
-the engine-level addition and the in-tree consumer that justifies it (e.g.
-"required by `binding-mcp` elicitation flow"); do not name downstream products
-or proprietary modules as motivation.
+PR and issue descriptions for engine SPI changes follow the same neutrality:
+justify the change entirely by the SPI's own contract gap, never by naming or
+describing the consumer that motivated it — in-tree or downstream, oss or
+commercial. See the root [AGENTS.md](../../AGENTS.md#justifying-changes-to-shared-components)
+for the general rule and the self-check to apply before writing one.
 
 ### Adding a method to `EngineContext`
 


### PR DESCRIPTION
## Description

`runtime/engine/AGENTS.md`'s existing neutrality rule for engine SPI PR descriptions carved out an exception: citing an in-tree consumer's use case (e.g. "required by `binding-mcp` elicitation flow") was presented as acceptable, only naming a downstream/proprietary consumer was disallowed. That carve-out is itself the anti-pattern — coupling an SPI change's justification to a specific dependent is the same layering violation whether the dependent is in this repo or external to it.

Replaces the carved-out example with a pointer to the general rule (see #2378, opened separately): justify a shared component's change by its own contract gap only, never by naming any consumer.

Independent of #2378 — this PR stands on its own (the link target section will resolve once #2378 merges; either can merge first with no functional dependency between them).

This is a documentation-only change with no code impact.

Fixes # (none — process documentation, not tied to a specific issue)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3)_