### PR TITLE
fix(binding-tls): merge net reply address into TlsClientFactory reply ProxyBeginEx

### DIFF
--- a/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
+++ b/runtime/binding-tls/src/main/java/io/aklivity/zilla/runtime/binding/tls/internal/stream/TlsClientFactory.java
@@ -1167,7 +1167,17 @@ public final class TlsClientFactory implements TlsStreamFactory
             doBegin(app, originId, routedId, replyId, replySeq, replyAck, replyMax, traceId, client.replyAuth, affinity,
                 ex -> ex.set((b, o, l) -> tlsBeginExRW.wrap(b, o, l)
                                                       .typeId(proxyTypeId)
-                                                      .address(a -> a.none(n -> {}))
+                                                      .address(a ->
+                                                      {
+                                                          if (client.extension != null)
+                                                          {
+                                                              a.set(client.extension.address());
+                                                          }
+                                                          else
+                                                          {
+                                                              a.none(n -> {});
+                                                          }
+                                                      })
                                                       .infos(is ->
                                                       {
                                                           if (protocol != null)
@@ -1296,6 +1306,8 @@ public final class TlsClientFactory implements TlsStreamFactory
             private final long initialId;
             private final long replyId;
 
+            private ProxyBeginExFW extension;
+
             private TlsClientDecoder decoder;
 
             private long replyAuth;
@@ -1401,6 +1413,15 @@ public final class TlsClientFactory implements TlsStreamFactory
                 final long acknowledge = begin.acknowledge();
                 final long traceId = begin.traceId();
                 final long authorization = begin.authorization();
+                final ProxyBeginExFW beginEx = begin.extension().get(beginExRO::tryWrap);
+
+                if (beginEx != null && beginEx.typeId() == proxyTypeId)
+                {
+                    // TODO: use decodeSlot instead of allocation
+                    MutableDirectBufferEx bufferEx = new UnsafeBufferEx(new byte[beginEx.sizeof()]);
+                    bufferEx.putBytes(0, beginEx.buffer(), beginEx.offset(), beginEx.sizeof());
+                    extension = new ProxyBeginExFW().wrap(bufferEx, 0, bufferEx.capacity());
+                }
 
                 assert acknowledge <= sequence;
                 assert sequence >= replySeq;


### PR DESCRIPTION
## Description

`TlsClientFactory.doAppBegin` (reply direction) unconditionally emitted `.address(a -> a.none(n -> {}))` on the reply `ProxyBeginEx`, dropping any address information even when the underlying network reply `BEGIN` carried a `ProxyBeginEx` of its own. `TlsServerFactory` already handles the analogous case for its initial direction by merging in the address from the corresponding lower-layer extension instead of replacing it with `NONE`.

This PR brings `TlsClientFactory`'s reply direction in line with that existing merge pattern:

- Added a `ProxyBeginExFW extension` field to `TlsClient` to retain the parsed net-level reply `ProxyBeginEx`.
- `TlsClient.onNetBegin` now parses `begin.extension()` for a `ProxyBeginExFW` and stores it (mirroring `TlsServerFactory.onNetBegin`).
- `TlsStream.doAppBegin` now merges `client.extension.address()` into the reply `ProxyBeginEx` when present, falling back to `.none()` only when there's nothing to convey. The existing ALPN/authority `infos` population is unchanged.

Fixes #2407

## Test plan

- [x] `./mvnw clean verify -pl runtime/binding-tls` passes (checkstyle, license headers, unit tests, k3po integration tests including `ProxyIT`, JaCoCo coverage gates)
- [x] `./mvnw checkstyle:check -pl runtime/binding-tls` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Li1vJAQbMpZaPMRYE3jS9H)_