### PR TITLE
fix(model-avro): fold installed extensions into the encoder pipeline too

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroParser.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroParser.java
@@ -123,6 +123,17 @@ public interface AvroParser
     String getString();
 
     /**
+     * The same text as {@link #getString()}, as a {@link CharSequence} a caller that only reads or
+     * re-encodes characters (never retains them past the current call) can use without forcing a
+     * {@code String} to be materialized. The returned instance is valid only for the duration of the
+     * current call and may be reused by the next one. The default falls back to {@link #getString()}.
+     */
+    default CharSequence getStringView()
+    {
+        return getString();
+    }
+
+    /**
      * Valid only on a {@link AvroEvent#FIELD_NAME} event; the record field name from the schema
      * (a cached string, no per-message allocation).
      */

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSource.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSource.java
@@ -47,6 +47,19 @@ public interface AvroSource
     String getString();
 
     /**
+     * The same text as {@link #getString()}, as a {@link CharSequence} a caller that only reads or
+     * re-encodes characters (never retains them past the current call) can use without forcing a
+     * {@code String} to be materialized. The returned instance is valid only for the duration of the
+     * current call and may be reused by the next one; a caller that needs to retain the text must copy
+     * it (e.g. {@code String.valueOf(...)}) or use {@link #getString()} instead. The default falls back
+     * to {@link #getString()}.
+     */
+    default CharSequence getStringView()
+    {
+        return getString();
+    }
+
+    /**
      * Valid only on a {@link AvroEvent#FIELD_NAME} event; the record field name from the schema
      * (a cached string, no per-message allocation).
      */

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSource.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroSource.java
@@ -51,13 +51,9 @@ public interface AvroSource
      * re-encodes characters (never retains them past the current call) can use without forcing a
      * {@code String} to be materialized. The returned instance is valid only for the duration of the
      * current call and may be reused by the next one; a caller that needs to retain the text must copy
-     * it (e.g. {@code String.valueOf(...)}) or use {@link #getString()} instead. The default falls back
-     * to {@link #getString()}.
+     * it (e.g. {@code String.valueOf(...)}) or use {@link #getString()} instead.
      */
-    default CharSequence getStringView()
-    {
-        return getString();
-    }
+    CharSequence getStringView();
 
     /**
      * Valid only on a {@link AvroEvent#FIELD_NAME} event; the record field name from the schema

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
@@ -22,7 +22,7 @@ package io.aklivity.zilla.runtime.common.avro;
  * obtain the runnable, resumable {@link AvroPipeline}. An {@code AvroStream} carries no state and is not
  * itself runnable.
  */
-public interface AvroStream extends AvroTransformable
+public interface AvroStream extends AvroTransformable<AvroStream>
 {
     /**
      * Appends a stage, in data-flow order. {@link AvroTransform#NONE} is dropped rather than appended, so a

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroTransformable.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroTransformable.java
@@ -16,11 +16,15 @@ package io.aklivity.zilla.runtime.common.avro;
 
 /**
  * Something an {@link AvroTransform} stage can be appended to, in data-flow order. {@link AvroStream} is
- * the primary implementation; this narrower supertype lets a caller outside {@code common-avro} append
- * stages to an in-progress stream without depending on {@link AvroStream}'s fuller, terminal-bearing API.
+ * the primary implementation; this narrower, self-bounded supertype lets a caller outside {@code common-avro}
+ * append stages to an in-progress stream and get back its own concrete stream type, without depending on
+ * {@link AvroStream}'s fuller, terminal-bearing API.
+ *
+ * @param <T>  the concrete stream type, so {@link #transform(AvroTransform)} returns it rather than this
+ *             narrower supertype
  */
-public interface AvroTransformable
+public interface AvroTransformable<T extends AvroTransformable<T>>
 {
-    AvroTransformable transform(
+    T transform(
         AvroTransform transform);
 }

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroParserImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroParserImpl.java
@@ -37,7 +37,6 @@ import static io.aklivity.zilla.runtime.common.avro.AvroEvent.START_RECORD;
 import static io.aklivity.zilla.runtime.common.avro.AvroEvent.STRING;
 import static io.aklivity.zilla.runtime.common.avro.AvroEvent.UNION_BRANCH;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
@@ -82,6 +81,7 @@ public final class AvroParserImpl implements AvroParser
     private final AvroNode root;
     private final UnsafeBufferEx segmentView;
     private final AvroLocationImpl location;
+    private final CharText chars;
 
     private DirectBufferEx buffer;
     private int offset;
@@ -125,6 +125,7 @@ public final class AvroParserImpl implements AvroParser
         this.root = (AvroNode) schema.type();
         this.segmentView = new UnsafeBufferEx(0, 0);
         this.location = new AvroLocationImpl();
+        this.chars = new CharText(64);
         this.nodeStack = new AvroNode[16];
         this.stateStack = new int[16];
         this.countStack = new long[16];
@@ -954,7 +955,20 @@ public final class AvroParserImpl implements AvroParser
         String value = string;
         if (value == null && valueLength > 0)
         {
-            value = decode();
+            chars.utf8(buffer, valueOffset, valueLength);
+            value = chars.toString();
+        }
+        return value;
+    }
+
+    @Override
+    public CharSequence getStringView()
+    {
+        CharSequence value = string;
+        if (value == null && valueLength > 0)
+        {
+            chars.utf8(buffer, valueOffset, valueLength);
+            value = chars;
         }
         return value;
     }
@@ -968,7 +982,11 @@ public final class AvroParserImpl implements AvroParser
     @Override
     public String getKey()
     {
-        return valueLength > 0 ? decode() : null;
+        if (valueLength > 0)
+        {
+            chars.utf8(buffer, valueOffset, valueLength);
+        }
+        return valueLength > 0 ? chars.toString() : null;
     }
 
     @Override
@@ -995,13 +1013,6 @@ public final class AvroParserImpl implements AvroParser
     public AvroLocation getLocation()
     {
         return location;
-    }
-
-    private String decode()
-    {
-        byte[] dst = new byte[valueLength];
-        buffer.getBytes(valueOffset, dst);
-        return new String(dst, UTF_8);
     }
 
     private int readVarint(

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -243,6 +243,12 @@ final class AvroPipelineImpl implements AvroPipeline
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return parser.getStringView();
+        }
+
+        @Override
         public String getField()
         {
             return parser.getField();

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/CharText.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/CharText.java
@@ -12,18 +12,18 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.aklivity.zilla.runtime.common.avro.internal.json;
+package io.aklivity.zilla.runtime.common.avro.internal;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 
 /**
  * A reusable {@link CharSequence} backed by a growable {@code char[]}, filled in place by decoding raw
- * UTF-8 bytes ({@link #utf8}) or base64-encoding raw bytes ({@link #base64}). Letting the
- * {@link io.aklivity.zilla.runtime.common.json.JsonGeneratorEx} write through this view avoids the per-value
- * {@code String} a {@code getString} / {@code Base64.encodeToString} would allocate; the backing array grows
- * only when a value exceeds the largest seen so far. Not thread-safe; one per worker thread.
+ * UTF-8 bytes ({@link #utf8}) or base64-encoding raw bytes ({@link #base64}). Letting a caller write
+ * through or read from this view avoids the per-value {@code String} a {@code getString} /
+ * {@code Base64.encodeToString} would allocate; the backing array grows only when a value exceeds the
+ * largest seen so far. Not thread-safe; one per worker thread.
  */
-final class CharText implements CharSequence
+public final class CharText implements CharSequence
 {
     private static final char[] BASE64 =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
@@ -31,13 +31,13 @@ final class CharText implements CharSequence
     private char[] chars;
     private int length;
 
-    CharText(
+    public CharText(
         int initialCapacity)
     {
         this.chars = new char[initialCapacity];
     }
 
-    void utf8(
+    public void utf8(
         DirectBufferEx source,
         int offset,
         int length)
@@ -82,7 +82,7 @@ final class CharText implements CharSequence
         this.length = count;
     }
 
-    void number(
+    public void number(
         long value)
     {
         ensure(20);
@@ -118,7 +118,7 @@ final class CharText implements CharSequence
         this.length = count;
     }
 
-    void base64(
+    public void base64(
         DirectBufferEx source,
         int offset,
         int length)

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonGeneratorImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonGeneratorImpl.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
 import io.aklivity.zilla.runtime.common.avro.AvroKind;
 import io.aklivity.zilla.runtime.common.avro.AvroSchema;
 import io.aklivity.zilla.runtime.common.avro.AvroType;
+import io.aklivity.zilla.runtime.common.avro.internal.CharText;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx.Completion;
 

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonParserImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/json/AvroJsonParserImpl.java
@@ -243,6 +243,12 @@ public final class AvroJsonParserImpl implements AvroParser
     }
 
     @Override
+    public CharSequence getStringView()
+    {
+        return valueChars;
+    }
+
+    @Override
     public String getField()
     {
         return fieldName;

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
@@ -67,6 +67,12 @@ public class AvroGeneratorTest
         assertEquals(AvroPipeline.Status.COMPLETED, sink.transform(NO_CONTROL, bytes, AvroEvent.BYTES));
     }
 
+    @Test
+    public void shouldFallBackStringViewToGetString()
+    {
+        assertEquals(zero.getString(), zero.getStringView());
+    }
+
     private static final class ZeroSource implements AvroSource
     {
         private final UnsafeBufferEx empty;

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroGeneratorTest.java
@@ -67,12 +67,6 @@ public class AvroGeneratorTest
         assertEquals(AvroPipeline.Status.COMPLETED, sink.transform(NO_CONTROL, bytes, AvroEvent.BYTES));
     }
 
-    @Test
-    public void shouldFallBackStringViewToGetString()
-    {
-        assertEquals(zero.getString(), zero.getStringView());
-    }
-
     private static final class ZeroSource implements AvroSource
     {
         private final UnsafeBufferEx empty;
@@ -131,6 +125,12 @@ public class AvroGeneratorTest
         public String getString()
         {
             return "";
+        }
+
+        @Override
+        public CharSequence getStringView()
+        {
+            return getString();
         }
 
         @Override

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroParserTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroParserTest.java
@@ -130,6 +130,32 @@ public class AvroParserTest
     }
 
     @Test
+    public void shouldViewString()
+    {
+        Entry entry = parse("\"string\"", new byte[] { 0x06, 0x66, 0x6f, 0x6f }).entries.get(0);
+        assertEquals(STRING, entry.event);
+        assertEquals("foo", entry.stringView);
+    }
+
+    @Test
+    public void shouldViewMultiByteUtf8String()
+    {
+        // "café" = c, a, f, 0xC3 0xA9 (é) -- 5 UTF-8 bytes, zigzag(5) = 0x0a
+        Entry entry = parse("\"string\"",
+            new byte[] { 0x0a, 0x63, 0x61, 0x66, (byte) 0xc3, (byte) 0xa9 }).entries.get(0);
+        assertEquals("café", entry.stringView);
+    }
+
+    @Test
+    public void shouldViewSurrogatePairString()
+    {
+        // U+1F600 (😀) = 0xF0 0x9F 0x98 0x80 -- 4 UTF-8 bytes, zigzag(4) = 0x08
+        Entry entry = parse("\"string\"",
+            new byte[] { 0x08, (byte) 0xf0, (byte) 0x9f, (byte) 0x98, (byte) 0x80 }).entries.get(0);
+        assertEquals("😀", entry.stringView);
+    }
+
+    @Test
     public void shouldParseRecord()
     {
         List<AvroEvent> events = parse("""

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroValues.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroValues.java
@@ -92,6 +92,7 @@ public final class AvroValues
         public final double doubleValue;
         public final byte[] bytes;
         public final String string;
+        public final String stringView;
 
         Entry(
             AvroEvent event,
@@ -109,6 +110,11 @@ public final class AvroValues
             this.bytes = event == AvroEvent.STRING || event == AvroEvent.BYTES ||
                 event == AvroEvent.FIXED || event == AvroEvent.MAP_KEY
                 ? copy(in)
+                : null;
+            // captured as a String immediately: getStringView()'s CharSequence is only valid for this call,
+            // and an Entry outlives it
+            this.stringView = event == AvroEvent.STRING || event == AvroEvent.ENUM
+                ? in.getStringView().toString()
                 : null;
         }
 

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/json/AvroJsonTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/json/AvroJsonTest.java
@@ -27,17 +27,56 @@ import org.junit.jupiter.api.Test;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.avro.Avro;
+import io.aklivity.zilla.runtime.common.avro.AvroEvent;
 import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
 import io.aklivity.zilla.runtime.common.avro.AvroSchema;
 import io.aklivity.zilla.runtime.common.avro.AvroSink;
+import io.aklivity.zilla.runtime.common.avro.AvroValues.Entry;
+import io.aklivity.zilla.runtime.common.avro.AvroValues.Recorder;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 
 public class AvroJsonTest
 {
+    @Test
+    public void shouldViewString()
+    {
+        Entry entry = recordJson(Avro.schema("\"string\""), "\"foo\"").entries.get(0);
+        assertEquals(AvroEvent.STRING, entry.event);
+        assertEquals("foo", entry.stringView);
+    }
+
+    @Test
+    public void shouldViewMultiByteUtf8String()
+    {
+        Entry entry = recordJson(Avro.schema("\"string\""), "\"café\"").entries.get(0);
+        assertEquals("café", entry.stringView);
+    }
+
+    @Test
+    public void shouldViewEscapedString()
+    {
+        // the CharSequence view is read after JSON escape decoding, same as getString()
+        Entry entry = recordJson(Avro.schema("\"string\""), "\"a\\nb\"").entries.get(0);
+        assertEquals("a\nb", entry.stringView);
+    }
+
+    private static Recorder recordJson(
+        AvroSchema schema,
+        String json)
+    {
+        byte[] jsonBytes = json.getBytes(UTF_8);
+        JsonParserEx parser = JsonEx.createParser();
+        Recorder recorder = new Recorder();
+        AvroPipeline pipeline = AvroJson.stream(schema, parser).into(recorder);
+        pipeline.reset();
+        recorder.status = pipeline.transform(new UnsafeBufferEx(jsonBytes), 0, jsonBytes.length);
+        return recorder;
+    }
+
     @Test
     public void shouldNotReportIdentityForJsonGeneratorPipeline()
     {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -16,6 +16,7 @@
 package io.aklivity.zilla.runtime.engine.test.internal.binding;
 
 import static io.aklivity.zilla.config.engine.test.internal.binding.config.TestBindingOptionsConfigAdapter.DEFAULT_ASSERTION_SCHEMA;
+import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NEEDS_PREAUTHORIZE;
 import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.NOT_AUTHORIZED;
@@ -51,6 +52,7 @@ import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.buffer.BufferPool;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
@@ -78,8 +80,6 @@ final class TestBindingFactory implements BindingHandler
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
-    // DataFW.FIELD_OFFSET_PAYLOAD -- a transform destination window must leave this much room in
-    // context.writeBuffer() for the frame header, or wrapping a full window as a DataFW payload overflows it
     private static final int DATA_FRAME_HEADER_SIZE = 85;
     private static final List<String> EMPTY_ROLES = emptyList();
 
@@ -113,7 +113,10 @@ final class TestBindingFactory implements BindingHandler
     private final EngineContext context;
     private final TestEventContext event;
     private final Long2ObjectHashMap<TestBindingConfig> bindings;
-    private final MutableDirectBufferEx modelBuffer;
+    private final BufferPool decodePool;
+    private final BufferPool encodePool;
+    private final int decodeMax;
+    private final int transformMax;
 
     private ModelHandler valueModel;
     private String schema;
@@ -145,7 +148,10 @@ final class TestBindingFactory implements BindingHandler
         this.context = context;
         this.event = new TestEventContext(context);
         this.bindings = new Long2ObjectHashMap<>();
-        this.modelBuffer = new UnsafeBufferEx(new byte[context.writeBuffer().capacity()]);
+        this.decodePool = context.bufferPool();
+        this.encodePool = decodePool.duplicate();
+        this.decodeMax = decodePool.slotCapacity();
+        this.transformMax = Math.min(context.writeBuffer().capacity() - DATA_FRAME_HEADER_SIZE, decodeMax);
     }
 
     public void attach(
@@ -339,18 +345,16 @@ final class TestBindingFactory implements BindingHandler
         private long pendingTraceId;
         private boolean storeAssertionsStarted;
         private final ModelPipeline pipeline;
-        // fixed-size destination window for pipeline.transform(); drained into a downstream DATA frame
-        // every time it fills, rather than accumulating a whole value, so a value larger than this window
-        // (or split across several onInitialData calls) is transformed correctly regardless of size
         private final MutableDirectBufferEx initialBuffer;
-        private boolean initialStarted;
-        // accumulates source bytes not yet consumed by the pipeline across onInitialData calls -- on
-        // ModelStatus#UNDERFLOW the pipeline may consume only part of what it was given (e.g. it saw a
-        // JSON field open a string value but the closing quote had not yet arrived), so the unconsumed
-        // tail must be preserved and prepended to the next DATA frame's bytes, not discarded. Grows on
-        // demand since a fragment's source size is independent of the destination window above
-        private MutableDirectBufferEx decodeSlot;
-        private int decodeLength;
+
+        private int decodeSlot = NO_SLOT;
+        private int decodeSlotOffset;
+
+        private int encodeSlot = NO_SLOT;
+        private int encodeSlotOffset;
+        private long encodeSlotTraceId;
+        private boolean encodeSlotFin;
+        private boolean replyStarted;
 
         private TestSource(
             MessageConsumer source,
@@ -367,8 +371,7 @@ final class TestBindingFactory implements BindingHandler
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
             this.pipeline = valueModel != null ? valueModel.supplyEncoder() : null;
-            this.initialBuffer = pipeline != null ?
-                new UnsafeBufferEx(new byte[modelBuffer.capacity() - DATA_FRAME_HEADER_SIZE]) : null;
+            this.initialBuffer = pipeline != null ? new UnsafeBufferEx(new byte[transformMax]) : null;
         }
 
         private void doAuthorize(
@@ -914,53 +917,67 @@ final class TestBindingFactory implements BindingHandler
 
             if (pipeline == null)
             {
-                target.doInitialData(traceId, flags, reserved, payload);
+                boolean fin = (flags & FLAGS_FIN) != 0;
+                target.doInitialData(traceId, fin, payload);
+            }
+            else if (decodeSlotOffset + payload.sizeof() > decodeMax)
+            {
+                pipeline.reset();
+                target.doInitialAbort(traceId);
+                doInitialReset(traceId);
+                cleanupDecodeSlot();
             }
             else
             {
-                int payloadLength = payload.sizeof();
-                if (decodeSlot == null || decodeSlot.capacity() < decodeLength + payloadLength)
+                if (decodeSlot == NO_SLOT)
                 {
-                    int capacity = Math.max(decodeLength + payloadLength,
-                        decodeSlot != null ? decodeSlot.capacity() * 2 : modelBuffer.capacity());
-                    MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
-                    if (decodeLength > 0)
-                    {
-                        grown.putBytes(0, decodeSlot, 0, decodeLength);
-                    }
-                    decodeSlot = grown;
+                    decodeSlot = decodePool.acquire(initialId);
                 }
-                decodeSlot.putBytes(decodeLength, payload.buffer(), payload.offset(), payloadLength);
-                decodeLength += payloadLength;
 
-                transformInitial(traceId, authorization, flags);
+                if (decodeSlot == NO_SLOT)
+                {
+                    pipeline.reset();
+                    target.doInitialAbort(traceId);
+                    doInitialReset(traceId);
+                }
+                else
+                {
+                    MutableDirectBufferEx decodeBuffer = decodePool.buffer(decodeSlot);
+                    decodeBuffer.putBytes(decodeSlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+                    decodeSlotOffset += payload.sizeof();
+
+                    transformInitial(traceId, authorization, flags, decodeBuffer, decodeSlotOffset);
+                    flushInitialWindow(traceId);
+                }
             }
         }
 
-        // drives pipeline.transform over the accumulated, not-yet-consumed source bytes, draining the
-        // fixed-size initialBuffer window into a downstream DATA frame every time it produces output,
-        // rather than accumulating a whole value -- ModelStatus#OVERFLOW means the window filled before
-        // the value completed, so the caller drains it and calls transform() again with the same source
-        // position and a freshly emptied window, per the ModelPipeline#transform contract. Loops while the
-        // pipeline reports OK/OVERFLOW and stops on COMPLETE, REJECTED, or UNDERFLOW. On UNDERFLOW the
-        // pipeline may have consumed only part of what it was given (e.g. a JSON string value whose
-        // closing quote had not yet arrived) -- the unconsumed tail is compacted to the front of
-        // decodeSlot and carried into the next onInitialData call, unless this frame carried
-        // FLAGS_FIN, in which case the value was truncated and is treated the same as REJECTED since no
-        // further frame will ever arrive to complete it
+        private void flushInitialWindow(
+            long traceId)
+        {
+            long newInitialAck = initialSeq - decodeSlotOffset;
+            if (newInitialAck > initialAck)
+            {
+                initialAck = newInitialAck;
+                doWindow(source, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId,
+                        initialBud, initialPad, initialCap);
+            }
+        }
+
         private void transformInitial(
             long traceId,
             long authorization,
-            int flags)
+            int flags,
+            MutableDirectBufferEx buffer,
+            int limit)
         {
             int srcAt = 0;
-            int limit = decodeLength;
             int stepFlags = flags;
             ModelStatus status;
             do
             {
                 final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
-                        decodeSlot, srcAt, limit, initialBuffer, 0, initialBuffer.capacity());
+                        buffer, srcAt, limit, initialBuffer, 0, initialBuffer.capacity());
                 status = result.status();
 
                 if (status != ModelStatus.REJECTED)
@@ -971,11 +988,9 @@ final class TestBindingFactory implements BindingHandler
                     int produced = result.produced();
                     if (produced > 0)
                     {
-                        int outFlags = (initialStarted ? 0x00 : FLAGS_INIT) |
-                            (status == ModelStatus.COMPLETE ? FLAGS_FIN : 0x00);
+                        boolean fin = status == ModelStatus.COMPLETE;
                         OctetsFW transformed = octetsRO.wrap(initialBuffer, 0, produced);
-                        target.doInitialData(traceId, outFlags, produced, transformed);
-                        initialStarted = true;
+                        target.doInitialData(traceId, fin, transformed);
                     }
                 }
             } while (status == ModelStatus.OK || status == ModelStatus.OVERFLOW);
@@ -985,23 +1000,21 @@ final class TestBindingFactory implements BindingHandler
             {
                 pipeline.reset();
                 target.doInitialAbort(traceId);
-                initialStarted = false;
-                decodeLength = 0;
+                cleanupDecodeSlot();
             }
             else if (status == ModelStatus.UNDERFLOW)
             {
                 int remaining = limit - srcAt;
                 if (remaining > 0 && srcAt > 0)
                 {
-                    decodeSlot.putBytes(0, decodeSlot, srcAt, remaining);
+                    decodePool.buffer(decodeSlot).putBytes(0, buffer, srcAt, remaining);
                 }
-                decodeLength = remaining;
+                decodeSlotOffset = remaining;
             }
             else if (status == ModelStatus.COMPLETE)
             {
                 pipeline.reset();
-                initialStarted = false;
-                decodeLength = 0;
+                cleanupDecodeSlot();
             }
         }
 
@@ -1016,6 +1029,8 @@ final class TestBindingFactory implements BindingHandler
             {
                 target.doInitialEnd(traceId);
             }
+
+            cleanupDecodeSlot();
         }
 
         private void onInitialAbort(
@@ -1029,6 +1044,8 @@ final class TestBindingFactory implements BindingHandler
             {
                 target.doInitialAbort(traceId);
             }
+
+            cleanupDecodeSlot();
         }
 
         private void releaseSession()
@@ -1081,7 +1098,13 @@ final class TestBindingFactory implements BindingHandler
             replyBud = window.budgetId();
             replyCap = window.capabilities();
 
-            target.doReplyWindow(traceId, replyAck, replyMax, replyBud, replyPad, replyCap);
+            if (encodeSlot != NO_SLOT)
+            {
+                encodeReply(encodeSlotTraceId, encodePool.buffer(encodeSlot), 0, encodeSlotOffset);
+            }
+
+            int maximum = target.pipeline != null ? Math.min(replyMax, decodeMax) : replyMax;
+            target.doReplyWindow(traceId, replyAck, maximum, replyBud, replyPad, replyCap);
 
             // defer store assertions until the reply stream is established and credited, so any
             // notification (e.g. watch) can emit an observable reply frame the script gates on
@@ -1110,7 +1133,7 @@ final class TestBindingFactory implements BindingHandler
             int padding,
             int capabilities)
         {
-            initialAck = acknowledge;
+            initialAck = pipeline != null ? Math.max(initialSeq - decodeSlotOffset, initialAck) : acknowledge;
             initialMax = maximum;
             initialBud = budgetId;
             initialPad = padding;
@@ -1134,26 +1157,101 @@ final class TestBindingFactory implements BindingHandler
 
         private void doReplyData(
             long traceId,
-            int flags,
-            int reserved,
+            boolean fin,
             OctetsFW payload)
         {
-            doData(source, originId, routedId, replyId, replySeq, replyAck, replyMax, replyBud,
-                    traceId, flags, reserved, payload);
+            DirectBufferEx buffer = payload.buffer();
+            int offset = payload.offset();
+            int limit = payload.limit();
 
-            replySeq += reserved;
+            if (encodeSlot != NO_SLOT)
+            {
+                MutableDirectBufferEx encodeBuffer = encodePool.buffer(encodeSlot);
+                encodeBuffer.putBytes(encodeSlotOffset, buffer, offset, limit - offset);
+                encodeSlotOffset += limit - offset;
+
+                buffer = encodeBuffer;
+                offset = 0;
+                limit = encodeSlotOffset;
+            }
+
+            encodeSlotTraceId = traceId;
+            encodeSlotFin = encodeSlotFin || fin;
+
+            encodeReply(traceId, buffer, offset, limit);
+        }
+
+        private void encodeReply(
+            long traceId,
+            DirectBufferEx buffer,
+            int offset,
+            int limit)
+        {
+            int maxLength = limit - offset;
+            int length = Math.max(Math.min(replyWindow() - replyPad, maxLength), 0);
+
+            if (length > 0)
+            {
+                boolean fin = length == maxLength && encodeSlotFin;
+                int reserved = length + replyPad;
+                int flags = (replyStarted ? 0x00 : FLAGS_INIT) | (fin ? FLAGS_FIN : 0x00);
+
+                OctetsFW out = octetsRO.wrap(buffer, offset, offset + length);
+                doData(source, originId, routedId, replyId, replySeq, replyAck, replyMax, replyBud,
+                        traceId, flags, reserved, out);
+
+                replySeq += reserved;
+                replyStarted = !fin;
+                if (fin)
+                {
+                    encodeSlotFin = false;
+                }
+            }
+
+            int remaining = maxLength - length;
+            if (remaining > 0)
+            {
+                if (encodeSlot == NO_SLOT)
+                {
+                    encodeSlot = encodePool.acquire(replyId);
+                }
+
+                if (encodeSlot == NO_SLOT)
+                {
+                    doReplyAbort(traceId);
+                }
+                else
+                {
+                    MutableDirectBufferEx encodeBuffer = encodePool.buffer(encodeSlot);
+                    encodeBuffer.putBytes(0, buffer, offset + length, remaining);
+                    encodeSlotOffset = remaining;
+                }
+            }
+            else
+            {
+                cleanupEncodeSlot();
+            }
+        }
+
+        private int replyWindow()
+        {
+            return replyMax - (int) (replySeq - replyAck) - encodeSlotOffset;
         }
 
         private void doReplyEnd(
             long traceId)
         {
             doEnd(source, originId, routedId, replyId, replySeq, replyAck, replyPad, traceId);
+
+            cleanupEncodeSlot();
         }
 
         private void doReplyAbort(
             long traceId)
         {
             doAbort(source, originId, routedId, replyId, replySeq, replyAck, replyPad, traceId);
+
+            cleanupEncodeSlot();
         }
 
         private void doReplyFlush(
@@ -1161,6 +1259,28 @@ final class TestBindingFactory implements BindingHandler
             int reserved)
         {
             doFlush(source, originId, routedId, replyId, replySeq, replyAck, replyPad, traceId, replyBud, reserved);
+        }
+
+        private void cleanupDecodeSlot()
+        {
+            if (decodeSlot != NO_SLOT)
+            {
+                decodePool.release(decodeSlot);
+                decodeSlot = NO_SLOT;
+                decodeSlotOffset = 0;
+            }
+        }
+
+        private void cleanupEncodeSlot()
+        {
+            if (encodeSlot != NO_SLOT)
+            {
+                encodePool.release(encodeSlot);
+                encodeSlot = NO_SLOT;
+                encodeSlotOffset = 0;
+                encodeSlotTraceId = 0;
+                encodeSlotFin = false;
+            }
         }
 
         private final class TestTarget
@@ -1187,12 +1307,16 @@ final class TestBindingFactory implements BindingHandler
 
             private final TestSource source;
             private final ModelPipeline pipeline;
-            // see TestSource.initialBuffer -- same fixed-size drain-per-produce window, for the reply direction
             private final MutableDirectBufferEx replyBuffer;
-            private boolean replyStarted;
-            // see TestSource.decodeSlot -- same not-yet-consumed source accumulation, for the reply direction
-            private MutableDirectBufferEx decodeSlot;
-            private int decodeLength;
+
+            private int decodeSlot = NO_SLOT;
+            private int decodeSlotOffset;
+
+            private int encodeSlot = NO_SLOT;
+            private int encodeSlotOffset;
+            private long encodeSlotTraceId;
+            private boolean encodeSlotFin;
+            private boolean initialStarted;
 
             private TestTarget(
                 long originId,
@@ -1204,8 +1328,7 @@ final class TestBindingFactory implements BindingHandler
                 this.replyId = context.supplyReplyId(initialId);
                 this.source = TestSource.this;
                 this.pipeline = valueModel != null ? valueModel.supplyDecoder() : null;
-                this.replyBuffer = pipeline != null ?
-                    new UnsafeBufferEx(new byte[modelBuffer.capacity() - DATA_FRAME_HEADER_SIZE]) : null;
+                this.replyBuffer = pipeline != null ? new UnsafeBufferEx(new byte[transformMax]) : null;
             }
 
             private void onMessage(
@@ -1270,7 +1393,13 @@ final class TestBindingFactory implements BindingHandler
                 initialBud = window.budgetId();
                 initialCap = window.capabilities();
 
-                source.doInitialWindow(traceId, initialAck, initialMax, initialBud, initialPad, initialCap);
+                if (encodeSlot != NO_SLOT)
+                {
+                    encodeInitial(encodeSlotTraceId, encodePool.buffer(encodeSlot), 0, encodeSlotOffset);
+                }
+
+                int maximum = source.pipeline != null ? Math.min(initialMax, decodeMax) : initialMax;
+                source.doInitialWindow(traceId, initialAck, maximum, initialBud, initialPad, initialCap);
             }
 
             private void onInitialChallenge(
@@ -1303,43 +1432,65 @@ final class TestBindingFactory implements BindingHandler
 
                 if (pipeline == null)
                 {
-                    source.doReplyData(traceId, flags, reserved, payload);
+                    boolean fin = (flags & FLAGS_FIN) != 0;
+                    source.doReplyData(traceId, fin, payload);
+                }
+                else if (decodeSlotOffset + payload.sizeof() > decodeMax)
+                {
+                    pipeline.reset();
+                    source.doReplyAbort(traceId);
+                    cleanupDecodeSlot();
                 }
                 else
                 {
-                    int payloadLength = payload.sizeof();
-                    if (decodeSlot == null || decodeSlot.capacity() < decodeLength + payloadLength)
+                    if (decodeSlot == NO_SLOT)
                     {
-                        int capacity = Math.max(decodeLength + payloadLength,
-                            decodeSlot != null ? decodeSlot.capacity() * 2 : modelBuffer.capacity());
-                        MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
-                        if (decodeLength > 0)
-                        {
-                            grown.putBytes(0, decodeSlot, 0, decodeLength);
-                        }
-                        decodeSlot = grown;
+                        decodeSlot = decodePool.acquire(replyId);
                     }
-                    decodeSlot.putBytes(decodeLength, payload.buffer(), payload.offset(), payloadLength);
-                    decodeLength += payloadLength;
 
-                    transformReply(traceId, authorization, flags);
+                    if (decodeSlot == NO_SLOT)
+                    {
+                        pipeline.reset();
+                        source.doReplyAbort(traceId);
+                    }
+                    else
+                    {
+                        MutableDirectBufferEx decodeBuffer = decodePool.buffer(decodeSlot);
+                        decodeBuffer.putBytes(decodeSlotOffset, payload.buffer(), payload.offset(), payload.sizeof());
+                        decodeSlotOffset += payload.sizeof();
+
+                        transformReply(traceId, authorization, flags, decodeBuffer, decodeSlotOffset);
+                        flushReplyWindow(traceId);
+                    }
                 }
             }
 
-            // see TestSource#transformInitial for the drain-and-continue loop this mirrors on the reply direction
+            private void flushReplyWindow(
+                long traceId)
+            {
+                long newReplyAck = replySeq - decodeSlotOffset;
+                if (newReplyAck > replyAck)
+                {
+                    replyAck = newReplyAck;
+                    doWindow(target, originId, routedId, replyId, replySeq, replyAck, replyMax,
+                            traceId, replyBud, replyPad, replyCap);
+                }
+            }
+
             private void transformReply(
                 long traceId,
                 long authorization,
-                int flags)
+                int flags,
+                MutableDirectBufferEx buffer,
+                int limit)
             {
                 int srcAt = 0;
-                int limit = decodeLength;
                 int stepFlags = flags;
                 ModelStatus status;
                 do
                 {
                     final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
-                            decodeSlot, srcAt, limit, replyBuffer, 0, replyBuffer.capacity());
+                            buffer, srcAt, limit, replyBuffer, 0, replyBuffer.capacity());
                     status = result.status();
 
                     if (status != ModelStatus.REJECTED)
@@ -1350,11 +1501,9 @@ final class TestBindingFactory implements BindingHandler
                         int produced = result.produced();
                         if (produced > 0)
                         {
-                            int outFlags = (replyStarted ? 0x00 : FLAGS_INIT) |
-                                (status == ModelStatus.COMPLETE ? FLAGS_FIN : 0x00);
+                            boolean fin = status == ModelStatus.COMPLETE;
                             OctetsFW transformed = octetsRO.wrap(replyBuffer, 0, produced);
-                            source.doReplyData(traceId, outFlags, produced, transformed);
-                            replyStarted = true;
+                            source.doReplyData(traceId, fin, transformed);
                         }
                     }
                 } while (status == ModelStatus.OK || status == ModelStatus.OVERFLOW);
@@ -1364,23 +1513,21 @@ final class TestBindingFactory implements BindingHandler
                 {
                     pipeline.reset();
                     source.doReplyAbort(traceId);
-                    replyStarted = false;
-                    decodeLength = 0;
+                    cleanupDecodeSlot();
                 }
                 else if (status == ModelStatus.UNDERFLOW)
                 {
                     int remaining = limit - srcAt;
                     if (remaining > 0 && srcAt > 0)
                     {
-                        decodeSlot.putBytes(0, decodeSlot, srcAt, remaining);
+                        decodePool.buffer(decodeSlot).putBytes(0, buffer, srcAt, remaining);
                     }
-                    decodeLength = remaining;
+                    decodeSlotOffset = remaining;
                 }
                 else if (status == ModelStatus.COMPLETE)
                 {
                     pipeline.reset();
-                    replyStarted = false;
-                    decodeLength = 0;
+                    cleanupDecodeSlot();
                 }
             }
 
@@ -1390,6 +1537,8 @@ final class TestBindingFactory implements BindingHandler
                 long traceId = end.traceId();
 
                 source.doReplyEnd(traceId);
+
+                cleanupDecodeSlot();
             }
 
             private void onReplyAbort(
@@ -1398,6 +1547,8 @@ final class TestBindingFactory implements BindingHandler
                 long traceId = abort.traceId();
 
                 source.doReplyAbort(traceId);
+
+                cleanupDecodeSlot();
             }
 
             private void onReplyFlush(
@@ -1417,26 +1568,101 @@ final class TestBindingFactory implements BindingHandler
 
             private void doInitialData(
                 long traceId,
-                int flags,
-                int reserved,
+                boolean fin,
                 OctetsFW payload)
             {
-                doData(target, originId, routedId, initialId, initialSeq, initialAck, initialMax, initialBud,
-                        traceId, flags, reserved, payload);
+                DirectBufferEx buffer = payload.buffer();
+                int offset = payload.offset();
+                int limit = payload.limit();
 
-                initialSeq += reserved;
+                if (encodeSlot != NO_SLOT)
+                {
+                    MutableDirectBufferEx encodeBuffer = encodePool.buffer(encodeSlot);
+                    encodeBuffer.putBytes(encodeSlotOffset, buffer, offset, limit - offset);
+                    encodeSlotOffset += limit - offset;
+
+                    buffer = encodeBuffer;
+                    offset = 0;
+                    limit = encodeSlotOffset;
+                }
+
+                encodeSlotTraceId = traceId;
+                encodeSlotFin = encodeSlotFin || fin;
+
+                encodeInitial(traceId, buffer, offset, limit);
+            }
+
+            private void encodeInitial(
+                long traceId,
+                DirectBufferEx buffer,
+                int offset,
+                int limit)
+            {
+                int maxLength = limit - offset;
+                int length = Math.max(Math.min(initialWindow() - initialPad, maxLength), 0);
+
+                if (length > 0)
+                {
+                    boolean fin = length == maxLength && encodeSlotFin;
+                    int reserved = length + initialPad;
+                    int flags = (initialStarted ? 0x00 : FLAGS_INIT) | (fin ? FLAGS_FIN : 0x00);
+
+                    OctetsFW out = octetsRO.wrap(buffer, offset, offset + length);
+                    doData(target, originId, routedId, initialId, initialSeq, initialAck, initialMax, initialBud,
+                            traceId, flags, reserved, out);
+
+                    initialSeq += reserved;
+                    initialStarted = !fin;
+                    if (fin)
+                    {
+                        encodeSlotFin = false;
+                    }
+                }
+
+                int remaining = maxLength - length;
+                if (remaining > 0)
+                {
+                    if (encodeSlot == NO_SLOT)
+                    {
+                        encodeSlot = encodePool.acquire(initialId);
+                    }
+
+                    if (encodeSlot == NO_SLOT)
+                    {
+                        doInitialAbort(traceId);
+                    }
+                    else
+                    {
+                        MutableDirectBufferEx encodeBuffer = encodePool.buffer(encodeSlot);
+                        encodeBuffer.putBytes(0, buffer, offset + length, remaining);
+                        encodeSlotOffset = remaining;
+                    }
+                }
+                else
+                {
+                    cleanupEncodeSlot();
+                }
+            }
+
+            private int initialWindow()
+            {
+                return initialMax - (int) (initialSeq - initialAck) - encodeSlotOffset;
             }
 
             private void doInitialEnd(
                 long traceId)
             {
                 doEnd(target, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId);
+
+                cleanupEncodeSlot();
             }
 
             private void doInitialAbort(
                 long traceId)
             {
                 doAbort(target, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId);
+
+                cleanupEncodeSlot();
             }
 
             private void doInitialFlush(
@@ -1460,7 +1686,7 @@ final class TestBindingFactory implements BindingHandler
                 int padding,
                 int capabilities)
             {
-                replyAck = acknowledge;
+                replyAck = pipeline != null ? Math.max(replySeq - decodeSlotOffset, replyAck) : acknowledge;
                 replyMax = maximum;
                 replyBud = budgetId;
                 replyPad = padding;
@@ -1474,6 +1700,28 @@ final class TestBindingFactory implements BindingHandler
                 long traceId)
             {
                 doChallenge(target, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId);
+            }
+
+            private void cleanupDecodeSlot()
+            {
+                if (decodeSlot != NO_SLOT)
+                {
+                    decodePool.release(decodeSlot);
+                    decodeSlot = NO_SLOT;
+                    decodeSlotOffset = 0;
+                }
+            }
+
+            private void cleanupEncodeSlot()
+            {
+                if (encodeSlot != NO_SLOT)
+                {
+                    encodePool.release(encodeSlot);
+                    encodeSlot = NO_SLOT;
+                    encodeSlotOffset = 0;
+                    encodeSlotTraceId = 0;
+                    encodeSlotFin = false;
+                }
             }
         }
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -78,7 +78,9 @@ final class TestBindingFactory implements BindingHandler
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
-    private static final int TRANSFORM_REJECTED = -1;
+    // DataFW.FIELD_OFFSET_PAYLOAD -- a transform destination window must leave this much room in
+    // context.writeBuffer() for the frame header, or wrapping a full window as a DataFW payload overflows it
+    private static final int DATA_FRAME_HEADER_SIZE = 85;
     private static final List<String> EMPTY_ROLES = emptyList();
 
     private final BeginFW beginRO = new BeginFW();
@@ -337,12 +339,18 @@ final class TestBindingFactory implements BindingHandler
         private long pendingTraceId;
         private boolean storeAssertionsStarted;
         private final ModelPipeline pipeline;
-        // holds a value's transformed bytes across onInitialData calls when the value's source arrives
-        // split over more than one DATA frame (flags without FLAGS_FIN); modelBuffer alone cannot serve
-        // this purpose since it is shared, single-threaded-safe scratch space reused synchronously within
-        // one onInitialData call, not state that survives until a later, possibly interleaved, call
+        // fixed-size destination window for pipeline.transform(); drained into a downstream DATA frame
+        // every time it fills, rather than accumulating a whole value, so a value larger than this window
+        // (or split across several onInitialData calls) is transformed correctly regardless of size
         private final MutableDirectBufferEx initialBuffer;
-        private int initialPending;
+        private boolean initialStarted;
+        // accumulates source bytes not yet consumed by the pipeline across onInitialData calls -- on
+        // ModelStatus#UNDERFLOW the pipeline may consume only part of what it was given (e.g. it saw a
+        // JSON field open a string value but the closing quote had not yet arrived), so the unconsumed
+        // tail must be preserved and prepended to the next DATA frame's bytes, not discarded. Grows on
+        // demand since a fragment's source size is independent of the destination window above
+        private MutableDirectBufferEx initialDecodeSlot;
+        private int initialDecodeLength;
 
         private TestSource(
             MessageConsumer source,
@@ -359,7 +367,8 @@ final class TestBindingFactory implements BindingHandler
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
             this.pipeline = valueModel != null ? valueModel.supplyEncoder() : null;
-            this.initialBuffer = pipeline != null ? new UnsafeBufferEx(new byte[modelBuffer.capacity()]) : null;
+            this.initialBuffer = pipeline != null ?
+                new UnsafeBufferEx(new byte[modelBuffer.capacity() - DATA_FRAME_HEADER_SIZE]) : null;
         }
 
         private void doAuthorize(
@@ -909,78 +918,91 @@ final class TestBindingFactory implements BindingHandler
             }
             else
             {
-                int total = transform(pipeline, initialBuffer, initialPending, traceId, authorization, flags,
-                    payload.buffer(), payload.offset(), payload.limit());
-                if (total == TRANSFORM_REJECTED)
+                int payloadLength = payload.sizeof();
+                if (initialDecodeSlot == null || initialDecodeSlot.capacity() < initialDecodeLength + payloadLength)
                 {
-                    target.doInitialAbort(traceId);
-                    initialPending = 0;
+                    int capacity = Math.max(initialDecodeLength + payloadLength,
+                        initialDecodeSlot != null ? initialDecodeSlot.capacity() * 2 : modelBuffer.capacity());
+                    MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
+                    if (initialDecodeLength > 0)
+                    {
+                        grown.putBytes(0, initialDecodeSlot, 0, initialDecodeLength);
+                    }
+                    initialDecodeSlot = grown;
                 }
-                else if ((flags & FLAGS_FIN) != 0)
-                {
-                    OctetsFW transformed = octetsRO.wrap(initialBuffer, 0, total);
-                    target.doInitialData(traceId, flags, total, transformed);
-                    initialPending = 0;
-                }
-                else
-                {
-                    initialPending = total;
-                }
+                initialDecodeSlot.putBytes(initialDecodeLength, payload.buffer(), payload.offset(), payloadLength);
+                initialDecodeLength += payloadLength;
+
+                transformInitial(traceId, authorization, flags);
             }
         }
 
-        // drives pipeline.transform over one DATA frame's worth of source, starting from any bytes
-        // already produced by a prior fragment (pending); loops internally while the pipeline reports
-        // OK/OVERFLOW (more destination room needed, no new source required), and stops on COMPLETE,
-        // REJECTED, or UNDERFLOW (this frame's source is exhausted but the value is not yet complete).
-        // UNDERFLOW while this frame carried FLAGS_FIN means the value was truncated -- treated the same
-        // as REJECTED, since no further frame will ever arrive to complete it
-        private int transform(
-            ModelPipeline pipeline,
-            MutableDirectBufferEx buffer,
-            int pending,
+        // drives pipeline.transform over the accumulated, not-yet-consumed source bytes, draining the
+        // fixed-size initialBuffer window into a downstream DATA frame every time it produces output,
+        // rather than accumulating a whole value -- ModelStatus#OVERFLOW means the window filled before
+        // the value completed, so the caller drains it and calls transform() again with the same source
+        // position and a freshly emptied window, per the ModelPipeline#transform contract. Loops while the
+        // pipeline reports OK/OVERFLOW and stops on COMPLETE, REJECTED, or UNDERFLOW. On UNDERFLOW the
+        // pipeline may have consumed only part of what it was given (e.g. a JSON string value whose
+        // closing quote had not yet arrived) -- the unconsumed tail is compacted to the front of
+        // initialDecodeSlot and carried into the next onInitialData call, unless this frame carried
+        // FLAGS_FIN, in which case the value was truncated and is treated the same as REJECTED since no
+        // further frame will ever arrive to complete it
+        private void transformInitial(
             long traceId,
             long authorization,
-            int flags,
-            DirectBufferEx data,
-            int index,
-            int limit)
+            int flags)
         {
-            int total = pending;
-            int srcAt = index;
+            int srcAt = 0;
+            int limit = initialDecodeLength;
             int stepFlags = flags;
             ModelStatus status;
             do
             {
                 final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
-                        data, srcAt, limit, buffer, total, buffer.capacity());
+                        initialDecodeSlot, srcAt, limit, initialBuffer, 0, initialBuffer.capacity());
                 status = result.status();
 
                 if (status != ModelStatus.REJECTED)
                 {
-                    total += result.produced();
                     srcAt += result.consumed();
                     stepFlags &= ~FLAGS_INIT;
+
+                    int produced = result.produced();
+                    if (produced > 0)
+                    {
+                        int outFlags = (initialStarted ? 0x00 : FLAGS_INIT) |
+                            (status == ModelStatus.COMPLETE ? FLAGS_FIN : 0x00);
+                        OctetsFW transformed = octetsRO.wrap(initialBuffer, 0, produced);
+                        target.doInitialData(traceId, outFlags, produced, transformed);
+                        initialStarted = true;
+                    }
                 }
             } while (status == ModelStatus.OK || status == ModelStatus.OVERFLOW);
 
             boolean truncated = status == ModelStatus.UNDERFLOW && (flags & FLAGS_FIN) != 0;
-            int outcome;
             if (status == ModelStatus.REJECTED || truncated)
             {
                 pipeline.reset();
-                outcome = TRANSFORM_REJECTED;
+                target.doInitialAbort(traceId);
+                initialStarted = false;
+                initialDecodeLength = 0;
+            }
+            else if (status == ModelStatus.UNDERFLOW)
+            {
+                int remaining = limit - srcAt;
+                if (remaining > 0 && srcAt > 0)
+                {
+                    initialDecodeSlot.putBytes(0, initialDecodeSlot, srcAt, remaining);
+                }
+                initialDecodeLength = remaining;
             }
             else if (status == ModelStatus.COMPLETE)
             {
                 pipeline.reset();
-                outcome = total;
+                initialStarted = false;
+                initialDecodeLength = 0;
             }
-            else
-            {
-                outcome = total;
-            }
-            return outcome;
         }
 
         private void onInitialEnd(
@@ -1165,9 +1187,12 @@ final class TestBindingFactory implements BindingHandler
 
             private final TestSource source;
             private final ModelPipeline pipeline;
-            // see TestSource.initialBuffer for why reply-direction fragmentation needs its own buffer too
+            // see TestSource.initialBuffer -- same fixed-size drain-per-produce window, for the reply direction
             private final MutableDirectBufferEx replyBuffer;
-            private int replyPending;
+            private boolean replyStarted;
+            // see TestSource.initialDecodeSlot -- same not-yet-consumed source accumulation, for the reply direction
+            private MutableDirectBufferEx replyDecodeSlot;
+            private int replyDecodeLength;
 
             private TestTarget(
                 long originId,
@@ -1179,7 +1204,8 @@ final class TestBindingFactory implements BindingHandler
                 this.replyId = context.supplyReplyId(initialId);
                 this.source = TestSource.this;
                 this.pipeline = valueModel != null ? valueModel.supplyDecoder() : null;
-                this.replyBuffer = pipeline != null ? new UnsafeBufferEx(new byte[modelBuffer.capacity()]) : null;
+                this.replyBuffer = pipeline != null ?
+                    new UnsafeBufferEx(new byte[modelBuffer.capacity() - DATA_FRAME_HEADER_SIZE]) : null;
             }
 
             private void onMessage(
@@ -1281,23 +1307,80 @@ final class TestBindingFactory implements BindingHandler
                 }
                 else
                 {
-                    int total = source.transform(pipeline, replyBuffer, replyPending, traceId, authorization, flags,
-                        payload.buffer(), payload.offset(), payload.limit());
-                    if (total == TRANSFORM_REJECTED)
+                    int payloadLength = payload.sizeof();
+                    if (replyDecodeSlot == null || replyDecodeSlot.capacity() < replyDecodeLength + payloadLength)
                     {
-                        source.doReplyAbort(traceId);
-                        replyPending = 0;
+                        int capacity = Math.max(replyDecodeLength + payloadLength,
+                            replyDecodeSlot != null ? replyDecodeSlot.capacity() * 2 : modelBuffer.capacity());
+                        MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
+                        if (replyDecodeLength > 0)
+                        {
+                            grown.putBytes(0, replyDecodeSlot, 0, replyDecodeLength);
+                        }
+                        replyDecodeSlot = grown;
                     }
-                    else if ((flags & FLAGS_FIN) != 0)
+                    replyDecodeSlot.putBytes(replyDecodeLength, payload.buffer(), payload.offset(), payloadLength);
+                    replyDecodeLength += payloadLength;
+
+                    transformReply(traceId, authorization, flags);
+                }
+            }
+
+            // see TestSource#transformInitial for the drain-and-continue loop this mirrors on the reply direction
+            private void transformReply(
+                long traceId,
+                long authorization,
+                int flags)
+            {
+                int srcAt = 0;
+                int limit = replyDecodeLength;
+                int stepFlags = flags;
+                ModelStatus status;
+                do
+                {
+                    final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
+                            replyDecodeSlot, srcAt, limit, replyBuffer, 0, replyBuffer.capacity());
+                    status = result.status();
+
+                    if (status != ModelStatus.REJECTED)
                     {
-                        OctetsFW transformed = octetsRO.wrap(replyBuffer, 0, total);
-                        source.doReplyData(traceId, flags, total, transformed);
-                        replyPending = 0;
+                        srcAt += result.consumed();
+                        stepFlags &= ~FLAGS_INIT;
+
+                        int produced = result.produced();
+                        if (produced > 0)
+                        {
+                            int outFlags = (replyStarted ? 0x00 : FLAGS_INIT) |
+                                (status == ModelStatus.COMPLETE ? FLAGS_FIN : 0x00);
+                            OctetsFW transformed = octetsRO.wrap(replyBuffer, 0, produced);
+                            source.doReplyData(traceId, outFlags, produced, transformed);
+                            replyStarted = true;
+                        }
                     }
-                    else
+                } while (status == ModelStatus.OK || status == ModelStatus.OVERFLOW);
+
+                boolean truncated = status == ModelStatus.UNDERFLOW && (flags & FLAGS_FIN) != 0;
+                if (status == ModelStatus.REJECTED || truncated)
+                {
+                    pipeline.reset();
+                    source.doReplyAbort(traceId);
+                    replyStarted = false;
+                    replyDecodeLength = 0;
+                }
+                else if (status == ModelStatus.UNDERFLOW)
+                {
+                    int remaining = limit - srcAt;
+                    if (remaining > 0 && srcAt > 0)
                     {
-                        replyPending = total;
+                        replyDecodeSlot.putBytes(0, replyDecodeSlot, srcAt, remaining);
                     }
+                    replyDecodeLength = remaining;
+                }
+                else if (status == ModelStatus.COMPLETE)
+                {
+                    pipeline.reset();
+                    replyStarted = false;
+                    replyDecodeLength = 0;
                 }
             }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -349,8 +349,8 @@ final class TestBindingFactory implements BindingHandler
         // JSON field open a string value but the closing quote had not yet arrived), so the unconsumed
         // tail must be preserved and prepended to the next DATA frame's bytes, not discarded. Grows on
         // demand since a fragment's source size is independent of the destination window above
-        private MutableDirectBufferEx initialDecodeSlot;
-        private int initialDecodeLength;
+        private MutableDirectBufferEx decodeSlot;
+        private int decodeLength;
 
         private TestSource(
             MessageConsumer source,
@@ -919,19 +919,19 @@ final class TestBindingFactory implements BindingHandler
             else
             {
                 int payloadLength = payload.sizeof();
-                if (initialDecodeSlot == null || initialDecodeSlot.capacity() < initialDecodeLength + payloadLength)
+                if (decodeSlot == null || decodeSlot.capacity() < decodeLength + payloadLength)
                 {
-                    int capacity = Math.max(initialDecodeLength + payloadLength,
-                        initialDecodeSlot != null ? initialDecodeSlot.capacity() * 2 : modelBuffer.capacity());
+                    int capacity = Math.max(decodeLength + payloadLength,
+                        decodeSlot != null ? decodeSlot.capacity() * 2 : modelBuffer.capacity());
                     MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
-                    if (initialDecodeLength > 0)
+                    if (decodeLength > 0)
                     {
-                        grown.putBytes(0, initialDecodeSlot, 0, initialDecodeLength);
+                        grown.putBytes(0, decodeSlot, 0, decodeLength);
                     }
-                    initialDecodeSlot = grown;
+                    decodeSlot = grown;
                 }
-                initialDecodeSlot.putBytes(initialDecodeLength, payload.buffer(), payload.offset(), payloadLength);
-                initialDecodeLength += payloadLength;
+                decodeSlot.putBytes(decodeLength, payload.buffer(), payload.offset(), payloadLength);
+                decodeLength += payloadLength;
 
                 transformInitial(traceId, authorization, flags);
             }
@@ -945,7 +945,7 @@ final class TestBindingFactory implements BindingHandler
         // pipeline reports OK/OVERFLOW and stops on COMPLETE, REJECTED, or UNDERFLOW. On UNDERFLOW the
         // pipeline may have consumed only part of what it was given (e.g. a JSON string value whose
         // closing quote had not yet arrived) -- the unconsumed tail is compacted to the front of
-        // initialDecodeSlot and carried into the next onInitialData call, unless this frame carried
+        // decodeSlot and carried into the next onInitialData call, unless this frame carried
         // FLAGS_FIN, in which case the value was truncated and is treated the same as REJECTED since no
         // further frame will ever arrive to complete it
         private void transformInitial(
@@ -954,13 +954,13 @@ final class TestBindingFactory implements BindingHandler
             int flags)
         {
             int srcAt = 0;
-            int limit = initialDecodeLength;
+            int limit = decodeLength;
             int stepFlags = flags;
             ModelStatus status;
             do
             {
                 final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
-                        initialDecodeSlot, srcAt, limit, initialBuffer, 0, initialBuffer.capacity());
+                        decodeSlot, srcAt, limit, initialBuffer, 0, initialBuffer.capacity());
                 status = result.status();
 
                 if (status != ModelStatus.REJECTED)
@@ -986,22 +986,22 @@ final class TestBindingFactory implements BindingHandler
                 pipeline.reset();
                 target.doInitialAbort(traceId);
                 initialStarted = false;
-                initialDecodeLength = 0;
+                decodeLength = 0;
             }
             else if (status == ModelStatus.UNDERFLOW)
             {
                 int remaining = limit - srcAt;
                 if (remaining > 0 && srcAt > 0)
                 {
-                    initialDecodeSlot.putBytes(0, initialDecodeSlot, srcAt, remaining);
+                    decodeSlot.putBytes(0, decodeSlot, srcAt, remaining);
                 }
-                initialDecodeLength = remaining;
+                decodeLength = remaining;
             }
             else if (status == ModelStatus.COMPLETE)
             {
                 pipeline.reset();
                 initialStarted = false;
-                initialDecodeLength = 0;
+                decodeLength = 0;
             }
         }
 
@@ -1190,9 +1190,9 @@ final class TestBindingFactory implements BindingHandler
             // see TestSource.initialBuffer -- same fixed-size drain-per-produce window, for the reply direction
             private final MutableDirectBufferEx replyBuffer;
             private boolean replyStarted;
-            // see TestSource.initialDecodeSlot -- same not-yet-consumed source accumulation, for the reply direction
-            private MutableDirectBufferEx replyDecodeSlot;
-            private int replyDecodeLength;
+            // see TestSource.decodeSlot -- same not-yet-consumed source accumulation, for the reply direction
+            private MutableDirectBufferEx decodeSlot;
+            private int decodeLength;
 
             private TestTarget(
                 long originId,
@@ -1308,19 +1308,19 @@ final class TestBindingFactory implements BindingHandler
                 else
                 {
                     int payloadLength = payload.sizeof();
-                    if (replyDecodeSlot == null || replyDecodeSlot.capacity() < replyDecodeLength + payloadLength)
+                    if (decodeSlot == null || decodeSlot.capacity() < decodeLength + payloadLength)
                     {
-                        int capacity = Math.max(replyDecodeLength + payloadLength,
-                            replyDecodeSlot != null ? replyDecodeSlot.capacity() * 2 : modelBuffer.capacity());
+                        int capacity = Math.max(decodeLength + payloadLength,
+                            decodeSlot != null ? decodeSlot.capacity() * 2 : modelBuffer.capacity());
                         MutableDirectBufferEx grown = new UnsafeBufferEx(new byte[capacity]);
-                        if (replyDecodeLength > 0)
+                        if (decodeLength > 0)
                         {
-                            grown.putBytes(0, replyDecodeSlot, 0, replyDecodeLength);
+                            grown.putBytes(0, decodeSlot, 0, decodeLength);
                         }
-                        replyDecodeSlot = grown;
+                        decodeSlot = grown;
                     }
-                    replyDecodeSlot.putBytes(replyDecodeLength, payload.buffer(), payload.offset(), payloadLength);
-                    replyDecodeLength += payloadLength;
+                    decodeSlot.putBytes(decodeLength, payload.buffer(), payload.offset(), payloadLength);
+                    decodeLength += payloadLength;
 
                     transformReply(traceId, authorization, flags);
                 }
@@ -1333,13 +1333,13 @@ final class TestBindingFactory implements BindingHandler
                 int flags)
             {
                 int srcAt = 0;
-                int limit = replyDecodeLength;
+                int limit = decodeLength;
                 int stepFlags = flags;
                 ModelStatus status;
                 do
                 {
                     final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
-                            replyDecodeSlot, srcAt, limit, replyBuffer, 0, replyBuffer.capacity());
+                            decodeSlot, srcAt, limit, replyBuffer, 0, replyBuffer.capacity());
                     status = result.status();
 
                     if (status != ModelStatus.REJECTED)
@@ -1365,22 +1365,22 @@ final class TestBindingFactory implements BindingHandler
                     pipeline.reset();
                     source.doReplyAbort(traceId);
                     replyStarted = false;
-                    replyDecodeLength = 0;
+                    decodeLength = 0;
                 }
                 else if (status == ModelStatus.UNDERFLOW)
                 {
                     int remaining = limit - srcAt;
                     if (remaining > 0 && srcAt > 0)
                     {
-                        replyDecodeSlot.putBytes(0, replyDecodeSlot, srcAt, remaining);
+                        decodeSlot.putBytes(0, decodeSlot, srcAt, remaining);
                     }
-                    replyDecodeLength = remaining;
+                    decodeLength = remaining;
                 }
                 else if (status == ModelStatus.COMPLETE)
                 {
                     pipeline.reset();
                     replyStarted = false;
-                    replyDecodeLength = 0;
+                    decodeLength = 0;
                 }
             }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -78,6 +78,7 @@ final class TestBindingFactory implements BindingHandler
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
+    private static final int TRANSFORM_REJECTED = -1;
     private static final List<String> EMPTY_ROLES = emptyList();
 
     private final BeginFW beginRO = new BeginFW();
@@ -336,6 +337,12 @@ final class TestBindingFactory implements BindingHandler
         private long pendingTraceId;
         private boolean storeAssertionsStarted;
         private final ModelPipeline pipeline;
+        // holds a value's transformed bytes across onInitialData calls when the value's source arrives
+        // split over more than one DATA frame (flags without FLAGS_FIN); modelBuffer alone cannot serve
+        // this purpose since it is shared, single-threaded-safe scratch space reused synchronously within
+        // one onInitialData call, not state that survives until a later, possibly interleaved, call
+        private final MutableDirectBufferEx initialBuffer;
+        private int initialPending;
 
         private TestSource(
             MessageConsumer source,
@@ -352,6 +359,7 @@ final class TestBindingFactory implements BindingHandler
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
             this.pipeline = valueModel != null ? valueModel.supplyEncoder() : null;
+            this.initialBuffer = pipeline != null ? new UnsafeBufferEx(new byte[modelBuffer.capacity()]) : null;
         }
 
         private void doAuthorize(
@@ -901,61 +909,78 @@ final class TestBindingFactory implements BindingHandler
             }
             else
             {
-                int total = transform(pipeline, traceId, authorization,
+                int total = transform(pipeline, initialBuffer, initialPending, traceId, authorization, flags,
                     payload.buffer(), payload.offset(), payload.limit());
-                if (total < 0)
+                if (total == TRANSFORM_REJECTED)
                 {
                     target.doInitialAbort(traceId);
+                    initialPending = 0;
+                }
+                else if ((flags & FLAGS_FIN) != 0)
+                {
+                    OctetsFW transformed = octetsRO.wrap(initialBuffer, 0, total);
+                    target.doInitialData(traceId, flags, total, transformed);
+                    initialPending = 0;
                 }
                 else
                 {
-                    OctetsFW transformed = octetsRO.wrap(modelBuffer, 0, total);
-                    target.doInitialData(traceId, flags, total, transformed);
+                    initialPending = total;
                 }
             }
         }
 
+        // drives pipeline.transform over one DATA frame's worth of source, starting from any bytes
+        // already produced by a prior fragment (pending); loops internally while the pipeline reports
+        // OK/OVERFLOW (more destination room needed, no new source required), and stops on COMPLETE,
+        // REJECTED, or UNDERFLOW (this frame's source is exhausted but the value is not yet complete).
+        // UNDERFLOW while this frame carried FLAGS_FIN means the value was truncated -- treated the same
+        // as REJECTED, since no further frame will ever arrive to complete it
         private int transform(
             ModelPipeline pipeline,
+            MutableDirectBufferEx buffer,
+            int pending,
             long traceId,
             long authorization,
+            int flags,
             DirectBufferEx data,
             int index,
             int limit)
         {
-            int total = 0;
+            int total = pending;
             int srcAt = index;
-            int flags = FLAGS_INIT | FLAGS_FIN;
-            boolean done = false;
-            while (!done)
+            int stepFlags = flags;
+            ModelStatus status;
+            do
             {
-                final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, flags,
-                        data, srcAt, limit, modelBuffer, total, modelBuffer.capacity());
-                final ModelStatus status = result.status();
+                final ModelPipelineResult result = pipeline.transform(traceId, routedId, authorization, stepFlags,
+                        data, srcAt, limit, buffer, total, buffer.capacity());
+                status = result.status();
 
-                if (status == ModelStatus.REJECTED)
-                {
-                    total = -1;
-                    done = true;
-                }
-                else
+                if (status != ModelStatus.REJECTED)
                 {
                     total += result.produced();
-
-                    if (status == ModelStatus.COMPLETE)
-                    {
-                        done = true;
-                    }
-                    else
-                    {
-                        srcAt += result.consumed();
-                        flags = FLAGS_FIN;
-                    }
+                    srcAt += result.consumed();
+                    stepFlags &= ~FLAGS_INIT;
                 }
-            }
+            } while (status == ModelStatus.OK || status == ModelStatus.OVERFLOW);
 
-            pipeline.reset();
-            return total;
+            boolean truncated = status == ModelStatus.UNDERFLOW && (flags & FLAGS_FIN) != 0;
+            int outcome;
+            if (status == ModelStatus.REJECTED || truncated)
+            {
+                pipeline.reset();
+                outcome = TRANSFORM_REJECTED;
+            }
+            else if (status == ModelStatus.COMPLETE)
+            {
+                pipeline.reset();
+                outcome = total;
+            }
+            else
+            {
+                outcome = total;
+            }
+            return outcome;
         }
 
         private void onInitialEnd(
@@ -1140,6 +1165,9 @@ final class TestBindingFactory implements BindingHandler
 
             private final TestSource source;
             private final ModelPipeline pipeline;
+            // see TestSource.initialBuffer for why reply-direction fragmentation needs its own buffer too
+            private final MutableDirectBufferEx replyBuffer;
+            private int replyPending;
 
             private TestTarget(
                 long originId,
@@ -1151,6 +1179,7 @@ final class TestBindingFactory implements BindingHandler
                 this.replyId = context.supplyReplyId(initialId);
                 this.source = TestSource.this;
                 this.pipeline = valueModel != null ? valueModel.supplyDecoder() : null;
+                this.replyBuffer = pipeline != null ? new UnsafeBufferEx(new byte[modelBuffer.capacity()]) : null;
             }
 
             private void onMessage(
@@ -1252,16 +1281,22 @@ final class TestBindingFactory implements BindingHandler
                 }
                 else
                 {
-                    int total = source.transform(pipeline, traceId, authorization,
+                    int total = source.transform(pipeline, replyBuffer, replyPending, traceId, authorization, flags,
                         payload.buffer(), payload.offset(), payload.limit());
-                    if (total < 0)
+                    if (total == TRANSFORM_REJECTED)
                     {
                         source.doReplyAbort(traceId);
+                        replyPending = 0;
+                    }
+                    else if ((flags & FLAGS_FIN) != 0)
+                    {
+                        OctetsFW transformed = octetsRO.wrap(replyBuffer, 0, total);
+                        source.doReplyData(traceId, flags, total, transformed);
+                        replyPending = 0;
                     }
                     else
                     {
-                        OctetsFW transformed = octetsRO.wrap(modelBuffer, 0, total);
-                        source.doReplyData(traceId, flags, total, transformed);
+                        replyPending = total;
                     }
                 }
             }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
@@ -27,11 +27,12 @@ public interface AvroModelExtHandler
      * Appends this extension's own stage or stages to {@code stream}, in data-flow order, returning the
      * result for the caller to continue building.
      *
+     * @param <T>     the caller's own concrete stream type
      * @param stream  the in-progress stream to extend
-     * @return the extended stream
+     * @return the extended stream, as the same concrete type supplied
      */
-    AvroTransformable transform(
-        AvroTransformable stream);
+    <T extends AvroTransformable<T>> T transform(
+        T stream);
 
     /**
      * Returns the maximum number of additional bytes this extension's transform may add to a decoded

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandler.java
@@ -19,20 +19,42 @@ import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 
 /**
  * Appends whatever stages this extension contributes to an in-progress avro pipeline, for one resolved
- * schema and configuration.
+ * schema and configuration. A pipeline decoding the canonical value into the view delivered to a reader
+ * and one encoding a caller's value into its canonical form are extended independently, so an extension
+ * that only applies to one direction overrides that method alone; the default leaves the other direction
+ * unchanged.
  */
 public interface AvroModelExtHandler
 {
     /**
-     * Appends this extension's own stage or stages to {@code stream}, in data-flow order, returning the
-     * result for the caller to continue building.
+     * Appends this extension's own stage or stages to {@code transformable}, in data-flow order, for a
+     * pipeline decoding the canonical value into the view delivered to a reader. The default passes
+     * {@code transformable} through unchanged.
      *
-     * @param <T>     the caller's own concrete stream type
-     * @param stream  the in-progress stream to extend
+     * @param <T>              the caller's own concrete stream type
+     * @param transformable    the in-progress stream to extend
      * @return the extended stream, as the same concrete type supplied
      */
-    <T extends AvroTransformable<T>> T transform(
-        T stream);
+    default <T extends AvroTransformable<T>> T decode(
+        T transformable)
+    {
+        return transformable;
+    }
+
+    /**
+     * Appends this extension's own stage or stages to {@code transformable}, in data-flow order, for a
+     * pipeline encoding a caller's value into its canonical form. The default passes {@code transformable}
+     * through unchanged.
+     *
+     * @param <T>              the caller's own concrete stream type
+     * @param transformable    the in-progress stream to extend
+     * @return the extended stream, as the same concrete type supplied
+     */
+    default <T extends AvroTransformable<T>> T encode(
+        T transformable)
+    {
+        return transformable;
+    }
 
     /**
      * Returns the maximum number of additional bytes this extension's transform may add to a decoded

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandler.java
@@ -135,7 +135,7 @@ public abstract class AvroModelHandler
     }
 
     // overridden by AvroModelHandlerImpl to sum the padding contributed by each installed model extension;
-    // the base (encoder) handler never installs extensions, so this stays 0 there
+    // this default (no extensions installed) stays 0
     protected int extPadding(
         AvroSchema schema)
     {

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -173,7 +173,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
             AvroGenerator generator = VIEW_JSON.equals(view)
                 ? AvroJson.generator(schema, json, true)
                 : Avro.generator(schema, new UnsafeBufferEx(new byte[1]), 0);
-            pipeline = extend(Avro.stream(Avro.parser(schema)), schema)
+            pipeline = extendDecode(Avro.stream(Avro.parser(schema)), schema)
                 .transform(adapter)
                 .lenient(lenient)
                 .reporting(reporter)
@@ -198,7 +198,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
             AvroStream stream = VIEW_JSON.equals(view)
                 ? AvroJson.stream(schema, JsonEx.createParser(), true)
                 : Avro.stream(Avro.parser(schema));
-            pipeline = extend(stream, schema)
+            pipeline = extendEncode(stream, schema)
                 .transform(adapter)
                 .lenient(lenient)
                 .reporting(reporter)
@@ -207,17 +207,32 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         return pipeline;
     }
 
-    // folds every installed avro model extension's own stage(s) into the stream, in discovery order,
-    // ahead of this handler's own adapter stage; used for both the decoder and encoder pipeline, so an
-    // extension that only transforms one direction is responsible for forwarding the other unchanged
-    private AvroStream extend(
+    // folds every installed avro model extension's own decode stage(s) into the stream, in discovery
+    // order, ahead of this handler's own adapter stage: the canonical value being decoded into the view
+    // delivered to a reader
+    private AvroStream extendDecode(
         AvroStream stream,
         AvroSchema schema)
     {
         AvroStream extended = stream;
         for (AvroModelExtContext ext : exts)
         {
-            extended = ext.supplyHandler(schema, options).transform(extended);
+            extended = ext.supplyHandler(schema, options).decode(extended);
+        }
+        return extended;
+    }
+
+    // folds every installed avro model extension's own encode stage(s) into the stream, in discovery
+    // order, ahead of this handler's own adapter stage: a caller's value being encoded into its canonical
+    // form
+    private AvroStream extendEncode(
+        AvroStream stream,
+        AvroSchema schema)
+    {
+        AvroStream extended = stream;
+        for (AvroModelExtContext ext : exts)
+        {
+            extended = ext.supplyHandler(schema, options).encode(extended);
         }
         return extended;
     }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -217,7 +217,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         AvroStream extended = stream;
         for (AvroModelExtContext ext : exts)
         {
-            extended = (AvroStream) ext.supplyHandler(schema, options).transform(extended);
+            extended = ext.supplyHandler(schema, options).transform(extended);
         }
         return extended;
     }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -110,7 +110,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
     int encodePadding(
         int length)
     {
-        return handler.encodePadding(length);
+        return handler.encodePadding(length) + supplyExtPadding(resolveSchemaId());
     }
 
     // the catalog framing the value carries on the wire, stripped once at the start of the first fragment
@@ -195,13 +195,10 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
             // a json view parses JSON input and re-encodes it as Avro binary; any other view validates
             // Avro binary input and reproduces it, so a malformed datum yields a binary "truncated datum"
             // diagnostic rather than a JSON parse failure
-            //
-            // model extensions are decode-only: encode is the write path into the broker, which must
-            // keep the source of truth intact, so extensions never fold into the encoder stream here
             AvroStream stream = VIEW_JSON.equals(view)
                 ? AvroJson.stream(schema, JsonEx.createParser(), true)
                 : Avro.stream(Avro.parser(schema));
-            pipeline = stream
+            pipeline = extend(stream, schema)
                 .transform(adapter)
                 .lenient(lenient)
                 .reporting(reporter)
@@ -210,9 +207,9 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         return pipeline;
     }
 
-    // folds every installed avro model extension's own stage(s) into the decoder stream, in discovery
-    // order, ahead of this handler's own adapter stage; decode is the read path out of the broker, where
-    // a read-side concern like disclosure redaction belongs
+    // folds every installed avro model extension's own stage(s) into the stream, in discovery order,
+    // ahead of this handler's own adapter stage; used for both the decoder and encoder pipeline, so an
+    // extension that only transforms one direction is responsible for forwarding the other unchanged
     private AvroStream extend(
         AvroStream stream,
         AvroSchema schema)

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransform.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransform.java
@@ -829,6 +829,12 @@ final class AvroModelTransform implements AvroTransform
         }
 
         @Override
+        public CharSequence getStringView()
+        {
+            return getString();
+        }
+
+        @Override
         public String getField()
         {
             return null;

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
-
 public class AvroModelExtHandlerTest
 {
     @Test
@@ -27,12 +25,6 @@ public class AvroModelExtHandlerTest
     {
         AvroModelExtHandler handler = new AvroModelExtHandler()
         {
-            @Override
-            public <T extends AvroTransformable<T>> T transform(
-                T stream)
-            {
-                return stream;
-            }
         };
 
         assertEquals(0, handler.padding(null));

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/ext/AvroModelExtHandlerTest.java
@@ -28,8 +28,8 @@ public class AvroModelExtHandlerTest
         AvroModelExtHandler handler = new AvroModelExtHandler()
         {
             @Override
-            public AvroTransformable transform(
-                AvroTransformable stream)
+            public <T extends AvroTransformable<T>> T transform(
+                T stream)
             {
                 return stream;
             }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -282,8 +282,8 @@ public class AvroModelDecoderPipelineTest
         return (schema, config) -> new AvroModelExtHandler()
         {
             @Override
-            public AvroTransformable transform(
-                AvroTransformable stream)
+            public <T extends AvroTransformable<T>> T transform(
+                T stream)
             {
                 return stream;
             }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -37,7 +37,6 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.avro.AvroSchema;
-import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
@@ -281,13 +280,6 @@ public class AvroModelDecoderPipelineTest
     {
         return (schema, config) -> new AvroModelExtHandler()
         {
-            @Override
-            public <T extends AvroTransformable<T>> T transform(
-                T stream)
-            {
-                return stream;
-            }
-
             @Override
             public int padding(
                 AvroSchema schema)

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
@@ -25,6 +25,7 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
+import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 
@@ -40,6 +41,7 @@ public class AvroModelIT
         .directory("target/zilla-itests")
         .countersBufferCapacity(4096)
         .configurationRoot("io/aklivity/zilla/specs/model/avro/config")
+        .configure(EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY, 65_536)
         .external("app0")
         .clean();
 
@@ -86,6 +88,39 @@ public class AvroModelIT
         "${app}/client.sent.avro.binary.truncated/server"
     })
     public void shouldRejectAvroBinaryTruncated() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.received.avro.ext.uppercase/client",
+        "${app}/client.received.avro.ext.uppercase/server"
+    })
+    public void shouldApplyExtensionOnDecode() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.received.avro.ext.uppercase.100k/client",
+        "${app}/client.received.avro.ext.uppercase.100k/server"
+    })
+    public void shouldDrainExtensionOverflowAcrossMultipleFrames() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.received.avro.ext.reject/client",
+        "${app}/client.received.avro.ext.reject/server"
+    })
+    public void shouldAbortWhenExtensionSignalsReject() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
@@ -109,7 +109,7 @@ public class AvroModelIT
         "${net}/client.received.avro.ext.uppercase.100k/client",
         "${app}/client.received.avro.ext.uppercase.100k/server"
     })
-    public void shouldDrainExtensionOverflowAcrossMultipleFrames() throws Exception
+    public void shouldDrainExtensionOverflowOnDecodeAcrossMultipleFrames() throws Exception
     {
         k3po.finish();
     }
@@ -120,7 +120,40 @@ public class AvroModelIT
         "${net}/client.received.avro.ext.reject/client",
         "${app}/client.received.avro.ext.reject/server"
     })
-    public void shouldAbortWhenExtensionSignalsReject() throws Exception
+    public void shouldAbortWhenExtensionSignalsRejectOnDecode() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.sent.avro.ext.uppercase/client",
+        "${app}/client.sent.avro.ext.uppercase/server"
+    })
+    public void shouldApplyExtensionOnEncode() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.sent.avro.ext.uppercase.100k/client",
+        "${app}/client.sent.avro.ext.uppercase.100k/server"
+    })
+    public void shouldDrainExtensionOverflowOnEncodeAcrossMultipleFrames() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("avro.ext.yaml")
+    @Specification({
+        "${net}/client.sent.avro.ext.reject/client",
+        "${app}/client.sent.avro.ext.reject/server"
+    })
+    public void shouldAbortWhenExtensionSignalsRejectOnEncode() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
@@ -38,6 +38,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.ExpandableDirectByteBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
@@ -51,6 +52,7 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
 import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtContext;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
 
 public class AvroModelTransformTest
 {
@@ -238,7 +240,15 @@ public class AvroModelTransformTest
     public void shouldApplyInstalledExtensionAheadOfCallerSuppliedTransform()
     {
         List<AvroModelExtContext> exts = List.of(
-            (schema, config) -> stream -> stream.transform(AvroModelTransform.of(new Declining("$.status"))));
+            (schema, config) -> new AvroModelExtHandler()
+            {
+                @Override
+                public <T extends AvroTransformable<T>> T transform(
+                    T stream)
+                {
+                    return stream.transform(AvroModelTransform.of(new Declining("$.status")));
+                }
+            });
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json", exts);
         ModelPipeline pipeline = handler.supplyDecoder(new Observing());
 

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
@@ -243,10 +243,10 @@ public class AvroModelTransformTest
             (schema, config) -> new AvroModelExtHandler()
             {
                 @Override
-                public <T extends AvroTransformable<T>> T transform(
-                    T stream)
+                public <T extends AvroTransformable<T>> T decode(
+                    T transformable)
                 {
-                    return stream.transform(AvroModelTransform.of(new Declining("$.status")));
+                    return transformable.transform(AvroModelTransform.of(new Declining("$.status")));
                 }
             });
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json", exts);

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
@@ -37,13 +37,13 @@ import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
 
 // Test-only AvroModelExt, registered only under src/test/resources/META-INF/services so it never ships
 // in the production jar. Exercises the same AvroModelExt composition mechanism a real installed
-// extension relies on -- apply-on-decode, fragment accumulation across multiple STRING chunks, drain
-// across a SUSPENDED terminal generator, and reject via AvroPipeline.Status.REJECTED -- without
-// model-avro needing to know anything about what a real extension might do with it. Uppercases the
-// string value of any field literally named "secret"; a captured value of "REJECT" rejects the datum.
+// extension relies on -- apply on both decode and encode, fragment accumulation across multiple STRING
+// chunks, drain across a SUSPENDED terminal generator, and reject via AvroPipeline.Status.REJECTED --
+// without model-avro needing to know anything about what a real extension might do with it. Uppercases
+// the string value of any field literally named "text"; a captured value of "REJECT" rejects the datum.
 public final class TestUppercaseAvroModelExtFactorySpi implements AvroModelExtFactorySpi
 {
-    private static final String TARGET_FIELD = "secret";
+    private static final String TARGET_FIELD = "text";
     private static final String REJECT_VALUE = "REJECT";
 
     @Override

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
@@ -276,6 +276,12 @@ public final class TestUppercaseAvroModelExtFactorySpi implements AvroModelExtFa
             }
 
             @Override
+            public CharSequence getStringView()
+            {
+                return getString();
+            }
+
+            @Override
             public String getField()
             {
                 return null;

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
@@ -73,10 +73,17 @@ public final class TestUppercaseAvroModelExtFactorySpi implements AvroModelExtFa
                     private final UppercaseTransform transform = new UppercaseTransform();
 
                     @Override
-                    public <T extends AvroTransformable<T>> T transform(
-                        T stream)
+                    public <T extends AvroTransformable<T>> T decode(
+                        T transformable)
                     {
-                        return stream.transform(transform);
+                        return transformable.transform(transform);
+                    }
+
+                    @Override
+                    public <T extends AvroTransformable<T>> T encode(
+                        T transformable)
+                    {
+                        return transformable.transform(transform);
                     }
                 };
             }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.avro.internal;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroEvent;
+import io.aklivity.zilla.runtime.common.avro.AvroLocation;
+import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
+import io.aklivity.zilla.runtime.common.avro.AvroSink;
+import io.aklivity.zilla.runtime.common.avro.AvroSource;
+import io.aklivity.zilla.runtime.common.avro.AvroTransform;
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
+import io.aklivity.zilla.runtime.common.avro.AvroType;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExt;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtContext;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtFactorySpi;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
+
+// Test-only AvroModelExt, registered only under src/test/resources/META-INF/services so it never ships
+// in the production jar. Exercises the same AvroModelExt composition mechanism a real installed
+// extension relies on -- apply-on-decode, fragment accumulation across multiple STRING chunks, drain
+// across a SUSPENDED terminal generator, and reject via AvroPipeline.Status.REJECTED -- without
+// model-avro needing to know anything about what a real extension might do with it. Uppercases the
+// string value of any field literally named "secret"; a captured value of "REJECT" rejects the datum.
+public final class TestUppercaseAvroModelExtFactorySpi implements AvroModelExtFactorySpi
+{
+    private static final String TARGET_FIELD = "secret";
+    private static final String REJECT_VALUE = "REJECT";
+
+    @Override
+    public String type()
+    {
+        return "test";
+    }
+
+    @Override
+    public AvroModelExt create(
+        Configuration config)
+    {
+        return new AvroModelExt()
+        {
+            @Override
+            public String name()
+            {
+                return "test";
+            }
+
+            @Override
+            public AvroModelExtContext supply(
+                EngineContext context)
+            {
+                return (schema, options) -> new AvroModelExtHandler()
+                {
+                    private final UppercaseTransform transform = new UppercaseTransform();
+
+                    @Override
+                    public AvroTransformable transform(
+                        AvroTransformable stream)
+                    {
+                        return stream.transform(transform);
+                    }
+                };
+            }
+        };
+    }
+
+    private static final class UppercaseTransform implements AvroTransform
+    {
+        private static final byte[] EMPTY = new byte[0];
+
+        private final Substitute substitute;
+        private final StringBuilder captured;
+
+        private boolean targeting;
+        private boolean emitting;
+
+        private UppercaseTransform()
+        {
+            this.substitute = new Substitute();
+            this.captured = new StringBuilder();
+        }
+
+        @Override
+        public Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            Status status;
+            switch (event)
+            {
+            case START_MESSAGE:
+                targeting = false;
+                captured.setLength(0);
+                status = sink.transform(control, source, event);
+                break;
+            case FIELD_NAME:
+                targeting = TARGET_FIELD.equals(source.getField());
+                status = sink.transform(control, source, event);
+                break;
+            case STRING:
+                status = targeting
+                    ? onTargetString(source, sink)
+                    : sink.transform(control, source, event);
+                break;
+            default:
+                status = sink.transform(control, source, event);
+                break;
+            }
+            return status;
+        }
+
+        @Override
+        public Status resume(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            Status status;
+            if (emitting)
+            {
+                status = sink.resume(substitute, substitute, substitute.event);
+                emitting = status == Status.SUSPENDED;
+            }
+            else
+            {
+                status = sink.resume(control, source, event);
+            }
+            return status;
+        }
+
+        @Override
+        public void reset()
+        {
+            targeting = false;
+            emitting = false;
+            captured.setLength(0);
+        }
+
+        // mirrors AvroSource#deferredBytes(): a STRING value larger than the input window arrives over
+        // several chunks, so the complete original text is accumulated until the final chunk before the
+        // uppercased (or rejected) substitute can be computed
+        private Status onTargetString(
+            AvroSource source,
+            AvroSink sink)
+        {
+            Status status;
+            captured.append(source.getString());
+
+            if (source.deferredBytes() == 0)
+            {
+                String original = captured.toString();
+                captured.setLength(0);
+                targeting = false;
+                if (REJECT_VALUE.equals(original))
+                {
+                    status = Status.REJECTED;
+                }
+                else
+                {
+                    byte[] upper = original.toUpperCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8);
+                    substitute.string(source.type(), upper);
+                    status = emit(sink);
+                }
+            }
+            else
+            {
+                status = Status.ADVANCED;
+            }
+            return status;
+        }
+
+        private Status emit(
+            AvroSink sink)
+        {
+            Status status = sink.transform(substitute, substitute, AvroEvent.STRING);
+            emitting = status == Status.SUSPENDED;
+            return status;
+        }
+
+        // the synthesized view fed to the downstream sink in place of the original string value
+        private static final class Substitute implements AvroSource, AvroController
+        {
+            private final UnsafeBufferEx content;
+            private final UnsafeBufferEx view;
+
+            private AvroEvent event;
+            private AvroType type;
+            private int length;
+            private int progress;
+
+            private Substitute()
+            {
+                this.content = new UnsafeBufferEx(EMPTY);
+                this.view = new UnsafeBufferEx(EMPTY);
+            }
+
+            private void string(
+                AvroType type,
+                byte[] bytes)
+            {
+                this.event = AvroEvent.STRING;
+                this.type = type;
+                this.progress = 0;
+                this.length = bytes.length;
+                content.wrap(bytes, 0, bytes.length);
+            }
+
+            @Override
+            public void segmentable()
+            {
+            }
+
+            @Override
+            public void consumed(
+                int sourceBytes)
+            {
+                progress += sourceBytes;
+            }
+
+            @Override
+            public boolean getBoolean()
+            {
+                return false;
+            }
+
+            @Override
+            public int getInt()
+            {
+                return 0;
+            }
+
+            @Override
+            public long getLong()
+            {
+                return 0L;
+            }
+
+            @Override
+            public float getFloat()
+            {
+                return 0f;
+            }
+
+            @Override
+            public double getDouble()
+            {
+                return 0d;
+            }
+
+            @Override
+            public String getString()
+            {
+                return "";
+            }
+
+            @Override
+            public String getField()
+            {
+                return null;
+            }
+
+            @Override
+            public String getKey()
+            {
+                return null;
+            }
+
+            @Override
+            public DirectBufferEx getSegment()
+            {
+                view.wrap(content, progress, length - progress);
+                return view;
+            }
+
+            @Override
+            public int deferredBytes()
+            {
+                return 0;
+            }
+
+            @Override
+            public AvroType type()
+            {
+                return type;
+            }
+
+            @Override
+            public AvroLocation getLocation()
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/TestUppercaseAvroModelExtFactorySpi.java
@@ -73,8 +73,8 @@ public final class TestUppercaseAvroModelExtFactorySpi implements AvroModelExtFa
                     private final UppercaseTransform transform = new UppercaseTransform();
 
                     @Override
-                    public AvroTransformable transform(
-                        AvroTransformable stream)
+                    public <T extends AvroTransformable<T>> T transform(
+                        T stream)
                     {
                         return stream.transform(transform);
                     }

--- a/runtime/model-avro/src/test/resources/META-INF/services/io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtFactorySpi
+++ b/runtime/model-avro/src/test/resources/META-INF/services/io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtFactorySpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.runtime.model.avro.internal.TestUppercaseAvroModelExtFactorySpi

--- a/specs/model-avro.spec/src/main/java/io/aklivity/zilla/specs/model/avro/internal/AvroFunctions.java
+++ b/specs/model-avro.spec/src/main/java/io/aklivity/zilla/specs/model/avro/internal/AvroFunctions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.specs.model.avro.internal;
+
+import io.aklivity.k3po.runtime.lang.el.Function;
+import io.aklivity.k3po.runtime.lang.el.spi.FunctionMapperSpi;
+
+public final class AvroFunctions
+{
+    @Function
+    public static String repeat(
+        String value,
+        int count)
+    {
+        return value.repeat(count);
+    }
+
+    public static class Mapper extends FunctionMapperSpi.Reflective
+    {
+        public Mapper()
+        {
+            super(AvroFunctions.class);
+        }
+
+        @Override
+        public String getPrefixName()
+        {
+            return "model_avro";
+        }
+    }
+
+    private AvroFunctions()
+    {
+        // utility
+    }
+}

--- a/specs/model-avro.spec/src/main/resources/META-INF/services/io.aklivity.k3po.runtime.lang.el.spi.FunctionMapperSpi
+++ b/specs/model-avro.spec/src/main/resources/META-INF/services/io.aklivity.k3po.runtime.lang.el.spi.FunctionMapperSpi
@@ -1,0 +1,1 @@
+io.aklivity.zilla.specs.model.avro.internal.AvroFunctions$Mapper

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/avro.ext.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/avro.ext.yaml
@@ -29,7 +29,7 @@ catalogs:
               "type": "string"
             },
             {
-              "name": "secret",
+              "name": "text",
               "type": "string"
             }
           ],

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/avro.ext.yaml
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/config/avro.ext.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+---
+name: test
+catalogs:
+  test0:
+    type: test
+    options:
+      id: 1
+      subject: test
+      schema: |
+        {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "secret",
+              "type": "string"
+            }
+          ],
+          "name": "Event",
+          "namespace": "io.aklivity.example",
+          "type": "record"
+        }
+bindings:
+  net0:
+    type: test
+    kind: server
+    options:
+      value:
+        model: avro
+        catalog:
+          test0:
+            - subject: test
+              version: latest
+    exit: app0

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write [0x06] "id0" [0x0e] "trigger"
+
+read [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/client.rpt
@@ -18,6 +18,6 @@ connect "zilla://streams/app0"
         option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "trigger"
+write [0x06] "id0" [0x0e] "PRIMARY"
 
 read [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read [0x06] "id0" [0x0e] "trigger"
+
+write [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.reject/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/app0"
 accepted
 connected
 
-read [0x06] "id0" [0x0e] "trigger"
+read [0x06] "id0" [0x0e] "PRIMARY"
 
 write [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/client.rpt
@@ -18,6 +18,6 @@ connect "zilla://streams/app0"
         option zilla:window 200000
 connected
 
-write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+write [0x06] "id0" [0x0e] "ORANGE1"
 
 read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:transmission "duplex"
+        option zilla:window 200000
+connected
+
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+
+read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/app0"
 accepted
 connected
 
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+read [0x06] "id0" [0x0e] "ORANGE1"
 
 write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase.100k/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 200000
+
+accepted
+connected
+
+read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/client.rpt
@@ -18,6 +18,6 @@ connect "zilla://streams/app0"
         option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "hunter2"
+write [0x06] "id0" [0x0e] "ORANGE1"
 
-read [0x06] "id0" [0x0e] "hunter2"
+read [0x06] "id0" [0x0e] "yellow1"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write [0x06] "id0" [0x0e] "hunter2"
+
+read [0x06] "id0" [0x0e] "hunter2"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/app0"
 accepted
 connected
 
-read [0x06] "id0" [0x0e] "hunter2"
+read [0x06] "id0" [0x0e] "ORANGE1"
 
-write [0x06] "id0" [0x0e] "hunter2"
+write [0x06] "id0" [0x0e] "yellow1"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.received.avro.ext.uppercase/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read [0x06] "id0" [0x0e] "hunter2"
+
+write [0x06] "id0" [0x0e] "hunter2"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.reject/client.rpt
@@ -13,11 +13,9 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
+connect "zilla://streams/app0"
         option zilla:transmission "duplex"
-        option zilla:window 200000
+        option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write abort

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.reject/server.rpt
@@ -13,11 +13,11 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read aborted

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase.100k/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase.100k/client.rpt
@@ -13,11 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
+connect "zilla://streams/app0"
         option zilla:transmission "duplex"
         option zilla:window 200000
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write close

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase.100k/server.rpt
@@ -13,11 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 200000
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
 read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read closed

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase/client.rpt
@@ -13,11 +13,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
+connect "zilla://streams/app0"
         option zilla:transmission "duplex"
-        option zilla:window 200000
+        option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write [0x06] "id0" [0x0e] "ORANGE1"
+write close

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/application/client.sent.avro.ext.uppercase/server.rpt
@@ -13,11 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/app0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read [0x06] "id0" [0x0e] "ORANGE1"
+read closed

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/client.rpt
@@ -18,6 +18,6 @@ connect "zilla://streams/net0"
         option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "trigger"
+write [0x06] "id0" [0x0e] "primary"
 
 read aborted

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write [0x06] "id0" [0x0e] "trigger"
+
+read aborted

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/net0"
 accepted
 connected
 
-read [0x06] "id0" [0x0e] "trigger"
+read [0x06] "id0" [0x0e] "primary"
 
 write abort

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.reject/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read [0x06] "id0" [0x0e] "trigger"
+
+write abort

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:transmission "duplex"
+        option zilla:window 200000
+connected
+
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+
+read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 200000
+
+accepted
+connected
+
+read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase.100k/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/net0"
 accepted
 connected
 
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+read [0x06] "id0" [0x0e] "orange1"
 
 write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/client.rpt
@@ -18,6 +18,6 @@ connect "zilla://streams/net0"
         option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "hunter2"
+write [0x06] "id0" [0x0e] "orange1"
 
-read [0x06] "id0" [0x0e] "HUNTER2"
+read [0x06] "id0" [0x0e] "YELLOW1"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/client.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:transmission "duplex"
+        option zilla:window 8192
+connected
+
+write [0x06] "id0" [0x0e] "hunter2"
+
+read [0x06] "id0" [0x0e] "HUNTER2"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/server.rpt
@@ -1,0 +1,25 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
+connected
+
+read [0x06] "id0" [0x0e] "hunter2"
+
+write [0x06] "id0" [0x0e] "HUNTER2"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.received.avro.ext.uppercase/server.rpt
@@ -20,6 +20,6 @@ accept "zilla://streams/net0"
 accepted
 connected
 
-read [0x06] "id0" [0x0e] "hunter2"
+read [0x06] "id0" [0x0e] "orange1"
 
-write [0x06] "id0" [0x0e] "HUNTER2"
+write [0x06] "id0" [0x0e] "YELLOW1"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.reject/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.reject/client.rpt
@@ -15,9 +15,7 @@
 
 connect "zilla://streams/net0"
         option zilla:transmission "duplex"
-        option zilla:window 200000
+        option zilla:window 8192
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.reject/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.reject/server.rpt
@@ -13,11 +13,11 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read [0x06] "id0" [0x0c] "REJECT"

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase.100k/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase.100k/client.rpt
@@ -18,6 +18,5 @@ connect "zilla://streams/net0"
         option zilla:window 200000
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+write close

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase.100k/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase.100k/server.rpt
@@ -13,11 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 200000
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("v", 100000)}
+read closed

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase/client.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase/client.rpt
@@ -15,9 +15,8 @@
 
 connect "zilla://streams/net0"
         option zilla:transmission "duplex"
-        option zilla:window 200000
+        option zilla:window 8192
 connected
 
 write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+write close

--- a/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase/server.rpt
+++ b/specs/model-avro.spec/src/main/scripts/io/aklivity/zilla/specs/model/avro/streams/network/client.sent.avro.ext.uppercase/server.rpt
@@ -13,11 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
-connect "zilla://streams/net0"
-        option zilla:transmission "duplex"
-        option zilla:window 200000
+accept "zilla://streams/net0"
+       option zilla:transmission "duplex"
+       option zilla:window 8192
+
+accepted
 connected
 
-write [0x06] "id0" [0x0e] "orange1"
-
-read [0x06] "id0" ${core:varint(100000)} ${model_avro:repeat("V", 100000)}
+read [0x06] "id0" [0x0e] "orange1"
+read closed

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/internal/AvroFunctionsTest.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/internal/AvroFunctionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.specs.model.avro.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.Test;
+
+public class AvroFunctionsTest
+{
+    @Test
+    public void shouldRepeat() throws Exception
+    {
+        assertEquals("vvv", AvroFunctions.repeat("v", 3));
+    }
+
+    @Test
+    public void shouldResolveMapperPrefix() throws Exception
+    {
+        AvroFunctions.Mapper mapper = new AvroFunctions.Mapper();
+
+        assertEquals("model_avro", mapper.getPrefixName());
+    }
+
+    @Test
+    public void shouldConstructUtilityClass() throws Exception
+    {
+        Constructor<AvroFunctions> constructor = AvroFunctions.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        constructor.newInstance();
+    }
+}

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/ApplicationIT.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/ApplicationIT.java
@@ -75,4 +75,34 @@ public class ApplicationIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/client.received.avro.ext.uppercase/client",
+        "${app}/client.received.avro.ext.uppercase/server"
+    })
+    public void shouldForwardAvroExtUppercase() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/client.received.avro.ext.uppercase.100k/client",
+        "${app}/client.received.avro.ext.uppercase.100k/server"
+    })
+    public void shouldForwardAvroExtUppercase100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/client.received.avro.ext.reject/client",
+        "${app}/client.received.avro.ext.reject/server"
+    })
+    public void shouldForwardAvroExtReject() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/ApplicationIT.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/ApplicationIT.java
@@ -105,4 +105,34 @@ public class ApplicationIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/client.sent.avro.ext.uppercase/client",
+        "${app}/client.sent.avro.ext.uppercase/server"
+    })
+    public void shouldSendAvroExtUppercase() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/client.sent.avro.ext.uppercase.100k/client",
+        "${app}/client.sent.avro.ext.uppercase.100k/server"
+    })
+    public void shouldSendAvroExtUppercase100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/client.sent.avro.ext.reject/client",
+        "${app}/client.sent.avro.ext.reject/server"
+    })
+    public void shouldSendAvroExtReject() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/NetworkIT.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/NetworkIT.java
@@ -105,4 +105,34 @@ public class NetworkIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${net}/client.sent.avro.ext.uppercase/client",
+        "${net}/client.sent.avro.ext.uppercase/server"
+    })
+    public void shouldSendAvroExtUppercase() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/client.sent.avro.ext.uppercase.100k/client",
+        "${net}/client.sent.avro.ext.uppercase.100k/server"
+    })
+    public void shouldSendAvroExtUppercase100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/client.sent.avro.ext.reject/client",
+        "${net}/client.sent.avro.ext.reject/server"
+    })
+    public void shouldSendAvroExtReject() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/NetworkIT.java
+++ b/specs/model-avro.spec/src/test/java/io/aklivity/zilla/specs/model/avro/streams/NetworkIT.java
@@ -75,4 +75,34 @@ public class NetworkIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${net}/client.received.avro.ext.uppercase/client",
+        "${net}/client.received.avro.ext.uppercase/server"
+    })
+    public void shouldForwardAvroExtUppercase() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/client.received.avro.ext.uppercase.100k/client",
+        "${net}/client.received.avro.ext.uppercase.100k/server"
+    })
+    public void shouldForwardAvroExtUppercase100k() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/client.received.avro.ext.reject/client",
+        "${net}/client.received.avro.ext.reject/server"
+    })
+    public void shouldForwardAvroExtReject() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.additional.property.fragmented/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.additional.property.fragmented/client.rpt
@@ -18,4 +18,7 @@ connect "zilla://streams/app0"
         option zilla:window 8192
 connected
 
+write "{\"id\":42,\"status\":\"OK\","
+write flush
+
 write abort

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.additional.property.fragmented/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.additional.property.fragmented/server.rpt
@@ -20,4 +20,5 @@ accept "zilla://streams/app0"
 accepted
 connected
 
+read "{\"id\":42,\"status\":\"OK\","
 read aborted

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.strict.missing.required.fragmented/client.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.strict.missing.required.fragmented/client.rpt
@@ -18,4 +18,7 @@ connect "zilla://streams/app0"
         option zilla:window 8192
 connected
 
+write "{\"id\""
+write flush
+
 write abort

--- a/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.strict.missing.required.fragmented/server.rpt
+++ b/specs/model-json.spec/src/main/scripts/io/aklivity/zilla/specs/model/json/streams/application/client.sent.json.strict.missing.required.fragmented/server.rpt
@@ -20,4 +20,5 @@ accept "zilla://streams/app0"
 accepted
 connected
 
+read "{\"id\""
 read aborted


### PR DESCRIPTION
## Description

`TestBindingFactory` (the `type: test` binding backing k3po `*IT.java` tests engine-wide) only ever applied a configured value model as an **encoder**, on the initial/produce direction — reply-direction data was always forwarded raw. That meant no k3po IT anywhere could exercise a model's decode-time behavior through a live engine. Fixing that surfaced a real gap in `AvroModelExt`'s own contract: nothing in `AvroModelExtHandler`/`AvroModelExtContext` restricts an installed extension to one direction, but `AvroModelHandlerImpl` only ever folded installed extensions into the decoder pipeline — the encoder pipeline built its stream without `extend()`, and `encodePadding()` never accounted for extension padding. An extension meant to participate in both directions had no way to actually contribute on encode.

### Changes

- `TestBindingFactory`: reassembles fragmented `DATA` frames on both the initial and reply direction (previously only implemented for one), draining and re-presenting not-yet-consumed bytes across both the destination and source windows, with a growable decode slot per direction. Fixes an `IndexOutOfBoundsException` from writing past the destination buffer's reserved header region, and a silent drop of partially-consumed bytes on `UNDERFLOW`.
- `AvroModelHandlerImpl`: `extend()` (which folds every installed extension's stage into the pipeline, in discovery order) is now applied to both the decoder and encoder pipeline built from the same schema, instead of the decoder pipeline only; `encodePadding()` now sums each installed extension's padding contribution the same way `decodePadding()` already did.
- New test-only `TestUppercaseAvroModelExtFactorySpi` (registered only under `src/test/resources/META-INF/services`, never shipped in the production jar) exercises the `AvroModelExt` composition mechanism end-to-end through a live engine: apply, fragment accumulation across multiple `STRING` chunks, drain across a `SUSPENDED` terminal generator at 100k scale, and reject via `AvroPipeline.Status.REJECTED` — independently for both the encode and decode direction, now that both are wired.
- Matching k3po scenario scripts and `AvroModelIT`/`NetworkIT`/`ApplicationIT` test methods (10 tests total, up from 4) covering both directions.

### Test plan

- [x] `./mvnw clean verify -pl runtime/engine` — 215 unit tests + k3po ITs, all green
- [x] `./mvnw clean verify -pl runtime/model-avro` — unit tests, 10 `AvroModelIT` tests (4 pre-existing unaffected + 6 new), checkstyle, JaCoCo all pass
- [x] `./mvnw clean verify -pl specs/model-avro.spec` — 10 `NetworkIT` + 10 `ApplicationIT` self-consistency tests, all pass
- [x] Confirmed the new tests fail for the right reason against the prior `AvroModelHandlerImpl` (encode-side transform never applied) before implementing the fix

Fixes # (none — surfaced while adding live-engine test coverage for the `AvroModelExt` composition mechanism, not tied to a specific issue)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3)_