### PR TITLE
feat(common-avro,common-json,common-protobuf): reach the metadata envelope from a format-native stage

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroController.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroController.java
@@ -28,6 +28,19 @@ public interface AvroController
     void segmentable();
 
     /**
+     * Returns the metadata travelling alongside the datum being transformed, addressed by name rather than
+     * by position within the datum. The default is {@link AvroEnvelope#NONE}, in force when no envelope was
+     * supplied to the pipeline, so a stage reads an empty envelope rather than no envelope at all. A
+     * mediating stage may supply its own to its downstream.
+     *
+     * @return the envelope in force for this pipeline
+     */
+    default AvroEnvelope envelope()
+    {
+        return AvroEnvelope.NONE;
+    }
+
+    /**
      * Reports {@code sourceBytes} payload bytes consumed by a bounded value write, so the upstream advances
      * its segment cursor and re-exposes the value's unconsumed remainder on resume — the output-side
      * back-pressure pushback that lets a terminal sink stream a length-delimited value without keeping its

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroEnvelope.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroEnvelope.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.avro;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The metadata travelling alongside a datum, addressed by name rather than by position within the datum.
+ * <p>
+ * An {@code AvroEnvelope} is a named, ordered, repeatable list of byte values and nothing more: it never
+ * interprets what any name means, and whether a name occurs zero, one, or many times is entirely up to
+ * whatever populates and consumes it. Its contents are not part of the datum, so nothing an
+ * {@link AvroStream} pipeline parses, validates, or generates reads or writes it — only a stage that asks
+ * for it does.
+ * </p>
+ * <p>
+ * An envelope is supplied once, at {@link AvroStream#envelope(AvroEnvelope)} time, so the pipeline binds
+ * to it as it is assembled rather than receiving it again per datum. The supplier owns its lifecycle and
+ * decides the scope its contents describe, clearing or repointing them through its own type as that scope
+ * turns over. A pipeline reads and writes whatever the envelope holds while it runs and never resets it.
+ * </p>
+ * <p>
+ * An envelope is confined to the same single thread as the pipeline it is supplied to.
+ * </p>
+ *
+ * @see AvroController#envelope()
+ */
+public interface AvroEnvelope
+{
+    /**
+     * Empty envelope, in force when no envelope is supplied to a pipeline. It reads as empty and discards
+     * what is written to it, so a stage reaches for the envelope the same way whether or not one is
+     * backing it.
+     */
+    AvroEnvelope NONE = new AvroEnvelope()
+    {
+        @Override
+        public int count(
+            String name)
+        {
+            return 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            return null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+        }
+    };
+
+    /**
+     * Returns how many values the envelope holds under {@code name}.
+     *
+     * @param name  the name to count the values of
+     * @return the number of values held under {@code name}, {@code 0} when the name is absent
+     */
+    int count(
+        String name);
+
+    /**
+     * Returns the value held under {@code name} at {@code index}, where the values under one name are
+     * ordered by the {@link #set(String, DirectBufferEx)} calls that added them and {@code index} runs
+     * from {@code 0} to {@link #count(String)} exclusive.
+     * <p>
+     * The buffer returned is a non-owning view valid only while the envelope is in scope; a consumer that
+     * needs the bytes beyond that must copy them out.
+     * </p>
+     *
+     * @param name   the name to read a value of
+     * @param index  the position of the value among those held under {@code name}
+     * @return the value at that position, or {@code null} when the name holds no value there
+     */
+    DirectBufferEx get(
+        String name,
+        int index);
+
+    /**
+     * Adds {@code value} to the values held under {@code name}, so a repeated call under one name adds a
+     * further occurrence rather than overwriting the one before it — {@link #count(String)} grows by one
+     * per call and each value stays retrievable by its own {@link #get(String, int)} index.
+     * <p>
+     * The bytes are copied out before the call returns, so the caller may reuse {@code value} immediately
+     * afterwards.
+     * </p>
+     *
+     * @param name   the name to add a value under
+     * @param value  the value bytes to add
+     */
+    void set(
+        String name,
+        DirectBufferEx value);
+}

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroStream.java
@@ -51,6 +51,15 @@ public interface AvroStream extends AvroTransformable<AvroStream>
     AvroStream reporting(
         AvroReporter reporter);
 
+    /**
+     * Binds the pipeline to the {@link AvroEnvelope} its stages read and write named metadata through,
+     * reachable from any stage via {@link AvroController#envelope()}. The last bound envelope wins; the
+     * default is {@link AvroEnvelope#NONE}, which reads as empty and discards writes, so a pipeline
+     * assembled without one costs a stage that never asks for it nothing.
+     */
+    AvroStream envelope(
+        AvroEnvelope envelope);
+
     AvroPipeline into(
         AvroSink sink);
 

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroPipelineImpl.java
@@ -24,6 +24,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.avro.AvroController;
 import io.aklivity.zilla.runtime.common.avro.AvroDiagnostic;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
 import io.aklivity.zilla.runtime.common.avro.AvroEvent;
 import io.aklivity.zilla.runtime.common.avro.AvroException;
 import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
@@ -70,11 +71,12 @@ final class AvroPipelineImpl implements AvroPipeline
         AvroSink root,
         AvroReporter reporter,
         AvroGenerator generator,
-        boolean lenient)
+        boolean lenient,
+        AvroEnvelope envelope)
     {
         this.parser = parser;
         this.source = new Source(parser);
-        this.control = new Control(parser);
+        this.control = new Control(parser, envelope);
         this.root = root;
         this.reporter = reporter;
         this.diagnostic = new Diagnostic();
@@ -291,13 +293,22 @@ final class AvroPipelineImpl implements AvroPipeline
     private static final class Control implements AvroController
     {
         private final AvroParser parser;
+        private final AvroEnvelope envelope;
 
         private boolean segmented;
 
         private Control(
-            AvroParser parser)
+            AvroParser parser,
+            AvroEnvelope envelope)
         {
             this.parser = parser;
+            this.envelope = envelope;
+        }
+
+        @Override
+        public AvroEnvelope envelope()
+        {
+            return envelope;
         }
 
         @Override

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroStreamImpl.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
 import io.aklivity.zilla.runtime.common.avro.AvroEvent;
 import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
 import io.aklivity.zilla.runtime.common.avro.AvroParser;
@@ -35,6 +36,7 @@ public final class AvroStreamImpl implements AvroStream
     private final List<AvroTransform> transforms;
 
     private AvroReporter reporter = AvroReporter.NONE;
+    private AvroEnvelope envelope = AvroEnvelope.NONE;
     private boolean lenient;
 
     public AvroStreamImpl(
@@ -72,10 +74,18 @@ public final class AvroStreamImpl implements AvroStream
     }
 
     @Override
+    public AvroStream envelope(
+        AvroEnvelope envelope)
+    {
+        this.envelope = envelope != null ? envelope : AvroEnvelope.NONE;
+        return this;
+    }
+
+    @Override
     public AvroPipeline into(
         AvroSink sink)
     {
-        return new AvroPipelineImpl(driver, bind(sink), reporter, null, lenient);
+        return new AvroPipelineImpl(driver, bind(sink), reporter, null, lenient, envelope);
     }
 
     @Override
@@ -83,7 +93,7 @@ public final class AvroStreamImpl implements AvroStream
         AvroGenerator generator)
     {
         // the pipeline owns the generator and re-targets it at the caller's destination per transform call
-        return new AvroPipelineImpl(driver, bind(new AvroSinkImpl(generator)), reporter, generator, lenient);
+        return new AvroPipelineImpl(driver, bind(new AvroSinkImpl(generator)), reporter, generator, lenient, envelope);
     }
 
     private AvroSink bind(

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroEnvelopeTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroEnvelopeTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.avro;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+
+class AvroEnvelopeTest
+{
+    private static final int SRC_OFFSET = 5;
+    private static final int DST_OFFSET = 7;
+
+    // "foo": length 3 (zigzag varint 0x06) followed by the three bytes
+    private static final byte[] FOO = { 0x06, 0x66, 0x6f, 0x6f };
+
+    @Test
+    void shouldReadEmptyAndDiscardWritesWhenNone()
+    {
+        AvroEnvelope envelope = AvroEnvelope.NONE;
+
+        envelope.set("trace", buffer("one"));
+
+        assertEquals(0, envelope.count("trace"));
+        assertNull(envelope.get("trace", 0));
+    }
+
+    @Test
+    void shouldSupplyNoneToStageWhenPipelineHasNoEnvelope()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        Observing observing = new Observing();
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(observing)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        transform(pipeline);
+
+        assertSame(AvroEnvelope.NONE, observing.envelope);
+    }
+
+    @Test
+    void shouldReadEnvelopeSuppliedToPipelineFromStage()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        Metadata envelope = new Metadata();
+        envelope.set("trace", buffer("one"));
+        envelope.set("trace", buffer("two"));
+
+        Reading reading = new Reading("trace");
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(reading)
+            .envelope(envelope)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        transform(pipeline);
+
+        assertEquals(List.of("one", "two"), reading.read);
+    }
+
+    @Test
+    void shouldWriteEnvelopeSuppliedToPipelineFromStage()
+    {
+        AvroSchema schema = Avro.schema("\"string\"");
+        Metadata envelope = new Metadata();
+
+        AvroPipeline pipeline = Avro.stream(Avro.parser(schema))
+            .transform(new Writing("seen"))
+            .envelope(envelope)
+            .into(generatorFor(schema));
+        pipeline.reset();
+
+        transform(pipeline);
+
+        assertEquals(1, envelope.count("seen"));
+        assertEquals("foo", text(envelope.get("seen", 0)));
+    }
+
+    @Test
+    void shouldAccumulateRepeatedValuesUnderOneName()
+    {
+        Metadata envelope = new Metadata();
+
+        envelope.set("trace", buffer("one"));
+        envelope.set("trace", buffer("two"));
+
+        assertEquals(2, envelope.count("trace"));
+        assertEquals("one", text(envelope.get("trace", 0)));
+        assertEquals("two", text(envelope.get("trace", 1)));
+        assertEquals(0, envelope.count("absent"));
+        assertNull(envelope.get("trace", 2));
+    }
+
+    private static void transform(
+        AvroPipeline pipeline)
+    {
+        MutableDirectBufferEx src = new UnsafeBufferEx(new byte[SRC_OFFSET + FOO.length]);
+        src.putBytes(SRC_OFFSET, FOO);
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[DST_OFFSET + 64]);
+
+        pipeline.transform(src, SRC_OFFSET, SRC_OFFSET + FOO.length, true, dst, DST_OFFSET, DST_OFFSET + 64);
+    }
+
+    private static AvroGenerator generatorFor(
+        AvroSchema schema)
+    {
+        return Avro.generator(schema, new UnsafeBufferEx(new byte[1]), 0);
+    }
+
+    private static DirectBufferEx buffer(
+        String value)
+    {
+        return new UnsafeBufferEx(value.getBytes(UTF_8));
+    }
+
+    private static String text(
+        DirectBufferEx value)
+    {
+        return value.getStringWithoutLengthUtf8(0, value.capacity());
+    }
+
+    // the envelope a caller supplies to the pipeline, backed by a copy of each value it is given
+    private static final class Metadata implements AvroEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        @Override
+        public int count(
+            String name)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
+    }
+
+    // captures the envelope the pipeline supplies, without touching its contents
+    private static final class Observing implements AvroTransform
+    {
+        private AvroEnvelope envelope;
+
+        @Override
+        public AvroPipeline.Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            envelope = control.envelope();
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // reads every value the envelope carries under one name, as the value opens
+    private static final class Reading implements AvroTransform
+    {
+        private final String name;
+        private final List<String> read = new ArrayList<>();
+
+        private Reading(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public AvroPipeline.Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            if (read.isEmpty())
+            {
+                AvroEnvelope envelope = control.envelope();
+                int count = envelope.count(name);
+                for (int index = 0; index < count; index++)
+                {
+                    read.add(text(envelope.get(name, index)));
+                }
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // writes each string value it observes into the envelope under one name
+    private static final class Writing implements AvroTransform
+    {
+        private final String name;
+
+        private Writing(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public AvroPipeline.Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            if (event == AvroEvent.STRING)
+            {
+                control.envelope().set(name, buffer(source.getString()));
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
@@ -28,6 +28,19 @@ public interface JsonController
     void segmentable();
 
     /**
+     * Returns the metadata travelling alongside the value being transformed, addressed by name rather than
+     * by position within the value. The default is {@link JsonEnvelope#NONE}, in force when no envelope
+     * was supplied to the pipeline, so a stage reads an empty envelope rather than no envelope at all. A
+     * mediating stage may supply its own to its downstream.
+     *
+     * @return the envelope in force for this pipeline
+     */
+    default JsonEnvelope envelope()
+    {
+        return JsonEnvelope.NONE;
+    }
+
+    /**
      * Opts in to receiving {@link JsonEvent#isVerbatim()} events: the caller is willing to read the current
      * value (and the run it coalesces into) as original source bytes via {@link JsonSource#getVerbatim(int)}
      * <em>alongside</em> the structured event stream, rather than re-serializing it canonically. Peer of

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEnvelope.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonEnvelope.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.json;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The metadata travelling alongside a value, addressed by name rather than by position within the value.
+ * <p>
+ * An {@code JsonEnvelope} is a named, ordered, repeatable list of byte values and nothing more: it never
+ * interprets what any name means, and whether a name occurs zero, one, or many times is entirely up to
+ * whatever populates and consumes it. Its contents are not part of the value, so nothing an
+ * {@link JsonStream} pipeline parses, validates, or generates reads or writes it — only a stage that asks
+ * for it does.
+ * </p>
+ * <p>
+ * An envelope is supplied once, at {@link JsonStream#envelope(JsonEnvelope)} time, so the pipeline binds
+ * to it as it is assembled rather than receiving it again per value. The supplier owns its lifecycle and
+ * decides the scope its contents describe, clearing or repointing them through its own type as that scope
+ * turns over. A pipeline reads and writes whatever the envelope holds while it runs and never resets it.
+ * </p>
+ * <p>
+ * An envelope is confined to the same single thread as the pipeline it is supplied to.
+ * </p>
+ *
+ * @see JsonController#envelope()
+ */
+public interface JsonEnvelope
+{
+    /**
+     * Empty envelope, in force when no envelope is supplied to a pipeline. It reads as empty and discards
+     * what is written to it, so a stage reaches for the envelope the same way whether or not one is
+     * backing it.
+     */
+    JsonEnvelope NONE = new JsonEnvelope()
+    {
+        @Override
+        public int count(
+            String name)
+        {
+            return 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            return null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+        }
+    };
+
+    /**
+     * Returns how many values the envelope holds under {@code name}.
+     *
+     * @param name  the name to count the values of
+     * @return the number of values held under {@code name}, {@code 0} when the name is absent
+     */
+    int count(
+        String name);
+
+    /**
+     * Returns the value held under {@code name} at {@code index}, where the values under one name are
+     * ordered by the {@link #set(String, DirectBufferEx)} calls that added them and {@code index} runs
+     * from {@code 0} to {@link #count(String)} exclusive.
+     * <p>
+     * The buffer returned is a non-owning view valid only while the envelope is in scope; a consumer that
+     * needs the bytes beyond that must copy them out.
+     * </p>
+     *
+     * @param name   the name to read a value of
+     * @param index  the position of the value among those held under {@code name}
+     * @return the value at that position, or {@code null} when the name holds no value there
+     */
+    DirectBufferEx get(
+        String name,
+        int index);
+
+    /**
+     * Adds {@code value} to the values held under {@code name}, so a repeated call under one name adds a
+     * further occurrence rather than overwriting the one before it — {@link #count(String)} grows by one
+     * per call and each value stays retrievable by its own {@link #get(String, int)} index.
+     * <p>
+     * The bytes are copied out before the call returns, so the caller may reuse {@code value} immediately
+     * afterwards.
+     * </p>
+     *
+     * @param name   the name to add a value under
+     * @param value  the value bytes to add
+     */
+    void set(
+        String name,
+        DirectBufferEx value);
+}

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonStream.java
@@ -46,6 +46,15 @@ public interface JsonStream extends JsonTransformable<JsonStream>
     JsonStream reporting(
         JsonReporter reporter);
 
+    /**
+     * Binds the pipeline to the {@link JsonEnvelope} its stages read and write named metadata through,
+     * reachable from any stage via {@link JsonController#envelope()}. The last bound envelope wins; the
+     * default is {@link JsonEnvelope#NONE}, which reads as empty and discards writes, so a pipeline
+     * assembled without one costs a stage that never asks for it nothing.
+     */
+    JsonStream envelope(
+        JsonEnvelope envelope);
+
     JsonPipeline into(
         JsonSink sink);
 

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -24,6 +24,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonController;
 import io.aklivity.zilla.runtime.common.json.JsonDiagnostic;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
@@ -64,12 +65,13 @@ public final class JsonPipelineImpl implements JsonPipeline
         JsonSink root,
         JsonReporter reporter,
         JsonGeneratorEx generator,
-        boolean lenient)
+        boolean lenient,
+        JsonEnvelope envelope)
     {
         this.parser = parser;
         // the source view and the upstream controller a stage steers are adapters over the parser surface
         this.source = new Source(parser);
-        this.control = new Control(parser);
+        this.control = new Control(parser, envelope);
         this.root = root;
         this.reporter = reporter;
         this.diagnostic = new Diagnostic();
@@ -324,13 +326,22 @@ public final class JsonPipelineImpl implements JsonPipeline
     private static final class Control implements JsonController
     {
         private final JsonParserEx parser;
+        private final JsonEnvelope envelope;
 
         private boolean segmented;
 
         private Control(
-            JsonParserEx parser)
+            JsonParserEx parser,
+            JsonEnvelope envelope)
         {
             this.parser = parser;
+            this.envelope = envelope;
+        }
+
+        @Override
+        public JsonEnvelope envelope()
+        {
+            return envelope;
         }
 
         @Override

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonStreamImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.aklivity.zilla.runtime.common.json.JsonController;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
 import io.aklivity.zilla.runtime.common.json.JsonEvent;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonParserEx;
@@ -42,6 +43,7 @@ public final class JsonStreamImpl implements JsonStream
     private final List<JsonTransform> transforms;
 
     private JsonReporter reporter = JsonReporter.NONE;
+    private JsonEnvelope envelope = JsonEnvelope.NONE;
     private boolean lenient;
 
     public JsonStreamImpl(
@@ -76,10 +78,18 @@ public final class JsonStreamImpl implements JsonStream
     }
 
     @Override
+    public JsonStream envelope(
+        JsonEnvelope envelope)
+    {
+        this.envelope = envelope != null ? envelope : JsonEnvelope.NONE;
+        return this;
+    }
+
+    @Override
     public JsonPipeline into(
         JsonSink sink)
     {
-        return new JsonPipelineImpl(parser, bind(sink), reporter, null, lenient);
+        return new JsonPipelineImpl(parser, bind(sink), reporter, null, lenient, envelope);
     }
 
     @Override
@@ -88,7 +98,7 @@ public final class JsonStreamImpl implements JsonStream
     {
         // the generator self-wraps an empty buffer on construction, so it is already in a sink-safe
         // state here; transform re-targets it at the caller's destination per call
-        return new JsonPipelineImpl(parser, bind(new JsonSinkImpl(generator)), reporter, generator, lenient);
+        return new JsonPipelineImpl(parser, bind(new JsonSinkImpl(generator)), reporter, generator, lenient, envelope);
     }
 
     @Override
@@ -97,7 +107,7 @@ public final class JsonStreamImpl implements JsonStream
         Map<String, ?> config)
     {
         boolean canonical = config.get(JsonSink.DELIVERY) == JsonSink.Delivery.STRUCTURED;
-        return new JsonPipelineImpl(parser, bind(new JsonSinkImpl(generator, canonical)), reporter, generator, lenient);
+        return new JsonPipelineImpl(parser, bind(new JsonSinkImpl(generator, canonical)), reporter, generator, lenient, envelope);
     }
 
     private JsonSink bind(

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufController.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufController.java
@@ -27,6 +27,19 @@ public interface ProtobufController
     void segmentable();
 
     /**
+     * Returns the metadata travelling alongside the value being transformed, addressed by name rather than
+     * by position within the value. The default is {@link ProtobufEnvelope#NONE}, in force when no envelope
+     * was supplied to the pipeline, so a stage reads an empty envelope rather than no envelope at all. A
+     * mediating stage may supply its own to its downstream.
+     *
+     * @return the envelope in force for this pipeline
+     */
+    default ProtobufEnvelope envelope()
+    {
+        return ProtobufEnvelope.NONE;
+    }
+
+    /**
      * Reports {@code sourceBytes} source bytes consumed by a verbatim segment write so the upstream advances
      * past them and re-exposes the value's remainder from {@link ProtobufSource#segment()} on resume — the
      * pushback that lets a bounded sink stream a length-delimited value without tracking its own write cursor.

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufEnvelope.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufEnvelope.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+
+/**
+ * The metadata travelling alongside a value, addressed by name rather than by position within the value.
+ * <p>
+ * An {@code ProtobufEnvelope} is a named, ordered, repeatable list of byte values and nothing more: it never
+ * interprets what any name means, and whether a name occurs zero, one, or many times is entirely up to
+ * whatever populates and consumes it. Its contents are not part of the value, so nothing an
+ * {@link ProtobufStream} pipeline parses, validates, or generates reads or writes it — only a stage that asks
+ * for it does.
+ * </p>
+ * <p>
+ * An envelope is supplied once, at {@link ProtobufStream#envelope(ProtobufEnvelope)} time, so the pipeline binds
+ * to it as it is assembled rather than receiving it again per value. The supplier owns its lifecycle and
+ * decides the scope its contents describe, clearing or repointing them through its own type as that scope
+ * turns over. A pipeline reads and writes whatever the envelope holds while it runs and never resets it.
+ * </p>
+ * <p>
+ * An envelope is confined to the same single thread as the pipeline it is supplied to.
+ * </p>
+ *
+ * @see ProtobufController#envelope()
+ */
+public interface ProtobufEnvelope
+{
+    /**
+     * Empty envelope, in force when no envelope is supplied to a pipeline. It reads as empty and discards
+     * what is written to it, so a stage reaches for the envelope the same way whether or not one is
+     * backing it.
+     */
+    ProtobufEnvelope NONE = new ProtobufEnvelope()
+    {
+        @Override
+        public int count(
+            String name)
+        {
+            return 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            return null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+        }
+    };
+
+    /**
+     * Returns how many values the envelope holds under {@code name}.
+     *
+     * @param name  the name to count the values of
+     * @return the number of values held under {@code name}, {@code 0} when the name is absent
+     */
+    int count(
+        String name);
+
+    /**
+     * Returns the value held under {@code name} at {@code index}, where the values under one name are
+     * ordered by the {@link #set(String, DirectBufferEx)} calls that added them and {@code index} runs
+     * from {@code 0} to {@link #count(String)} exclusive.
+     * <p>
+     * The buffer returned is a non-owning view valid only while the envelope is in scope; a consumer that
+     * needs the bytes beyond that must copy them out.
+     * </p>
+     *
+     * @param name   the name to read a value of
+     * @param index  the position of the value among those held under {@code name}
+     * @return the value at that position, or {@code null} when the name holds no value there
+     */
+    DirectBufferEx get(
+        String name,
+        int index);
+
+    /**
+     * Adds {@code value} to the values held under {@code name}, so a repeated call under one name adds a
+     * further occurrence rather than overwriting the one before it — {@link #count(String)} grows by one
+     * per call and each value stays retrievable by its own {@link #get(String, int)} index.
+     * <p>
+     * The bytes are copied out before the call returns, so the caller may reuse {@code value} immediately
+     * afterwards.
+     * </p>
+     *
+     * @param name   the name to add a value under
+     * @param value  the value bytes to add
+     */
+    void set(
+        String name,
+        DirectBufferEx value);
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufStream.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufStream.java
@@ -46,6 +46,15 @@ public interface ProtobufStream extends ProtobufTransformable<ProtobufStream>
     ProtobufStream reporting(
         ProtobufReporter reporter);
 
+    /**
+     * Binds the pipeline to the {@link ProtobufEnvelope} its stages read and write named metadata through,
+     * reachable from any stage via {@link ProtobufController#envelope()}. The last bound envelope wins; the
+     * default is {@link ProtobufEnvelope#NONE}, which reads as empty and discards writes, so a pipeline
+     * assembled without one costs a stage that never asks for it nothing.
+     */
+    ProtobufStream envelope(
+        ProtobufEnvelope envelope);
+
     ProtobufPipeline into(
         ProtobufSink sink);
 

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufPipelineImpl.java
@@ -20,6 +20,7 @@ import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufDiagnostic;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
@@ -48,6 +49,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     private final ProtobufParser parser;
     private final Source source;
     private final Control control;
+    private final ProtobufEnvelope envelope;
     private final ProtobufSink head;
     private final ProtobufReporter reporter;
     private final Diagnostic diagnostic;
@@ -67,7 +69,8 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         ProtobufSink sink,
         ProtobufReporter reporter,
         ProtobufGenerator generator,
-        boolean lenient)
+        boolean lenient,
+        ProtobufEnvelope envelope)
     {
         this.parser = parser;
         this.reporter = reporter;
@@ -79,6 +82,7 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
         // that records a stage's segment request which the pump turns into the SEGMENTED mode on the next pull
         this.source = new Source(parser);
         this.control = new Control();
+        this.envelope = envelope;
 
         ProtobufSink chain = sink;
         for (int i = transforms.size() - 1; i >= 0; i--)
@@ -330,6 +334,12 @@ public final class ProtobufPipelineImpl implements ProtobufPipeline
     private final class Control implements ProtobufController
     {
         private boolean segmented;
+
+        @Override
+        public ProtobufEnvelope envelope()
+        {
+            return envelope;
+        }
 
         @Override
         public void segmentable()

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufStreamImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufStreamImpl.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.common.protobuf.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
@@ -36,6 +37,7 @@ public final class ProtobufStreamImpl implements ProtobufStream
     private final List<ProtobufTransform> transforms;
 
     private ProtobufReporter reporter = ProtobufReporter.NONE;
+    private ProtobufEnvelope envelope = ProtobufEnvelope.NONE;
     private boolean lenient;
 
     public ProtobufStreamImpl(
@@ -70,10 +72,18 @@ public final class ProtobufStreamImpl implements ProtobufStream
     }
 
     @Override
+    public ProtobufStream envelope(
+        ProtobufEnvelope envelope)
+    {
+        this.envelope = envelope != null ? envelope : ProtobufEnvelope.NONE;
+        return this;
+    }
+
+    @Override
     public ProtobufPipeline into(
         ProtobufSink sink)
     {
-        return new ProtobufPipelineImpl(parser, transforms, sink, reporter, null, lenient);
+        return new ProtobufPipelineImpl(parser, transforms, sink, reporter, null, lenient, envelope);
     }
 
     @Override
@@ -81,7 +91,7 @@ public final class ProtobufStreamImpl implements ProtobufStream
         ProtobufGenerator generator)
     {
         // the pipeline owns the generator and re-targets it at the caller's destination per transform call
-        return new ProtobufPipelineImpl(parser, transforms, ProtobufSink.of(generator), reporter, generator, lenient);
+        return new ProtobufPipelineImpl(parser, transforms, ProtobufSink.of(generator), reporter, generator, lenient, envelope);
     }
 
     @Override
@@ -92,6 +102,6 @@ public final class ProtobufStreamImpl implements ProtobufStream
     {
         // the pipeline owns the generator and re-targets it at the caller's destination per transform call
         return new ProtobufPipelineImpl(parser, transforms, ProtobufSink.of(generator, schema, messageName), reporter,
-            generator, lenient);
+            generator, lenient, envelope);
     }
 }

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -21,6 +21,7 @@ import org.agrona.collections.Int2ObjectCache;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.avro.AvroDiagnostic;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
 import io.aklivity.zilla.runtime.common.avro.AvroPipelineResult;
@@ -45,6 +46,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
     private final AvroModelHandlerImpl handler;
     private final JsonGeneratorEx generator;
     private final AvroTransform adapter;
+    private final AvroEnvelope envelope;
     private final Int2ObjectCache<AvroPipeline> pipelines;
     private final ModelPipelineResult result;
 
@@ -53,9 +55,11 @@ final class AvroModelDecoderPipeline implements ModelPipeline
 
     AvroModelDecoderPipeline(
         AvroModelHandlerImpl handler,
+        AvroEnvelope envelope,
         ModelTransform transform)
     {
         this.handler = handler;
+        this.envelope = envelope;
         this.generator = JsonEx.createGenerator();
         this.adapter = AvroModelTransform.of(transform);
         this.pipelines = new Int2ObjectCache<>(1, 16, p -> {});
@@ -153,7 +157,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         int schemaId)
     {
         return pipelines.computeIfAbsent(schemaId,
-            id -> handler.newPipeline(id, handler.decodeLenient, generator, adapter, this::onRejected));
+            id -> handler.newPipeline(id, handler.decodeLenient, generator, adapter, this::onRejected, envelope));
     }
 
     private void onRejected(

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
@@ -19,6 +19,7 @@ import org.agrona.collections.Int2ObjectCache;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.avro.AvroDiagnostic;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
 import io.aklivity.zilla.runtime.common.avro.AvroPipelineResult;
@@ -39,6 +40,7 @@ final class AvroModelEncoderPipeline implements ModelPipeline
 
     private final AvroModelHandlerImpl handler;
     private final AvroTransform adapter;
+    private final AvroEnvelope envelope;
     private final Int2ObjectCache<AvroPipeline> pipelines;
     private final ModelPipelineResult result;
 
@@ -49,9 +51,11 @@ final class AvroModelEncoderPipeline implements ModelPipeline
 
     AvroModelEncoderPipeline(
         AvroModelHandlerImpl handler,
+        AvroEnvelope envelope,
         ModelTransform transform)
     {
         this.handler = handler;
+        this.envelope = envelope;
         this.adapter = AvroModelTransform.of(transform);
         this.pipelines = new Int2ObjectCache<>(1, 16, p -> {});
         this.result = new ModelPipelineResult();
@@ -172,7 +176,7 @@ final class AvroModelEncoderPipeline implements ModelPipeline
         int schemaId)
     {
         return pipelines.computeIfAbsent(schemaId,
-            id -> handler.newPipeline(id, handler.encodeLenient, adapter, this::onRejected));
+            id -> handler.newPipeline(id, handler.encodeLenient, adapter, this::onRejected, envelope));
     }
 
     private void onRejected(

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEnvelope.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEnvelope.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.avro.internal;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+
+// The model-avro adapter between the engine's ModelEnvelope, supplied to a pipeline by the caller driving
+// it, and the AvroEnvelope a common-avro stage reads and writes through its own controller. Both describe
+// the same named, ordered, repeatable byte values, so this forwards each call unchanged; it exists only to
+// bridge two vocabularies that cannot name each other. Bound once, as the pipeline is assembled, so no
+// per-value or per-call adaptation happens on the hot path.
+final class AvroModelEnvelope implements AvroEnvelope
+{
+    private final ModelEnvelope delegate;
+
+    // NONE on either side is the same contract — reads empty, discards writes — so a caller that supplies
+    // none leaves the stages reading common-avro's own NONE rather than a wrapper around the engine's
+    static AvroEnvelope of(
+        ModelEnvelope envelope)
+    {
+        return envelope == ModelEnvelope.NONE ? AvroEnvelope.NONE : new AvroModelEnvelope(envelope);
+    }
+
+    private AvroModelEnvelope(
+        ModelEnvelope delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int count(
+        String name)
+    {
+        return delegate.count(name);
+    }
+
+    @Override
+    public DirectBufferEx get(
+        String name,
+        int index)
+    {
+        return delegate.get(name, index);
+    }
+
+    @Override
+    public void set(
+        String name,
+        DirectBufferEx value)
+    {
+        delegate.set(name, value);
+    }
+}

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -23,6 +23,7 @@ import io.aklivity.zilla.config.model.avro.AvroModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
 import io.aklivity.zilla.runtime.common.avro.Avro;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
 import io.aklivity.zilla.runtime.common.avro.AvroGenerator;
 import io.aklivity.zilla.runtime.common.avro.AvroPipeline;
 import io.aklivity.zilla.runtime.common.avro.AvroReporter;
@@ -70,9 +71,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new AvroModelDecoderPipeline(this, requireNonNull(transform));
+        return new AvroModelDecoderPipeline(this, AvroModelEnvelope.of(requireNonNull(envelope)), requireNonNull(transform));
     }
 
     @Override
@@ -80,9 +79,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new AvroModelEncoderPipeline(this, requireNonNull(transform));
+        return new AvroModelEncoderPipeline(this, AvroModelEnvelope.of(requireNonNull(envelope)), requireNonNull(transform));
     }
 
     int decodePadding(
@@ -169,7 +166,8 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         boolean lenient,
         JsonGeneratorEx json,
         AvroTransform adapter,
-        AvroReporter reporter)
+        AvroReporter reporter,
+        AvroEnvelope envelope)
     {
         AvroSchema schema = supplySchema(schemaId);
         AvroPipeline pipeline = null;
@@ -184,6 +182,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
                 .transform(adapter)
                 .lenient(lenient)
                 .reporting(reporter)
+                .envelope(envelope)
                 .into(generator);
         }
         return pipeline;
@@ -193,7 +192,8 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         int schemaId,
         boolean lenient,
         AvroTransform adapter,
-        AvroReporter reporter)
+        AvroReporter reporter,
+        AvroEnvelope envelope)
     {
         AvroSchema schema = supplySchema(schemaId);
         AvroPipeline pipeline = null;
@@ -209,6 +209,7 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
                 .transform(adapter)
                 .lenient(lenient)
                 .reporting(reporter)
+                .envelope(envelope)
                 .into(Avro.generator(schema, new UnsafeBufferEx(new byte[1]), 0));
         }
         return pipeline;

--- a/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEnvelopeTest.java
+++ b/runtime/model-avro/src/test/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEnvelopeTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.avro.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.avro.AvroModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.avro.AvroController;
+import io.aklivity.zilla.runtime.common.avro.AvroEnvelope;
+import io.aklivity.zilla.runtime.common.avro.AvroEvent;
+import io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status;
+import io.aklivity.zilla.runtime.common.avro.AvroSink;
+import io.aklivity.zilla.runtime.common.avro.AvroSource;
+import io.aklivity.zilla.runtime.common.avro.AvroTransform;
+import io.aklivity.zilla.runtime.common.avro.AvroTransformable;
+import io.aklivity.zilla.runtime.engine.Configuration;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEvent;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelSink;
+import io.aklivity.zilla.runtime.engine.model.ModelSource;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtContext;
+import io.aklivity.zilla.runtime.model.avro.ext.AvroModelExtHandler;
+
+public class AvroModelEnvelopeTest
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String SCHEMA = """
+        {
+            "fields":
+            [
+                { "name": "id", "type": "string" }
+            ],
+            "name": "Event",
+            "namespace": "io.aklivity.example",
+            "type": "record"
+        }""";
+
+    // id="id0" (len 3)
+    private static final byte[] AVRO = {0x06, 0x69, 0x64, 0x30};
+
+    private EngineContext context;
+    private AvroModelConfiguration config;
+
+    @Before
+    public void init()
+    {
+        config = new AvroModelConfiguration(new Configuration());
+        context = mock(EngineContext.class);
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+        envelope.set("mark", buffer("two"));
+
+        AvroModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertEquals(2, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+        assertEquals("two", text(envelope.get("echo", 1)));
+    }
+
+    @Test
+    public void shouldWriteEnvelopeSuppliedToEncoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+
+        AvroModelHandlerImpl handler = newHandler(List.of(capturingExt("captured")));
+        ModelPipeline pipeline = handler.supplyEncoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertEquals(1, envelope.count("captured"));
+        assertEquals("id0", text(envelope.get("captured", 0)));
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStageAndModelTransform()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+
+        // the caller composes its own generic stage over the same envelope it supplies to the pipeline, so
+        // both vocabularies observe one store
+        Reading reading = new Reading(envelope, "mark");
+        AvroModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, reading);
+
+        transform(pipeline);
+
+        assertEquals(List.of("one"), reading.read);
+        assertEquals(1, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+    }
+
+    @Test
+    public void shouldSupplyNoneToFormatNativeStageWhenCallerSuppliesNone()
+    {
+        Observing observing = new Observing();
+
+        AvroModelHandlerImpl handler = newHandler(List.of(observingExt(observing)));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertSame(AvroEnvelope.NONE, observing.envelope);
+    }
+
+    private static void transform(
+        ModelPipeline pipeline)
+    {
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(AVRO), 0, AVRO.length, dst, 0, dst.capacity());
+    }
+
+    private AvroModelHandlerImpl newHandler(
+        List<AvroModelExtContext> exts)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(9)
+                .schema(SCHEMA)
+                .build()
+            .build();
+        AvroModelConfig model = AvroModelConfig.builder()
+            .catalog()
+                .name("test0")
+                    .schema()
+                        .strategy("topic")
+                        .version("latest")
+                        .subject("test-value")
+                        .build()
+                .build()
+            .build();
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new AvroModelHandlerImpl(config, model, context, exts);
+    }
+
+    // an extension whose format-native stage echoes every value the envelope carries under one name back
+    // under another, so what a stage read is observable from the envelope the caller supplied
+    private static AvroModelExtContext echoingExt(
+        String source,
+        String target)
+    {
+        return (schema, options) -> new AvroModelExtHandler()
+        {
+            private final AvroTransform transform = new Echoing(source, target);
+
+            @Override
+            public <T extends AvroTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends AvroTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    // an extension whose format-native stage writes each string value it observes into the envelope
+    private static AvroModelExtContext capturingExt(
+        String name)
+    {
+        return (schema, options) -> new AvroModelExtHandler()
+        {
+            private final AvroTransform transform = new Capturing(name);
+
+            @Override
+            public <T extends AvroTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends AvroTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    private static AvroModelExtContext observingExt(
+        AvroTransform observing)
+    {
+        return (schema, options) -> new AvroModelExtHandler()
+        {
+            @Override
+            public <T extends AvroTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(observing);
+            }
+        };
+    }
+
+    private static DirectBufferEx buffer(
+        String value)
+    {
+        return new UnsafeBufferEx(value.getBytes(UTF_8));
+    }
+
+    private static String text(
+        DirectBufferEx value)
+    {
+        return value.getStringWithoutLengthUtf8(0, value.capacity());
+    }
+
+    // the envelope a caller supplies to the pipeline, backed by a copy of each value it is given
+    private static final class Metadata implements ModelEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        @Override
+        public int count(
+            String name)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
+    }
+
+    // format-native stage: copies every value under one name to another, once per datum
+    private static final class Echoing implements AvroTransform
+    {
+        private final String source;
+        private final String target;
+
+        private boolean echoed;
+
+        private Echoing(
+            String source,
+            String target)
+        {
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public Status transform(
+            AvroController control,
+            AvroSource avroSource,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            if (!echoed)
+            {
+                echoed = true;
+                AvroEnvelope envelope = control.envelope();
+                int count = envelope.count(source);
+                for (int index = 0; index < count; index++)
+                {
+                    envelope.set(target, envelope.get(source, index));
+                }
+            }
+            return sink.transform(control, avroSource, event);
+        }
+
+        @Override
+        public void reset()
+        {
+            echoed = false;
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: writes each string value it observes into the envelope under one name
+    private static final class Capturing implements AvroTransform
+    {
+        private final String name;
+
+        private Capturing(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            if (event == AvroEvent.STRING)
+            {
+                control.envelope().set(name, buffer(source.getString()));
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: captures the envelope the pipeline supplies, without touching its contents
+    private static final class Observing implements AvroTransform
+    {
+        private AvroEnvelope envelope;
+
+        @Override
+        public Status transform(
+            AvroController control,
+            AvroSource source,
+            AvroEvent event,
+            AvroSink sink)
+        {
+            envelope = control.envelope();
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // a generic stage the caller composes over the same envelope it supplies to the pipeline
+    private static final class Reading implements ModelTransform
+    {
+        private final ModelEnvelope envelope;
+        private final String name;
+        private final List<String> read = new ArrayList<>();
+
+        private Reading(
+            ModelEnvelope envelope,
+            String name)
+        {
+            this.envelope = envelope;
+            this.name = name;
+        }
+
+        @Override
+        public ModelStatus transform(
+            ModelController control,
+            ModelSource source,
+            ModelEvent event,
+            ModelSink sink)
+        {
+            if (read.isEmpty())
+            {
+                int count = envelope.count(name);
+                for (int index = 0; index < count; index++)
+                {
+                    read.add(text(envelope.get(name, index)));
+                }
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+}

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -21,6 +21,7 @@ import org.agrona.collections.Int2ObjectCache;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonDiagnostic;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
@@ -47,6 +48,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
     private final JsonGeneratorEx generator;
     private final JsonExtractor extractor;
     private final Int2ObjectCache<JsonPipeline> pipelines;
+    private final JsonEnvelope envelope;
     private final ModelPipelineResult result;
 
     private JsonPipeline active;
@@ -58,8 +60,10 @@ final class JsonModelDecoderPipeline implements ModelPipeline
 
     JsonModelDecoderPipeline(
         JsonModelHandlerImpl handler,
+        JsonEnvelope envelope,
         ModelTransform transform)
     {
+        this.envelope = envelope;
         this.handler = handler;
         this.bridge = transform != ModelTransform.NONE ? new ModelFieldBridge(transform) : null;
         this.generator = JsonEx.createGenerator();
@@ -172,7 +176,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         int schemaId)
     {
         return pipelines.computeIfAbsent(schemaId,
-            id -> handler.newPipeline(id, handler.decodeLenient, generator, extractor, this::onRejected));
+            id -> handler.newPipeline(id, handler.decodeLenient, generator, extractor, this::onRejected, envelope));
     }
 
     private void onRejected(

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
@@ -19,6 +19,7 @@ import org.agrona.collections.Int2ObjectCache;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonDiagnostic;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
@@ -39,6 +40,7 @@ final class JsonModelEncoderPipeline implements ModelPipeline
     private final JsonModelHandlerImpl handler;
     private final JsonGeneratorEx generator;
     private final Int2ObjectCache<JsonPipeline> pipelines;
+    private final JsonEnvelope envelope;
     private final ModelPipelineResult result;
 
     private JsonPipeline active;
@@ -51,8 +53,10 @@ final class JsonModelEncoderPipeline implements ModelPipeline
     private long bindingId;
 
     JsonModelEncoderPipeline(
-        JsonModelHandlerImpl handler)
+        JsonModelHandlerImpl handler,
+        JsonEnvelope envelope)
     {
+        this.envelope = envelope;
         this.handler = handler;
         this.generator = JsonEx.createGenerator();
         this.pipelines = new Int2ObjectCache<>(1, 16, p -> {});
@@ -171,7 +175,7 @@ final class JsonModelEncoderPipeline implements ModelPipeline
         int schemaId)
     {
         return pipelines.computeIfAbsent(schemaId,
-            id -> handler.newPipeline(id, handler.encodeLenient, generator, this::onRejected));
+            id -> handler.newPipeline(id, handler.encodeLenient, generator, this::onRejected, envelope));
     }
 
     private void onRejected(

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEnvelope.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEnvelope.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.json.internal;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+
+// The model-json adapter between the engine's ModelEnvelope, supplied to a pipeline by the caller driving
+// it, and the JsonEnvelope a common-json stage reads and writes through its own controller. Both describe
+// the same named, ordered, repeatable byte values, so this forwards each call unchanged; it exists only to
+// bridge two vocabularies that cannot name each other. Bound once, as the pipeline is assembled, so no
+// per-value or per-call adaptation happens on the hot path.
+final class JsonModelEnvelope implements JsonEnvelope
+{
+    private final ModelEnvelope delegate;
+
+    // NONE on either side is the same contract — reads empty, discards writes — so a caller that supplies
+    // none leaves the stages reading common-json's own NONE rather than a wrapper around the engine's
+    static JsonEnvelope of(
+        ModelEnvelope envelope)
+    {
+        return envelope == ModelEnvelope.NONE ? JsonEnvelope.NONE : new JsonModelEnvelope(envelope);
+    }
+
+    private JsonModelEnvelope(
+        ModelEnvelope delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int count(
+        String name)
+    {
+        return delegate.count(name);
+    }
+
+    @Override
+    public DirectBufferEx get(
+        String name,
+        int index)
+    {
+        return delegate.get(name, index);
+    }
+
+    @Override
+    public void set(
+        String name,
+        DirectBufferEx value)
+    {
+        delegate.set(name, value);
+    }
+}

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import io.aklivity.zilla.config.model.json.JsonModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.json.JsonGeneratorEx;
 import io.aklivity.zilla.runtime.common.json.JsonPipeline;
@@ -71,9 +72,7 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new JsonModelDecoderPipeline(this, requireNonNull(transform));
+        return new JsonModelDecoderPipeline(this, JsonModelEnvelope.of(requireNonNull(envelope)), requireNonNull(transform));
     }
 
     @Override
@@ -81,9 +80,7 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new JsonModelEncoderPipeline(this);
+        return new JsonModelEncoderPipeline(this, JsonModelEnvelope.of(requireNonNull(envelope)));
     }
 
     int decodePadding(
@@ -175,7 +172,8 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
         boolean lenient,
         JsonGeneratorEx generator,
         JsonTransform extractor,
-        JsonReporter reporter)
+        JsonReporter reporter,
+        JsonEnvelope envelope)
     {
         JsonSchema schema = supplySchema(schemaId);
         JsonStream stream = schema != null
@@ -185,6 +183,7 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
             ? (extractor != null ? stream.transform(extractor) : stream)
                 .lenient(lenient)
                 .reporting(reporter)
+                .envelope(envelope)
             : null;
         return terminal != null
             ? exts.isEmpty()
@@ -203,7 +202,8 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
         int schemaId,
         boolean lenient,
         JsonGeneratorEx generator,
-        JsonReporter reporter)
+        JsonReporter reporter,
+        JsonEnvelope envelope)
     {
         JsonSchema schema = supplySchema(schemaId);
         JsonStream terminal = schema != null
@@ -211,6 +211,7 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
                 .transform(schema.validator(lenient))
                 .lenient(lenient)
                 .reporting(reporter)
+                .envelope(envelope)
             : null;
         return terminal != null
             ? exts.isEmpty()

--- a/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEnvelopeTest.java
+++ b/runtime/model-json/src/test/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEnvelopeTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.json.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.json.JsonModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonController;
+import io.aklivity.zilla.runtime.common.json.JsonEnvelope;
+import io.aklivity.zilla.runtime.common.json.JsonEvent;
+import io.aklivity.zilla.runtime.common.json.JsonPipeline.Status;
+import io.aklivity.zilla.runtime.common.json.JsonSink;
+import io.aklivity.zilla.runtime.common.json.JsonSource;
+import io.aklivity.zilla.runtime.common.json.JsonTransform;
+import io.aklivity.zilla.runtime.common.json.JsonTransformable;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEvent;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelSink;
+import io.aklivity.zilla.runtime.engine.model.ModelSource;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.json.ext.JsonModelExtContext;
+import io.aklivity.zilla.runtime.model.json.ext.JsonModelExtHandler;
+
+public class JsonModelEnvelopeTest
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String SCHEMA = """
+        {
+            "type": "object",
+            "properties":
+            {
+                "id": { "type": "string" }
+            },
+            "required": [ "id" ]
+        }""";
+
+    private static final byte[] JSON = "{\"id\":\"id0\"}".getBytes(UTF_8);
+
+    private EngineContext context;
+
+    @Before
+    public void init()
+    {
+        context = mock(EngineContext.class);
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+        envelope.set("mark", buffer("two"));
+
+        JsonModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertEquals(2, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+        assertEquals("two", text(envelope.get("echo", 1)));
+    }
+
+    @Test
+    public void shouldWriteEnvelopeSuppliedToEncoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+
+        JsonModelHandlerImpl handler = newHandler(List.of(capturingExt("captured")));
+        ModelPipeline pipeline = handler.supplyEncoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertEquals(1, envelope.count("captured"));
+        assertEquals("id0", text(envelope.get("captured", 0)));
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStageAndModelTransform()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+
+        // the caller composes its own generic stage over the same envelope it supplies to the pipeline, so
+        // both vocabularies observe one store
+        Reading reading = new Reading(envelope, "mark");
+        JsonModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, reading);
+
+        transform(pipeline);
+
+        assertEquals(List.of("one"), reading.read);
+        assertEquals(1, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+    }
+
+    @Test
+    public void shouldSupplyNoneToFormatNativeStageWhenCallerSuppliesNone()
+    {
+        Observing observing = new Observing();
+
+        JsonModelHandlerImpl handler = newHandler(List.of(observingExt(observing)));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertSame(JsonEnvelope.NONE, observing.envelope);
+    }
+
+    private static void transform(
+        ModelPipeline pipeline)
+    {
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(JSON), 0, JSON.length, dst, 0, dst.capacity());
+    }
+
+    private JsonModelHandlerImpl newHandler(
+        List<JsonModelExtContext> exts)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(9)
+                .schema(SCHEMA)
+                .build()
+            .build();
+        JsonModelConfig model = JsonModelConfig.builder()
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .subject(null)
+                    .version("latest")
+                    .id(0)
+                    .build()
+                .build()
+            .build();
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new JsonModelHandlerImpl(model, context, exts);
+    }
+
+    // an extension whose format-native stage echoes every value the envelope carries under one name back
+    // under another, so what a stage read is observable from the envelope the caller supplied
+    private static JsonModelExtContext echoingExt(
+        String source,
+        String target)
+    {
+        return (schema, options) -> new JsonModelExtHandler()
+        {
+            private final JsonTransform transform = new Echoing(source, target);
+
+            @Override
+            public <T extends JsonTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends JsonTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    // an extension whose format-native stage writes each string value it observes into the envelope
+    private static JsonModelExtContext capturingExt(
+        String name)
+    {
+        return (schema, options) -> new JsonModelExtHandler()
+        {
+            private final JsonTransform transform = new Capturing(name);
+
+            @Override
+            public <T extends JsonTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends JsonTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    private static JsonModelExtContext observingExt(
+        JsonTransform observing)
+    {
+        return (schema, options) -> new JsonModelExtHandler()
+        {
+            @Override
+            public <T extends JsonTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(observing);
+            }
+        };
+    }
+
+    private static DirectBufferEx buffer(
+        String value)
+    {
+        return new UnsafeBufferEx(value.getBytes(UTF_8));
+    }
+
+    private static String text(
+        DirectBufferEx value)
+    {
+        return value.getStringWithoutLengthUtf8(0, value.capacity());
+    }
+
+    // the envelope a caller supplies to the pipeline, backed by a copy of each value it is given
+    private static final class Metadata implements ModelEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        @Override
+        public int count(
+            String name)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
+    }
+
+    // format-native stage: copies every value under one name to another, once per datum
+    private static final class Echoing implements JsonTransform
+    {
+        private final String source;
+        private final String target;
+
+        private boolean echoed;
+
+        private Echoing(
+            String source,
+            String target)
+        {
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public Status transform(
+            JsonController control,
+            JsonSource avroSource,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            if (!echoed)
+            {
+                echoed = true;
+                JsonEnvelope envelope = control.envelope();
+                int count = envelope.count(source);
+                for (int index = 0; index < count; index++)
+                {
+                    envelope.set(target, envelope.get(source, index));
+                }
+            }
+            return sink.transform(control, avroSource, event);
+        }
+
+        @Override
+        public void reset()
+        {
+            echoed = false;
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: writes each string value it observes into the envelope under one name
+    private static final class Capturing implements JsonTransform
+    {
+        private final String name;
+
+        private Capturing(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public Status transform(
+            JsonController control,
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            if (event == JsonEvent.VALUE_STRING)
+            {
+                control.envelope().set(name, buffer(source.getString()));
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: captures the envelope the pipeline supplies, without touching its contents
+    private static final class Observing implements JsonTransform
+    {
+        private JsonEnvelope envelope;
+
+        @Override
+        public Status transform(
+            JsonController control,
+            JsonSource source,
+            JsonEvent event,
+            JsonSink sink)
+        {
+            envelope = control.envelope();
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // a generic stage the caller composes over the same envelope it supplies to the pipeline
+    private static final class Reading implements ModelTransform
+    {
+        private final ModelEnvelope envelope;
+        private final String name;
+        private final List<String> read = new ArrayList<>();
+
+        private Reading(
+            ModelEnvelope envelope,
+            String name)
+        {
+            this.envelope = envelope;
+            this.name = name;
+        }
+
+        @Override
+        public ModelStatus transform(
+            ModelController control,
+            ModelSource source,
+            ModelEvent event,
+            ModelSink sink)
+        {
+            if (read.isEmpty())
+            {
+                int count = envelope.count(name);
+                for (int index = 0; index < count; index++)
+                {
+                    read.add(text(envelope.get(name, index)));
+                }
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufDiagnostic;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
@@ -47,6 +48,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
     private final ModelFieldBridge bridge;
     private final ProtobufExtractor extractor;
     private final Map<String, ProtobufPipeline> pipelines;
+    private final ProtobufEnvelope envelope;
     private final ModelPipelineResult result;
 
     private ProtobufPipeline active;
@@ -54,8 +56,10 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
 
     ProtobufModelDecoderPipeline(
         ProtobufModelHandlerImpl handler,
+        ProtobufEnvelope envelope,
         ModelTransform transform)
     {
+        this.envelope = envelope;
         this.handler = handler;
         this.bridge = transform != ModelTransform.NONE ? new ModelFieldBridge(transform) : null;
         // a NONE transform keeps the verbatim/SEGMENTED fast path: no extractor stage, no structured field events
@@ -175,7 +179,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
         ProtobufPipeline pipeline = pipelines.get(messageName);
         if (pipeline == null)
         {
-            pipeline = handler.newPipeline(schemaId, handler.decodeLenient, messageName, extractor, this::onRejected);
+            pipeline = handler.newPipeline(schemaId, handler.decodeLenient, messageName, extractor, this::onRejected, envelope);
             pipelines.put(messageName, pipeline);
         }
         return pipeline;

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufDiagnostic;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
@@ -39,6 +40,7 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
 
     private final ProtobufModelHandlerImpl handler;
     private final Map<String, ProtobufPipeline> pipelines;
+    private final ProtobufEnvelope envelope;
     private final ModelPipelineResult result;
 
     private ProtobufPipeline active;
@@ -47,8 +49,10 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
     private int prefixAt;
 
     ProtobufModelEncoderPipeline(
-        ProtobufModelHandlerImpl handler)
+        ProtobufModelHandlerImpl handler,
+        ProtobufEnvelope envelope)
     {
+        this.envelope = envelope;
         this.handler = handler;
         this.pipelines = new HashMap<>();
         this.result = new ModelPipelineResult();
@@ -178,7 +182,7 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
         ProtobufPipeline pipeline = pipelines.get(messageName);
         if (pipeline == null)
         {
-            pipeline = handler.newPipeline(schemaId, handler.encodeLenient, messageName, this::onRejected);
+            pipeline = handler.newPipeline(schemaId, handler.encodeLenient, messageName, this::onRejected, envelope);
             pipelines.put(messageName, pipeline);
         }
         return pipeline;

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEnvelope.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEnvelope.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+
+// The model-protobuf adapter between the engine's ModelEnvelope, supplied to a pipeline by the caller driving
+// it, and the ProtobufEnvelope a common-protobuf stage reads and writes through its own controller. Both describe
+// the same named, ordered, repeatable byte values, so this forwards each call unchanged; it exists only to
+// bridge two vocabularies that cannot name each other. Bound once, as the pipeline is assembled, so no
+// per-value or per-call adaptation happens on the hot path.
+final class ProtobufModelEnvelope implements ProtobufEnvelope
+{
+    private final ModelEnvelope delegate;
+
+    // NONE on either side is the same contract — reads empty, discards writes — so a caller that supplies
+    // none leaves the stages reading common-protobuf's own NONE rather than a wrapper around the engine's
+    static ProtobufEnvelope of(
+        ModelEnvelope envelope)
+    {
+        return envelope == ModelEnvelope.NONE ? ProtobufEnvelope.NONE : new ProtobufModelEnvelope(envelope);
+    }
+
+    private ProtobufModelEnvelope(
+        ModelEnvelope delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int count(
+        String name)
+    {
+        return delegate.count(name);
+    }
+
+    @Override
+    public DirectBufferEx get(
+        String name,
+        int index)
+    {
+        return delegate.get(name, index);
+    }
+
+    @Override
+    public void set(
+        String name,
+        DirectBufferEx value)
+    {
+        delegate.set(name, value);
+    }
+}

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -27,6 +27,7 @@ import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.json.JsonEx;
 import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
@@ -82,9 +83,8 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new ProtobufModelDecoderPipeline(this, requireNonNull(transform));
+        return new ProtobufModelDecoderPipeline(this, ProtobufModelEnvelope.of(requireNonNull(envelope)),
+            requireNonNull(transform));
     }
 
     @Override
@@ -92,9 +92,7 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        assert envelope != null;
-
-        return new ProtobufModelEncoderPipeline(this);
+        return new ProtobufModelEncoderPipeline(this, ProtobufModelEnvelope.of(requireNonNull(envelope)));
     }
 
     int decodePadding(
@@ -252,7 +250,8 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         boolean lenient,
         String messageName,
         ProtobufExtractor extractor,
-        ProtobufReporter reporter)
+        ProtobufReporter reporter,
+        ProtobufEnvelope envelope)
     {
         ProtobufSchema schema = supplySchema(schemaId);
         ProtobufPipeline pipeline = null;
@@ -268,10 +267,12 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
                     .transform(extractor)
                     .lenient(lenient)
                     .reporting(reporter)
+                    .envelope(envelope)
                     .into(generator, schema, messageName)
                 : extendDecode(Protobuf.stream(Protobuf.parser(schema, messageName)), schema)
                     .lenient(lenient)
                     .reporting(reporter)
+                    .envelope(envelope)
                     .into(generator, schema, messageName);
         }
         return pipeline;
@@ -281,7 +282,8 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         int schemaId,
         boolean lenient,
         String messageName,
-        ProtobufReporter reporter)
+        ProtobufReporter reporter,
+        ProtobufEnvelope envelope)
     {
         ProtobufSchema schema = supplySchema(schemaId);
         ProtobufPipeline pipeline = null;
@@ -296,6 +298,7 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
             pipeline = extendEncode(Protobuf.stream(parser), schema)
                 .lenient(lenient)
                 .reporting(reporter)
+                .envelope(envelope)
                 .into(Protobuf.generator(), schema, messageName);
         }
         return pipeline;

--- a/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEnvelopeTest.java
+++ b/runtime/model-protobuf/src/test/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEnvelopeTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.model.protobuf.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.GenericCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogConfig;
+import io.aklivity.zilla.config.engine.test.internal.catalog.config.TestCatalogOptionsConfig;
+import io.aklivity.zilla.config.model.protobuf.ProtobufModelConfig;
+import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufController;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEnvelope;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufEvent;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSource;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransform;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufTransformable;
+import io.aklivity.zilla.runtime.engine.EngineContext;
+import io.aklivity.zilla.runtime.engine.model.ModelController;
+import io.aklivity.zilla.runtime.engine.model.ModelEnvelope;
+import io.aklivity.zilla.runtime.engine.model.ModelEvent;
+import io.aklivity.zilla.runtime.engine.model.ModelPipeline;
+import io.aklivity.zilla.runtime.engine.model.ModelSink;
+import io.aklivity.zilla.runtime.engine.model.ModelSource;
+import io.aklivity.zilla.runtime.engine.model.ModelStatus;
+import io.aklivity.zilla.runtime.engine.model.ModelTransform;
+import io.aklivity.zilla.runtime.engine.test.internal.catalog.TestCatalogHandler;
+import io.aklivity.zilla.runtime.model.protobuf.ext.ProtobufModelExtContext;
+import io.aklivity.zilla.runtime.model.protobuf.ext.ProtobufModelExtHandler;
+
+public class ProtobufModelEnvelopeTest
+{
+    private static final int FLAGS_COMPLETE = 0x03;
+
+    private static final String SCHEMA = """
+                                            syntax = "proto3";
+                                            package io.aklivity.examples.clients.proto;
+                                            message SimpleMessage {
+                                                string content = 1;
+                                            }
+                                            """;
+
+    // a single index byte, then content="OK"
+    private static final byte[] WIRE = {0x00, 0x0a, 0x02, 0x4f, 0x4b};
+    // the encoder's own input: the json view of the same message, which it encodes into WIRE
+    private static final byte[] JSON = "{\"content\":\"OK\"}".getBytes(UTF_8);
+
+    private EngineContext context;
+
+    @Before
+    public void init()
+    {
+        context = mock(EngineContext.class);
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+        envelope.set("mark", buffer("two"));
+
+        ProtobufModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertEquals(2, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+        assertEquals("two", text(envelope.get("echo", 1)));
+    }
+
+    @Test
+    public void shouldWriteEnvelopeSuppliedToEncoderFromFormatNativeStage()
+    {
+        Metadata envelope = new Metadata();
+
+        ProtobufModelHandlerImpl handler = newHandler(List.of(capturingExt("captured")));
+        ModelPipeline pipeline = handler.supplyEncoder(envelope, ModelTransform.NONE);
+
+        transform(pipeline, JSON);
+
+        assertEquals(1, envelope.count("captured"));
+        assertEquals("OK", text(envelope.get("captured", 0)));
+    }
+
+    @Test
+    public void shouldReadEnvelopeSuppliedToDecoderFromFormatNativeStageAndModelTransform()
+    {
+        Metadata envelope = new Metadata();
+        envelope.set("mark", buffer("one"));
+
+        // the caller composes its own generic stage over the same envelope it supplies to the pipeline, so
+        // both vocabularies observe one store
+        Reading reading = new Reading(envelope, "mark");
+        ProtobufModelHandlerImpl handler = newHandler(List.of(echoingExt("mark", "echo")));
+        ModelPipeline pipeline = handler.supplyDecoder(envelope, reading);
+
+        transform(pipeline);
+
+        assertEquals(List.of("one"), reading.read);
+        assertEquals(1, envelope.count("echo"));
+        assertEquals("one", text(envelope.get("echo", 0)));
+    }
+
+    @Test
+    public void shouldSupplyNoneToFormatNativeStageWhenCallerSuppliesNone()
+    {
+        Observing observing = new Observing();
+
+        ProtobufModelHandlerImpl handler = newHandler(List.of(observingExt(observing)));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+
+        transform(pipeline);
+
+        assertSame(ProtobufEnvelope.NONE, observing.envelope);
+    }
+
+    private static void transform(
+        ModelPipeline pipeline)
+    {
+        transform(pipeline, WIRE);
+    }
+
+    private static void transform(
+        ModelPipeline pipeline,
+        byte[] in)
+    {
+        MutableDirectBufferEx dst = new UnsafeBufferEx(new byte[256]);
+        pipeline.transform(0L, 0L, 0L, FLAGS_COMPLETE,
+            new UnsafeBufferEx(in), 0, in.length, dst, 0, dst.capacity());
+    }
+
+    private ProtobufModelHandlerImpl newHandler(
+        List<ProtobufModelExtContext> exts)
+    {
+        TestCatalogConfig catalog = GenericCatalogConfig.builder(TestCatalogConfig::new)
+            .namespace("test")
+            .name("test0")
+            .type("test")
+            .options(TestCatalogOptionsConfig::builder)
+                .id(1)
+                .schema(SCHEMA)
+                .build()
+            .build();
+        ProtobufModelConfig model = ProtobufModelConfig.builder()
+            .view("json")
+            .catalog()
+                .name("test0")
+                .schema()
+                    .strategy("topic")
+                    .version("latest")
+                    .subject("test-value")
+                    .record("SimpleMessage")
+                    .build()
+                .build()
+            .build();
+        when(context.supplyCatalog(catalog.id)).thenReturn(new TestCatalogHandler(catalog.options));
+        return new ProtobufModelHandlerImpl(model, context, exts);
+    }
+
+    // an extension whose format-native stage echoes every value the envelope carries under one name back
+    // under another, so what a stage read is observable from the envelope the caller supplied
+    private static ProtobufModelExtContext echoingExt(
+        String source,
+        String target)
+    {
+        return (schema, options) -> new ProtobufModelExtHandler()
+        {
+            private final ProtobufTransform transform = new Echoing(source, target);
+
+            @Override
+            public <T extends ProtobufTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends ProtobufTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    // an extension whose format-native stage writes each string value it observes into the envelope
+    private static ProtobufModelExtContext capturingExt(
+        String name)
+    {
+        return (schema, options) -> new ProtobufModelExtHandler()
+        {
+            private final ProtobufTransform transform = new Capturing(name);
+
+            @Override
+            public <T extends ProtobufTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+
+            @Override
+            public <T extends ProtobufTransformable<T>> T encode(
+                T transformable)
+            {
+                return transformable.transform(transform);
+            }
+        };
+    }
+
+    private static ProtobufModelExtContext observingExt(
+        ProtobufTransform observing)
+    {
+        return (schema, options) -> new ProtobufModelExtHandler()
+        {
+            @Override
+            public <T extends ProtobufTransformable<T>> T decode(
+                T transformable)
+            {
+                return transformable.transform(observing);
+            }
+        };
+    }
+
+    private static DirectBufferEx buffer(
+        String value)
+    {
+        return new UnsafeBufferEx(value.getBytes(UTF_8));
+    }
+
+    private static String text(
+        DirectBufferEx value)
+    {
+        return value.getStringWithoutLengthUtf8(0, value.capacity());
+    }
+
+    // the envelope a caller supplies to the pipeline, backed by a copy of each value it is given
+    private static final class Metadata implements ModelEnvelope
+    {
+        private final Map<String, List<DirectBufferEx>> values = new LinkedHashMap<>();
+
+        @Override
+        public int count(
+            String name)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null ? named.size() : 0;
+        }
+
+        @Override
+        public DirectBufferEx get(
+            String name,
+            int index)
+        {
+            List<DirectBufferEx> named = values.get(name);
+            return named != null && index < named.size() ? named.get(index) : null;
+        }
+
+        @Override
+        public void set(
+            String name,
+            DirectBufferEx value)
+        {
+            byte[] copy = new byte[value.capacity()];
+            value.getBytes(0, copy);
+            values.computeIfAbsent(name, n -> new ArrayList<>()).add(new UnsafeBufferEx(copy));
+        }
+    }
+
+    // format-native stage: copies every value under one name to another, once per datum
+    private static final class Echoing implements ProtobufTransform
+    {
+        private final String source;
+        private final String target;
+
+        private boolean echoed;
+
+        private Echoing(
+            String source,
+            String target)
+        {
+            this.source = source;
+            this.target = target;
+        }
+
+        @Override
+        public Status transform(
+            ProtobufController control,
+            ProtobufSource avroSource,
+            ProtobufEvent event,
+            ProtobufSink sink)
+        {
+            if (!echoed)
+            {
+                echoed = true;
+                ProtobufEnvelope envelope = control.envelope();
+                int count = envelope.count(source);
+                for (int index = 0; index < count; index++)
+                {
+                    envelope.set(target, envelope.get(source, index));
+                }
+            }
+            return sink.transform(control, avroSource, event);
+        }
+
+        @Override
+        public void reset()
+        {
+            echoed = false;
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: writes each string value it observes into the envelope under one name
+    private static final class Capturing implements ProtobufTransform
+    {
+        private final String name;
+
+        private Capturing(
+            String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public Status transform(
+            ProtobufController control,
+            ProtobufSource source,
+            ProtobufEvent event,
+            ProtobufSink sink)
+        {
+            if (event == ProtobufEvent.VALUE)
+            {
+                control.envelope().set(name, source.segment());
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // format-native stage: captures the envelope the pipeline supplies, without touching its contents
+    private static final class Observing implements ProtobufTransform
+    {
+        private ProtobufEnvelope envelope;
+
+        @Override
+        public Status transform(
+            ProtobufController control,
+            ProtobufSource source,
+            ProtobufEvent event,
+            ProtobufSink sink)
+        {
+            envelope = control.envelope();
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+
+    // a generic stage the caller composes over the same envelope it supplies to the pipeline
+    private static final class Reading implements ModelTransform
+    {
+        private final ModelEnvelope envelope;
+        private final String name;
+        private final List<String> read = new ArrayList<>();
+
+        private Reading(
+            ModelEnvelope envelope,
+            String name)
+        {
+            this.envelope = envelope;
+            this.name = name;
+        }
+
+        @Override
+        public ModelStatus transform(
+            ModelController control,
+            ModelSource source,
+            ModelEvent event,
+            ModelSink sink)
+        {
+            if (read.isEmpty())
+            {
+                int count = envelope.count(name);
+                for (int index = 0; index < count; index++)
+                {
+                    read.add(text(envelope.get(name, index)));
+                }
+            }
+            return sink.transform(control, source, event);
+        }
+
+        @Override
+        public boolean identity()
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Description

A stage working over a format's own event stream had no place to read or write data that travels with a value but is not part of its encoding. The engine's metadata channel could not fill the gap either: `common-avro`, `common-json`, and `common-protobuf` do not depend on `engine`, so none of them can name `ModelEnvelope`.

Each format layer gains its own channel, and each model module adapts.

**`AvroEnvelope` / `JsonEnvelope` / `ProtobufEnvelope`** — a named, ordered, repeatable list of byte values per format, all three with the same contract: `set` accumulates so a repeated call under one name adds a further occurrence rather than overwriting the one before it, `get` returns `null` for an absent name or an index past the end, and the bytes are copied out before `set` returns. Scope is the supplier's to decide; the interface claims only thread confinement, being a property of the pipeline it is bound to.

Bound to a pipeline once, as it is assembled:

```java
Avro.stream(Avro.parser(schema))
    .transform(adapter)
    .lenient(lenient)
    .reporting(reporter)
    .envelope(envelope)
    .into(generator);
```

and read back from any stage through the format's own controller — `AvroController.envelope()`, `JsonController.envelope()`, `ProtobufController.envelope()` — each defaulting to that format's `NONE`, which reads as empty and discards writes. A pipeline assembled without one costs a stage that never asks for it nothing.

**`AvroModelEnvelope` / `JsonModelEnvelope` / `ProtobufModelEnvelope`** bridge the two vocabularies, forwarding each call to the `ModelEnvelope` the caller supplied at `supplyDecoder` / `supplyEncoder` time. Each resolves to its format's own `NONE` when the caller supplied `ModelEnvelope.NONE`, so nothing wraps a channel that carries nothing. The adaptation happens once, as the pipeline is assembled, leaving the hot path unchanged — no per-value or per-call adaptation.

Both directions: decode and encode chains each bind the envelope, so a stage appended to either reaches it on the same terms.

### Scope

Implements #2389 §3 (per-format interface, the alternative chosen over a shared home), §4, and §5 for the three `common-*`/`model-*` pairs.

§2 asked for per-message supply. That is answered rather than built: #2390 binds the envelope at supply time and makes the supplier responsible for turning its contents over, so the pipeline never receives an envelope belonging to a different message by construction. The issue description is amended to match.

`model-core` is not covered here. Its extension stages take one fully-buffered value with no control handle to reach an envelope through, and its extension handler declares no direction at all — reshaping that contract is #2393, and the envelope for those two models follows from it.

### Coverage

`AvroEnvelopeTest` in `common-avro` covers the contract itself, `NONE` in force when a pipeline is assembled without one, and a stage reading and writing through its controller.

`AvroModelEnvelopeTest`, `JsonModelEnvelopeTest`, and `ProtobufModelEnvelopeTest` each cover an extension's format-native stage reading a name the caller supplied on decode, writing one on encode for the caller to drain, one envelope observed identically by a format-native stage and a `ModelTransform`, and `NONE` reaching a stage when the caller supplies none.

Verified with `./mvnw clean install` — integration tests included — over `common-avro`, `common-json`, `common-protobuf`, `model-avro`, `model-json`, and `model-protobuf`: BUILD SUCCESS, checkstyle and JaCoCo clean across all six.

Fixes #2389

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZhZD2wyJbgzXrFMbWYY3y)_