### PR TITLE
feat(model-json): support refs, attach(), and authorization

### DIFF
--- a/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfig.java
+++ b/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfig.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import io.aklivity.zilla.config.engine.CatalogedConfig;
 import io.aklivity.zilla.config.engine.Config;
 import io.aklivity.zilla.config.engine.ModelConfig;
+import io.aklivity.zilla.config.engine.NamedConfig;
 import io.aklivity.zilla.config.engine.ValidateConfig;
 
 public final class JsonModelConfig extends ModelConfig
@@ -31,9 +32,10 @@ public final class JsonModelConfig extends ModelConfig
         List<CatalogedConfig> cataloged,
         String subject,
         ValidateConfig validate,
-        Map<String, Config> extensions)
+        Map<String, Config> extensions,
+        List<NamedConfig> refs)
     {
-        super("json", cataloged, validate, extensions);
+        super("json", cataloged, validate, extensions, refs);
         this.subject = subject;
     }
 

--- a/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfigBuilder.java
+++ b/config/model-json.conf/src/main/java/io/aklivity/zilla/config/model/json/JsonModelConfigBuilder.java
@@ -77,6 +77,6 @@ public class JsonModelConfigBuilder<T> extends ConfigBuilder.Extensible<T, JsonM
     @Override
     public T build()
     {
-        return mapper.apply(new JsonModelConfig(catalogs, subject, validate, extensions()));
+        return mapper.apply(new JsonModelConfig(catalogs, subject, validate, extensions(), refs()));
     }
 }

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonController.java
@@ -28,6 +28,21 @@ public interface JsonController
     void segmentable();
 
     /**
+     * Returns the authorization in effect for the value currently being transformed.
+     * <p>
+     * A mediating stage may override this to scope the authorization further for a nested composition; a
+     * non-mediating stage passes its own through, so this reflects the authorization the pipeline received
+     * via {@link JsonPipeline#authorization(long)} unless narrowed. The default is {@code 0L}, for a
+     * pipeline that never received one.
+     *
+     * @return the authorization in effect for the current value
+     */
+    default long authorization()
+    {
+        return 0L;
+    }
+
+    /**
      * Returns the metadata travelling alongside the value being transformed, addressed by name rather than
      * by position within the value. The default is {@link JsonEnvelope#NONE}, in force when no envelope
      * was supplied to the pipeline, so a stage reads an empty envelope rather than no envelope at all. A

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/JsonPipeline.java
@@ -47,6 +47,18 @@ public interface JsonPipeline
     void reset();
 
     /**
+     * Sets the authorization in effect for the next datum {@link #transform fed} to this pipeline, reached
+     * by any stage via {@link JsonController#authorization()}. The default does nothing, for a pipeline
+     * that never carries one.
+     *
+     * @param authorization the authorization in effect for the next datum
+     */
+    default void authorization(
+        long authorization)
+    {
+    }
+
+    /**
      * Whether this pipeline reproduces its input bytes for every accepted datum — the composition of its
      * parser, transform stages, and terminal generator all being identity.
      */

--- a/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
+++ b/runtime/common-json/src/main/java/io/aklivity/zilla/runtime/common/json/internal/JsonPipelineImpl.java
@@ -91,6 +91,13 @@ public final class JsonPipelineImpl implements JsonPipeline
     }
 
     @Override
+    public void authorization(
+        long authorization)
+    {
+        control.authorization = authorization;
+    }
+
+    @Override
     public boolean identity()
     {
         return parser.identity() && root.identity();
@@ -329,6 +336,7 @@ public final class JsonPipelineImpl implements JsonPipeline
         private final JsonEnvelope envelope;
 
         private boolean segmented;
+        private long authorization;
 
         private Control(
             JsonParserEx parser,
@@ -336,6 +344,12 @@ public final class JsonPipelineImpl implements JsonPipeline
         {
             this.parser = parser;
             this.envelope = envelope;
+        }
+
+        @Override
+        public long authorization()
+        {
+            return authorization;
         }
 
         @Override

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/ext/JsonModelExtContext.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/ext/JsonModelExtContext.java
@@ -24,6 +24,20 @@ import io.aklivity.zilla.runtime.common.json.JsonSchema;
 public interface JsonModelExtContext
 {
     /**
+     * Called once when a binding attaches this configuration, before any schema is resolved or any
+     * stream begins. An extension whose behavior depends on a resource that resolves asynchronously
+     * (e.g. a vault-wrapped key) can use this to kick off that resolution eagerly, from whatever the
+     * configuration alone already determines, so the resource is more likely to already be resolved by
+     * the time a real stream needs it. The default does nothing.
+     *
+     * @param config  the json model configuration
+     */
+    default void attach(
+        JsonModelConfig config)
+    {
+    }
+
+    /**
      * Supplies the handler for one resolved schema, bound to a specific {@link JsonModelConfig}.
      *
      * @param schema  the resolved schema

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelContext.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelContext.java
@@ -41,6 +41,8 @@ public class JsonModelContext implements ModelContext
     public ModelHandler supplyHandler(
         ModelConfig config)
     {
-        return new JsonModelHandlerImpl(JsonModelConfig.class.cast(config), context, exts);
+        JsonModelConfig jsonOptions = JsonModelConfig.class.cast(config);
+        exts.forEach(ext -> ext.attach(jsonOptions));
+        return new JsonModelHandlerImpl(jsonOptions, context, exts);
     }
 }

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelDecoderPipeline.java
@@ -101,6 +101,7 @@ final class JsonModelDecoderPipeline implements ModelPipeline
             if (active != null)
             {
                 active.reset();
+                active.authorization(authorization);
             }
             diagnostic = null;
         }

--- a/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
+++ b/runtime/model-json/src/main/java/io/aklivity/zilla/runtime/model/json/internal/JsonModelEncoderPipeline.java
@@ -89,6 +89,7 @@ final class JsonModelEncoderPipeline implements ModelPipeline
             if (active != null)
             {
                 active.reset();
+                active.authorization(authorization);
                 // the schema framing prefix is emitted once into the destination ahead of the value
                 prefix = writePrefix(traceId, bindingId, schemaId, src, srcIndex, srcLength, dst, dstIndex);
             }


### PR DESCRIPTION
## Description

`JsonModelConfig` had no `refs`, unlike `ModelConfig`'s own base contract and unlike the equivalent avro model config, so a json model extension had no way to resolve a named engine resource (e.g. a vault) declared elsewhere in the config tree. `JsonModelExtContext` also had no `attach()` hook, so an extension had no point to eagerly resolve a resource that depends only on the configuration, before any schema is resolved or any stream begins.

Separately, `JsonController` had no way for a `JsonTransform` to observe the authorization in effect for the value it is transforming, unlike `AvroController`'s own `authorization()`.

This PR:

- Threads `refs` through `JsonModelConfig`/`JsonModelConfigBuilder`, matching `ModelConfig`'s own constructor contract (and the support avro's model config already has).
- Adds a default `attach(JsonModelConfig)` method to `JsonModelExtContext`, mirroring the equivalent avro model extension hook. `JsonModelContext#supplyHandler` now calls it once per extension before constructing the handler.
- Adds `JsonController#authorization()` (default `0L`) and `JsonPipeline#authorization(long)`, the setter a decoder/encoder pipeline uses to record the authorization it received. `JsonModelDecoderPipeline`/`JsonModelEncoderPipeline` now record it in their `FLAGS_INIT` handling.

No behavior change for existing json model usage — every new method is additive plumbing or a default that returns the previous implicit value (no refs, authorization `0L`).

## Test plan

- `./mvnw clean install -pl runtime/common-json,config/model-json.conf,runtime/model-json -am` — full suite passes: 4950 `common-json` unit tests, 17 `model-json` k3po ITs, JaCoCo coverage requirements met, 0 checkstyle violations
- Verified the only production call site of `JsonModelConfig`'s constructor (`JsonModelConfigBuilder#build()`) was updated for the new `refs` parameter


---
_Generated by [Claude Code](https://claude.ai/code/session_015U6AztBUTqwWMaV5FRdBtS)_