### PR TITLE
test(model-avro): drop unneeded ENGINE_BUFFER_SLOT_CAPACITY override in AvroModelIT

### DIFF
--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelIT.java
@@ -25,7 +25,6 @@ import org.junit.rules.Timeout;
 
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
-import io.aklivity.zilla.runtime.engine.EngineConfiguration;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
 
@@ -41,7 +40,6 @@ public class AvroModelIT
         .directory("target/zilla-itests")
         .countersBufferCapacity(4096)
         .configurationRoot("io/aklivity/zilla/specs/model/avro/config")
-        .configure(EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY, 65_536)
         .external("app0")
         .clean();
 


### PR DESCRIPTION
## Description

`AvroModelIT` overrode `ENGINE_BUFFER_SLOT_CAPACITY` to 64KB, double the engine's default (32KB). This override predates the recent `TestBindingFactory` fragmentation fixes and was never revisited once genuine cross-frame reassembly landed.

Confirmed by running the full IT suite with the override removed: the engine's default 32KB slot capacity is already sufficient for the extension-overflow scenarios (`shouldDrainExtensionOverflowOnDecodeAcrossMultipleFrames`, `shouldDrainExtensionOverflowOnEncodeAcrossMultipleFrames`) to genuinely exercise multi-frame draining across the decode and encode pipelines. The override added no coverage the default capacity doesn't already provide.

### Changes

- `AvroModelIT`: removed the `.configure(EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY, 65_536)` call and its now-unused `EngineConfiguration` import.

### Test plan

- [x] `./mvnw clean verify -pl runtime/model-avro` — all 12 tests (10 `AvroModelIT` + 2 `AvroModelEventIT`), checkstyle, and JaCoCo coverage all pass with the override removed

Fixes # (none — test-infrastructure cleanup surfaced while reviewing `AvroModelIT`'s `EngineRule` setup)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKWELiLVoasTwsuvaXg2Y3)_