### PR TITLE
feat(engine): add ModelEnvelope, bound to a pipeline at supply time

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModel.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/config/HttpModel.java
@@ -17,10 +17,12 @@ package io.aklivity.zilla.runtime.binding.http.internal.config;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 
 /**
  * Per-stream driver around a decode {@link ModelPipeline} for the http binding.
@@ -50,7 +52,7 @@ public final class HttpModel
         MutableDirectBufferEx scratch)
     {
         return handler != null
-            ? new HttpModel(handler.supplyDecoder(), scratch)
+            ? new HttpModel(handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE), scratch)
             : NONE;
     }
 

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModel.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.binding.kafka.internal.cache;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -48,7 +49,7 @@ public final class KafkaCacheModel
         MutableDirectBufferEx scratch)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyDecoder(transform), scratch)
+            ? new KafkaCacheModel(handler.supplyDecoder(ModelEnvelope.NONE, transform), scratch)
             : NONE;
     }
 
@@ -57,7 +58,7 @@ public final class KafkaCacheModel
         MutableDirectBufferEx scratch)
     {
         return handler != null
-            ? new KafkaCacheModel(handler.supplyEncoder(), scratch)
+            ? new KafkaCacheModel(handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE), scratch)
             : NONE;
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCacheModelTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.config.engine.test.internal.model.config.TestModelConfi
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelFieldBridge;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
@@ -138,7 +139,8 @@ public class KafkaCacheModelTest
     @Test
     public void shouldRejectValueRejectedByModel()
     {
-        KafkaCacheModel model = new KafkaCacheModel(rejectingHandler("$.id").supplyDecoder(),
+        KafkaCacheModel model = new KafkaCacheModel(
+            rejectingHandler("$.id").supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE),
             new UnsafeBufferEx(new byte[256]));
 
         int produced = model.transform(0L, 0L, 0L, value("hello"), 0, 5, sink);
@@ -191,6 +193,7 @@ public class KafkaCacheModelTest
         {
             @Override
             public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
                 return new RejectingPipeline(transform, path);
@@ -198,9 +201,10 @@ public class KafkaCacheModelTest
 
             @Override
             public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
-                return supplyDecoder(transform);
+                return supplyDecoder(envelope, transform);
             }
         };
     }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaCachePartitionTest.java
@@ -52,6 +52,7 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.types.cache.KafkaCachePa
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelFieldBridge;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
@@ -404,6 +405,7 @@ public class KafkaCachePartitionTest
         {
             @Override
             public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
                 return new ExtractingPipeline(transform, pathsAndValues);
@@ -411,9 +413,10 @@ public class KafkaCachePartitionTest
 
             @Override
             public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
-                return supplyDecoder(transform);
+                return supplyDecoder(envelope, transform);
             }
         };
     }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipelineTest.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/KafkaPipelineTest.java
@@ -35,6 +35,7 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.config.KafkaTopicTransfo
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelFieldBridge;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
@@ -245,6 +246,7 @@ public class KafkaPipelineTest
         {
             @Override
             public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
                 return new FieldsPipeline(transform, pathsAndValues, false);
@@ -252,9 +254,10 @@ public class KafkaPipelineTest
 
             @Override
             public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
-                return supplyDecoder(transform);
+                return supplyDecoder(envelope, transform);
             }
         };
     }
@@ -268,6 +271,7 @@ public class KafkaPipelineTest
         {
             @Override
             public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
                 return new FieldsPipeline(transform, new String[] { path, "east" }, true);
@@ -275,9 +279,10 @@ public class KafkaPipelineTest
 
             @Override
             public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
-                return supplyDecoder(transform);
+                return supplyDecoder(envelope, transform);
             }
         };
     }

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaPipelineBM.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaPipelineBM.java
@@ -44,6 +44,7 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.config.KafkaTopicTransfo
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelFieldBridge;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
@@ -156,6 +157,7 @@ public class KafkaPipelineBM
         {
             @Override
             public ModelPipeline supplyDecoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
                 return new FieldsPipeline(transform, pathsAndValues);
@@ -163,9 +165,10 @@ public class KafkaPipelineBM
 
             @Override
             public ModelPipeline supplyEncoder(
+                ModelEnvelope envelope,
                 ModelTransform transform)
             {
-                return supplyDecoder(transform);
+                return supplyDecoder(envelope, transform);
             }
         };
     }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -59,10 +59,12 @@ import io.aklivity.zilla.runtime.common.json.JsonParserEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 
 public final class McpBindingConfig
 {
@@ -500,7 +502,7 @@ public final class McpBindingConfig
         final ModelConfig toolModel = modelConfig.adaptFromJson(model);
         toolModel.cataloged.get(0).id = template.id;
         final ModelHandler handler = supplyModel.apply(toolModel);
-        return handler != null ? handler.supplyDecoder() : null;
+        return handler != null ? handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE) : null;
     }
 
     public void injectHeaders(

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModel.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/config/MqttModel.java
@@ -17,10 +17,12 @@ package io.aklivity.zilla.runtime.binding.mqtt.internal.config;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 
 /**
  * Per-stream driver around a decode {@link ModelPipeline} for the mqtt binding.
@@ -46,7 +48,7 @@ public final class MqttModel
         MutableDirectBufferEx scratch)
     {
         return handler != null
-            ? new MqttModel(handler.supplyDecoder(), scratch)
+            ? new MqttModel(handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE), scratch)
             : NONE;
     }
 

--- a/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModel.java
+++ b/runtime/binding-sse/src/main/java/io/aklivity/zilla/runtime/binding/sse/internal/config/SseModel.java
@@ -17,10 +17,12 @@ package io.aklivity.zilla.runtime.binding.sse.internal.config;
 
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 
 /**
  * Per-stream driver around a decode {@link ModelPipeline} for the sse binding.
@@ -45,7 +47,7 @@ public final class SseModel
         MutableDirectBufferEx scratch)
     {
         return handler != null
-            ? new SseModel(handler.supplyDecoder(), scratch)
+            ? new SseModel(handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE), scratch)
             : NONE;
     }
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
@@ -39,24 +39,6 @@ public interface ModelController
     long authorization();
 
     /**
-     * Returns the metadata travelling alongside the message currently being transformed, addressed by
-     * name rather than by position in the value.
-     * <p>
-     * A mediating stage may override this to supply its own envelope to a nested composition; a
-     * non-mediating stage passes {@code control} through, so this reflects the envelope the caller
-     * driving the chain supplied for the current message unless some stage along the way has replaced it.
-     * The default is {@link ModelEnvelope#NONE}, so a caller that offers no metadata channel leaves a
-     * stage reading an empty envelope rather than no envelope at all.
-     * </p>
-     *
-     * @return the envelope in effect for the current message
-     */
-    default ModelEnvelope envelope()
-    {
-        return ModelEnvelope.NONE;
-    }
-
-    /**
      * Signals that the current value must be rejected, supplying the diagnostic the adapter reports.
      * <p>
      * A stage raising this also returns {@link ModelStatus#REJECTED}; the diagnostic is what distinguishes

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelController.java
@@ -39,6 +39,24 @@ public interface ModelController
     long authorization();
 
     /**
+     * Returns the metadata travelling alongside the message currently being transformed, addressed by
+     * name rather than by position in the value.
+     * <p>
+     * A mediating stage may override this to supply its own envelope to a nested composition; a
+     * non-mediating stage passes {@code control} through, so this reflects the envelope the caller
+     * driving the chain supplied for the current message unless some stage along the way has replaced it.
+     * The default is {@link ModelEnvelope#NONE}, so a caller that offers no metadata channel leaves a
+     * stage reading an empty envelope rather than no envelope at all.
+     * </p>
+     *
+     * @return the envelope in effect for the current message
+     */
+    default ModelEnvelope envelope()
+    {
+        return ModelEnvelope.NONE;
+    }
+
+    /**
      * Signals that the current value must be rejected, supplying the diagnostic the adapter reports.
      * <p>
      * A stage raising this also returns {@link ModelStatus#REJECTED}; the diagnostic is what distinguishes

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelope.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelope.java
@@ -18,22 +18,27 @@ package io.aklivity.zilla.runtime.engine.model;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 
 /**
- * The metadata travelling alongside the message currently being transformed, addressed by name rather
- * than by position in the value.
+ * The metadata travelling alongside a value, addressed by name rather than by position within the value.
  * <p>
  * A {@code ModelEnvelope} is a named, ordered, repeatable list of byte values and nothing more: it never
- * interprets what any name means, and whether a name occurs zero, one, or many times per message is
- * entirely up to whatever populates and consumes it. The caller supplying the envelope decides where its
- * contents come from on the way in and where they end up on the way out — typically the out-of-band
- * channel the caller's own transport offers — so a {@link ModelTransform} written against this interface
- * works unmodified wherever an envelope is supplied.
+ * interprets what any name means, and whether a name occurs zero, one, or many times is entirely up to
+ * whatever populates and consumes it. The caller supplying the envelope decides where its contents come
+ * from on the way in and where they end up on the way out — typically the out-of-band channel the
+ * caller's own transport offers.
  * </p>
  * <p>
- * An envelope is scoped to one message and confined to the same single I/O thread as the pipeline
- * reading it.
+ * An envelope is supplied once, at {@link ModelHandler#supplyDecoder} or
+ * {@link ModelHandler#supplyEncoder} time, so the pipeline binds to it as it is built rather than
+ * receiving it again per value. The supplier owns its lifecycle and decides the scope its contents
+ * describe, clearing or repointing them through its own type as that scope turns over — per message
+ * where the transport carries per-message metadata, per stream where the metadata describes the stream.
+ * A pipeline reads and writes whatever the envelope holds while it runs and never resets it.
+ * </p>
+ * <p>
+ * An envelope is confined to the same single I/O thread as the pipeline it is supplied to.
  * </p>
  *
- * @see ModelController#envelope()
+ * @see ModelHandler#supplyDecoder(ModelEnvelope, ModelTransform)
  */
 public interface ModelEnvelope
 {

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelope.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelope.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.model;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The metadata travelling alongside the message currently being transformed, addressed by name rather
+ * than by position in the value.
+ * <p>
+ * A {@code ModelEnvelope} is a named, ordered, repeatable list of byte values and nothing more: it never
+ * interprets what any name means, and whether a name occurs zero, one, or many times per message is
+ * entirely up to whatever populates and consumes it. The caller supplying the envelope decides where its
+ * contents come from on the way in and where they end up on the way out — typically the out-of-band
+ * channel the caller's own transport offers — so a {@link ModelTransform} written against this interface
+ * works unmodified wherever an envelope is supplied.
+ * </p>
+ * <p>
+ * An envelope is scoped to one message and confined to the same single I/O thread as the pipeline
+ * reading it.
+ * </p>
+ *
+ * @see ModelController#envelope()
+ */
+public interface ModelEnvelope
+{
+    /**
+     * Empty envelope, supplied when the caller offers no metadata channel for the current message. It
+     * reads as empty and discards what is written to it, so a stage reaches for the envelope the same way
+     * whether or not one is backing it.
+     */
+    ModelEnvelope NONE = new ModelEnvelope()
+    {
+        @Override
+        public int count(
+            String name)
+        {
+            return 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            return null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+        }
+    };
+
+    /**
+     * Returns how many values the envelope holds under {@code name}.
+     *
+     * @param name  the name to count the values of
+     * @return the number of values held under {@code name}, {@code 0} when the name is absent
+     */
+    int count(
+        String name);
+
+    /**
+     * Returns the value held under {@code name} at {@code index}, where the values under one name are
+     * ordered by the {@link #set(String, DirectBufferEx)} calls that added them and {@code index} runs
+     * from {@code 0} to {@link #count(String)} exclusive.
+     * <p>
+     * The buffer returned is a non-owning view valid only while the envelope is in scope for the current
+     * message; a consumer that needs the bytes beyond that must copy them out.
+     * </p>
+     *
+     * @param name   the name to read a value of
+     * @param index  the position of the value among those held under {@code name}
+     * @return the value at that position, or {@code null} when the name holds no value there
+     */
+    DirectBufferEx get(
+        String name,
+        int index);
+
+    /**
+     * Adds {@code value} to the values held under {@code name}, so a repeated call under one name adds a
+     * further occurrence rather than overwriting the one before it — {@link #count(String)} grows by one
+     * per call and each value stays retrievable by its own {@link #get(String, int)} index.
+     * <p>
+     * The bytes are copied out before the call returns, so the caller may reuse {@code value} immediately
+     * afterwards.
+     * </p>
+     *
+     * @param name   the name to add a value under
+     * @param value  the value bytes to add
+     */
+    void set(
+        String name,
+        DirectBufferEx value);
+}

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/model/ModelHandler.java
@@ -28,9 +28,12 @@ package io.aklivity.zilla.runtime.engine.model;
  * {@code null} handler forwards its bytes unchanged rather than driving a pipeline.
  * </p>
  * <p>
- * The transform supplied to {@link #supplyDecoder(ModelTransform)} and {@link #supplyEncoder(ModelTransform)}
- * is never {@code null}; a caller with no per-field policy passes {@link ModelTransform#NONE}, which an
- * implementation is free to recognize and wire away entirely.
+ * Neither the {@link ModelEnvelope} nor the {@link ModelTransform} supplied to
+ * {@link #supplyDecoder(ModelEnvelope, ModelTransform)} and
+ * {@link #supplyEncoder(ModelEnvelope, ModelTransform)} is ever {@code null}: a caller with no metadata
+ * channel passes {@link ModelEnvelope#NONE} and a caller with no per-field policy passes
+ * {@link ModelTransform#NONE}, both of which an implementation is free to recognize and wire away
+ * entirely.
  * </p>
  *
  * @see ModelContext
@@ -39,44 +42,39 @@ package io.aklivity.zilla.runtime.engine.model;
 public interface ModelHandler
 {
     /**
-     * Supplies a new read-direction {@link ModelPipeline} for a single stream, wiring the given
-     * {@link ModelTransform} into the pipeline so it observes, substitutes, or declines each field of
-     * every value the pipeline transforms.
+     * Supplies a new read-direction {@link ModelPipeline} for a single stream, binding it to the given
+     * {@link ModelEnvelope} so the pipeline reads the metadata travelling alongside each value it
+     * transforms, and wiring the given {@link ModelTransform} into it so the transform observes,
+     * substitutes, or declines each field of that value.
+     * <p>
+     * The envelope is bound as the pipeline is built rather than supplied again per value, so an
+     * implementation adapts it into its own internals once. The supplier owns its lifecycle from there.
+     * </p>
      *
+     * @param envelope   the metadata channel to bind the pipeline to
      * @param transform  the per-field transform to wire into the pipeline
      * @return a new per-stream decode pipeline
      */
     ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform);
 
     /**
-     * Supplies a new read-direction {@link ModelPipeline} for a single stream with no per-field transform.
+     * Supplies a new write-direction {@link ModelPipeline} for a single stream, binding it to the given
+     * {@link ModelEnvelope} so the pipeline writes the metadata travelling alongside each value it
+     * transforms, and wiring the given {@link ModelTransform} into it so the transform observes,
+     * substitutes, or declines each field of that value.
+     * <p>
+     * The envelope is bound as the pipeline is built rather than supplied again per value, so an
+     * implementation adapts it into its own internals once. The supplier owns its lifecycle from there,
+     * draining whatever accumulated into it as the scope it describes turns over.
+     * </p>
      *
-     * @return a new per-stream decode pipeline
-     */
-    default ModelPipeline supplyDecoder()
-    {
-        return supplyDecoder(ModelTransform.NONE);
-    }
-
-    /**
-     * Supplies a new write-direction {@link ModelPipeline} for a single stream, wiring the given
-     * {@link ModelTransform} into the pipeline so it observes, substitutes, or declines each field of
-     * every value the pipeline transforms.
-     *
+     * @param envelope   the metadata channel to bind the pipeline to
      * @param transform  the per-field transform to wire into the pipeline
      * @return a new per-stream encode pipeline
      */
     ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform);
-
-    /**
-     * Supplies a new write-direction {@link ModelPipeline} for a single stream with no per-field transform.
-     *
-     * @return a new per-stream encode pipeline
-     */
-    default ModelPipeline supplyEncoder()
-    {
-        return supplyEncoder(ModelTransform.NONE);
-    }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelopeTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelopeTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.model;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+
+public class ModelEnvelopeTest
+{
+    @Test
+    public void shouldSupplyEmptyEnvelopeByDefault()
+    {
+        ModelController control = new ModelController()
+        {
+            @Override
+            public long authorization()
+            {
+                return 0L;
+            }
+
+            @Override
+            public void reject(
+                String diagnostic)
+            {
+            }
+        };
+
+        assertSame(ModelEnvelope.NONE, control.envelope());
+    }
+
+    @Test
+    public void shouldReadEmptyAndDiscardWritesWhenNone()
+    {
+        ModelEnvelope envelope = ModelEnvelope.NONE;
+
+        envelope.set("trace", buffer("one"));
+
+        assertEquals(0, envelope.count("trace"));
+        assertNull(envelope.get("trace", 0));
+    }
+
+    @Test
+    public void shouldCountZeroForAbsentName()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("trace", buffer("one"));
+
+        assertEquals(0, envelope.count("absent"));
+        assertNull(envelope.get("absent", 0));
+        assertNull(envelope.get("trace", 1));
+    }
+
+    @Test
+    public void shouldAccumulateRepeatedValuesUnderOneName()
+    {
+        Metadata envelope = new Metadata();
+
+        envelope.set("trace", buffer("one"));
+        envelope.set("trace", buffer("two"));
+
+        assertEquals(2, envelope.count("trace"));
+        assertEquals("one", text(envelope.get("trace", 0)));
+        assertEquals("two", text(envelope.get("trace", 1)));
+    }
+
+    @Test
+    public void shouldCopyValueBytesOnSet()
+    {
+        Metadata envelope = new Metadata();
+        byte[] bytes = "one".getBytes(UTF_8);
+
+        envelope.set("trace", new UnsafeBufferEx(bytes));
+        bytes[0] = 'X';
+
+        assertEquals("one", text(envelope.get("trace", 0)));
+    }
+
+    @Test
+    public void shouldReadNamedMetadataFromEnvelope()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("trace", buffer("one"));
+        envelope.set("trace", buffer("two"));
+
+        Carrying transform = new Carrying("trace");
+
+        transform.transform(new Control(envelope), new Field("$.id", "x"), ModelEvent.FIELD, new Recorder());
+
+        assertEquals(List.of("one", "two"), transform.read);
+    }
+
+    @Test
+    public void shouldWriteNamedMetadataToEnvelope()
+    {
+        Metadata envelope = new Metadata();
+        Control control = new Control(envelope);
+        Recorder recorder = new Recorder();
+        Carrying transform = new Carrying("trace");
+
+        transform.transform(control, new Field("$.id", "x"), ModelEvent.FIELD, recorder);
+        transform.flush(control, new Field(null, ""), recorder);
+
+        assertEquals(1, envelope.count("trace"));
+        assertEquals("$.id=x", text(envelope.get("trace", 0)));
+    }
+
+    @Test
+    public void shouldLeaveEnvelopeUntouchedWhenTransformIgnoresIt()
+    {
+        Metadata envelope = new Metadata();
+        Control control = new Control(envelope);
+        Recorder recorder = new Recorder();
+
+        ModelTransform.NONE.transform(control, new Field("$.id", "x"), ModelEvent.FIELD, recorder);
+        ModelTransform.NONE.flush(control, new Field(null, ""), recorder);
+
+        assertEquals(0, envelope.reads);
+        assertEquals(0, envelope.writes);
+        assertEquals(0, envelope.count("trace"));
+    }
+
+    private static DirectBufferEx buffer(
+        String value)
+    {
+        return new UnsafeBufferEx(value.getBytes(UTF_8));
+    }
+
+    private static String text(
+        DirectBufferEx value)
+    {
+        return value.getStringWithoutLengthUtf8(0, value.capacity());
+    }
+
+    // the envelope a caller supplies for one message, backed by a copy of each value it is given
+    private static final class Metadata implements ModelEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        private int reads;
+        private int writes;
+
+        @Override
+        public int count(
+            String name)
+        {
+            reads++;
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            reads++;
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            writes++;
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
+    }
+
+    private static final class Control implements ModelController
+    {
+        private final ModelEnvelope envelope;
+
+        private Control(
+            ModelEnvelope envelope)
+        {
+            this.envelope = envelope;
+        }
+
+        @Override
+        public long authorization()
+        {
+            return 0L;
+        }
+
+        @Override
+        public ModelEnvelope envelope()
+        {
+            return envelope;
+        }
+
+        @Override
+        public void reject(
+            String diagnostic)
+        {
+        }
+    }
+
+    // reads every value the envelope carries under one name as fields arrive, and writes what it saw back
+    // under the same name when the value completes
+    private static final class Carrying implements ModelTransform
+    {
+        private final String name;
+        private final List<String> read = new ArrayList<>();
+
+        private String field;
+
+        private Carrying(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public ModelStatus transform(
+            ModelController control,
+            ModelSource source,
+            ModelEvent event,
+            ModelSink sink)
+        {
+            if (event == ModelEvent.FIELD)
+            {
+                ModelEnvelope envelope = control.envelope();
+                int count = envelope.count(name);
+                for (int index = 0; index < count; index++)
+                {
+                    read.add(text(envelope.get(name, index)));
+                }
+                DirectBufferEx value = source.getValue();
+                field = source.getPath() + "=" + value.getStringWithoutLengthUtf8(0, value.capacity());
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public ModelStatus flush(
+            ModelController control,
+            ModelSource source,
+            ModelSink sink)
+        {
+            if (field != null)
+            {
+                control.envelope().set(name, buffer(field));
+            }
+            return sink.flush(control, source);
+        }
+    }
+
+    private static final class Field implements ModelSource
+    {
+        private final String path;
+        private final DirectBufferEx value;
+
+        private Field(
+            String path,
+            String value)
+        {
+            this.path = path;
+            this.value = buffer(value);
+        }
+
+        @Override
+        public String getPath()
+        {
+            return path;
+        }
+
+        @Override
+        public DirectBufferEx getValue()
+        {
+            return value;
+        }
+    }
+
+    private static final class Recorder implements ModelSink
+    {
+        @Override
+        public ModelStatus transform(
+            ModelController control,
+            ModelSource source,
+            ModelEvent event)
+        {
+            return ModelStatus.OK;
+        }
+
+        @Override
+        public ModelStatus flush(
+            ModelController control,
+            ModelSource source)
+        {
+            return ModelStatus.OK;
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelopeTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/model/ModelEnvelopeTest.java
@@ -18,7 +18,6 @@ package io.aklivity.zilla.runtime.engine.model;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -32,26 +31,20 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 
 public class ModelEnvelopeTest
 {
-    @Test
-    public void shouldSupplyEmptyEnvelopeByDefault()
+    private static final ModelController NO_CONTROL = new ModelController()
     {
-        ModelController control = new ModelController()
+        @Override
+        public long authorization()
         {
-            @Override
-            public long authorization()
-            {
-                return 0L;
-            }
+            return 0L;
+        }
 
-            @Override
-            public void reject(
-                String diagnostic)
-            {
-            }
-        };
-
-        assertSame(ModelEnvelope.NONE, control.envelope());
-    }
+        @Override
+        public void reject(
+            String diagnostic)
+        {
+        }
+    };
 
     @Test
     public void shouldReadEmptyAndDiscardWritesWhenNone()
@@ -101,43 +94,30 @@ public class ModelEnvelopeTest
     }
 
     @Test
-    public void shouldReadNamedMetadataFromEnvelope()
+    public void shouldReadAndWriteNamedMetadataFromTransform()
     {
         Metadata envelope = new Metadata();
         envelope.set("trace", buffer("one"));
         envelope.set("trace", buffer("two"));
 
-        Carrying transform = new Carrying("trace");
+        Carrying transform = new Carrying(envelope, "trace");
 
-        transform.transform(new Control(envelope), new Field("$.id", "x"), ModelEvent.FIELD, new Recorder());
+        transform.transform(NO_CONTROL, new Field("$.id", "x"), ModelEvent.FIELD, new Recorder());
+        transform.flush(NO_CONTROL, new Field(null, ""), new Recorder());
 
         assertEquals(List.of("one", "two"), transform.read);
-    }
-
-    @Test
-    public void shouldWriteNamedMetadataToEnvelope()
-    {
-        Metadata envelope = new Metadata();
-        Control control = new Control(envelope);
-        Recorder recorder = new Recorder();
-        Carrying transform = new Carrying("trace");
-
-        transform.transform(control, new Field("$.id", "x"), ModelEvent.FIELD, recorder);
-        transform.flush(control, new Field(null, ""), recorder);
-
-        assertEquals(1, envelope.count("trace"));
-        assertEquals("$.id=x", text(envelope.get("trace", 0)));
+        assertEquals(3, envelope.count("trace"));
+        assertEquals("$.id=x", text(envelope.get("trace", 2)));
     }
 
     @Test
     public void shouldLeaveEnvelopeUntouchedWhenTransformIgnoresIt()
     {
         Metadata envelope = new Metadata();
-        Control control = new Control(envelope);
         Recorder recorder = new Recorder();
 
-        ModelTransform.NONE.transform(control, new Field("$.id", "x"), ModelEvent.FIELD, recorder);
-        ModelTransform.NONE.flush(control, new Field(null, ""), recorder);
+        ModelTransform.NONE.transform(NO_CONTROL, new Field("$.id", "x"), ModelEvent.FIELD, recorder);
+        ModelTransform.NONE.flush(NO_CONTROL, new Field(null, ""), recorder);
 
         assertEquals(0, envelope.reads);
         assertEquals(0, envelope.writes);
@@ -156,7 +136,7 @@ public class ModelEnvelopeTest
         return value.getStringWithoutLengthUtf8(0, value.capacity());
     }
 
-    // the envelope a caller supplies for one message, backed by a copy of each value it is given
+    // the envelope a caller supplies to the pipeline, backed by a copy of each value it is given
     private static final class Metadata implements ModelEnvelope
     {
         private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
@@ -195,47 +175,22 @@ public class ModelEnvelopeTest
         }
     }
 
-    private static final class Control implements ModelController
-    {
-        private final ModelEnvelope envelope;
-
-        private Control(
-            ModelEnvelope envelope)
-        {
-            this.envelope = envelope;
-        }
-
-        @Override
-        public long authorization()
-        {
-            return 0L;
-        }
-
-        @Override
-        public ModelEnvelope envelope()
-        {
-            return envelope;
-        }
-
-        @Override
-        public void reject(
-            String diagnostic)
-        {
-        }
-    }
-
-    // reads every value the envelope carries under one name as fields arrive, and writes what it saw back
-    // under the same name when the value completes
+    // a stage supplied with the same envelope the pipeline was supplied with: it reads every value the
+    // envelope carries under one name as fields arrive, and writes what it saw back under the same name
+    // when the value completes
     private static final class Carrying implements ModelTransform
     {
+        private final ModelEnvelope envelope;
         private final String name;
         private final List<String> read = new ArrayList<>();
 
         private String field;
 
         private Carrying(
+            ModelEnvelope envelope,
             String name)
         {
+            this.envelope = envelope;
             this.name = name;
         }
 
@@ -248,14 +203,12 @@ public class ModelEnvelopeTest
         {
             if (event == ModelEvent.FIELD)
             {
-                ModelEnvelope envelope = control.envelope();
                 int count = envelope.count(name);
                 for (int index = 0; index < count; index++)
                 {
                     read.add(text(envelope.get(name, index)));
                 }
-                DirectBufferEx value = source.getValue();
-                field = source.getPath() + "=" + value.getStringWithoutLengthUtf8(0, value.capacity());
+                field = source.getPath() + "=" + text(source.getValue());
             }
             return sink.transform(control, source, event);
         }
@@ -268,7 +221,7 @@ public class ModelEnvelopeTest
         {
             if (field != null)
             {
-                control.envelope().set(name, buffer(field));
+                envelope.set(name, buffer(field));
             }
             return sink.flush(control, source);
         }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/binding/TestBindingFactory.java
@@ -57,10 +57,12 @@ import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 import io.aklivity.zilla.runtime.engine.guard.GuardHandler.LongCompletionCallback;
 import io.aklivity.zilla.runtime.engine.metrics.Metric;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.namespace.NamespacedId;
 import io.aklivity.zilla.runtime.engine.security.Trusted;
 import io.aklivity.zilla.runtime.engine.store.StoreHandler;
@@ -370,7 +372,7 @@ final class TestBindingFactory implements BindingHandler
             this.initialId = initialId;
             this.replyId = replyId;
             this.target = resolvedId != 0L ? new TestTarget(routedId, resolvedId) : null;
-            this.pipeline = valueModel != null ? valueModel.supplyEncoder() : null;
+            this.pipeline = valueModel != null ? valueModel.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE) : null;
             this.initialBuffer = pipeline != null ? new UnsafeBufferEx(new byte[transformMax]) : null;
         }
 
@@ -1327,7 +1329,7 @@ final class TestBindingFactory implements BindingHandler
                 this.initialId = context.supplyInitialId(routedId);
                 this.replyId = context.supplyReplyId(initialId);
                 this.source = TestSource.this;
-                this.pipeline = valueModel != null ? valueModel.supplyDecoder() : null;
+                this.pipeline = valueModel != null ? valueModel.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE) : null;
                 this.replyBuffer = pipeline != null ? new UnsafeBufferEx(new byte[transformMax]) : null;
             }
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import io.aklivity.zilla.config.engine.ValidateMode;
 import io.aklivity.zilla.config.engine.test.internal.model.config.TestModelConfig;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -45,15 +46,17 @@ public class TestModelHandler implements ModelHandler
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, decodeLenient, transform);
+        return new TestModelPipeline(length, transformLength, fields, decodeLenient, envelope, transform);
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, encodeLenient, transform);
+        return new TestModelPipeline(length, transformLength, fields, encodeLenient, envelope, transform);
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandlerTest.java
@@ -21,17 +21,21 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
 import io.aklivity.zilla.config.engine.ValidateConfig;
 import io.aklivity.zilla.config.engine.ValidateMode;
 import io.aklivity.zilla.config.engine.test.internal.model.config.TestModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
@@ -103,13 +107,13 @@ public class TestModelHandlerTest
 
         byte[] bytes = {1, 2, 3};
 
-        ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline decoder = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[16]);
         ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
-        ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline encoder = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[16]);
         ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, encodeDst, 0, encodeDst.capacity());
@@ -219,7 +223,7 @@ public class TestModelHandlerTest
                 return true;
             }
         };
-        ModelPipeline pipeline = handler.supplyDecoder(transform);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, transform);
 
         byte[] bytes = {1, 2, 3, 4};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -234,6 +238,54 @@ public class TestModelHandlerTest
         assertFalse(observed.isEmpty());
         assertTrue(observed.subList(0, firstValueEvents).stream().allMatch(a -> a == 0x0102L));
         assertTrue(observed.subList(firstValueEvents, observed.size()).stream().allMatch(a -> a == 0x0304L));
+    }
+
+    @Test
+    public void shouldWriteExtractedFieldsToSuppliedEnvelope()
+    {
+        TestModelConfig config = TestModelConfig.builder()
+            .length(4)
+            .field("a")
+            .field("b")
+            .build();
+        ModelHandler handler = new TestModelContext(context).supplyHandler(config);
+
+        Metadata envelope = new Metadata();
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, ModelTransform.NONE);
+
+        byte[] bytes = {1, 2, 3, 4};
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
+
+        assertEquals(1, envelope.count("$.a"));
+        assertEquals(1, envelope.count("$.b"));
+        assertEquals(0, envelope.count("$.c"));
+    }
+
+    @Test
+    public void shouldKeepSuppliedEnvelopeAcrossValues()
+    {
+        TestModelConfig config = TestModelConfig.builder()
+            .length(4)
+            .field("a")
+            .build();
+        ModelHandler handler = new TestModelContext(context).supplyHandler(config);
+
+        Metadata envelope = new Metadata();
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, ModelTransform.NONE);
+
+        byte[] bytes = {1, 2, 3, 4};
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
+        pipeline.reset();
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
+
+        // the pipeline binds to the envelope it was supplied with and never resets it; the supplier owns
+        // when its contents turn over, so a second value accumulates alongside the first
+        assertEquals(2, envelope.count("$.a"));
     }
 
     @Test
@@ -252,7 +304,7 @@ public class TestModelHandlerTest
             .transformLength(8)
             .build();
         ModelHandler handler = new TestModelContext(context).supplyHandler(config);
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertFalse(pipeline.identity());
     }
@@ -261,14 +313,14 @@ public class TestModelHandlerTest
         int length)
     {
         ModelHandler handler = new TestModelContext(context).supplyHandler(config(length));
-        return handler.supplyDecoder(ModelTransform.NONE);
+        return handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
     }
 
     private ModelPipeline writePipeline(
         int length)
     {
         ModelHandler handler = new TestModelContext(context).supplyHandler(config(length));
-        return handler.supplyEncoder();
+        return handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
     }
 
     private ModelPipeline lenientReadPipeline(
@@ -279,12 +331,45 @@ public class TestModelHandlerTest
             .validate(ValidateConfig.builder().decode(ValidateMode.LENIENT).encode(ValidateMode.LENIENT).build())
             .build();
         ModelHandler handler = new TestModelContext(context).supplyHandler(config);
-        return handler.supplyDecoder(ModelTransform.NONE);
+        return handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
     }
 
     private static TestModelConfig config(
         int length)
     {
         return TestModelConfig.builder().length(length).build();
+    }
+
+    // an envelope a caller supplies to the pipeline, recording what the model writes into it
+    private static final class Metadata implements ModelEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        @Override
+        public int count(
+            String name)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
@@ -22,6 +22,7 @@ import java.util.List;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelFieldBridge;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -35,7 +36,9 @@ import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 // is copied through into dst unchanged (identity); when a transformed length is configured, the accepted
 // value is padded or truncated to that length so a non-identity, length-changing transform can be exercised.
 // When a real transform is wired, every configured top-level field surfaces a fixed token to it as its
-// value when an accepted value completes. State lives on the pipeline so interleaved streams stay isolated.
+// value when an accepted value completes; the same fields are written to the supplied envelope under their
+// own paths, so a caller supplying a real envelope observes what the model surfaced without wiring a
+// transform at all. State lives on the pipeline so interleaved streams stay isolated.
 final class TestModelPipeline implements ModelPipeline
 {
     private static final int FLAGS_INIT = 0x02;
@@ -47,6 +50,7 @@ final class TestModelPipeline implements ModelPipeline
     private final int transformLength;
     private final List<String> fields;
     private final boolean lenient;
+    private final ModelEnvelope envelope;
     private final ModelFieldBridge bridge;
     private final ModelPipelineResult result;
 
@@ -57,12 +61,14 @@ final class TestModelPipeline implements ModelPipeline
         int transformLength,
         List<String> fields,
         boolean lenient,
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
         this.length = length;
         this.transformLength = transformLength;
         this.fields = fields;
         this.lenient = lenient;
+        this.envelope = envelope;
         this.bridge = transform != ModelTransform.NONE ? new ModelFieldBridge(transform) : null;
         this.result = new ModelPipelineResult();
     }
@@ -163,10 +169,22 @@ final class TestModelPipeline implements ModelPipeline
         if (bridge != null)
         {
             bridge.start(authorization);
-            for (int i = 0; i < fields.size(); i++)
+        }
+
+        for (int i = 0; i < fields.size(); i++)
+        {
+            final String path = "$." + fields.get(i);
+
+            if (bridge != null)
             {
-                bridge.field("$." + fields.get(i), extractedValue, 0, extractedValue.capacity());
+                bridge.field(path, extractedValue, 0, extractedValue.capacity());
             }
+
+            envelope.set(path, extractedValue);
+        }
+
+        if (bridge != null)
+        {
             bridge.end();
         }
     }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -34,6 +34,7 @@ import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -66,15 +67,21 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new AvroModelDecoderPipeline(this, requireNonNull(transform));
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new AvroModelEncoderPipeline(this, requireNonNull(transform));
     }
 

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipelineTest.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.common.avro.AvroSchema;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -104,8 +105,8 @@ public class AvroModelDecoderPipelineTest
     {
         AvroModelHandlerImpl handler = newHandler();
         // two per-stream pipelines from the same per-worker handler
-        ModelPipeline a = handler.supplyDecoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // stream A split at the field boundary: the id field first, the status field on the final fragment
         byte[] a1 = {0x06, 0x69, 0x64, 0x30};
@@ -141,7 +142,7 @@ public class AvroModelDecoderPipelineTest
         AvroModelHandlerImpl handler = newHandler();
 
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -158,7 +159,7 @@ public class AvroModelDecoderPipelineTest
         AvroModelHandlerImpl handler = newHandler(SCALARS_SCHEMA, "json");
 
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         // i=5, l=7, f=1.5, d=2.5, b=true, e=index 1
         byte[] scalars =
@@ -187,7 +188,7 @@ public class AvroModelDecoderPipelineTest
     public void shouldReportDecodePadding()
     {
         AvroModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertTrue(pipeline.padding(new UnsafeBufferEx(AVRO), 0, AVRO.length) >= 0);
     }
@@ -198,9 +199,9 @@ public class AvroModelDecoderPipelineTest
         AvroModelHandlerImpl baseline = newHandler(SCHEMA, "json", List.of());
         AvroModelHandlerImpl extended = newHandler(SCHEMA, "json", List.of(expandingExt(64)));
 
-        int basePadding = baseline.supplyDecoder(ModelTransform.NONE)
+        int basePadding = baseline.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(AVRO), 0, AVRO.length);
-        int extPadding = extended.supplyDecoder(ModelTransform.NONE)
+        int extPadding = extended.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(AVRO), 0, AVRO.length);
 
         assertEquals(basePadding + 64, extPadding);
@@ -210,7 +211,7 @@ public class AvroModelDecoderPipelineTest
     public void shouldReportIdentityWhenNoView()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertFalse(pipeline.identity());
 
@@ -225,7 +226,7 @@ public class AvroModelDecoderPipelineTest
     public void shouldNotReportIdentityWhenJsonView()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipelineTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipelineTest.java
@@ -38,6 +38,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
@@ -81,8 +82,8 @@ public class AvroModelEncoderPipelineTest
     {
         AvroModelHandlerImpl handler = newHandler();
         // two per-stream pipelines from the same per-worker handler
-        ModelPipeline a = handler.supplyEncoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] a1 = "{\"id\":\"id0\",".getBytes(UTF_8);
         byte[] a2tail = "\"status\":\"positive\"}".getBytes(UTF_8);
@@ -120,7 +121,7 @@ public class AvroModelEncoderPipelineTest
         when(context.clock()).thenReturn(Clock.systemUTC());
         when(context.supplyEventWriter()).thenReturn(mock(MessageConsumer.class));
         AvroModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // raw protobuf-style binary, not valid JSON, fed under view: json -> the underlying JSON parser would
         // throw a JsonParsingException; the parser boundary must translate it to a clean REJECTED, not crash
@@ -136,7 +137,7 @@ public class AvroModelEncoderPipelineTest
     public void shouldReportEncodePadding()
     {
         AvroModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = JSON.getBytes(UTF_8);
         assertTrue(pipeline.padding(new UnsafeBufferEx(in), 0, in.length) >= 0);

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelTransformTest.java
@@ -43,6 +43,7 @@ import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -167,7 +168,7 @@ public class AvroModelTransformTest
     public void shouldReplaceStringField()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.id", "replaced"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.id", "replaced"));
 
         assertEquals("{\"id\":\"replaced\",\"status\":\"positive\"}", decode(pipeline, AVRO));
     }
@@ -177,7 +178,7 @@ public class AvroModelTransformTest
     {
         String longer = "a-much-longer-replacement-value-than-the-original";
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.status", longer));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.status", longer));
 
         assertEquals("{\"id\":\"id0\",\"status\":\"" + longer + "\"}", decode(pipeline, AVRO));
     }
@@ -186,7 +187,7 @@ public class AvroModelTransformTest
     public void shouldDeclineStringField()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Declining("$.status"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Declining("$.status"));
 
         assertEquals("{\"id\":\"id0\",\"status\":\"\"}", decode(pipeline, AVRO));
     }
@@ -195,7 +196,7 @@ public class AvroModelTransformTest
     public void shouldReplaceScalarField()
     {
         AvroModelHandlerImpl handler = newHandler(SCALARS_SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.l", "99"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.l", "99"));
 
         assertEquals("{\"i\":5,\"l\":99,\"f\":1.5,\"d\":2.5,\"b\":true,\"e\":\"HIGH\"}", decode(pipeline, SCALARS));
     }
@@ -204,7 +205,7 @@ public class AvroModelTransformTest
     public void shouldDeclineScalarFields()
     {
         AvroModelHandlerImpl handler = newHandler(SCALARS_SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Declining("$.i", "$.b", "$.e"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Declining("$.i", "$.b", "$.e"));
 
         assertEquals("{\"i\":0,\"l\":7,\"f\":1.5,\"d\":2.5,\"b\":false,\"e\":\"LOW\"}", decode(pipeline, SCALARS));
     }
@@ -213,7 +214,7 @@ public class AvroModelTransformTest
     public void shouldReplaceNestedScalarField()
     {
         AvroModelHandlerImpl handler = newHandler(NESTED_SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.user.ssn", "replaced"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.user.ssn", "replaced"));
 
         assertEquals("{\"id\":\"a\",\"user\":{\"ssn\":\"replaced\"}}", decode(pipeline, NESTED));
     }
@@ -222,7 +223,7 @@ public class AvroModelTransformTest
     public void shouldDeclineNestedScalarField()
     {
         AvroModelHandlerImpl handler = newHandler(NESTED_SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Declining("$.user.ssn"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Declining("$.user.ssn"));
 
         assertEquals("{\"id\":\"a\",\"user\":{\"ssn\":\"\"}}", decode(pipeline, NESTED));
     }
@@ -231,7 +232,7 @@ public class AvroModelTransformTest
     public void shouldNotDescendMatchingByLeafNameAloneAcrossDepths()
     {
         AvroModelHandlerImpl handler = newHandler(NESTED_SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Declining("$.ssn"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Declining("$.ssn"));
 
         assertEquals("{\"id\":\"a\",\"user\":{\"ssn\":\"ssn0\"}}", decode(pipeline, NESTED));
     }
@@ -250,7 +251,7 @@ public class AvroModelTransformTest
                 }
             });
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json", exts);
-        ModelPipeline pipeline = handler.supplyDecoder(new Observing());
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Observing());
 
         assertEquals("{\"id\":\"id0\",\"status\":\"\"}", decode(pipeline, AVRO));
     }
@@ -259,7 +260,7 @@ public class AvroModelTransformTest
     public void shouldForwardEveryFieldUntouchedWhenNoPathMatches()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.absent", "replaced"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.absent", "replaced"));
 
         assertEquals("{\"id\":\"id0\",\"status\":\"positive\"}", decode(pipeline, AVRO));
     }
@@ -268,7 +269,7 @@ public class AvroModelTransformTest
     public void shouldReproduceEveryFieldWhenSubstitutingIdenticalValues()
     {
         AvroModelHandlerImpl handler = newHandler(MIXED_SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Echoing());
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Echoing());
 
         assertArrayEquals(MIXED, decodeChunked(pipeline, MIXED, 256));
     }
@@ -277,7 +278,8 @@ public class AvroModelTransformTest
     public void shouldWritePlaceholderForEveryDeclinedField()
     {
         AvroModelHandlerImpl handler = newHandler(MIXED_SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Declining("$.u", "$.y", "$.x", "$.b", "$.f", "$.d"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE,
+            new Declining("$.u", "$.y", "$.x", "$.b", "$.f", "$.d"));
 
         byte[] expected =
         {
@@ -297,7 +299,7 @@ public class AvroModelTransformTest
     public void shouldResumeAcrossBoundedOutput()
     {
         AvroModelHandlerImpl handler = newHandler(MIXED_SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Echoing());
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Echoing());
 
         assertArrayEquals(MIXED, decodeChunked(pipeline, MIXED, 24));
     }
@@ -307,7 +309,7 @@ public class AvroModelTransformTest
     {
         String longer = "a-much-longer-replacement-value-than-the-original";
         AvroModelHandlerImpl handler = newHandler(SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.status", longer));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.status", longer));
 
         byte[] status = longer.getBytes(UTF_8);
         byte[] expected = new byte[5 + status.length];
@@ -328,7 +330,7 @@ public class AvroModelTransformTest
         Recording recording = new Recording(true);
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
 
-        decode(handler.supplyDecoder(recording), AVRO);
+        decode(handler.supplyDecoder(ModelEnvelope.NONE, recording), AVRO);
 
         assertEquals(FRAMED, recording.events);
     }
@@ -339,7 +341,7 @@ public class AvroModelTransformTest
         Recording recording = new Recording(false);
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
 
-        decode(handler.supplyDecoder(recording), AVRO);
+        decode(handler.supplyDecoder(ModelEnvelope.NONE, recording), AVRO);
 
         // the pump stops the moment the terminal sink closes the top-level record, so END_MESSAGE never
         // reaches the adapter; the run must still close off the datum completing
@@ -352,7 +354,7 @@ public class AvroModelTransformTest
         when(context.clock()).thenReturn(Clock.systemUTC());
         when(context.supplyEventWriter()).thenReturn(mock(MessageConsumer.class));
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyDecoder(new Rejecting("$.status"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rejecting("$.status"));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -365,7 +367,7 @@ public class AvroModelTransformTest
     public void shouldNotReportIdentityWhenMediating()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Rewriting("$.id", "replaced"));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Rewriting("$.id", "replaced"));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -378,7 +380,7 @@ public class AvroModelTransformTest
     public void shouldReportIdentityWhenObserving()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, null);
-        ModelPipeline pipeline = handler.supplyDecoder(new Observing());
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, new Observing());
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -391,7 +393,7 @@ public class AvroModelTransformTest
     public void shouldReplaceFieldOnEncode()
     {
         AvroModelHandlerImpl handler = newHandler(SCHEMA, "json");
-        ModelPipeline pipeline = handler.supplyEncoder(new Rewriting("$.id", "replaced"));
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, new Rewriting("$.id", "replaced"));
 
         byte[] json = "{\"id\":\"id0\",\"status\":\"positive\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelDecoderPipelineBM.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelDecoderPipelineBM.java
@@ -44,6 +44,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -91,8 +92,8 @@ public class AvroModelDecoderPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        toJson = newHandler("json").supplyDecoder(ModelTransform.NONE);
-        identity = newHandler(null).supplyDecoder(ModelTransform.NONE);
+        toJson = newHandler("json").supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        identity = newHandler(null).supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         src = new UnsafeBufferEx(AVRO);
         dst = new UnsafeBufferEx(new byte[256]);
     }

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelEncoderPipelineBM.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/bench/AvroModelEncoderPipelineBM.java
@@ -46,6 +46,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -95,8 +96,8 @@ public class AvroModelEncoderPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        fromJson = newHandler("json").supplyEncoder(ModelTransform.NONE);
-        identity = newHandler(null).supplyEncoder(ModelTransform.NONE);
+        fromJson = newHandler("json").supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        identity = newHandler(null).supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
         jsonSrc = new UnsafeBufferEx(JSON);
         avroSrc = new UnsafeBufferEx(AVRO);
         dst = new UnsafeBufferEx(new byte[256]);

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelHandler.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -53,15 +54,19 @@ final class CoreExtModelHandler implements ModelHandler
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new CoreExtModelPipeline(plain, supplier.get(), decodeLenient, transforms, padding);
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return plain.supplyEncoder(transform);
+        return plain.supplyEncoder(envelope, transform);
     }
 }

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelHandler.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelHandler.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.model.core.internal;
 import java.util.function.Supplier;
 
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -49,15 +50,21 @@ final class CoreModelHandler implements ModelHandler
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new CoreModelPipeline(this, supplier.get(), decodeLenient);
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new CoreModelPipeline(this, supplier.get(), encodeLenient);
     }
 

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BooleanModelPipelineTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -52,7 +53,7 @@ public class BooleanModelPipelineTest
     public void shouldTransformFalseValue()
     {
         ModelHandler handler = handler();
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {0x00};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[8]);
@@ -67,7 +68,7 @@ public class BooleanModelPipelineTest
     public void shouldRejectTooLong()
     {
         ModelHandler handler = handler();
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {0x01, 0x00};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[8]);

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BytesModelContextTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/BytesModelContextTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.config.model.core.BytesModelConfig;
 import io.aklivity.zilla.config.model.core.StringModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -50,7 +51,7 @@ public class BytesModelContextTest
 
         assertThat(handler, instanceOf(CoreModelHandler.class));
 
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = { (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF };
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
@@ -75,7 +76,7 @@ public class BytesModelContextTest
 
         assertThat(handler, instanceOf(CoreExtModelHandler.class));
 
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = "ignored".getBytes();
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
@@ -104,7 +105,7 @@ public class BytesModelContextTest
         byte[] bytes = "abc".getBytes();
         for (int i = 0; i < 3; i++)
         {
-            ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+            ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
             UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
             pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
                 new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
@@ -130,7 +131,7 @@ public class BytesModelContextTest
         assertThat(bytesHandler, instanceOf(CoreExtModelHandler.class));
         assertThat(stringHandler, instanceOf(CoreModelHandler.class));
 
-        ModelPipeline stringPipeline = stringHandler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline stringPipeline = stringHandler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = "unaffected".getBytes();
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[32]);
 

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipelineTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import io.aklivity.zilla.config.model.core.BytesModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -47,7 +48,7 @@ public class CoreExtModelPipelineTest
 
         BytesModelContext context = new BytesModelContext(mock(EngineContext.class), List.of(ext1, ext2));
         ModelHandler handler = context.supplyHandler(BytesModelConfig.builder().build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertEquals(10, pipeline.padding(new UnsafeBufferEx(new byte[0]), 0, 0));
     }

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelLenientTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreModelLenientTest.java
@@ -32,6 +32,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -65,7 +66,7 @@ public class CoreModelLenientTest
     {
         ModelHandler handler = new Int32ModelContext(context).supplyHandler(
             Int32ModelConfig.builder().format("text").validate(STRICT).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "12x".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -80,7 +81,7 @@ public class CoreModelLenientTest
     {
         ModelHandler handler = new Int32ModelContext(context).supplyHandler(
             Int32ModelConfig.builder().format("text").validate(LENIENT).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "12x".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -99,13 +100,13 @@ public class CoreModelLenientTest
 
         byte[] bytes = "42".getBytes();
 
-        ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline decoder = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[16]);
         ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
-        ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline encoder = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[16]);
         ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(bytes), 0, bytes.length, encodeDst, 0, encodeDst.capacity());
@@ -119,7 +120,7 @@ public class CoreModelLenientTest
     {
         ModelHandler handler = new StringModelContext(context, List.of()).supplyHandler(
             StringModelConfig.builder().maxLength(2).validate(STRICT).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "hello".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -134,7 +135,7 @@ public class CoreModelLenientTest
     {
         ModelHandler handler = new StringModelContext(context, List.of()).supplyHandler(
             StringModelConfig.builder().maxLength(2).validate(LENIENT).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "hello".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/DoubleModelPipelineTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -54,7 +55,7 @@ public class DoubleModelPipelineTest
     public void shouldTransformSignedDecimalValue()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "+10.1119998321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -69,7 +70,7 @@ public class DoubleModelPipelineTest
     public void shouldTransformNegativeLeadingDotValue()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-.11190092111111112".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -83,7 +84,7 @@ public class DoubleModelPipelineTest
     public void shouldRejectMultipleDecimalPoints()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-.11.19987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -97,7 +98,7 @@ public class DoubleModelPipelineTest
     public void shouldTransformWithinMaxLimit()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").max(99.9987654321).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "99.9987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -115,7 +116,7 @@ public class DoubleModelPipelineTest
             .max(99.9987654321)
             .exclusiveMax(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "99.9987654321".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -133,7 +134,7 @@ public class DoubleModelPipelineTest
             .min(10.0)
             .exclusiveMin(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "10.0".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -147,7 +148,7 @@ public class DoubleModelPipelineTest
     public void shouldRejectNotMultiple()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").multiple(10.0).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "25".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -161,7 +162,7 @@ public class DoubleModelPipelineTest
     public void shouldTransformBinaryValue()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {-64, 0, 0, 0, 0, 0, 0, 0};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -176,7 +177,7 @@ public class DoubleModelPipelineTest
     public void shouldRejectBinaryTooLong()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Invalid Double".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
@@ -190,7 +191,7 @@ public class DoubleModelPipelineTest
     public void shouldTransformBinaryFragmented()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {-1, -17, 94};
         byte[] mid = {-95};
@@ -214,7 +215,7 @@ public class DoubleModelPipelineTest
     public void shouldRejectBinaryFragmentedTooShort()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {0, 0, 0};
         byte[] mid = {0, 0};
@@ -238,7 +239,7 @@ public class DoubleModelPipelineTest
     public void shouldResetForNextValue()
     {
         ModelHandler handler = handler(DoubleModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "4.2".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/FloatModelPipelineTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -54,7 +55,7 @@ public class FloatModelPipelineTest
     public void shouldTransformSignedSuffixedValue()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "+10.1119f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -69,7 +70,7 @@ public class FloatModelPipelineTest
     public void shouldTransformNegativeSuffixedValue()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-.1119f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -83,7 +84,7 @@ public class FloatModelPipelineTest
     public void shouldRejectMultipleDecimalPoints()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-.11.19f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -97,7 +98,7 @@ public class FloatModelPipelineTest
     public void shouldTransformWithinMaxLimit()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("text").max(99.99f).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "99.99f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -115,7 +116,7 @@ public class FloatModelPipelineTest
             .max(99.99f)
             .exclusiveMax(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "99.99f".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -133,7 +134,7 @@ public class FloatModelPipelineTest
             .min(10.0f)
             .exclusiveMin(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "10.0".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -147,7 +148,7 @@ public class FloatModelPipelineTest
     public void shouldRejectNotMultiple()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("text").multiple(10.0f).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "25".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -161,7 +162,7 @@ public class FloatModelPipelineTest
     public void shouldTransformBinaryValue()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {62, -128, 5, 8};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -176,7 +177,7 @@ public class FloatModelPipelineTest
     public void shouldRejectBinaryTooLong()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Invalid Float".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
@@ -190,7 +191,7 @@ public class FloatModelPipelineTest
     public void shouldTransformBinaryFragmented()
     {
         ModelHandler handler = handler(FloatModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {62, -128};
         byte[] tail = {5, 8};

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int32ModelPipelineTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -54,7 +55,7 @@ public class Int32ModelPipelineTest
     public void shouldTransformSignedValue()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "+8449999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -68,7 +69,7 @@ public class Int32ModelPipelineTest
     public void shouldTransformNegativeValue()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-125".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -86,7 +87,7 @@ public class Int32ModelPipelineTest
             .max(999)
             .exclusiveMax(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -104,7 +105,7 @@ public class Int32ModelPipelineTest
             .min(999)
             .exclusiveMin(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -118,7 +119,7 @@ public class Int32ModelPipelineTest
     public void shouldTransformBinaryWholeValue()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {0, 0, 0, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -133,7 +134,7 @@ public class Int32ModelPipelineTest
     public void shouldRejectBinaryTooLong()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Test value".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
@@ -147,7 +148,7 @@ public class Int32ModelPipelineTest
     public void shouldRejectBinaryFragmentedTooShort()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {0, 0, 0};
         byte[] tail = {0, 42};
@@ -166,7 +167,7 @@ public class Int32ModelPipelineTest
     public void shouldTransformBinaryFragmented()
     {
         ModelHandler handler = handler(Int32ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {0x00, 0x00};
         byte[] tail = {0x00, 0x2a};

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/Int64ModelPipelineTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -54,7 +55,7 @@ public class Int64ModelPipelineTest
     public void shouldTransformSignedSuffixedValue()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "+8449999L".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -69,7 +70,7 @@ public class Int64ModelPipelineTest
     public void shouldTransformNegativeValue()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("text").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "-125".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -83,7 +84,7 @@ public class Int64ModelPipelineTest
     public void shouldRejectAboveMaxLimit()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("text").max(999L).build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "8449999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -101,7 +102,7 @@ public class Int64ModelPipelineTest
             .max(999L)
             .exclusiveMax(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -119,7 +120,7 @@ public class Int64ModelPipelineTest
             .min(999L)
             .exclusiveMin(true)
             .build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "999".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[32]);
@@ -133,7 +134,7 @@ public class Int64ModelPipelineTest
     public void shouldTransformBinaryValue()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {0, 0, 0, 0, 0, 0, 0, 42};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -148,7 +149,7 @@ public class Int64ModelPipelineTest
     public void shouldTransformSignedBinaryValue()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = {-1, -1, -1, -1, -1, -1, -1, -32};
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -162,7 +163,7 @@ public class Int64ModelPipelineTest
     public void shouldRejectBinaryTooLong()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Test value!".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[64]);
@@ -176,7 +177,7 @@ public class Int64ModelPipelineTest
     public void shouldTransformBinaryFragmented()
     {
         ModelHandler handler = handler(Int64ModelConfig.builder().format("binary").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] head = {0, 0, 0, 0};
         byte[] tail = {0, 0, 1, 42};

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelContextTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelContextTest.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.config.model.core.BytesModelConfig;
 import io.aklivity.zilla.config.model.core.StringModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -50,7 +51,7 @@ public class StringModelContextTest
 
         assertThat(handler, instanceOf(CoreModelHandler.class));
 
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = "hello".getBytes();
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
@@ -75,7 +76,7 @@ public class StringModelContextTest
 
         assertThat(handler, instanceOf(CoreExtModelHandler.class));
 
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = "ignored".getBytes();
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
 
@@ -104,7 +105,7 @@ public class StringModelContextTest
         byte[] bytes = "abc".getBytes();
         for (int i = 0; i < 3; i++)
         {
-            ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+            ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
             UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
             pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
                 new UnsafeBufferEx(bytes), 0, bytes.length, dst, 0, dst.capacity());
@@ -130,7 +131,7 @@ public class StringModelContextTest
         assertThat(stringHandler, instanceOf(CoreExtModelHandler.class));
         assertThat(bytesHandler, instanceOf(CoreModelHandler.class));
 
-        ModelPipeline bytesPipeline = bytesHandler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline bytesPipeline = bytesHandler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         byte[] bytes = { 1, 2, 3, 4 };
         UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
 

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/StringModelPipelineTest.java
@@ -29,6 +29,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -55,7 +56,7 @@ public class StringModelPipelineTest
     public void shouldOverflowBoundedDestination()
     {
         ModelHandler handler = handler(StringModelConfig.builder().encoding("utf_8").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Valid String".getBytes();
         MutableDirectBufferEx src = new UnsafeBufferEx(bytes);
@@ -82,7 +83,7 @@ public class StringModelPipelineTest
     public void shouldOverflowWithEmptyDestination()
     {
         ModelHandler handler = handler(StringModelConfig.builder().encoding("utf_8").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "Valid String".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[0]);
@@ -99,8 +100,8 @@ public class StringModelPipelineTest
     {
         ModelHandler handler = handler(StringModelConfig.builder().encoding("utf_8").build());
         // one per-worker handler vends two per-stream pipelines; fragmenting A across B must not corrupt A
-        ModelPipeline a = handler.supplyDecoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] a1 = "Valid ".getBytes();
         byte[] a2 = "String".getBytes();
@@ -124,7 +125,7 @@ public class StringModelPipelineTest
     public void shouldResetForNextValue()
     {
         ModelHandler handler = handler(StringModelConfig.builder().encoding("utf_8").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] bytes = "abc".getBytes();
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[16]);
@@ -142,7 +143,7 @@ public class StringModelPipelineTest
     public void shouldTransformMultiByteFragmented()
     {
         ModelHandler handler = handler(StringModelConfig.builder().encoding("utf_8").build());
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // "é€" split at the character boundary: "é" is 2 bytes, "€" is 3 bytes
         byte[] head = "é".getBytes(java.nio.charset.StandardCharsets.UTF_8);

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
@@ -32,6 +32,7 @@ import io.aklivity.zilla.runtime.common.json.JsonStream;
 import io.aklivity.zilla.runtime.common.json.JsonTransform;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -67,15 +68,21 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new JsonModelDecoderPipeline(this, requireNonNull(transform));
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new JsonModelEncoderPipeline(this);
     }
 

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipelineTest.java
@@ -48,6 +48,7 @@ import io.aklivity.zilla.runtime.common.json.JsonTransformable;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -105,8 +106,8 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler();
         // two per-stream pipelines from the same per-worker handler
-        ModelPipeline a = handler.supplyDecoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] a1 = "{\"id\":\"A\",".getBytes(UTF_8);
         byte[] a2tail = "\"status\":\"OK\"}".getBytes(UTF_8);
@@ -141,7 +142,7 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler();
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
@@ -158,7 +159,7 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler();
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         // "id" holds a 3-byte BMP char (中) and a 2-byte char (é); "status" holds a surrogate-pair emoji (😀)
         byte[] in = "{\"id\":\"中é\",\"status\":\"😀\"}".getBytes(UTF_8);
@@ -176,7 +177,7 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler();
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         // \uD800 is an unpaired high surrogate; String.getBytes(UTF_8) replaces it with '?' (0x3F)
         byte[] in = "{\"id\":\"a\\uD800b\",\"status\":\"OK\"}".getBytes(UTF_8);
@@ -193,7 +194,7 @@ public class JsonModelDecoderPipelineTest
     {
         JsonModelHandlerImpl handler = newHandler(UNCONSTRAINED_VALUE_SCHEMA);
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         // "note" has no content keyword, so a value spanning an input window is forwarded to the
         // extractor in fragments (Validator's forward-and-suppress path) instead of being reassembled
@@ -231,7 +232,7 @@ public class JsonModelDecoderPipelineTest
     public void shouldReportDecodePadding()
     {
         JsonModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         assertTrue(pipeline.padding(new UnsafeBufferEx(in), 0, in.length) >= 0);
@@ -241,7 +242,7 @@ public class JsonModelDecoderPipelineTest
     public void shouldReportIdentity()
     {
         JsonModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertFalse(pipeline.identity());
 
@@ -260,7 +261,7 @@ public class JsonModelDecoderPipelineTest
         // model's own validator stage turns an otherwise-valid document into a schema-rejected one
         List<JsonModelExtContext> exts = List.of(dropping("status"));
         JsonModelHandlerImpl handler = newHandler(OBJECT_SCHEMA, exts);
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
@@ -286,7 +287,7 @@ public class JsonModelDecoderPipelineTest
         List<JsonModelExtContext> exts = List.of(dropping("id"), dropping("status"));
         JsonModelHandlerImpl handler = newHandler(schema, exts);
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
@@ -305,9 +306,9 @@ public class JsonModelDecoderPipelineTest
         JsonModelHandlerImpl extended = newHandler(OBJECT_SCHEMA, List.of(expandingExt(64)));
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
-        int basePadding = baseline.supplyDecoder(ModelTransform.NONE)
+        int basePadding = baseline.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(in), 0, in.length);
-        int extPadding = extended.supplyDecoder(ModelTransform.NONE)
+        int extPadding = extended.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(in), 0, in.length);
 
         assertEquals(basePadding + 64, extPadding);

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipelineTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipelineTest.java
@@ -32,6 +32,7 @@ import io.aklivity.zilla.config.model.json.JsonModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
@@ -63,7 +64,7 @@ public class JsonModelEncoderPipelineTest
     public void shouldReportEncodePadding()
     {
         JsonModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = "{\"id\":\"123\",\"status\":\"OK\"}".getBytes(UTF_8);
         assertTrue(pipeline.padding(new UnsafeBufferEx(in), 0, in.length) >= 0);

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelLenientTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelLenientTest.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
@@ -78,13 +79,13 @@ public class JsonModelLenientTest
 
         byte[] in = "{\"id\":123}".getBytes(UTF_8);
 
-        ModelPipeline decoder = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline decoder = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx decodeDst = new UnsafeBufferEx(new byte[256]);
         ModelPipelineResult decoded = decoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, decodeDst, 0, decodeDst.capacity());
         assertEquals(ModelStatus.COMPLETE, decoded.status());
 
-        ModelPipeline encoder = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline encoder = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx encodeDst = new UnsafeBufferEx(new byte[256]);
         ModelPipelineResult encoded = encoder.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, encodeDst, 0, encodeDst.capacity());
@@ -95,7 +96,7 @@ public class JsonModelLenientTest
     @Test
     public void shouldCompleteConformingUnderLenient()
     {
-        ModelPipeline pipeline = newHandler(lenient()).supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = newHandler(lenient()).supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = "{\"id\":\"abc\"}".getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelOverlayTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelOverlayTest.java
@@ -34,6 +34,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
@@ -103,7 +104,7 @@ public class JsonModelOverlayTest
         JsonModelHandlerImpl handler,
         byte[] in)
     {
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         return pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
             new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelDecoderPipelineBM.java
@@ -45,6 +45,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -97,8 +98,8 @@ public class JsonModelDecoderPipelineBM
     public void init()
     {
         JsonModelHandlerImpl handler = newHandler();
-        plainPipeline = handler.supplyDecoder(ModelTransform.NONE);
-        extractingPipeline = handler.supplyDecoder(fieldCounter());
+        plainPipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        extractingPipeline = handler.supplyDecoder(ModelEnvelope.NONE, fieldCounter());
 
         byte[] validBytes = VALID_DOCUMENT.getBytes(UTF_8);
         validBuffer = new UnsafeBufferEx(validBytes);

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/bench/JsonModelEncoderPipelineBM.java
@@ -46,6 +46,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -98,7 +99,7 @@ public class JsonModelEncoderPipelineBM
     public void init()
     {
         JsonModelHandlerImpl handler = newHandler();
-        pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] smallBytes = SMALL_DOCUMENT.getBytes(UTF_8);
         byte[] largeBytes = LARGE_DOCUMENT.getBytes(UTF_8);

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -37,6 +37,7 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufStream;
 import io.aklivity.zilla.runtime.common.protobuf.json.ProtobufJson;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelHandler;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -78,15 +79,21 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
 
     @Override
     public ModelPipeline supplyDecoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new ProtobufModelDecoderPipeline(this, requireNonNull(transform));
     }
 
     @Override
     public ModelPipeline supplyEncoder(
+        ModelEnvelope envelope,
         ModelTransform transform)
     {
+        assert envelope != null;
+
         return new ProtobufModelEncoderPipeline(this);
     }
 

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipelineTest.java
@@ -40,6 +40,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelEvent;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
@@ -108,8 +109,8 @@ public class ProtobufModelDecoderPipelineTest
     {
         ProtobufModelHandlerImpl handler = newHandler(null);
         // two per-stream pipelines from the same per-worker handler
-        ModelPipeline a = handler.supplyDecoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // stream A split at the field boundary: index byte + content field first, date_time on the final fragment
         byte[] a1 = {0x00, 0x0a, 0x02, 0x4f, 0x4b};
@@ -147,7 +148,7 @@ public class ProtobufModelDecoderPipelineTest
         ProtobufModelHandlerImpl handler = newHandler(null);
 
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         ModelPipelineResult result = pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -184,7 +185,7 @@ public class ProtobufModelDecoderPipelineTest
         ProtobufModelHandlerImpl handler = new ProtobufModelHandlerImpl(model, context, List.of());
 
         Map<String, String> extracted = new HashMap<>();
-        ModelPipeline pipeline = handler.supplyDecoder(observer(extracted));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, observer(extracted));
 
         // leading message index 0, then the complex message's scalar fields (matches the legacy extract case)
         byte[] wire = {0, 9, 119, -66, -97, 26, 47, -35, 94, 64, 21, 102, -26, -11, 66, 24, -107, -102, -17, 58,
@@ -207,7 +208,7 @@ public class ProtobufModelDecoderPipelineTest
     public void shouldDrainJsonOnOverflow()
     {
         ProtobufModelHandlerImpl handler = newHandler("json");
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // a 2000-byte content field forces the JSON output past a small destination window, exercising the
         // bounded-chunk OVERFLOW drain across re-transforms (INIT cleared on every re-call after the first)
@@ -251,7 +252,7 @@ public class ProtobufModelDecoderPipelineTest
     public void shouldReportIdentityWhenNoView()
     {
         ProtobufModelHandlerImpl handler = newHandler(null);
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         assertFalse(pipeline.identity());
 
@@ -266,7 +267,7 @@ public class ProtobufModelDecoderPipelineTest
     public void shouldNotReportIdentityWhenJsonView()
     {
         ProtobufModelHandlerImpl handler = newHandler("json");
-        ModelPipeline pipeline = handler.supplyDecoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
         pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
@@ -281,9 +282,9 @@ public class ProtobufModelDecoderPipelineTest
         ProtobufModelHandlerImpl baseline = newHandler("json", List.of());
         ProtobufModelHandlerImpl extended = newHandler("json", List.of(expandingExt(64)));
 
-        int basePadding = baseline.supplyDecoder(ModelTransform.NONE)
+        int basePadding = baseline.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(WIRE), 0, WIRE.length);
-        int extPadding = extended.supplyDecoder(ModelTransform.NONE)
+        int extPadding = extended.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE)
             .padding(new UnsafeBufferEx(WIRE), 0, WIRE.length);
 
         assertEquals(basePadding + 64, extPadding);

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipelineTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipelineTest.java
@@ -35,6 +35,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.binding.function.MessageConsumer;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelStatus;
@@ -74,8 +75,8 @@ public class ProtobufModelEncoderPipelineTest
     {
         ProtobufModelHandlerImpl handler = newHandler();
         // two per-stream pipelines from the same per-worker handler
-        ModelPipeline a = handler.supplyEncoder(ModelTransform.NONE);
-        ModelPipeline b = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline a = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        ModelPipeline b = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] a1 = "{\"content\":\"OK\",".getBytes(UTF_8);
         byte[] a2tail = "\"date_time\":\"01012024\"}".getBytes(UTF_8);
@@ -111,7 +112,7 @@ public class ProtobufModelEncoderPipelineTest
     public void shouldDrainOnOverflow()
     {
         ProtobufModelHandlerImpl handler = newHandler();
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         // a 2000-byte content value forces the wire output past a small destination window, exercising the
         // bounded-chunk OVERFLOW drain across re-transforms (INIT cleared on every re-call after the first)
@@ -144,7 +145,7 @@ public class ProtobufModelEncoderPipelineTest
         when(context.clock()).thenReturn(Clock.systemUTC());
         when(context.supplyEventWriter()).thenReturn(mock(MessageConsumer.class));
         ProtobufModelHandlerImpl handler = newHandler("Nonexistent");
-        ModelPipeline pipeline = handler.supplyEncoder(ModelTransform.NONE);
+        ModelPipeline pipeline = handler.supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
 
         byte[] in = JSON.getBytes(UTF_8);
         MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelDecoderPipelineBM.java
@@ -43,6 +43,7 @@ import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -86,8 +87,8 @@ public class ProtobufModelDecoderPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        wirePipeline = newHandler(null).supplyDecoder(ModelTransform.NONE);
-        jsonPipeline = newHandler("json").supplyDecoder(ModelTransform.NONE);
+        wirePipeline = newHandler(null).supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        jsonPipeline = newHandler("json").supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
     }
 
     @Benchmark

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/bench/ProtobufModelEncoderPipelineBM.java
@@ -44,6 +44,7 @@ import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
 import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
 import io.aklivity.zilla.runtime.engine.model.ModelPipelineResult;
 import io.aklivity.zilla.runtime.engine.model.ModelTransform;
@@ -84,7 +85,7 @@ public class ProtobufModelEncoderPipelineBM
     @Setup(Level.Trial)
     public void init()
     {
-        pipeline = newHandler().supplyEncoder(ModelTransform.NONE);
+        pipeline = newHandler().supplyEncoder(ModelEnvelope.NONE, ModelTransform.NONE);
     }
 
     @Benchmark


### PR DESCRIPTION
## Description

`ModelPipeline`'s contract describes the value being transformed and nothing else, so nothing reaching a pipeline has a place to read or write data that travels with a value but is not part of its own encoding. Shaping an accessor after one transport's out-of-band channel would tie the model SPI to that transport's vocabulary, which the SPI-neutrality convention exists to prevent.

**`ModelEnvelope`** — a named, ordered, repeatable list of byte values that never interprets its own contents:

```java
public interface ModelEnvelope
{
    int count(String name);
    DirectBufferEx get(String name, int index);
    void set(String name, DirectBufferEx value);
}
```

`set` accumulates: a repeated call under one name adds a further occurrence rather than overwriting the one before it, so each stays retrievable by its own `get(name, index)`. The Javadoc says so explicitly, since "set" read in isolation more commonly connotes overwrite. `get` returns `null` for an absent name or an index past the end, per the engine's null-defaults convention; the buffer it returns is a non-owning view, and `set` copies the bytes out before returning so the caller may reuse its buffer immediately.

Scope is the supplier's to decide, and the interface makes no claim of its own: the supplier owns the envelope's lifecycle and clears or repoints its contents through its own type as the scope it describes turns over — per message where the transport carries per-message metadata, per stream where the metadata describes the stream. A pipeline reads and writes whatever the envelope holds and never resets it. Thread confinement is the one invariant the SPI does state, being a property of the pipeline the envelope is bound to.

**Bound at supply time.** `ModelHandler.supplyDecoder` and `supplyEncoder` take the envelope ahead of the `ModelTransform`, since the envelope covers the whole pipeline while the transform is one stage within it:

```java
ModelPipeline supplyDecoder(ModelEnvelope envelope, ModelTransform transform);
ModelPipeline supplyEncoder(ModelEnvelope envelope, ModelTransform transform);
```

Binding as the pipeline is built lets an implementation adapt the envelope into its own internals once, rather than pushing it through a per-value callback that every stage would have to carry. The no-argument overloads are gone so neither argument can be left implicit: both are documented as never `null`, implementations assert the envelope, and every call site passes `ModelEnvelope.NONE` / `ModelTransform.NONE` explicitly. `ModelEnvelope.NONE` reads as empty and discards writes, so a caller with no metadata channel is spelled out rather than inferred.

Threads the new parameter through every `ModelHandler` implementation (`model-core`, `model-json`, `model-protobuf`, `model-avro`, engine's `TestModelHandler`) and every call site (`binding-sse`, `binding-http`, `binding-mqtt`, `binding-mcp`, `binding-kafka`'s cache read/write paths). `ModelPipeline.transform(...)` is unchanged.

No `ModelController` accessor: it would only reach stages the caller composes itself, and such a caller can construct those stages with the envelope directly, so it carried no capability of its own. Adapting the envelope into each format layer's own internals is tracked in #2389.

### Coverage

`ModelEnvelopeTest`: accumulation under a repeated name; `count() == 0` and no value for an absent name and for an index past the end; the bytes being copied out of the caller's buffer on `set`; a stage reading and writing named metadata through the envelope it was supplied with; the `NONE` defaults including a discarded write; and an envelope left with zero reads and zero writes by a transform that never touches it.

`TestModelHandlerTest`: the engine's test model writes each extracted field into the supplied envelope, so the seam is covered end to end — fields written under their own paths, an untouched name still reading zero, and a second value accumulating alongside the first to show the binding survives a pipeline reset.

Verified with `./mvnw clean install -DskipITs` over `runtime/engine`, `model-core`, `model-json`, `model-protobuf`, `model-avro`, `binding-kafka`, `binding-http`, `binding-sse`, `binding-mqtt`, `binding-mcp` (BUILD SUCCESS), plus `checkstyle:check` and `license:check` clean across all ten and the engine's JaCoCo gate green at 223 tests.

Fixes #2384