### PR TITLE
fix(engine): emit terminal frame for a completed test-binding transform with zero produced bytes

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -986,7 +986,7 @@ final class TestBindingFactory implements BindingHandler
                     stepFlags &= ~FLAGS_INIT;
 
                     int produced = result.produced();
-                    if (produced > 0)
+                    if (produced > 0 || status == ModelStatus.COMPLETE)
                     {
                         boolean fin = status == ModelStatus.COMPLETE;
                         OctetsFW transformed = octetsRO.wrap(initialBuffer, 0, produced);
@@ -1189,10 +1189,10 @@ final class TestBindingFactory implements BindingHandler
         {
             int maxLength = limit - offset;
             int length = Math.max(Math.min(replyWindow() - replyPad, maxLength), 0);
+            boolean fin = length == maxLength && encodeSlotFin;
 
-            if (length > 0)
+            if (length > 0 || fin)
             {
-                boolean fin = length == maxLength && encodeSlotFin;
                 int reserved = length + replyPad;
                 int flags = (replyStarted ? 0x00 : FLAGS_INIT) | (fin ? FLAGS_FIN : 0x00);
 
@@ -1499,7 +1499,7 @@ final class TestBindingFactory implements BindingHandler
                         stepFlags &= ~FLAGS_INIT;
 
                         int produced = result.produced();
-                        if (produced > 0)
+                        if (produced > 0 || status == ModelStatus.COMPLETE)
                         {
                             boolean fin = status == ModelStatus.COMPLETE;
                             OctetsFW transformed = octetsRO.wrap(replyBuffer, 0, produced);
@@ -1600,10 +1600,10 @@ final class TestBindingFactory implements BindingHandler
             {
                 int maxLength = limit - offset;
                 int length = Math.max(Math.min(initialWindow() - initialPad, maxLength), 0);
+                boolean fin = length == maxLength && encodeSlotFin;
 
-                if (length > 0)
+                if (length > 0 || fin)
                 {
-                    boolean fin = length == maxLength && encodeSlotFin;
                     int reserved = length + initialPad;
                     int flags = (initialStarted ? 0x00 : FLAGS_INIT) | (fin ? FLAGS_FIN : 0x00);
 


### PR DESCRIPTION
## Description

`TestBindingFactory.transformReply()`/`transformInitial()` gated calling `doReplyData()`/`doInitialData()` on `produced > 0`, so a `ModelPipeline` transform that legitimately completes with zero produced bytes never had its result delivered at all — silently dropping the `fin` signal. `encodeReply()`/`encodeInitial()` had the same conflation one level down: gating the actual wire `DATA` frame emission on `length > 0`, so even a caller that did pass `fin=true` with zero bytes still lost it if nothing else was queued to flush.

Completion is a property of the decode side finishing (`ModelStatus.COMPLETE`), independent of how many bytes a given transform step happened to produce — a transform can consume all remaining input and complete while legitimately producing zero output bytes. Both methods now emit a frame (a zero-length `DATA` frame, when necessary) whenever `status == COMPLETE`, regardless of produced count, instead of silently dropping the terminal signal.

## Test plan

- `./mvnw clean verify -pl runtime/engine -am` — full unit + IT suite green, including `DuplexIT`/`HalfDuplexIT`/`SimplexIT` (176 tests total), which exhaustively exercise this class's stream state machine — no regressions
- Checkstyle and license header checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_019GiDK3riHzYaNDYJe2UyDz)_