### PR TITLE
test(engine): apply the configured value model as decoder on reply direction too

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -336,6 +336,9 @@ final class TestBindingFactory implements BindingHandler
         private long pendingTraceId;
         private boolean storeAssertionsStarted;
         private final ModelPipeline valuePipeline;
+        // mirrors valuePipeline for the opposite direction: a real binding decodes on read (reply) and
+        // encodes on write (initial), so this test binding applies the same configured model both ways
+        private final ModelPipeline replyPipeline;
 
         private TestSource(
             MessageConsumer source,
@@ -352,6 +355,7 @@ final class TestBindingFactory implements BindingHandler
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
             this.valuePipeline = valueModel != null ? valueModel.supplyEncoder() : null;
+            this.replyPipeline = valueModel != null ? valueModel.supplyDecoder() : null;
         }
 
         private void doAuthorize(
@@ -901,7 +905,8 @@ final class TestBindingFactory implements BindingHandler
             }
             else
             {
-                int total = transform(traceId, authorization, payload.buffer(), payload.offset(), payload.limit());
+                int total = transform(valuePipeline, traceId, authorization,
+                    payload.buffer(), payload.offset(), payload.limit());
                 if (total < 0)
                 {
                     target.doInitialAbort(traceId);
@@ -915,6 +920,7 @@ final class TestBindingFactory implements BindingHandler
         }
 
         private int transform(
+            ModelPipeline pipeline,
             long traceId,
             long authorization,
             DirectBufferEx data,
@@ -927,7 +933,7 @@ final class TestBindingFactory implements BindingHandler
             boolean done = false;
             while (!done)
             {
-                final ModelPipelineResult result = valuePipeline.transform(traceId, routedId, authorization, flags,
+                final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, flags,
                         data, srcAt, limit, modelBuffer, total, modelBuffer.capacity());
                 final ModelStatus status = result.status();
 
@@ -952,7 +958,7 @@ final class TestBindingFactory implements BindingHandler
                 }
             }
 
-            valuePipeline.reset();
+            pipeline.reset();
             return total;
         }
 
@@ -1235,13 +1241,31 @@ final class TestBindingFactory implements BindingHandler
             {
                 long sequence = data.sequence();
                 long traceId = data.traceId();
+                long authorization = data.authorization();
                 int reserved = data.reserved();
                 int flags = data.flags();
                 OctetsFW payload = data.payload();
 
                 replySeq = sequence + reserved;
 
-                source.doReplyData(traceId, flags, reserved, payload);
+                if (source.replyPipeline == null)
+                {
+                    source.doReplyData(traceId, flags, reserved, payload);
+                }
+                else
+                {
+                    int total = source.transform(source.replyPipeline, traceId, authorization,
+                        payload.buffer(), payload.offset(), payload.limit());
+                    if (total < 0)
+                    {
+                        source.doReplyAbort(traceId);
+                    }
+                    else
+                    {
+                        OctetsFW transformed = octetsRO.wrap(modelBuffer, 0, total);
+                        source.doReplyData(traceId, flags, total, transformed);
+                    }
+                }
             }
 
             private void onReplyEnd(

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -335,10 +335,7 @@ final class TestBindingFactory implements BindingHandler
         private boolean pendingBegin;
         private long pendingTraceId;
         private boolean storeAssertionsStarted;
-        private final ModelPipeline valuePipeline;
-        // mirrors valuePipeline for the opposite direction: a real binding decodes on read (reply) and
-        // encodes on write (initial), so this test binding applies the same configured model both ways
-        private final ModelPipeline replyPipeline;
+        private final ModelPipeline pipeline;
 
         private TestSource(
             MessageConsumer source,
@@ -354,8 +351,7 @@ final class TestBindingFactory implements BindingHandler
             this.initialId = initialId;
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
-            this.valuePipeline = valueModel != null ? valueModel.supplyEncoder() : null;
-            this.replyPipeline = valueModel != null ? valueModel.supplyDecoder() : null;
+            this.pipeline = valueModel != null ? valueModel.supplyEncoder() : null;
         }
 
         private void doAuthorize(
@@ -899,13 +895,13 @@ final class TestBindingFactory implements BindingHandler
 
             initialSeq = sequence + reserved;
 
-            if (valuePipeline == null)
+            if (pipeline == null)
             {
                 target.doInitialData(traceId, flags, reserved, payload);
             }
             else
             {
-                int total = transform(valuePipeline, traceId, authorization,
+                int total = transform(pipeline, traceId, authorization,
                     payload.buffer(), payload.offset(), payload.limit());
                 if (total < 0)
                 {
@@ -1143,6 +1139,7 @@ final class TestBindingFactory implements BindingHandler
             private int replyCap;
 
             private final TestSource source;
+            private final ModelPipeline pipeline;
 
             private TestTarget(
                 long originId,
@@ -1153,6 +1150,7 @@ final class TestBindingFactory implements BindingHandler
                 this.initialId = context.supplyInitialId(routedId);
                 this.replyId = context.supplyReplyId(initialId);
                 this.source = TestSource.this;
+                this.pipeline = valueModel != null ? valueModel.supplyDecoder() : null;
             }
 
             private void onMessage(
@@ -1248,13 +1246,13 @@ final class TestBindingFactory implements BindingHandler
 
                 replySeq = sequence + reserved;
 
-                if (source.replyPipeline == null)
+                if (pipeline == null)
                 {
                     source.doReplyData(traceId, flags, reserved, payload);
                 }
                 else
                 {
-                    int total = source.transform(source.replyPipeline, traceId, authorization,
+                    int total = source.transform(pipeline, traceId, authorization,
                         payload.buffer(), payload.offset(), payload.limit());
                     if (total < 0)
                     {


### PR DESCRIPTION
## Description

`TestBindingFactory` (the `type: test` binding backing k3po `*IT.java` tests engine-wide) only ever applied a configured value model as an **encoder**, on the **initial/produce** direction. Reply-direction data was always forwarded raw, with no model applied at all — so no k3po IT anywhere could exercise a model's decode-time behavior through a live engine; that coverage only ever existed as plain JUnit tests bypassing the engine entirely.

Adds a second pipeline (`supplyDecoder()`) applied on the reply direction, mirroring the existing initial-direction encoder, so a real `EngineRule`+`K3poRule` IT can prove decode-time behavior (e.g. a model extension's field substitution) actually fires end-to-end through a live engine.

### Safety

Gated on the same `valueModel != null` check the existing encoder uses, so every `type: test` usage without a value model is entirely unaffected. For usages that do configure a value model: audited every `type: test` binding with a `value:` model configured across the whole reactor (`model-avro.spec`, `model-json.spec`, `model-protobuf.spec`, `model-core.spec`) and confirmed none currently sends or asserts a reply-direction payload — every existing scenario is produce/initial-only (the exact gap this closes), so applying a decoder in that direction is a no-op for every existing assertion.

### Test plan

- [x] `./mvnw clean verify -pl runtime/engine` — 215 unit tests + 183 k3po ITs, all green
- [x] `./mvnw clean verify -pl runtime/model-avro,runtime/model-json,runtime/model-protobuf,runtime/model-core` — all four modules' own ITs (which share this same test binding) green, no regressions
- [x] checkstyle, license headers clean

Fixes # (none — shared test infrastructure enhancement, not tied to a specific issue)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3)_