### PR TITLE
fix(examples): make a failing example run diagnosable and pin the mcp.proxy everything server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,6 +261,17 @@ jobs:
         uses: jwalton/gh-docker-logs@v2
         with:
           dest: "./logs"
+      # `zilla dump` reads a collected engine directory, so ship it with the logs.
+      # Copied out rather than bind-mounted: a host mount over /var/run/zilla can
+      # collide with the container user's ownership of it and break the example
+      # itself. Lands inside ./logs, which is already tarred and uploaded below.
+      - name: Collect zilla engine directory on failure
+        if: failure()
+        working-directory: examples/${{ matrix.dir }}
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/logs"
+          docker compose cp zilla:/var/run/zilla "$GITHUB_WORKSPACE/logs/engine" || true
+
       - name: Tar logs
         if: failure()
         run: tar cvzf ./logs.tgz ./logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,6 +252,14 @@ jobs:
 
       - name: Execute Test
         working-directory: examples/${{ matrix.dir }}
+        # Without a cap this step inherits GitHub's 6h job ceiling, and a test that
+        # stalls holds a runner that whole time while serving no logs -- in-progress
+        # jobs have none, so the failure is invisible until it is hours old. The cap
+        # also converts a stall into failure(), which is what runs the docker log and
+        # engine directory collection below; a hang collects nothing. Every example
+        # except mcp.proxy finishes inside two minutes, and mcp.proxy's own bounded
+        # worst case sits well under this, so 30m only ever fires on a genuine stall.
+        timeout-minutes: 30
         run: |
           set -o pipefail
           ./.github/test.sh | tee $GITHUB_STEP_SUMMARY

--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -51,7 +51,12 @@ services:
     image: node:20-alpine
     hostname: everything
     restart: unless-stopped
-    command: ["npx", "-y", "@modelcontextprotocol/server-everything", "streamableHttp"]
+    # Pinned: unpinned "latest" silently changed behavior (e.g. added a new
+    # "tasks" initialize capability) and reintroduced this container's own
+    # npm-registry fetch time into the cache-hydration budget on every test
+    # run, both of which showed up as an intermittent "cache never finished
+    # hydrating" failure for this toolkit specifically.
+    command: ["npx", "-y", "@modelcontextprotocol/server-everything@2026.7.4", "streamableHttp"]
     environment:
       PORT: "3001"
     healthcheck:
@@ -361,6 +366,14 @@ services:
       - ./resource-subscribe-client:/work/resource-subscribe-client
       - ./url-elicit:/work/url-elicit
       - /var/run/docker.sock:/var/run/docker.sock
+    # verify.sh defaults this to 1 and documents FAIL_FAST=0 as the override, but
+    # `docker compose run` passes no host environment through on its own, so
+    # without declaring it here the override never reaches the container. Fail-fast
+    # stays the default because the workflow copies out zilla's engine directory on
+    # failure: `zilla dump` over it is only useful while the most recent frames are
+    # the failing ones, and ~40 further assertions would bury them.
+    environment:
+      FAIL_FAST: "${FAIL_FAST:-1}"
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -161,8 +161,12 @@ set -x
 # Stop at the first failure so a failing run is diagnosable from its own logs
 # rather than needing a rerun. The workflow collects docker logs on failure, and
 # ~40 further assertions after the first one buries the relevant output under
-# traffic that is no longer about the failure. Override with FAIL_FAST=0 to see
-# the full assertion sweep instead.
+# traffic that is no longer about the failure. The same holds for the engine
+# directory it copies out alongside them: `zilla dump` over that capture is only
+# useful while the most recent frames are the failing ones. Override with
+# FAIL_FAST=0 to see the full assertion sweep instead -- note the override only
+# reaches this container because compose.yaml declares FAIL_FAST on the verify
+# service.
 FAIL_FAST=${FAIL_FAST:-1}
 
 . /test-lib.sh


### PR DESCRIPTION
## Description

Four changes to how examples run under GitHub Actions. None of them touches what any example asserts — this is entirely about making a failing run diagnosable from its own artifacts, and removing a source of intermittent failure in `examples/mcp.proxy`.

**Cap the test step** (`.github/workflows/build.yml`)

The `Execute Test` step had no timeout, so it inherited GitHub's 6h job ceiling. A test that stalls held a runner for that whole time and served no logs while doing it — in-progress jobs have none — so the failure stayed invisible until it was hours old. `timeout-minutes: 30` also converts a stall into `failure()`, which is what triggers the collection steps below it; a hang collects nothing. Every example except `mcp.proxy` finishes inside two minutes, and `mcp.proxy`'s own bounded worst case sits well under 30m, so the cap only ever fires on a genuine stall.

**Collect the engine directory on failure** (`.github/workflows/build.yml`)

The `testing` job already collects docker logs when an example fails, but `zilla dump` reads a collected engine directory, and nothing was shipping one. A frame-level failure was therefore only diagnosable by reproducing the run. A new `Collect zilla engine directory on failure` step copies `/var/run/zilla` out of the container into `./logs/engine`, which is inside the directory the existing steps already tar and upload — so the tar and upload steps are unchanged.

Copied rather than bind-mounted: a host mount over `/var/run/zilla` can collide with the container user's ownership of it and break the example itself. The step is guarded with `|| true` because it runs for every example in the matrix, including any whose gateway service is not named `zilla` or whose container is already gone.

**Pin the everything server** (`examples/mcp.proxy/compose.yaml`)

The `everything` service ran `npx -y @modelcontextprotocol/server-everything` unpinned. Resolving `latest` on every run puts an npm-registry fetch inside that container's health budget, and lets the server's own behavior change underneath the example — a new `tasks` capability appearing in its `initialize` result being one observed instance. Both surfaced as an intermittent "cache never finished hydrating" failure for that toolkit specifically. Now pinned to `@2026.7.4`, which is the version `latest` currently resolves to, so this is behavior-preserving today and only guards against future drift.

**Make the `FAIL_FAST` override reachable** (`examples/mcp.proxy/compose.yaml`, `etc/test/verify.sh`)

`verify.sh` defaults `FAIL_FAST` to `1` and documents `FAIL_FAST=0` as the way to see the full assertion sweep, but `docker compose run` passes no host environment through on its own, so the documented override could never reach the `verify` container. The service now declares `FAIL_FAST: "${FAIL_FAST:-1}"`.

Fail-fast stays the default, and that matters more now than it did before: `zilla dump` over the newly collected engine directory is only useful while the most recent frames are the failing ones, and ~40 further assertions after the first failure would bury them. The comment block above `FAIL_FAST` in `verify.sh` is updated to say so.

### Verification

- `docker compose --profile test config` resolves `FAIL_FAST` to `"1"` with nothing set and `"0"` with `FAIL_FAST=0` in the environment.
- `docker compose config` confirms the pinned `@2026.7.4` command, and the registry confirms that version is published.
- The workflow YAML parses.

CI on this branch is the real check for the two workflow steps, since nothing here runs them locally.

Fixes # (issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)