### PR TITLE
fix(model-core): forward named-config refs from BytesModelConfig/StringModelConfig

### DIFF
--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfig.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfig.java
@@ -14,20 +14,23 @@
  */
 package io.aklivity.zilla.config.model.core;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
+import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class BytesModelConfig extends ModelConfig
 {
     BytesModelConfig(
         ValidateConfig validate,
-        Map<String, Config> extensions)
+        Map<String, Config> extensions,
+        List<NamedConfig> refs)
     {
-        super("bytes", null, validate, extensions);
+        super("bytes", null, validate, extensions, refs);
     }
 
     public static <T> BytesModelConfigBuilder<T> builder(

--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfigBuilder.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/BytesModelConfigBuilder.java
@@ -48,6 +48,6 @@ public class BytesModelConfigBuilder<T> extends ConfigBuilder.Extensible<T, Byte
     @Override
     public T build()
     {
-        return mapper.apply(new BytesModelConfig(validate, extensions()));
+        return mapper.apply(new BytesModelConfig(validate, extensions(), refs()));
     }
 }

--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfig.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfig.java
@@ -14,11 +14,13 @@
  */
 package io.aklivity.zilla.config.model.core;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
+import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class StringModelConfig extends ModelConfig
@@ -34,9 +36,10 @@ public final class StringModelConfig extends ModelConfig
         int maxLength,
         int minLength,
         ValidateConfig validate,
-        Map<String, Config> extensions)
+        Map<String, Config> extensions,
+        List<NamedConfig> refs)
     {
-        super("string", null, validate, extensions);
+        super("string", null, validate, extensions, refs);
         this.encoding = encoding;
         this.pattern = pattern;
         this.maxLength = maxLength;

--- a/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfigBuilder.java
+++ b/config/model-core.conf/src/main/java/io/aklivity/zilla/config/model/core/StringModelConfigBuilder.java
@@ -83,6 +83,7 @@ public class StringModelConfigBuilder<T> extends ConfigBuilder.Extensible<T, Str
     public T build()
     {
         String encoding = this.encoding != null ? this.encoding : DEFAULT_ENCODING;
-        return mapper.apply(new StringModelConfig(encoding, pattern, maxLength, minLength, validate, extensions()));
+        return mapper.apply(
+            new StringModelConfig(encoding, pattern, maxLength, minLength, validate, extensions(), refs()));
     }
 }

--- a/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/BytesModelConfigTest.java
+++ b/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/BytesModelConfigTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.config.model.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
+
+public class BytesModelConfigTest
+{
+    @Test
+    public void shouldForwardRefContributedByExtension()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+
+        BytesModelConfig config = BytesModelConfig.builder()
+            .ref(vaulted)
+            .build();
+
+        List<NamedConfig> refs = config.refs();
+        assertThat(refs, hasItem(vaulted));
+    }
+
+    @Test
+    public void shouldDefaultRefsToEmpty()
+    {
+        BytesModelConfig config = BytesModelConfig.builder().build();
+
+        assertThat(config.refs(), empty());
+    }
+}

--- a/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/StringModelConfigTest.java
+++ b/config/model-core.conf/src/test/java/io/aklivity/zilla/config/model/core/StringModelConfigTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.config.model.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.aklivity.zilla.config.engine.NamedConfig;
+import io.aklivity.zilla.config.engine.VaultedConfig;
+
+public class StringModelConfigTest
+{
+    @Test
+    public void shouldForwardRefContributedByExtension()
+    {
+        VaultedConfig vaulted = VaultedConfig.builder().name("vault0").build();
+
+        StringModelConfig config = StringModelConfig.builder()
+            .ref(vaulted)
+            .build();
+
+        List<NamedConfig> refs = config.refs();
+        assertThat(refs, hasItem(vaulted));
+    }
+
+    @Test
+    public void shouldDefaultRefsToEmpty()
+    {
+        StringModelConfig config = StringModelConfig.builder().build();
+
+        assertThat(config.refs(), empty());
+    }
+}


### PR DESCRIPTION
## Description

`BytesModelConfig`/`StringModelConfig` (and their builders) never forward a `refs` list to `ModelConfig`'s super constructor, unlike `AvroModelConfig`, which already does.

`ConfigExtAdapter.adaptRef` already bubbles any extension config's own `Config.Extensible#refs()` (e.g. a `vault:`/`guarded:` reference contributed by an installed `bytes`/`string` model extension) up onto `BytesModelConfigBuilder`/`StringModelConfigBuilder` generically via `.ref(...)` — that part already works today, for free, since both builders extend `ConfigBuilder.Extensible`. But `BytesModelConfigBuilder#build()`/`StringModelConfigBuilder#build()` never call `refs()`, and `BytesModelConfig`/`StringModelConfig`'s constructors don't even accept a `refs` parameter — so every bubbled ref is silently dropped before the engine's generic name→id resolution walk ever sees it.

This is a parity fix: `BytesModelConfig`/`StringModelConfig` gain exactly the `refs` constructor parameter and forwarding that `ModelConfig` already supports and `AvroModelConfig` already exercises. No behavior changes for either model absent an installed extension that contributes a named reference.

## Test plan

- `./mvnw install -pl config/model-core.conf -am` passes with no failures.
- No other callers of the now-5-arg `BytesModelConfig`/6-arg `StringModelConfig` constructors exist outside their own builders.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BM4DuDAs8Xs73PHYnA9866)_