### PR TITLE
Resolve guarded expressions in inline catalog subject before lookup

### DIFF
--- a/config/catalog-apicurio.conf/src/main/java/io/aklivity/zilla/config/catalog/apicurio/ApicurioCatalogConfig.java
+++ b/config/catalog-apicurio.conf/src/main/java/io/aklivity/zilla/config/catalog/apicurio/ApicurioCatalogConfig.java
@@ -37,8 +37,9 @@ public final class ApicurioCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-apicurio.conf/src/main/java/io/aklivity/zilla/config/catalog/apicurio/ApicurioCatalogConfigBuilder.java
+++ b/config/catalog-apicurio.conf/src/main/java/io/aklivity/zilla/config/catalog/apicurio/ApicurioCatalogConfigBuilder.java
@@ -48,8 +48,9 @@ public final class ApicurioCatalogConfigBuilder<T> extends CatalogConfigBuilder<
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new ApicurioCatalogConfig(namespace, name, type, vault, options);
+        return new ApicurioCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-filesystem.conf/src/main/java/io/aklivity/zilla/config/catalog/filesystem/FilesystemCatalogConfig.java
+++ b/config/catalog-filesystem.conf/src/main/java/io/aklivity/zilla/config/catalog/filesystem/FilesystemCatalogConfig.java
@@ -37,8 +37,9 @@ public final class FilesystemCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-filesystem.conf/src/main/java/io/aklivity/zilla/config/catalog/filesystem/FilesystemCatalogConfigBuilder.java
+++ b/config/catalog-filesystem.conf/src/main/java/io/aklivity/zilla/config/catalog/filesystem/FilesystemCatalogConfigBuilder.java
@@ -48,8 +48,9 @@ public final class FilesystemCatalogConfigBuilder<T> extends CatalogConfigBuilde
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new FilesystemCatalogConfig(namespace, name, type, vault, options);
+        return new FilesystemCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-inline.conf/src/main/java/io/aklivity/zilla/config/catalog/inline/InlineCatalogConfig.java
+++ b/config/catalog-inline.conf/src/main/java/io/aklivity/zilla/config/catalog/inline/InlineCatalogConfig.java
@@ -37,8 +37,9 @@ public final class InlineCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-inline.conf/src/main/java/io/aklivity/zilla/config/catalog/inline/InlineCatalogConfigBuilder.java
+++ b/config/catalog-inline.conf/src/main/java/io/aklivity/zilla/config/catalog/inline/InlineCatalogConfigBuilder.java
@@ -48,8 +48,9 @@ public final class InlineCatalogConfigBuilder<T> extends CatalogConfigBuilder<T,
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new InlineCatalogConfig(namespace, name, type, vault, options);
+        return new InlineCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-karapace.conf/src/main/java/io/aklivity/zilla/config/catalog/karapace/KarapaceCatalogConfig.java
+++ b/config/catalog-karapace.conf/src/main/java/io/aklivity/zilla/config/catalog/karapace/KarapaceCatalogConfig.java
@@ -37,8 +37,9 @@ public final class KarapaceCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-karapace.conf/src/main/java/io/aklivity/zilla/config/catalog/karapace/KarapaceCatalogConfigBuilder.java
+++ b/config/catalog-karapace.conf/src/main/java/io/aklivity/zilla/config/catalog/karapace/KarapaceCatalogConfigBuilder.java
@@ -48,8 +48,9 @@ public final class KarapaceCatalogConfigBuilder<T> extends CatalogConfigBuilder<
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new KarapaceCatalogConfig(namespace, name, type, vault, options);
+        return new KarapaceCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-schema-registry.conf/src/main/java/io/aklivity/zilla/config/catalog/schema/registry/SchemaRegistryCatalogConfig.java
+++ b/config/catalog-schema-registry.conf/src/main/java/io/aklivity/zilla/config/catalog/schema/registry/SchemaRegistryCatalogConfig.java
@@ -37,8 +37,9 @@ public final class SchemaRegistryCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/catalog-schema-registry.conf/src/main/java/io/aklivity/zilla/config/catalog/schema/registry/SchemaRegistryCatalogConfigBuilder.java
+++ b/config/catalog-schema-registry.conf/src/main/java/io/aklivity/zilla/config/catalog/schema/registry/SchemaRegistryCatalogConfigBuilder.java
@@ -49,8 +49,9 @@ public final class SchemaRegistryCatalogConfigBuilder<T>
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new SchemaRegistryCatalogConfig(namespace, name, type, vault, options);
+        return new SchemaRegistryCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfig.java
@@ -20,12 +20,14 @@ public abstract class CatalogConfig extends Config
 {
     public transient long id;
     public transient long vaultId;
+    public transient long guardId;
 
     public final String namespace;
     public final String name;
     public final String qname;
     public final String type;
     public final String vault;
+    public final String guard;
     public final OptionsConfig options;
 
     protected CatalogConfig(
@@ -33,6 +35,7 @@ public abstract class CatalogConfig extends Config
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
         this.namespace = requireNonNull(namespace);
@@ -40,6 +43,7 @@ public abstract class CatalogConfig extends Config
         this.qname = String.format("%s:%s", namespace, name);
         this.type = requireNonNull(type);
         this.vault = vault;
+        this.guard = guard;
         this.options = options;
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfigBuilder.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/CatalogConfigBuilder.java
@@ -26,6 +26,7 @@ public abstract class CatalogConfigBuilder<T, B extends CatalogConfigBuilder<T, 
     private String name;
     private String type;
     private String vault;
+    private String guard;
     private OptionsConfig options;
 
     protected CatalogConfigBuilder(
@@ -62,6 +63,13 @@ public abstract class CatalogConfigBuilder<T, B extends CatalogConfigBuilder<T, 
         return thisType().cast(this);
     }
 
+    public B guard(
+        String guard)
+    {
+        this.guard = guard;
+        return thisType().cast(this);
+    }
+
     protected <C extends ConfigBuilder<B, C>> C options(
         Function<Function<OptionsConfig, B>, C> options)
     {
@@ -78,7 +86,7 @@ public abstract class CatalogConfigBuilder<T, B extends CatalogConfigBuilder<T, 
     @Override
     public T build()
     {
-        return mapper.apply(newCatalog(namespace, name, type, vault, options));
+        return mapper.apply(newCatalog(namespace, name, type, vault, guard, options));
     }
 
     protected abstract CatalogConfig newCatalog(
@@ -86,5 +94,6 @@ public abstract class CatalogConfigBuilder<T, B extends CatalogConfigBuilder<T, 
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options);
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GenericCatalogConfig.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GenericCatalogConfig.java
@@ -34,8 +34,9 @@ public final class GenericCatalogConfig extends CatalogConfig
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        super(namespace, name, type, vault, options);
+        super(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GenericCatalogConfigBuilder.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/GenericCatalogConfigBuilder.java
@@ -51,8 +51,9 @@ public final class GenericCatalogConfigBuilder<T> extends CatalogConfigBuilder<T
         String name,
         String type,
         String vault,
+        String guard,
         OptionsConfig options)
     {
-        return new GenericCatalogConfig(namespace, name, type, vault, options);
+        return new GenericCatalogConfig(namespace, name, type, vault, guard, options);
     }
 }

--- a/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/internal/CatalogConfigAdapter.java
+++ b/config/engine.conf/src/main/java/io/aklivity/zilla/config/engine/internal/CatalogConfigAdapter.java
@@ -29,6 +29,7 @@ public class CatalogConfigAdapter
 {
     private static final String TYPE_NAME = "type";
     private static final String VAULT_NAME = "vault";
+    private static final String GUARD_NAME = "guard";
     private static final String OPTIONS_NAME = "options";
 
     private final String type;
@@ -69,6 +70,11 @@ public class CatalogConfigAdapter
         if (object.containsKey(VAULT_NAME))
         {
             builder.vault(object.getString(VAULT_NAME));
+        }
+
+        if (object.containsKey(GUARD_NAME))
+        {
+            builder.guard(object.getString(GUARD_NAME));
         }
 
         if (object.containsKey(OPTIONS_NAME))

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalog.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalog.java
@@ -38,6 +38,6 @@ public class InlineCatalog implements Catalog
     public CatalogContext supply(
         EngineContext context)
     {
-        return new InlineCatalogContext();
+        return new InlineCatalogContext(context);
     }
 }

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogContext.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogContext.java
@@ -16,15 +16,26 @@ package io.aklivity.zilla.runtime.catalog.inline.internal;
 
 import io.aklivity.zilla.config.catalog.inline.InlineOptionsConfig;
 import io.aklivity.zilla.config.engine.CatalogConfig;
+import io.aklivity.zilla.runtime.engine.EngineContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogContext;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 
 public class InlineCatalogContext implements CatalogContext
 {
+    private final EngineContext context;
+
+    public InlineCatalogContext(
+        EngineContext context)
+    {
+        this.context = context;
+    }
+
     @Override
     public CatalogHandler attach(
         CatalogConfig catalog)
     {
-        return new InlineCatalogHandler(InlineOptionsConfig.class.cast(catalog.options));
+        GuardHandler guard = catalog.guard != null ? context.supplyGuard(catalog.guardId) : null;
+        return new InlineCatalogHandler(InlineOptionsConfig.class.cast(catalog.options), guard);
     }
 }

--- a/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandler.java
+++ b/runtime/catalog-inline/src/main/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandler.java
@@ -15,6 +15,10 @@
 package io.aklivity.zilla.runtime.catalog.inline.internal;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.CRC32C;
 
 import org.agrona.collections.Int2IntHashMap;
@@ -24,6 +28,7 @@ import org.agrona.collections.Object2IntHashMap;
 import io.aklivity.zilla.config.catalog.inline.InlineOptionsConfig;
 import io.aklivity.zilla.config.catalog.inline.InlineSchemaConfig;
 import io.aklivity.zilla.runtime.engine.catalog.CatalogHandler;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 
 public class InlineCatalogHandler implements CatalogHandler
 {
@@ -31,18 +36,37 @@ public class InlineCatalogHandler implements CatalogHandler
     private static final int NO_REFERENCES = 0;
     private static final int[] NO_SCHEMA_IDS = new int[0];
 
+    // matches the same ${guarded['name'].identity} / ${guarded['name'].attributes.x} syntax
+    // kafka-proxy's topics[].alias already resolves per-connection, so a subject configured
+    // on the consuming model (e.g. catalog.subject) can reference the caller's identity the
+    // same way a topic alias does. The guard name inside the brackets is not re-resolved
+    // here — an inline catalog carries at most one guard (catalog.guard), applied regardless
+    // of which name is written in the expression.
+    private static final Pattern IDENTITY_PATTERN =
+        Pattern.compile("\\$\\{guarded(?:\\['([a-zA-Z]+[a-zA-Z0-9\\._\\:\\-]*)'\\]).identity\\}");
+    private static final Pattern ATTRIBUTE_PATTERN =
+        Pattern.compile("\\$\\{guarded(?:\\['([a-zA-Z]+[a-zA-Z0-9\\._\\:\\-]*)'\\]).attributes" +
+            ".([a-zA-Z]+[a-zA-Z0-9\\._\\:\\-]*)\\}");
+
     private final Int2ObjectHashMap<String> schemas;
     private final Object2IntHashMap<String> schemaIds;
     private final Int2IntHashMap references;
     private final CRC32C crc32c;
+    private final GuardHandler guard;
+    private final Matcher identityMatcher;
+    private final Matcher attributeMatcher;
 
     public InlineCatalogHandler(
-        InlineOptionsConfig config)
+        InlineOptionsConfig config,
+        GuardHandler guard)
     {
         this.schemas = new Int2ObjectHashMap<>();
         this.schemaIds = new Object2IntHashMap<>(NO_SCHEMA_ID);
         this.references = new Int2IntHashMap(NO_REFERENCES);
         this.crc32c = new CRC32C();
+        this.guard = guard;
+        this.identityMatcher = IDENTITY_PATTERN.matcher("");
+        this.attributeMatcher = ATTRIBUTE_PATTERN.matcher("");
         if (config != null)
         {
             registerSchema(config.subjects);
@@ -84,6 +108,45 @@ public class InlineCatalogHandler implements CatalogHandler
         String version)
     {
         return schemaIds.getValue(subject + version);
+    }
+
+    @Override
+    public int resolve(
+        String subject,
+        String version,
+        long authorization)
+    {
+        String resolved = guard != null ? resolveExpression(subject, authorization) : subject;
+        return schemaIds.getValue(resolved + version);
+    }
+
+    private String resolveExpression(
+        String subject,
+        long authorization)
+    {
+        String resolved = findAndReplace(subject, identityMatcher, r -> orEmpty(guard.identity(authorization)));
+        resolved = findAndReplace(resolved, attributeMatcher, r -> orEmpty(guard.attribute(authorization, r.group(2))));
+        return resolved;
+    }
+
+    private static String orEmpty(
+        String value)
+    {
+        return value != null ? value : "";
+    }
+
+    private static String findAndReplace(
+        String value,
+        Matcher matcher,
+        Function<MatchResult, String> replacer)
+    {
+        matcher.reset(value);
+        while (matcher.find())
+        {
+            value = matcher.replaceAll(replacer);
+            matcher.reset(value);
+        }
+        return value;
     }
 
     private int register(

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandlerTest.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineCatalogHandlerTest.java
@@ -20,9 +20,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
 import io.aklivity.zilla.config.catalog.inline.InlineOptionsConfig;
+import io.aklivity.zilla.runtime.engine.guard.GuardHandler;
 
 public class InlineCatalogHandlerTest
 {
@@ -32,7 +36,7 @@ public class InlineCatalogHandlerTest
     private InlineCatalogHandler newHandler()
     {
         InlineOptionsConfig options = InlineOptionsConfig.builder().build();
-        return new InlineCatalogHandler(options);
+        return new InlineCatalogHandler(options, null);
     }
 
     @Test
@@ -50,7 +54,7 @@ public class InlineCatalogHandlerTest
     @Test
     public void shouldConstructWithoutOptionsAndAcceptRuntimeRegistration()
     {
-        InlineCatalogHandler handler = new InlineCatalogHandler(null);
+        InlineCatalogHandler handler = new InlineCatalogHandler(null, null);
 
         int schemaId = handler.register("weather", SCHEMA_A);
 
@@ -139,5 +143,149 @@ public class InlineCatalogHandlerTest
         InlineCatalogHandler handler = newHandler();
 
         assertThat(handler.resolve("missing", "latest"), equalTo(NO_SCHEMA_ID));
+    }
+
+    @Test
+    public void shouldResolveGuardedIdentityExpressionInSubjectBeforeLookup()
+    {
+        InlineOptionsConfig options = InlineOptionsConfig.builder().build();
+        InlineCatalogHandler handler = new InlineCatalogHandler(options, new TestGuard("alice", null));
+
+        int schemaId = handler.register("orders.alice-value", SCHEMA_A);
+
+        int resolved = handler.resolve("orders.${guarded['product:api_keys'].identity}-value", "latest", 7L);
+
+        assertThat(resolved, equalTo(schemaId));
+    }
+
+    @Test
+    public void shouldResolveGuardedAttributeExpressionInSubjectBeforeLookup()
+    {
+        InlineOptionsConfig options = InlineOptionsConfig.builder().build();
+        InlineCatalogHandler handler =
+            new InlineCatalogHandler(options, new TestGuard(null, Map.of("tenant", "acme")));
+
+        int schemaId = handler.register("orders.acme-value", SCHEMA_A);
+
+        int resolved =
+            handler.resolve("orders.${guarded['product:api_keys'].attributes.tenant}-value", "latest", 7L);
+
+        assertThat(resolved, equalTo(schemaId));
+    }
+
+    @Test
+    public void shouldFailToResolveGuardedExpressionWhenNoGuardConfigured()
+    {
+        InlineCatalogHandler handler = newHandler();
+
+        handler.register("orders.alice-value", SCHEMA_A);
+
+        int resolved = handler.resolve("orders.${guarded['product:api_keys'].identity}-value", "latest", 7L);
+
+        assertThat(resolved, equalTo(NO_SCHEMA_ID));
+    }
+
+    @Test
+    public void shouldIgnoreGuardedExpressionSyntaxWhenAuthorizationOverloadIsNotUsed()
+    {
+        InlineOptionsConfig options = InlineOptionsConfig.builder().build();
+        InlineCatalogHandler handler = new InlineCatalogHandler(options, new TestGuard("alice", null));
+
+        int schemaId = handler.register("weather", SCHEMA_A);
+
+        assertThat(handler.resolve("weather", "latest"), equalTo(schemaId));
+    }
+
+    private static final class TestGuard implements GuardHandler
+    {
+        private final String identity;
+        private final Map<String, String> attributes;
+
+        private TestGuard(
+            String identity,
+            Map<String, String> attributes)
+        {
+            this.identity = identity;
+            this.attributes = attributes;
+        }
+
+        @Override
+        public long reauthorize(
+            long traceId,
+            long bindingId,
+            long contextId,
+            String credentials)
+        {
+            return NOT_AUTHORIZED;
+        }
+
+        @Override
+        public void reauthorize(
+            long traceId,
+            long bindingId,
+            long contextId,
+            String credentials,
+            LongCompletionCallback completion)
+        {
+            completion.completed(contextId, NOT_AUTHORIZED);
+        }
+
+        @Override
+        public void deauthorize(
+            long sessionId)
+        {
+        }
+
+        @Override
+        public String identity(
+            long sessionId)
+        {
+            return identity;
+        }
+
+        @Override
+        public String attribute(
+            long sessionId,
+            String name)
+        {
+            return attributes != null ? attributes.get(name) : null;
+        }
+
+        @Override
+        public String credentials(
+            long sessionId)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean verify(
+            long sessionId,
+            List<String> roles)
+        {
+            return false;
+        }
+
+        @Override
+        public long expiresAt(
+            long sessionId)
+        {
+            return EXPIRES_NEVER;
+        }
+
+        @Override
+        public long expiringAt(
+            long sessionId)
+        {
+            return EXPIRES_NEVER;
+        }
+
+        @Override
+        public boolean challenge(
+            long sessionId,
+            long now)
+        {
+            return false;
+        }
     }
 }

--- a/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineIT.java
+++ b/runtime/catalog-inline/src/test/java/io/aklivity/zilla/runtime/catalog/inline/internal/InlineIT.java
@@ -53,7 +53,7 @@ public class InlineIT
                 "{\"name\":\"status\",\"type\":\"string\"}]," +
                 "\"name\":\"Event\",\"namespace\":\"io.aklivity.example\",\"type\":\"record\"}";
 
-        InlineCatalogHandler catalog = new InlineCatalogHandler(config);
+        InlineCatalogHandler catalog = new InlineCatalogHandler(config, null);
 
         int schemaId = catalog.resolve("subject1", "latest");
         String schema = catalog.resolve(schemaId);
@@ -65,7 +65,7 @@ public class InlineIT
     @Test
     public void shouldResolveSchemaIdAndProcessData()
     {
-        InlineCatalogHandler catalog = new InlineCatalogHandler(config);
+        InlineCatalogHandler catalog = new InlineCatalogHandler(config, null);
 
         DirectBufferEx data = new UnsafeBufferEx();
 
@@ -85,7 +85,7 @@ public class InlineIT
     @Test
     public void shouldVerifyEncodedData()
     {
-        InlineCatalogHandler catalog = new InlineCatalogHandler(config);
+        InlineCatalogHandler catalog = new InlineCatalogHandler(config, null);
 
         DirectBufferEx data = new UnsafeBufferEx();
 

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandler.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandler.java
@@ -238,6 +238,32 @@ public interface CatalogHandler
         String version);
 
     /**
+     * Resolves the schema id for a given subject name and version string, where the
+     * subject may itself contain a guarded expression (e.g. {@code ${guarded['name']
+     * .identity}}) that must be evaluated against the connection's authorization before
+     * the resolved subject is looked up.
+     * <p>
+     * Catalogs that do not support guarded expressions in subjects (the majority — e.g.
+     * remote schema registries, where subjects are looked up by literal name) can
+     * ignore {@code authorization} entirely; the default implementation does exactly
+     * that, delegating to {@link #resolve(String, String)} unchanged.
+     * </p>
+     *
+     * @param subject        the subject name, potentially containing a guarded expression
+     * @param version        the version string (e.g., {@code "latest"} or a numeric version)
+     * @param authorization  the connection's authorization, used to evaluate any guarded
+     *                       expression in {@code subject}
+     * @return the resolved schema id, or {@link #NO_SCHEMA_ID} if not found
+     */
+    default int resolve(
+        String subject,
+        String version,
+        long authorization)
+    {
+        return resolve(subject, version);
+    }
+
+    /**
      * Attempts to extract a schema id embedded in the payload bytes themselves
      * (e.g., a Confluent-framed message with a magic byte + 4-byte schema id prefix).
      * <p>

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineManager.java
@@ -391,6 +391,10 @@ public class EngineManager
             {
                 catalog.vaultId = resolver.resolve(catalog.vault);
             }
+            if (catalog.guard != null)
+            {
+                catalog.guardId = resolver.resolve(catalog.guard);
+            }
         }
 
         for (MetricConfig metric : namespace.telemetry.metrics)

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandlerTest.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/catalog/CatalogHandlerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.catalog;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+public class CatalogHandlerTest
+{
+    @Test
+    public void shouldDelegateAuthorizedResolveToUnauthorizedResolveByDefault()
+    {
+        CatalogHandler handler = new CatalogHandler()
+        {
+            @Override
+            public String resolve(
+                int schemaId)
+            {
+                return null;
+            }
+
+            @Override
+            public int resolve(
+                String subject,
+                String version)
+            {
+                return 42;
+            }
+        };
+
+        assertThat(handler.resolve("subject", "latest", 0L), equalTo(42));
+        assertThat(handler.resolve("subject", "latest", 1L), equalTo(42));
+    }
+
+    @Test
+    public void shouldPreferAuthorizedResolveOverrideWhenProvided()
+    {
+        CatalogHandler handler = new CatalogHandler()
+        {
+            @Override
+            public String resolve(
+                int schemaId)
+            {
+                return null;
+            }
+
+            @Override
+            public int resolve(
+                String subject,
+                String version)
+            {
+                return CatalogHandler.NO_SCHEMA_ID;
+            }
+
+            @Override
+            public int resolve(
+                String subject,
+                String version,
+                long authorization)
+            {
+                return authorization == 7L ? 42 : CatalogHandler.NO_SCHEMA_ID;
+            }
+        };
+
+        assertThat(handler.resolve("subject", "latest", 7L), equalTo(42));
+        assertThat(handler.resolve("subject", "latest", 1L), equalTo(CatalogHandler.NO_SCHEMA_ID));
+    }
+}

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelDecoderPipeline.java
@@ -87,7 +87,7 @@ final class AvroModelDecoderPipeline implements ModelPipeline
         {
             // the catalog framing sits at the value start; strip it once on the first fragment and select
             // the schema-bound pipeline, then later fragments stream straight through
-            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength);
+            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength, authorization);
             prefix = handler.prefix(src, srcIndex, srcLength);
             active = schemaId != NO_SCHEMA_ID ? supplyPipeline(schemaId) : null;
             if (active != null)

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelEncoderPipeline.java
@@ -80,7 +80,7 @@ final class AvroModelEncoderPipeline implements ModelPipeline
         int prefix = 0;
         if ((flags & FLAGS_INIT) != 0)
         {
-            int schemaId = handler.resolveSchemaId();
+            int schemaId = handler.resolveSchemaId(authorization);
             active = supplyPipeline(schemaId);
             diagnostic = null;
             if (active != null)

--- a/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
+++ b/runtime/model-avro/src/main/java/io/aklivity/zilla/runtime/model/avro/internal/AvroModelHandlerImpl.java
@@ -127,21 +127,36 @@ public final class AvroModelHandlerImpl extends AvroModelHandler implements Mode
         int index,
         int length)
     {
+        return resolveSchemaId(data, index, length, 0L);
+    }
+
+    int resolveSchemaId(
+        DirectBufferEx data,
+        int index,
+        int length,
+        long authorization)
+    {
         int schemaId = handler.resolve(data, index, length);
         if (schemaId == NO_SCHEMA_ID)
         {
             schemaId = catalog.id != NO_SCHEMA_ID
                 ? catalog.id
-                : handler.resolve(subject, catalog.version);
+                : handler.resolve(subject, catalog.version, authorization);
         }
         return schemaId;
     }
 
     int resolveSchemaId()
     {
+        return resolveSchemaId(0L);
+    }
+
+    int resolveSchemaId(
+        long authorization)
+    {
         return catalog != null && catalog.id != NO_SCHEMA_ID
             ? catalog.id
-            : handler.resolve(subject, catalog.version);
+            : handler.resolve(subject, catalog.version, authorization);
     }
 
     // writes the schema framing prefix for the resolved schema id into next, returning the bytes written

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -91,7 +91,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
         {
             // the catalog framing sits at the value start; strip it once on the first fragment and select
             // the schema-bound pipeline, then later fragments stream straight through
-            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength);
+            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength, authorization);
             prefix = handler.decodePadding(src, srcIndex, srcLength);
             active = schemaId != NO_SCHEMA_ID ? supplyPipeline(schemaId) : null;
             if (active != null)

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
@@ -79,7 +79,7 @@ final class JsonModelEncoderPipeline implements ModelPipeline
         int prefix = 0;
         if ((flags & FLAGS_INIT) != 0)
         {
-            int schemaId = handler.resolveSchemaId();
+            int schemaId = handler.resolveSchemaId(authorization);
             active = supplyPipeline(schemaId);
             diagnostic = null;
             if (active != null)

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelHandlerImpl.java
@@ -82,21 +82,36 @@ public final class JsonModelHandlerImpl extends JsonModelHandler implements Mode
         int index,
         int length)
     {
+        return resolveSchemaId(data, index, length, 0L);
+    }
+
+    int resolveSchemaId(
+        DirectBufferEx data,
+        int index,
+        int length,
+        long authorization)
+    {
         int schemaId = handler.resolve(data, index, length);
         if (schemaId == NO_SCHEMA_ID)
         {
             schemaId = catalog.id != NO_SCHEMA_ID
                 ? catalog.id
-                : handler.resolve(subject, catalog.version);
+                : handler.resolve(subject, catalog.version, authorization);
         }
         return schemaId;
     }
 
     int resolveSchemaId()
     {
+        return resolveSchemaId(0L);
+    }
+
+    int resolveSchemaId(
+        long authorization)
+    {
         return catalog != null && catalog.id != NO_SCHEMA_ID
             ? catalog.id
-            : handler.resolve(subject, catalog.version);
+            : handler.resolve(subject, catalog.version, authorization);
     }
 
     // writes the schema framing prefix for the resolved schema id into next, returning the bytes written

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelDecoderPipeline.java
@@ -85,7 +85,7 @@ final class ProtobufModelDecoderPipeline implements ModelPipeline
             // the catalog framing then the message-index prefix sit at the value start; strip both once on the
             // first fragment and select the schema-bound pipeline, then later fragments stream straight through
             int catalogPrefix = handler.prefix(src, srcIndex, srcLength);
-            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength);
+            int schemaId = handler.resolveSchemaId(src, srcIndex, srcLength, authorization);
             int indexProgress = handler.messageProgress(src, srcIndex + catalogPrefix, srcLength - catalogPrefix);
             ProtobufMessage message = handler.message(schemaId);
             prefix = catalogPrefix + indexProgress;

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelEncoderPipeline.java
@@ -72,7 +72,7 @@ final class ProtobufModelEncoderPipeline implements ModelPipeline
         int prefix = 0;
         if ((flags & FLAGS_INIT) != 0)
         {
-            int schemaId = handler.resolveSchemaId();
+            int schemaId = handler.resolveSchemaId(authorization);
             int[] path = handler.messagePath(schemaId);
             ProtobufMessage message = handler.message(schemaId, path);
             diagnostic = null;

--- a/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
+++ b/runtime/model-protobuf/src/main/java/io/aklivity/zilla/runtime/model/protobuf/internal/ProtobufModelHandlerImpl.java
@@ -115,21 +115,36 @@ public final class ProtobufModelHandlerImpl extends ProtobufModelHandler impleme
         int index,
         int length)
     {
+        return resolveSchemaId(data, index, length, 0L);
+    }
+
+    int resolveSchemaId(
+        DirectBufferEx data,
+        int index,
+        int length,
+        long authorization)
+    {
         int schemaId = handler.resolve(data, index, length);
         if (schemaId == NO_SCHEMA_ID)
         {
             schemaId = catalog.id != NO_SCHEMA_ID
                 ? catalog.id
-                : handler.resolve(subject, catalog.version);
+                : handler.resolve(subject, catalog.version, authorization);
         }
         return schemaId;
     }
 
     int resolveSchemaId()
     {
+        return resolveSchemaId(0L);
+    }
+
+    int resolveSchemaId(
+        long authorization)
+    {
         return catalog != null && catalog.id > 0
             ? catalog.id
-            : handler.resolve(subject, catalog.version);
+            : handler.resolve(subject, catalog.version, authorization);
     }
 
     // consumes the message-index varints at the value start (after the catalog framing), returning the number

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/engine.schema.json
@@ -267,6 +267,11 @@
                     "title": "Vault",
                     "type": "string"
                 },
+                "guard":
+                {
+                    "title": "Guard",
+                    "type": "string"
+                },
                 "options":
                 {
                     "title": "Options",


### PR DESCRIPTION
## Summary
- Stacks on #2397 (`CatalogHandler.resolve(subject, version, authorization)`). Once #2397 merges this PR's diff will shrink to just the changes below.
- Adds `guard`/`guardId` to `CatalogConfig`, mirroring the existing `vault`/`vaultId` pattern exactly (all 6 catalog subtypes + builders + JSON adapter + `engine.schema.json`).
- `InlineCatalogHandler.resolve(subject, version, authorization)` now resolves `${guarded['name'].identity}` and `${guarded['name'].attributes.x}` expressions in `subject` via the configured `GuardHandler` before the `schemaIds` lookup — same syntax `topics[].alias` already supports for kafka-proxy routing (`TlsWithResolver`/`HttpKafkaWithResolver`/`GrpcKafkaWithResolver`/`SseKafkaWithResolver`), now available on the catalog side too.
- The guard name inside the expression brackets is not re-resolved — an inline catalog carries at most one configured `guard`, applied regardless of which name literal appears in `${guarded['...']...}`. Flagging this as an open design question: happy to add per-name guard resolution if reviewers want closer parity with the binding-side resolvers.
- No schema change needed on the subject-being-resolved side (`catalog.subject` in `model-json`/`model-protobuf`/`model-avro` is already an unconstrained string).

## Test plan
- [x] `./mvnw -pl runtime/engine,config/engine.conf,config/catalog-inline.conf,config/catalog-apicurio.conf,config/catalog-schema-registry.conf,config/catalog-filesystem.conf,config/catalog-karapace.conf,runtime/catalog-inline install -o` — green, checkstyle clean across all 8 modules
- [x] New `InlineCatalogHandlerTest` cases: identity-expression resolution, attribute-expression resolution, no-guard-configured fallback (`NO_SCHEMA_ID`), and 2-arg overload ignores expression syntax entirely (backward compat)
- [x] Existing `InlineIT` (3 tests) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)