### PR TITLE
fix(engine): honor affinity's embedded worker index for routing

### DIFF
--- a/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
+++ b/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
@@ -126,6 +126,7 @@ add_field("authorization", ProtoField.uint64("zilla.authorization", "Authorizati
 
 -- begin frame
 add_field("affinity", ProtoField.uint64("zilla.affinity", "Affinity", base.HEX))
+add_field("redirected_id", ProtoField.uint64("zilla.redirected_id", "Redirected ID", base.HEX))
 
 -- data frame
 add_field("flags", ProtoField.uint8("zilla.flags", "Flags", base.HEX))
@@ -277,7 +278,9 @@ end
 function handle_begin_frame(buffer, offset, subtree, pinfo, info)
     local slice_affinity = buffer(offset, 8)
     subtree:add_le(fields.affinity, slice_affinity)
-    handle_extension(buffer, subtree, pinfo, info, offset + 8, BEGIN_ID)
+    local slice_redirected_id = buffer(offset + 8, 8)
+    subtree:add_le(fields.redirected_id, slice_redirected_id)
+    handle_extension(buffer, subtree, pinfo, info, offset + 16, BEGIN_ID)
 end
 
 function handle_redirect_frame(buffer, offset, subtree, pinfo, info)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
@@ -31,14 +31,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 137, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000058
+    Offset: 0x00000060
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -61,14 +61,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 129, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 137, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000000b0
+    Offset: 0x000000c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -95,14 +95,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000110
+    Offset: 0x00000120
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -129,14 +129,14 @@ Zilla Frame
 Frame 5: 219 bytes on wire (1752 bits), 219 bytes captured (1752 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 266, Ack: 266, Len: 145
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 274, Ack: 274, Len: 145
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000170
+    Offset: 0x00000180
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -170,14 +170,14 @@ Advanced Message Queuing Protocol
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 411, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 419, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000001d8
+    Offset: 0x000001e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -204,14 +204,14 @@ Zilla Frame
 Frame 7: 219 bytes on wire (1752 bits), 219 bytes captured (1752 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 548, Len: 145
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 556, Len: 145
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000238
+    Offset: 0x00000248
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -245,14 +245,14 @@ Advanced Message Queuing Protocol
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 411, Ack: 548, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 419, Ack: 556, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000002a0
+    Offset: 0x000002b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -279,14 +279,14 @@ Zilla Frame
 Frame 9: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 548, Ack: 548, Len: 159
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 556, Ack: 556, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000300
+    Offset: 0x00000310
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -320,14 +320,14 @@ Advanced Message Queuing Protocol
 Frame 10: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 707, Ack: 548, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 715, Ack: 556, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000378
+    Offset: 0x00000388
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -354,14 +354,14 @@ Zilla Frame
 Frame 11: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 548, Ack: 844, Len: 159
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 556, Ack: 852, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000003d8
+    Offset: 0x000003e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -395,14 +395,14 @@ Advanced Message Queuing Protocol
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 707, Ack: 844, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 715, Ack: 852, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000450
+    Offset: 0x00000460
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -429,14 +429,14 @@ Zilla Frame
 Frame 13: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 844, Ack: 844, Len: 164
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 852, Ack: 852, Len: 164
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000004b0
+    Offset: 0x000004c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -470,14 +470,14 @@ Advanced Message Queuing Protocol
 Frame 14: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1008, Ack: 844, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1016, Ack: 852, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000528
+    Offset: 0x00000538
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -504,14 +504,14 @@ Zilla Frame
 Frame 15: 240 bytes on wire (1920 bits), 240 bytes captured (1920 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 844, Ack: 1145, Len: 166
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 852, Ack: 1153, Len: 166
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000588
+    Offset: 0x00000598
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -545,14 +545,14 @@ Advanced Message Queuing Protocol
 Frame 16: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1010, Ack: 1145, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1018, Ack: 1153, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000608
+    Offset: 0x00000618
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -579,14 +579,14 @@ Zilla Frame
 Frame 17: 253 bytes on wire (2024 bits), 253 bytes captured (2024 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1145, Ack: 1147, Len: 179
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1153, Ack: 1155, Len: 179
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000668
+    Offset: 0x00000678
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -620,14 +620,14 @@ Advanced Message Queuing Protocol
 Frame 18: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1324, Ack: 1147, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1332, Ack: 1155, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000006f0
+    Offset: 0x00000700
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -654,14 +654,14 @@ Zilla Frame
 Frame 19: 260 bytes on wire (2080 bits), 260 bytes captured (2080 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1147, Ack: 1461, Len: 186
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1155, Ack: 1469, Len: 186
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000750
+    Offset: 0x00000760
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -695,14 +695,14 @@ Advanced Message Queuing Protocol
 Frame 20: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1333, Ack: 1461, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1341, Ack: 1469, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000007e0
+    Offset: 0x000007f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -729,14 +729,14 @@ Zilla Frame
 Frame 21: 239 bytes on wire (1912 bits), 239 bytes captured (1912 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1461, Ack: 1470, Len: 165
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1469, Ack: 1478, Len: 165
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000840
+    Offset: 0x00000850
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -770,14 +770,14 @@ Advanced Message Queuing Protocol
 Frame 22: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1626, Ack: 1470, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1634, Ack: 1478, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x000008c0
+    Offset: 0x000008d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -800,14 +800,14 @@ Zilla Frame
 Frame 23: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1758, Ack: 1470, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1766, Ack: 1478, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000918
+    Offset: 0x00000928
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -834,14 +834,14 @@ Zilla Frame
 Frame 24: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1470, Ack: 1895, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1478, Ack: 1903, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x112dc182
     Protocol Type: amqp
     Worker: 0
-    Offset: 0x00000978
+    Offset: 0x00000988
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -55,6 +56,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
@@ -1,7 +1,7 @@
-Frame 1: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 1: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 128
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -28,10 +28,10 @@ Zilla Frame
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
@@ -40,14 +40,14 @@ Zilla Frame
 Frame 2: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 152, Len: 159
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 160, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000070
+    Offset: 0x00000078
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -79,14 +79,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 152, Ack: 152, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 160, Ack: 160, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000e0
+    Offset: 0x000000f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -113,14 +113,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 152, Ack: 289, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 160, Ack: 297, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000140
+    Offset: 0x00000150
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -147,14 +147,14 @@ Zilla Frame
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 289, Ack: 289, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 297, Ack: 297, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001a0
+    Offset: 0x000001b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -177,14 +177,14 @@ Zilla Frame
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 289, Ack: 421, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 297, Ack: 429, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001f8
+    Offset: 0x00000208
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
@@ -1,7 +1,7 @@
-Frame 1: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
+Frame 1: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 151
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -37,10 +37,10 @@ Zilla Frame
         Sender Settle Mode: SETTLED (1)
         Receiver Settle Mode: FIRST (0)
 
-Frame 2: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
+Frame 2: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 152, Len: 151
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 152, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: amqp
         Stream Type ID: 0x82c12d11
         Stream Type: amqp
@@ -64,6 +65,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: amqp
         Stream Type ID: 0x82c12d11
         Stream Type: amqp

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
@@ -58,14 +58,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 179, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 187, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000088
+    Offset: 0x00000090
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -92,14 +92,14 @@ Zilla Frame
 Frame 3: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 316, Ack: 1, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 324, Ack: 1, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000e8
+    Offset: 0x000000f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -122,14 +122,14 @@ Zilla Frame
 Frame 4: 269 bytes on wire (2152 bits), 269 bytes captured (2152 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 448, Len: 195
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 456, Len: 195
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000140
+    Offset: 0x00000148
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -179,14 +179,14 @@ Zilla Frame
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 188, Ack: 448, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 196, Ack: 456, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001d0
+    Offset: 0x000001e0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -209,14 +209,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 320, Ack: 448, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 328, Ack: 456, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000228
+    Offset: 0x00000238
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
@@ -1,7 +1,7 @@
-Frame 1: 252 bytes on wire (2016 bits), 252 bytes captured (2016 bits)
+Frame 1: 260 bytes on wire (2080 bits), 260 bytes captured (2080 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 178
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 186
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -119,10 +119,10 @@ Zilla Frame
     Budget ID: 0x0000000000000000
     Reserved: 0
 
-Frame 4: 261 bytes on wire (2088 bits), 261 bytes captured (2088 bits)
+Frame 4: 269 bytes on wire (2152 bits), 269 bytes captured (2152 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 448, Len: 187
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 448, Len: 195
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: filesystem
         Stream Type ID: 0x9eaae6e4
         Stream Type: filesystem
@@ -146,6 +147,7 @@ Zilla Frame
     Trace ID: 0x8000000000000004
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: filesystem
         Stream Type ID: 0x9eaae6e4
         Stream Type: filesystem

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: grpc
         Stream Type ID: 0x3a58c7f9
         Stream Type: grpc
@@ -219,6 +220,7 @@ Zilla Frame
     Trace ID: 0x8000000000000006
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 7: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
@@ -57,14 +57,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 223, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 231, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000b8
+    Offset: 0x000000c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -91,14 +91,14 @@ Zilla Frame
 Frame 3: 224 bytes on wire (1792 bits), 224 bytes captured (1792 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 360, Ack: 1, Len: 150
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 368, Ack: 1, Len: 150
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000118
+    Offset: 0x00000120
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -131,14 +131,14 @@ Zilla Frame
 Frame 4: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 510, Ack: 1, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 518, Ack: 1, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000188
+    Offset: 0x00000190
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -161,14 +161,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 642, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 650, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001e0
+    Offset: 0x000001e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -195,14 +195,14 @@ Zilla Frame
 Frame 6: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 779, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 787, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000240
+    Offset: 0x00000248
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -225,14 +225,14 @@ Zilla Frame
 Frame 7: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 779, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 787, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000298
+    Offset: 0x000002a8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -259,14 +259,14 @@ Zilla Frame
 Frame 8: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 779, Len: 151
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 787, Len: 151
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002f8
+    Offset: 0x00000308
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -299,14 +299,14 @@ Zilla Frame
 Frame 9: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 417, Ack: 779, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 425, Ack: 787, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000368
+    Offset: 0x00000378
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -333,14 +333,14 @@ Zilla Frame
 Frame 10: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 554, Ack: 779, Len: 151
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 562, Ack: 787, Len: 151
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003c8
+    Offset: 0x000003d8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -373,14 +373,14 @@ Zilla Frame
 Frame 11: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 705, Ack: 779, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 713, Ack: 787, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000438
+    Offset: 0x00000448
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -403,14 +403,14 @@ Zilla Frame
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 837, Ack: 779, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 845, Ack: 787, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000490
+    Offset: 0x000004a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
@@ -1,7 +1,7 @@
-Frame 1: 296 bytes on wire (2368 bits), 296 bytes captured (2368 bits)
+Frame 1: 304 bytes on wire (2432 bits), 304 bytes captured (2432 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 222
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 230
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -192,10 +192,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 6: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 6: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 779, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 779, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
@@ -1,7 +1,7 @@
-Frame 1: 316 bytes on wire (2528 bits), 316 bytes captured (2528 bits)
+Frame 1: 324 bytes on wire (2592 bits), 324 bytes captured (2592 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 242
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 250
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -123,10 +123,10 @@ Zilla Frame
     Budget ID: 0x0000000000000000
     Reserved: 0
 
-Frame 4: 317 bytes on wire (2536 bits), 317 bytes captured (2536 bits)
+Frame 4: 325 bytes on wire (2600 bits), 325 bytes captured (2600 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 512, Len: 243
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 512, Len: 251
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000001
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: http
         Stream Type ID: 0x4620b68a
         Stream Type: http
@@ -150,6 +151,7 @@ Zilla Frame
     Trace ID: 0x8000000000000004
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: http
         Stream Type ID: 0x4620b68a
         Stream Type: http

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
@@ -62,14 +62,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 243, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 251, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000c8
+    Offset: 0x000000d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -96,14 +96,14 @@ Zilla Frame
 Frame 3: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 380, Ack: 1, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 388, Ack: 1, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000128
+    Offset: 0x00000130
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -126,14 +126,14 @@ Zilla Frame
 Frame 4: 325 bytes on wire (2600 bits), 325 bytes captured (2600 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 512, Len: 251
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 520, Len: 251
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000180
+    Offset: 0x00000188
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -182,14 +182,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 244, Ack: 512, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 252, Ack: 520, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000248
+    Offset: 0x00000258
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -216,14 +216,14 @@ Zilla Frame
 Frame 6: 230 bytes on wire (1840 bits), 230 bytes captured (1840 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 381, Ack: 512, Len: 156
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 389, Ack: 520, Len: 156
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002a8
+    Offset: 0x000002b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -256,14 +256,14 @@ Zilla Frame
 Frame 7: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 537, Ack: 512, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 545, Ack: 520, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000318
+    Offset: 0x00000328
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -290,14 +290,14 @@ Zilla Frame
 Frame 8: 275 bytes on wire (2200 bits), 275 bytes captured (2200 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 674, Ack: 512, Len: 201
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 682, Ack: 520, Len: 201
 Zilla Frame
     Frame Type ID: 0x40000004
     Frame Type: CHALLENGE
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000378
+    Offset: 0x00000388
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -334,14 +334,14 @@ Zilla Frame
 Frame 9: 312 bytes on wire (2496 bits), 312 bytes captured (2496 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 875, Ack: 512, Len: 238
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 883, Ack: 520, Len: 238
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000418
+    Offset: 0x00000428
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -374,14 +374,14 @@ Zilla Frame
 Frame 10: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1113, Ack: 512, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1121, Ack: 520, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004e0
+    Offset: 0x000004f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -404,14 +404,14 @@ Zilla Frame
 Frame 11: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1245, Ack: 512, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1253, Ack: 520, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000538
+    Offset: 0x00000548
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -55,6 +56,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
@@ -31,14 +31,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 137, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000058
+    Offset: 0x00000060
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -61,14 +61,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 129, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 137, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000000b0
+    Offset: 0x000000c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -95,14 +95,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000110
+    Offset: 0x00000120
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -129,14 +129,14 @@ Zilla Frame
 Frame 5: 235 bytes on wire (1880 bits), 235 bytes captured (1880 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 266, Ack: 266, Len: 161
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 274, Ack: 274, Len: 161
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000170
+    Offset: 0x00000180
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -170,14 +170,14 @@ HyperText Transfer Protocol 2
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 427, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 435, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000001e8
+    Offset: 0x000001f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -204,14 +204,14 @@ Zilla Frame
 Frame 7: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 564, Len: 164
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 572, Len: 164
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000248
+    Offset: 0x00000258
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -245,14 +245,14 @@ HyperText Transfer Protocol 2
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 430, Ack: 564, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 438, Ack: 572, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000002c0
+    Offset: 0x000002d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -279,14 +279,14 @@ Zilla Frame
 Frame 9: 232 bytes on wire (1856 bits), 232 bytes captured (1856 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 564, Ack: 567, Len: 158
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 572, Ack: 575, Len: 158
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000320
+    Offset: 0x00000330
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -320,14 +320,14 @@ HyperText Transfer Protocol 2
 Frame 10: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 722, Ack: 567, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 730, Ack: 575, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000398
+    Offset: 0x000003a8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -354,14 +354,14 @@ Zilla Frame
 Frame 11: 220 bytes on wire (1760 bits), 220 bytes captured (1760 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 567, Ack: 859, Len: 146
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 575, Ack: 867, Len: 146
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000003f8
+    Offset: 0x00000408
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -395,14 +395,14 @@ HyperText Transfer Protocol 2
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 713, Ack: 859, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 721, Ack: 867, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000460
+    Offset: 0x00000470
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -429,14 +429,14 @@ Zilla Frame
 Frame 13: 220 bytes on wire (1760 bits), 220 bytes captured (1760 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 859, Ack: 850, Len: 146
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 867, Ack: 858, Len: 146
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000004c0
+    Offset: 0x000004d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -470,14 +470,14 @@ HyperText Transfer Protocol 2
 Frame 14: 269 bytes on wire (2152 bits), 269 bytes captured (2152 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1005, Ack: 850, Len: 195
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1013, Ack: 858, Len: 195
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000528
+    Offset: 0x00000538
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -511,14 +511,14 @@ HyperText Transfer Protocol 2
 Frame 15: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1200, Ack: 850, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1208, Ack: 858, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000005c0
+    Offset: 0x000005d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -545,14 +545,14 @@ Zilla Frame
 Frame 16: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1337, Ack: 850, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1345, Ack: 858, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000620
+    Offset: 0x00000630
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -579,14 +579,14 @@ Zilla Frame
 Frame 17: 281 bytes on wire (2248 bits), 281 bytes captured (2248 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 850, Ack: 1474, Len: 207
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 858, Ack: 1482, Len: 207
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000680
+    Offset: 0x00000690
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -620,14 +620,14 @@ HyperText Transfer Protocol 2
 Frame 18: 239 bytes on wire (1912 bits), 239 bytes captured (1912 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1057, Ack: 1474, Len: 165
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1065, Ack: 1482, Len: 165
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000728
+    Offset: 0x00000738
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -661,14 +661,14 @@ HyperText Transfer Protocol 2
 Frame 19: 321 bytes on wire (2568 bits), 321 bytes captured (2568 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1222, Ack: 1474, Len: 247
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1230, Ack: 1482, Len: 247
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000007a8
+    Offset: 0x000007b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -702,14 +702,14 @@ HyperText Transfer Protocol 2
 Frame 20: 224 bytes on wire (1792 bits), 224 bytes captured (1792 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1469, Ack: 1474, Len: 150
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1477, Ack: 1482, Len: 150
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000878
+    Offset: 0x00000888
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -743,14 +743,14 @@ HyperText Transfer Protocol 2
 Frame 21: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1619, Ack: 1474, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1627, Ack: 1482, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000008e8
+    Offset: 0x000008f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -777,14 +777,14 @@ Zilla Frame
 Frame 22: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1756, Ack: 1474, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1764, Ack: 1482, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000948
+    Offset: 0x00000958
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -811,14 +811,14 @@ Zilla Frame
 Frame 23: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1893, Ack: 1474, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1901, Ack: 1482, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x000009a8
+    Offset: 0x000009b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -845,14 +845,14 @@ Zilla Frame
 Frame 24: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 2030, Ack: 1474, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 2038, Ack: 1482, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000a08
+    Offset: 0x00000a18
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -879,14 +879,14 @@ Zilla Frame
 Frame 25: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1474, Ack: 2167, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1482, Ack: 2175, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000a68
+    Offset: 0x00000a78
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -909,14 +909,14 @@ Zilla Frame
 Frame 26: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 2167, Ack: 1606, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 2175, Ack: 1614, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x8ab62046
     Protocol Type: http
     Worker: 0
-    Offset: 0x00000ac0
+    Offset: 0x00000ad0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
@@ -1,7 +1,7 @@
-Frame 1: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 1: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 128
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -28,10 +28,10 @@ Zilla Frame
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
@@ -44,14 +44,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 172, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 180, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000080
+    Offset: 0x00000088
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -78,14 +78,14 @@ Zilla Frame
 Frame 3: 253 bytes on wire (2024 bits), 253 bytes captured (2024 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 309, Len: 179
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 317, Len: 179
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000e0
+    Offset: 0x000000e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -121,14 +121,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 172, Ack: 309, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 180, Ack: 317, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000160
+    Offset: 0x00000170
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -155,14 +155,14 @@ Zilla Frame
 Frame 5: 257 bytes on wire (2056 bits), 257 bytes captured (2056 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 309, Ack: 309, Len: 183
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 317, Ack: 317, Len: 183
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001c0
+    Offset: 0x000001d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -208,14 +208,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 492, Ack: 309, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 500, Ack: 317, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000250
+    Offset: 0x00000260
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -242,14 +242,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 309, Ack: 629, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 317, Ack: 637, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002b0
+    Offset: 0x000002c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -272,14 +272,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 629, Ack: 441, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 637, Ack: 449, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000308
+    Offset: 0x00000318
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -102,6 +103,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
@@ -1,7 +1,7 @@
-Frame 1: 245 bytes on wire (1960 bits), 245 bytes captured (1960 bits)
+Frame 1: 253 bytes on wire (2024 bits), 253 bytes captured (2024 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 171
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 179
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -75,10 +75,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 245 bytes on wire (1960 bits), 245 bytes captured (1960 bits)
+Frame 3: 253 bytes on wire (2024 bits), 253 bytes captured (2024 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 309, Len: 171
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 309, Len: 179
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
@@ -31,14 +31,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 137, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000058
+    Offset: 0x00000060
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -61,14 +61,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 129, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 137, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x000000b0
+    Offset: 0x000000c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -95,14 +95,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000110
+    Offset: 0x00000120
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -129,14 +129,14 @@ Zilla Frame
 Frame 5: 261 bytes on wire (2088 bits), 261 bytes captured (2088 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 266, Ack: 266, Len: 187
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 274, Ack: 274, Len: 187
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000170
+    Offset: 0x00000180
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -170,14 +170,14 @@ Kafka (DescribeConfigs v0 Request)
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 453, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 461, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000200
+    Offset: 0x00000210
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -204,14 +204,14 @@ Zilla Frame
 Frame 7: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 590, Len: 196
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 598, Len: 196
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000260
+    Offset: 0x00000270
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -245,14 +245,14 @@ Kafka (DescribeConfigs v0 Response)
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 462, Ack: 590, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 470, Ack: 598, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x000002f8
+    Offset: 0x00000308
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -279,14 +279,14 @@ Zilla Frame
 Frame 9: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 590, Ack: 599, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 598, Ack: 607, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x00000358
+    Offset: 0x00000368
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -309,14 +309,14 @@ Zilla Frame
 Frame 10: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 599, Ack: 722, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 607, Ack: 730, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x084b20e1
     Protocol Type: kafka
     Worker: 0
-    Offset: 0x000003b0
+    Offset: 0x000003c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -55,6 +56,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
@@ -1,7 +1,7 @@
-Frame 1: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 1: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 128
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -28,10 +28,10 @@ Zilla Frame
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
@@ -1,7 +1,7 @@
-Frame 1: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 1: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 147
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -69,10 +69,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 147
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -223,10 +223,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 7: 262 bytes on wire (2096 bits), 262 bytes captured (2096 bits)
+Frame 7: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 188
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 196
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -338,10 +338,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 10: 262 bytes on wire (2096 bits), 262 bytes captured (2096 bits)
+Frame 10: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 326, Len: 188
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 326, Len: 196
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -96,6 +97,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -249,6 +251,7 @@ Zilla Frame
     Trace ID: 0x8000000000000007
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -363,6 +366,7 @@ Zilla Frame
     Trace ID: 0x800000000000000a
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
@@ -38,14 +38,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 148, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 156, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000068
+    Offset: 0x00000070
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -72,14 +72,14 @@ Zilla Frame
 Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 293, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000c8
+    Offset: 0x000000d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -109,14 +109,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 148, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 156, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000140
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -143,14 +143,14 @@ Zilla Frame
 Frame 5: 240 bytes on wire (1920 bits), 240 bytes captured (1920 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 285, Ack: 285, Len: 166
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 293, Ack: 293, Len: 166
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000190
+    Offset: 0x000001a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -192,14 +192,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 451, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 459, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000210
+    Offset: 0x00000220
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -233,7 +233,7 @@ Zilla Frame
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000270
+    Offset: 0x00000280
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -277,14 +277,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 285, Ack: 588, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 293, Ack: 596, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000300
+    Offset: 0x00000318
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -307,14 +307,14 @@ Zilla Frame
 Frame 9: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 189, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 197, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000358
+    Offset: 0x00000370
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -341,14 +341,14 @@ Zilla Frame
 Frame 10: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 326, Len: 196
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 334, Len: 196
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003b8
+    Offset: 0x000003d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -392,14 +392,14 @@ Zilla Frame
 Frame 11: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 588, Ack: 417, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 596, Ack: 425, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000448
+    Offset: 0x00000468
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -422,14 +422,14 @@ Zilla Frame
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 189, Ack: 326, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 197, Ack: 334, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004a0
+    Offset: 0x000004c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -456,14 +456,14 @@ Zilla Frame
 Frame 13: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 326, Ack: 326, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 334, Ack: 334, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000500
+    Offset: 0x00000520
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -486,14 +486,14 @@ Zilla Frame
 Frame 14: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 326, Ack: 458, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 334, Ack: 466, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000558
+    Offset: 0x00000578
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -110,6 +111,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
@@ -1,7 +1,7 @@
-Frame 1: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
+Frame 1: 254 bytes on wire (2032 bits), 254 bytes captured (2032 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 172
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 180
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -83,10 +83,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
+Frame 3: 278 bytes on wire (2224 bits), 278 bytes captured (2224 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 310, Len: 196
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 310, Len: 204
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
@@ -52,14 +52,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 173, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 181, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000080
+    Offset: 0x00000088
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -86,14 +86,14 @@ Zilla Frame
 Frame 3: 278 bytes on wire (2224 bits), 278 bytes captured (2224 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 310, Len: 204
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 318, Len: 204
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000e0
+    Offset: 0x000000e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -137,14 +137,14 @@ Zilla Frame
 Frame 4: 268 bytes on wire (2144 bits), 268 bytes captured (2144 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 197, Ack: 310, Len: 194
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 205, Ack: 318, Len: 194
 Zilla Frame
     Frame Type ID: 0x00000005
     Frame Type: FLUSH
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000178
+    Offset: 0x00000188
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -188,14 +188,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 391, Ack: 310, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 399, Ack: 318, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000210
+    Offset: 0x00000220
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -222,14 +222,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 310, Ack: 528, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 318, Ack: 536, Len: 137
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000270
+    Offset: 0x00000280
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -261,14 +261,14 @@ Zilla Frame
 Frame 7: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 447, Ack: 528, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 455, Ack: 536, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002d0
+    Offset: 0x000002e0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -295,14 +295,14 @@ Zilla Frame
 Frame 8: 268 bytes on wire (2144 bits), 268 bytes captured (2144 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 528, Ack: 584, Len: 194
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 536, Ack: 592, Len: 194
 Zilla Frame
     Frame Type ID: 0x00000005
     Frame Type: FLUSH
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000330
+    Offset: 0x00000340
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -346,14 +346,14 @@ Zilla Frame
 Frame 9: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 584, Ack: 722, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 592, Ack: 730, Len: 137
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003c8
+    Offset: 0x000003d8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -385,14 +385,14 @@ Zilla Frame
 Frame 10: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 721, Ack: 722, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 729, Ack: 730, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000428
+    Offset: 0x00000438
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -419,14 +419,14 @@ Zilla Frame
 Frame 11: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 722, Ack: 858, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 730, Ack: 866, Len: 137
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000488
+    Offset: 0x00000498
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -458,14 +458,14 @@ Zilla Frame
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 859, Ack: 858, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 867, Ack: 866, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004e8
+    Offset: 0x000004f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -492,14 +492,14 @@ Zilla Frame
 Frame 13: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 858, Ack: 996, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 866, Ack: 1004, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000548
+    Offset: 0x00000558
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -522,14 +522,14 @@ Zilla Frame
 Frame 14: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 996, Ack: 990, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1004, Ack: 998, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000005a0
+    Offset: 0x000005b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
@@ -1,7 +1,7 @@
-Frame 1: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
+Frame 1: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 151
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -68,10 +68,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits)
+Frame 3: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 289, Len: 151
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 289, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -95,6 +96,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
@@ -37,14 +37,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 152, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 160, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000070
+    Offset: 0x00000078
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -71,14 +71,14 @@ Zilla Frame
 Frame 3: 233 bytes on wire (1864 bits), 233 bytes captured (1864 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 289, Len: 159
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 297, Len: 159
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d0
+    Offset: 0x000000d8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -107,14 +107,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 152, Ack: 289, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 160, Ack: 297, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000140
+    Offset: 0x00000150
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -141,14 +141,14 @@ Zilla Frame
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 289, Ack: 289, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 297, Ack: 297, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001a0
+    Offset: 0x000001b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -171,14 +171,14 @@ Zilla Frame
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 289, Ack: 421, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 297, Ack: 429, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001f8
+    Offset: 0x00000208
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -134,6 +135,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
@@ -76,14 +76,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 246, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 254, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d0
+    Offset: 0x000000d8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -110,14 +110,14 @@ Zilla Frame
 Frame 3: 327 bytes on wire (2616 bits), 327 bytes captured (2616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 383, Len: 253
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 391, Len: 253
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000138
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -185,14 +185,14 @@ Zilla Frame
 Frame 4: 328 bytes on wire (2624 bits), 328 bytes captured (2624 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 246, Ack: 383, Len: 254
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 254, Ack: 391, Len: 254
 Zilla Frame
     Frame Type ID: 0x00000005
     Frame Type: FLUSH
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000200
+    Offset: 0x00000210
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -255,14 +255,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 500, Ack: 383, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 508, Ack: 391, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002d8
+    Offset: 0x000002e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -289,14 +289,14 @@ Zilla Frame
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 383, Ack: 637, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 391, Ack: 645, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000338
+    Offset: 0x00000348
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -319,14 +319,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 637, Ack: 515, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 645, Ack: 523, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000390
+    Offset: 0x000003a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
@@ -1,7 +1,7 @@
-Frame 1: 319 bytes on wire (2552 bits), 319 bytes captured (2552 bits)
+Frame 1: 327 bytes on wire (2616 bits), 327 bytes captured (2616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 245
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 253
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -107,10 +107,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 319 bytes on wire (2552 bits), 319 bytes captured (2552 bits)
+Frame 3: 327 bytes on wire (2616 bits), 327 bytes captured (2616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 383, Len: 245
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 383, Len: 253
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -96,6 +97,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
@@ -38,14 +38,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 148, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 156, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000068
+    Offset: 0x00000070
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -72,14 +72,14 @@ Zilla Frame
 Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 293, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000c8
+    Offset: 0x000000d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -109,14 +109,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 148, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 156, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000140
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -143,14 +143,14 @@ Zilla Frame
 Frame 5: 248 bytes on wire (1984 bits), 248 bytes captured (1984 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 285, Ack: 285, Len: 174
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 293, Ack: 293, Len: 174
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000190
+    Offset: 0x000001a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -195,14 +195,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 459, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 467, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000218
+    Offset: 0x00000228
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -229,14 +229,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 285, Ack: 596, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 293, Ack: 604, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000278
+    Offset: 0x00000288
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -259,14 +259,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 596, Ack: 417, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 604, Ack: 425, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002d0
+    Offset: 0x000002e0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
@@ -1,7 +1,7 @@
-Frame 1: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 1: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 147
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -69,10 +69,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 147
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
@@ -48,14 +48,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 196, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 204, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000098
+    Offset: 0x000000a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -82,14 +82,14 @@ Zilla Frame
 Frame 3: 277 bytes on wire (2216 bits), 277 bytes captured (2216 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 333, Ack: 1, Len: 203
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 341, Ack: 1, Len: 203
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000f8
+    Offset: 0x00000100
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -138,14 +138,14 @@ Zilla Frame
 Frame 4: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 536, Ack: 1, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 544, Ack: 1, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000198
+    Offset: 0x000001a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -168,14 +168,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 668, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 676, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001f0
+    Offset: 0x000001f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -202,14 +202,14 @@ Zilla Frame
 Frame 6: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 805, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 813, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000250
+    Offset: 0x00000258
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -232,14 +232,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 805, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 813, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002a8
+    Offset: 0x000002b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -262,14 +262,14 @@ Zilla Frame
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 261, Ack: 805, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 269, Ack: 813, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000300
+    Offset: 0x00000310
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -226,6 +227,7 @@ Zilla Frame
     Trace ID: 0x8000000000000006
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
@@ -1,7 +1,7 @@
-Frame 1: 269 bytes on wire (2152 bits), 269 bytes captured (2152 bits)
+Frame 1: 277 bytes on wire (2216 bits), 277 bytes captured (2216 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 195
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 203
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -199,10 +199,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 6: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 6: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 805, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 805, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
@@ -1,7 +1,7 @@
-Frame 1: 268 bytes on wire (2144 bits), 268 bytes captured (2144 bits)
+Frame 1: 276 bytes on wire (2208 bits), 276 bytes captured (2208 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 194
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 202
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -80,10 +80,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 3: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 332, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 332, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
@@ -49,14 +49,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 195, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 203, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000098
+    Offset: 0x000000a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -83,14 +83,14 @@ Zilla Frame
 Frame 3: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 332, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 340, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000f8
+    Offset: 0x00000100
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -113,14 +113,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 332, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 340, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000150
+    Offset: 0x00000160
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -147,14 +147,14 @@ Zilla Frame
 Frame 5: 259 bytes on wire (2072 bits), 259 bytes captured (2072 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 332, Len: 185
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 340, Len: 185
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001b0
+    Offset: 0x000001c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -200,14 +200,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 451, Ack: 332, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 459, Ack: 340, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000240
+    Offset: 0x00000250
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -234,14 +234,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 332, Ack: 588, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 340, Ack: 596, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002a0
+    Offset: 0x000002b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -264,14 +264,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 588, Ack: 464, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 596, Ack: 472, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002f8
+    Offset: 0x00000308
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -107,6 +108,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
@@ -38,14 +38,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 148, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 156, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000068
+    Offset: 0x00000070
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -72,14 +72,14 @@ Zilla Frame
 Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 293, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000c8
+    Offset: 0x000000d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -109,14 +109,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 148, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 156, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000140
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -143,14 +143,14 @@ Zilla Frame
 Frame 5: 240 bytes on wire (1920 bits), 240 bytes captured (1920 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 285, Ack: 285, Len: 166
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 293, Ack: 293, Len: 166
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000190
+    Offset: 0x000001a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -192,14 +192,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 451, Ack: 285, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 459, Ack: 293, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000210
+    Offset: 0x00000220
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -233,7 +233,7 @@ Zilla Frame
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000270
+    Offset: 0x00000280
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -274,14 +274,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 285, Ack: 588, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 293, Ack: 596, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002f8
+    Offset: 0x00000310
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -304,14 +304,14 @@ Zilla Frame
 Frame 9: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 179, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 187, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000350
+    Offset: 0x00000368
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -338,14 +338,14 @@ Zilla Frame
 Frame 10: 260 bytes on wire (2080 bits), 260 bytes captured (2080 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 316, Len: 186
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 324, Len: 186
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003b0
+    Offset: 0x000003c8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -386,14 +386,14 @@ Zilla Frame
 Frame 11: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 588, Ack: 417, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 596, Ack: 425, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000438
+    Offset: 0x00000458
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -416,14 +416,14 @@ Zilla Frame
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 179, Ack: 316, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 187, Ack: 324, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000490
+    Offset: 0x000004b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -450,14 +450,14 @@ Zilla Frame
 Frame 13: 277 bytes on wire (2216 bits), 277 bytes captured (2216 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 316, Ack: 316, Len: 203
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 324, Ack: 324, Len: 203
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004f0
+    Offset: 0x00000510
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -509,14 +509,14 @@ Zilla Frame
 Frame 14: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 519, Ack: 316, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 527, Ack: 324, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000590
+    Offset: 0x000005b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -539,14 +539,14 @@ Zilla Frame
 Frame 15: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 651, Ack: 316, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 659, Ack: 324, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000005e8
+    Offset: 0x00000608
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -573,14 +573,14 @@ Zilla Frame
 Frame 16: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 316, Ack: 788, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 324, Ack: 796, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000648
+    Offset: 0x00000668
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -96,6 +97,7 @@ Zilla Frame
     Trace ID: 0x8000000000000003
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -249,6 +251,7 @@ Zilla Frame
     Trace ID: 0x8000000000000007
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka
@@ -360,6 +363,7 @@ Zilla Frame
     Trace ID: 0x800000000000000a
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: kafka
         Stream Type ID: 0xe1204b08
         Stream Type: kafka

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
@@ -1,7 +1,7 @@
-Frame 1: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 1: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 147
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -69,10 +69,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 3: 221 bytes on wire (1768 bits), 221 bytes captured (1768 bits)
+Frame 3: 229 bytes on wire (1832 bits), 229 bytes captured (1832 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 147
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 285, Len: 155
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -223,10 +223,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 7: 252 bytes on wire (2016 bits), 252 bytes captured (2016 bits)
+Frame 7: 260 bytes on wire (2080 bits), 260 bytes captured (2080 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 178
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 186
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -335,10 +335,10 @@ Zilla Frame
     Progress: 0
     Progress/Maximum: 0/8192
 
-Frame 10: 252 bytes on wire (2016 bits), 252 bytes captured (2016 bits)
+Frame 10: 260 bytes on wire (2080 bits), 260 bytes captured (2080 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 316, Len: 178
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 316, Len: 186
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
@@ -52,14 +52,14 @@ Zilla Frame
 Frame 2: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 172
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 173, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000078
+    Offset: 0x00000080
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -103,14 +103,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 165, Ack: 165, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 173, Ack: 173, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000f0
+    Offset: 0x00000100
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -137,14 +137,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 165, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 173, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000150
+    Offset: 0x00000160
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -171,14 +171,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 302, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 310, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001b0
+    Offset: 0x000001c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -210,14 +210,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 439, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 447, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000210
+    Offset: 0x00000220
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -244,14 +244,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 302, Ack: 576, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 310, Ack: 584, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000270
+    Offset: 0x00000280
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -274,14 +274,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 576, Ack: 434, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 584, Ack: 442, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002c8
+    Offset: 0x000002d8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -311,7 +311,7 @@ Zilla Frame
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000320
+    Offset: 0x00000330
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -347,14 +347,14 @@ Zilla Frame
 Frame 10: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 164, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 172, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000398
+    Offset: 0x000003b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -377,14 +377,14 @@ Zilla Frame
 Frame 11: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 164, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 172, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003f0
+    Offset: 0x00000410
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -411,14 +411,14 @@ Zilla Frame
 Frame 12: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 301, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 309, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000450
+    Offset: 0x00000470
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -445,14 +445,14 @@ Zilla Frame
 Frame 13: 281 bytes on wire (2248 bits), 281 bytes captured (2248 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 301, Ack: 266, Len: 207
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 309, Ack: 274, Len: 207
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004b0
+    Offset: 0x000004d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -508,14 +508,14 @@ Zilla Frame
 Frame 14: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 508, Ack: 266, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 516, Ack: 274, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000558
+    Offset: 0x00000578
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -538,14 +538,14 @@ Zilla Frame
 Frame 15: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 640, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 648, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000005b0
+    Offset: 0x000005d0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -572,14 +572,14 @@ Zilla Frame
 Frame 16: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 777, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 785, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000610
+    Offset: 0x00000630
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -76,6 +77,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -327,6 +329,7 @@ Zilla Frame
     Trace ID: 0x8000000000000009
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -369,6 +372,7 @@ Zilla Frame
     Trace ID: 0x800000000000000a
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 11: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
@@ -1,7 +1,7 @@
-Frame 1: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
+Frame 1: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 164
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -49,10 +49,10 @@ Zilla Frame
         Packet IDs (-1 items)
             Size: -1
 
-Frame 2: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
+Frame 2: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 164
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -301,10 +301,10 @@ Zilla Frame
     Budget ID: 0x0000000000000000
     Reserved: 0
 
-Frame 9: 237 bytes on wire (1896 bits), 237 bytes captured (1896 bits)
+Frame 9: 245 bytes on wire (1960 bits), 245 bytes captured (1960 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 163
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 171
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -344,10 +344,10 @@ Zilla Frame
             .... ...0 = RETAIN: Not set (0)
         QoS: AT_MOST_ONCE (0)
 
-Frame 10: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 10: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 164, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 164, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -55,6 +56,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
@@ -1,7 +1,7 @@
-Frame 1: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 1: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 128
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -28,10 +28,10 @@ Zilla Frame
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
@@ -31,14 +31,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 137, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000058
+    Offset: 0x00000060
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -61,14 +61,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 129, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 137, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x000000b0
+    Offset: 0x000000c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -95,14 +95,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000110
+    Offset: 0x00000120
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -129,14 +129,14 @@ Zilla Frame
 Frame 5: 237 bytes on wire (1896 bits), 237 bytes captured (1896 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 266, Ack: 266, Len: 163
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 274, Ack: 274, Len: 163
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000170
+    Offset: 0x00000180
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -170,14 +170,14 @@ MQ Telemetry Transport Protocol, Connect Command
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 429, Ack: 266, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 437, Ack: 274, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x000001e8
+    Offset: 0x000001f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -204,14 +204,14 @@ Zilla Frame
 Frame 7: 216 bytes on wire (1728 bits), 216 bytes captured (1728 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 566, Len: 142
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 574, Len: 142
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000248
+    Offset: 0x00000258
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -245,14 +245,14 @@ MQ Telemetry Transport Protocol, Connect Ack
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 408, Ack: 566, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 416, Ack: 574, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x000002b0
+    Offset: 0x000002c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -279,14 +279,14 @@ Zilla Frame
 Frame 9: 270 bytes on wire (2160 bits), 270 bytes captured (2160 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 566, Ack: 545, Len: 196
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 574, Ack: 553, Len: 196
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000310
+    Offset: 0x00000320
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -320,14 +320,14 @@ MQ Telemetry Transport Protocol, Publish Message
 Frame 10: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 762, Ack: 545, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 770, Ack: 553, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x000003a8
+    Offset: 0x000003b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -350,14 +350,14 @@ Zilla Frame
 Frame 11: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 894, Ack: 545, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 902, Ack: 553, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000400
+    Offset: 0x00000410
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0
@@ -384,14 +384,14 @@ Zilla Frame
 Frame 12: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 545, Ack: 1031, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 553, Ack: 1039, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0xd0d41a76
     Protocol Type: mqtt
     Worker: 0
-    Offset: 0x00000460
+    Offset: 0x00000470
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: net0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -76,6 +77,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -481,6 +483,7 @@ Zilla Frame
     Trace ID: 0x800000000000000d
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: mqtt
         Stream Type ID: 0x761ad4d0
         Stream Type: mqtt
@@ -533,6 +536,7 @@ Zilla Frame
     Trace ID: 0x800000000000000e
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 15: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
@@ -1,7 +1,7 @@
-Frame 1: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
+Frame 1: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 164
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -49,10 +49,10 @@ Zilla Frame
         Packet IDs (-1 items)
             Size: -1
 
-Frame 2: 238 bytes on wire (1904 bits), 238 bytes captured (1904 bits)
+Frame 2: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 164
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -455,10 +455,10 @@ Zilla Frame
     Budget ID: 0x0000000000000000
     Reserved: 0
 
-Frame 13: 251 bytes on wire (2008 bits), 251 bytes captured (2008 bits)
+Frame 13: 259 bytes on wire (2072 bits), 259 bytes captured (2072 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 177
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 185
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -508,10 +508,10 @@ Zilla Frame
                 Length: 10
                 Pattern: sensor/one
 
-Frame 14: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 14: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 178, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 178, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
@@ -52,14 +52,14 @@ Zilla Frame
 Frame 2: 246 bytes on wire (1968 bits), 246 bytes captured (1968 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 165, Len: 172
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 173, Len: 172
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000078
+    Offset: 0x00000080
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -103,14 +103,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 165, Ack: 165, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 173, Ack: 173, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000f0
+    Offset: 0x00000100
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -137,14 +137,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 165, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 173, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000150
+    Offset: 0x00000160
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -171,14 +171,14 @@ Zilla Frame
 Frame 5: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 302, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 310, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001b0
+    Offset: 0x000001c0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -210,14 +210,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 439, Ack: 302, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 447, Ack: 310, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000210
+    Offset: 0x00000220
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -244,14 +244,14 @@ Zilla Frame
 Frame 7: 257 bytes on wire (2056 bits), 257 bytes captured (2056 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 302, Ack: 576, Len: 183
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 310, Ack: 584, Len: 183
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000270
+    Offset: 0x00000280
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -290,14 +290,14 @@ Zilla Frame
 Frame 8: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 485, Ack: 576, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 493, Ack: 584, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000300
+    Offset: 0x00000310
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -324,14 +324,14 @@ Zilla Frame
 Frame 9: 239 bytes on wire (1912 bits), 239 bytes captured (1912 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 576, Ack: 622, Len: 165
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 584, Ack: 630, Len: 165
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000360
+    Offset: 0x00000370
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -364,14 +364,14 @@ Zilla Frame
 Frame 10: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 741, Ack: 622, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 749, Ack: 630, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000003e0
+    Offset: 0x000003f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -398,14 +398,14 @@ Zilla Frame
 Frame 11: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 622, Ack: 878, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 630, Ack: 886, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000440
+    Offset: 0x00000450
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -428,14 +428,14 @@ Zilla Frame
 Frame 12: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 878, Ack: 754, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 886, Ack: 762, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000498
+    Offset: 0x000004a8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -465,7 +465,7 @@ Zilla Frame
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000004f0
+    Offset: 0x00000500
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -511,14 +511,14 @@ Zilla Frame
 Frame 14: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 178, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 186, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000578
+    Offset: 0x00000590
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -541,14 +541,14 @@ Zilla Frame
 Frame 15: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 178, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 186, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000005d0
+    Offset: 0x000005f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -575,14 +575,14 @@ Zilla Frame
 Frame 16: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 315, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 323, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000630
+    Offset: 0x00000650
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -609,14 +609,14 @@ Zilla Frame
 Frame 17: 281 bytes on wire (2248 bits), 281 bytes captured (2248 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 315, Len: 207
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 323, Len: 207
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000690
+    Offset: 0x000006b0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -680,14 +680,14 @@ Zilla Frame
 Frame 18: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 473, Ack: 315, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 481, Ack: 323, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000738
+    Offset: 0x00000758
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -714,14 +714,14 @@ Zilla Frame
 Frame 19: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:4, Dst: fe80::3f3f:0:0:5
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 315, Ack: 610, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 323, Ack: 618, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000798
+    Offset: 0x000007b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -744,14 +744,14 @@ Zilla Frame
 Frame 20: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:5, Dst: fe80::3f3f:0:0:4
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 610, Ack: 447, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 618, Ack: 455, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000007f0
+    Offset: 0x00000810
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
@@ -44,14 +44,14 @@ Zilla Frame
 Frame 2: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 163, Ack: 1, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 171, Ack: 1, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000078
+    Offset: 0x00000080
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -78,14 +78,14 @@ Zilla Frame
 Frame 3: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 300, Ack: 1, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 308, Ack: 1, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d8
+    Offset: 0x000000e0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -108,14 +108,14 @@ Zilla Frame
 Frame 4: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 432, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 440, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000138
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -138,14 +138,14 @@ Zilla Frame
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 432, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 440, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000188
+    Offset: 0x00000198
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -168,14 +168,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 261, Ack: 432, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 269, Ack: 440, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001e0
+    Offset: 0x000001f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: proxy
         Stream Type ID: 0x50a8ce8d
         Stream Type: proxy
@@ -132,6 +133,7 @@ Zilla Frame
     Trace ID: 0x8000000000000004
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
@@ -1,7 +1,7 @@
-Frame 1: 236 bytes on wire (1888 bits), 236 bytes captured (1888 bits)
+Frame 1: 244 bytes on wire (1952 bits), 244 bytes captured (1952 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 162
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 170
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -105,10 +105,10 @@ Zilla Frame
     Budget ID: 0x0000000000000000
     Reserved: 0
 
-Frame 4: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 4: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 432, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 432, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
@@ -1,7 +1,7 @@
-Frame 1: 255 bytes on wire (2040 bits), 255 bytes captured (2040 bits)
+Frame 1: 263 bytes on wire (2104 bits), 263 bytes captured (2104 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 181
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 189
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -43,10 +43,10 @@ Zilla Frame
             Length: -1
             Last ID: 
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 182, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 182, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: sse
         Stream Type ID: 0x2e9e4003
         Stream Type: sse
@@ -70,6 +71,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
@@ -46,14 +46,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 182, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 190, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000090
+    Offset: 0x00000098
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -76,14 +76,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 182, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 190, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000e8
+    Offset: 0x000000f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -110,14 +110,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 319, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 327, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000148
+    Offset: 0x00000158
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -144,14 +144,14 @@ Zilla Frame
 Frame 5: 245 bytes on wire (1960 bits), 245 bytes captured (1960 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 319, Len: 171
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 327, Len: 171
 Zilla Frame
     Frame Type ID: 0x00000002
     Frame Type: DATA
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001a8
+    Offset: 0x000001b8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -194,14 +194,14 @@ Zilla Frame
 Frame 6: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 437, Ack: 319, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 445, Ack: 327, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000228
+    Offset: 0x00000238
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -228,14 +228,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 319, Ack: 574, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 327, Ack: 582, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000288
+    Offset: 0x00000298
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -258,14 +258,14 @@ Zilla Frame
 Frame 8: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 574, Ack: 451, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 582, Ack: 459, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000002e0
+    Offset: 0x000002f0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: proxy
         Stream Type ID: 0x50a8ce8d
         Stream Type: proxy
@@ -67,6 +68,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
@@ -1,7 +1,7 @@
-Frame 1: 235 bytes on wire (1880 bits), 235 bytes captured (1880 bits)
+Frame 1: 243 bytes on wire (1944 bits), 243 bytes captured (1944 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 161
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 169
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -40,10 +40,10 @@ Zilla Frame
             Length: 9
             Value: localhost
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 162, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 162, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
@@ -43,14 +43,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 162, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 170, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000078
+    Offset: 0x00000080
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -73,14 +73,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 162, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 170, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d0
+    Offset: 0x000000e0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -107,14 +107,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 299, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 307, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000130
+    Offset: 0x00000140
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -141,14 +141,14 @@ Zilla Frame
 Frame 5: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 299, Ack: 266, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 307, Ack: 274, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000190
+    Offset: 0x000001a0
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -171,14 +171,14 @@ Zilla Frame
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 431, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 439, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001e8
+    Offset: 0x000001f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -55,6 +56,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
@@ -1,7 +1,7 @@
-Frame 1: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 1: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 128
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -28,10 +28,10 @@ Zilla Frame
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 129, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
@@ -1,7 +1,7 @@
-Frame 1: 241 bytes on wire (1928 bits), 241 bytes captured (1928 bits)
+Frame 1: 249 bytes on wire (1992 bits), 249 bytes captured (1992 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 167
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 175
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -43,10 +43,10 @@ Zilla Frame
             Length: 5
             Path: /echo
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
@@ -46,14 +46,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 176, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000080
+    Offset: 0x00000088
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -76,14 +76,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 168, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 176, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d8
+    Offset: 0x000000e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -110,14 +110,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 305, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 313, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000138
+    Offset: 0x00000148
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -144,14 +144,14 @@ Zilla Frame
 Frame 5: 194 bytes on wire (1552 bits), 194 bytes captured (1552 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Ack: 305, Len: 120
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Ack: 313, Len: 120
 Zilla Frame
     Frame Type ID: 0x40000004
     Frame Type: CHALLENGE
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000198
+    Offset: 0x000001a8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -172,14 +172,14 @@ Zilla Frame
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 305, Ack: 386, Len: 132
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 313, Ack: 394, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000001e8
+    Offset: 0x000001f8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -202,14 +202,14 @@ Zilla Frame
 Frame 7: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 386, Ack: 437, Len: 132
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 394, Ack: 445, Len: 132
 Zilla Frame
     Frame Type ID: 0x00000003
     Frame Type: END
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000240
+    Offset: 0x00000250
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: ws
         Stream Type ID: 0xe9cd9d56
         Stream Type: ws
@@ -70,6 +71,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
@@ -1,7 +1,7 @@
-Frame 1: 241 bytes on wire (1928 bits), 241 bytes captured (1928 bits)
+Frame 1: 249 bytes on wire (1992 bits), 249 bytes captured (1992 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 167
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 1, Ack: 1, Len: 175
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
@@ -43,10 +43,10 @@ Zilla Frame
             Length: 5
             Path: /echo
 
-Frame 2: 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits)
+Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 128
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
@@ -26,6 +26,7 @@ Zilla Frame
     Trace ID: 0x8000000000000001
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
     Extension: ws
         Stream Type ID: 0xe9cd9d56
         Stream Type: ws
@@ -70,6 +71,7 @@ Zilla Frame
     Trace ID: 0x8000000000000002
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
+    Redirected ID: 0x0000000000000000
 
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
@@ -167,6 +169,7 @@ Zilla Frame
     Trace ID: 0x8000000000000005
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
+    Redirected ID: 0x0000000000000000
     Extension: ws
         Stream Type ID: 0xe9cd9d56
         Stream Type: ws

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
@@ -46,14 +46,14 @@ Zilla Frame
 Frame 2: 210 bytes on wire (1680 bits), 210 bytes captured (1680 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 168, Len: 136
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 1, Ack: 176, Len: 136
 Zilla Frame
     Frame Type ID: 0x00000001
     Frame Type: BEGIN
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000080
+    Offset: 0x00000088
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -76,14 +76,14 @@ Zilla Frame
 Frame 3: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 168, Ack: 129, Len: 137
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 176, Ack: 137, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x000000d8
+    Offset: 0x000000e8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -110,14 +110,14 @@ Zilla Frame
 Frame 4: 211 bytes on wire (1688 bits), 211 bytes captured (1688 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 129, Ack: 305, Len: 137
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 137, Ack: 313, Len: 137
 Zilla Frame
     Frame Type ID: 0x40000002
     Frame Type: WINDOW
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000138
+    Offset: 0x00000148
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -144,14 +144,14 @@ Zilla Frame
 Frame 5: 241 bytes on wire (1928 bits), 241 bytes captured (1928 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:2, Dst: fe80::3f3f:0:0:3
-Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 305, Len: 167
+Transmission Control Protocol, Src Port: 37114, Dst Port: 7114, Seq: 313, Len: 167
 Zilla Frame
     Frame Type ID: 0x40000005
     Frame Type: REDIRECT
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000198
+    Offset: 0x000001a8
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0
@@ -169,7 +169,6 @@ Zilla Frame
     Trace ID: 0x8000000000000005
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
-    Redirected ID: 0x0000000000000000
     Extension: ws
         Stream Type ID: 0xe9cd9d56
         Stream Type: ws
@@ -189,14 +188,14 @@ Zilla Frame
 Frame 6: 194 bytes on wire (1552 bits), 194 bytes captured (1552 bits)
 Ethernet II, Src: Send_00 (20:53:45:4e:44:00), Dst: Receive_00 (20:52:45:43:56:00)
 Internet Protocol Version 6, Src: fe80::3f3f:0:0:3, Dst: fe80::3f3f:0:0:2
-Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 266, Len: 120
+Transmission Control Protocol, Src Port: 7114, Dst Port: 37114, Seq: 274, Len: 120
 Zilla Frame
     Frame Type ID: 0x40000001
     Frame Type: RESET
     Protocol Type ID: 0x00000000
     Protocol Type: 
     Worker: 0
-    Offset: 0x00000218
+    Offset: 0x00000228
     Origin ID: 0x0000000100000002
     Origin Namespace: test
     Origin Binding: app0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/golden.lua
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/golden.lua
@@ -126,6 +126,7 @@ add_field("authorization", ProtoField.uint64("zilla.authorization", "Authorizati
 
 -- begin frame
 add_field("affinity", ProtoField.uint64("zilla.affinity", "Affinity", base.HEX))
+add_field("redirected_id", ProtoField.uint64("zilla.redirected_id", "Redirected ID", base.HEX))
 
 -- data frame
 add_field("flags", ProtoField.uint8("zilla.flags", "Flags", base.HEX))
@@ -277,7 +278,9 @@ end
 function handle_begin_frame(buffer, offset, subtree, pinfo, info)
     local slice_affinity = buffer(offset, 8)
     subtree:add_le(fields.affinity, slice_affinity)
-    handle_extension(buffer, subtree, pinfo, info, offset + 8, BEGIN_ID)
+    local slice_redirected_id = buffer(offset + 8, 8)
+    subtree:add_le(fields.redirected_id, slice_redirected_id)
+    handle_extension(buffer, subtree, pinfo, info, offset + 16, BEGIN_ID)
 end
 
 function handle_redirect_frame(buffer, offset, subtree, pinfo, info)

--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpServerFactory.java
@@ -714,6 +714,7 @@ public final class HttpServerFactory implements HttpStreamFactory
         MessageConsumer sender,
         long originId,
         long routedId,
+        long redirectedId,
         long streamId,
         long sequence,
         long acknowledge,
@@ -733,6 +734,7 @@ public final class HttpServerFactory implements HttpStreamFactory
                 .traceId(traceId)
                 .authorization(authorization)
                 .affinity(affinity)
+                .redirectedId(redirectedId)
                 .extension(extension.buffer(), extension.offset(), extension.sizeof())
                 .build();
 
@@ -2852,7 +2854,7 @@ public final class HttpServerFactory implements HttpStreamFactory
         private final class HttpExchange
         {
             private final long originId;
-            private final long routedId;
+            private long routedId;
             private final long traceId;
             private final long sessionId;
             private final HttpPolicyConfig policy;
@@ -2924,8 +2926,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                 requestSeq = 0;
                 requestAck = requestSeq;
 
-                application = newStream(this::onExchange, originId, routedId, requestId, requestSeq, requestAck, requestMax,
-                    traceId, sessionId, affinity, extension);
+                application = newStream(this::onExchange, originId, routedId, 0L, requestId, requestSeq, requestAck,
+                    requestMax, traceId, sessionId, affinity, extension);
             }
 
             private int doRequestData(
@@ -3119,12 +3121,15 @@ public final class HttpServerFactory implements HttpStreamFactory
 
                 clear();
 
+                final long redirectedId = routedId;
+                routedId = context.resolveRoutedId(redirectedId, newAffinity);
+
                 requestId = context.supplyInitialId(routedId, newAffinity);
                 responseId = supplyReplyId.applyAsLong(requestId);
                 affinity = newAffinity;
 
-                application = newStream(this::onExchange, originId, routedId, requestId, requestSeq, requestAck, requestMax,
-                    traceId, sessionId, affinity, extension);
+                application = newStream(this::onExchange, originId, routedId, redirectedId, requestId, requestSeq,
+                    requestAck, requestMax, traceId, sessionId, affinity, extension);
 
                 if (wasRequestClosed)
                 {
@@ -6016,7 +6021,7 @@ public final class HttpServerFactory implements HttpStreamFactory
         private final class Http2Exchange
         {
             private final long originId;
-            private final long routedId;
+            private long routedId;
             private final long traceId;
             private final int streamId;
             private final long sessionId;
@@ -6100,8 +6105,8 @@ public final class HttpServerFactory implements HttpStreamFactory
                 assert state == 0;
                 state = HttpState.openingInitial(state);
 
-                application = newStream(this::onExchange, originId, routedId, requestId, requestSeq, requestAck, requestMax,
-                    traceId, sessionId, affinity, extension);
+                application = newStream(this::onExchange, originId, routedId, 0L, requestId, requestSeq, requestAck,
+                    requestMax, traceId, sessionId, affinity, extension);
                 streams.put(streamId, this);
                 streamsActive[streamId & 0x01]++;
                 applicationHeadersProcessed.add(streamId);
@@ -6298,14 +6303,17 @@ public final class HttpServerFactory implements HttpStreamFactory
 
                 clear();
 
+                final long redirectedId = routedId;
+                routedId = context.resolveRoutedId(redirectedId, newAffinity);
+
                 requestId = context.supplyInitialId(routedId, newAffinity);
                 responseId = supplyReplyId.applyAsLong(requestId);
                 affinity = newAffinity;
                 state = HttpState.openingInitial(state);
                 localBudget = localSettings.initialWindowSize;
 
-                application = newStream(this::onExchange, originId, routedId, requestId, requestSeq, requestAck, requestMax,
-                    traceId, sessionId, affinity, extension);
+                application = newStream(this::onExchange, originId, routedId, redirectedId, requestId, requestSeq,
+                    requestAck, requestMax, traceId, sessionId, affinity, extension);
                 streams.put(streamId, this);
 
                 onResponseWindowUpdate(traceId, sessionId, remoteSettings.initialWindowSize);

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -64,7 +64,9 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdFeedExternal")
     public void shouldHydrate() throws Exception
     {
         k3po.finish();
@@ -74,7 +76,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate.error/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldHydrateError() throws Exception
     {
         k3po.finish();
@@ -84,7 +86,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.credentials.yaml")
     @Specification({
         "${app}/cache.hydrate.credentials/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldHydrateWithCredentials() throws Exception
     {
         k3po.finish();
@@ -94,6 +96,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.toolkit.yaml")
     @Specification({
         "${app}/cache.hydrate.toolkit/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldHydrateToolkit() throws Exception
     {
         k3po.finish();
@@ -103,7 +106,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.credentials.toolkit.yaml")
     @Specification({
         "${app}/cache.hydrate.credentials.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldHydrateToolkitWithRouteCredentials() throws Exception
     {
@@ -115,6 +118,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.hydrate.toolkit.multi.skip.unauthorized/server",
         "${app}/cache.hydrate.toolkit.multi.skip.unauthorized/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldHydrateToolkitMultiSkippingUnauthorizedRoute() throws Exception
     {
@@ -126,6 +130,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.refresh.toolkit.keep.stale.on.failure/server",
         "${app}/cache.refresh.toolkit.keep.stale.on.failure/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldRefreshToolkitKeepingStaleOnFailure() throws Exception
     {
@@ -137,6 +142,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.hydrate.toolkit.multi.title.collision/server",
         "${app}/cache.hydrate.toolkit.multi.title.collision/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldHydrateToolkitMultiDisambiguatingCollidingTitles() throws Exception
     {
@@ -167,7 +173,9 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.tools.call.reject.bearer/client",
         "${app}/cache.tools.call.reject.bearer/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldRejectToolsCallWithBearerChallenge() throws Exception
     {
         k3po.finish();
@@ -178,7 +186,9 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.tools.call.valid.input/client",
         "${app}/cache.tools.call.valid.input/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldProxyToolsCallWithValidInput() throws Exception
     {
         k3po.finish();
@@ -189,7 +199,9 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.tools.call.invalid.input/client",
         "${app}/cache.tools.call.invalid.input/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldRejectToolsCallWithInvalidInput() throws Exception
     {
         k3po.finish();
@@ -200,7 +212,9 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.tools.call.no.schema/client",
         "${app}/cache.tools.call.no.schema/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldForwardToolsCallWithoutSchema() throws Exception
     {
         k3po.finish();
@@ -210,7 +224,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate.lifecycle.reconnect/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldReconnectAfterLifecycleAbort() throws Exception
     {
         k3po.finish();
@@ -291,7 +305,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.tools.list.toolkit.filtered/server",
         "${app}/cache.serve.tools.list.toolkit.filtered/client" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsListFilteredByAllowSet() throws Exception
     {
@@ -303,7 +317,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.tools.list.security.schemes.filtered/server",
         "${app}/cache.serve.tools.list.security.schemes.filtered/client" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsListFilteredBySecuritySchemes() throws Exception
     {
@@ -315,6 +329,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.tools.list.route.guarded.unauthorized/server",
         "${app}/cache.serve.tools.list.route.guarded.unauthorized/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsListExcludingRouteGuardedToolkitFromUnauthorizedCaller() throws Exception
     {
@@ -326,6 +341,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.tools.list.route.guarded.partial.scope/server",
         "${app}/cache.serve.tools.list.route.guarded.partial.scope/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsListRouteGuardedToolkitWithPartialScope() throws Exception
     {
@@ -337,6 +353,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.resources.list.route.guarded.unauthorized/server",
         "${app}/cache.serve.resources.list.route.guarded.unauthorized/client" })
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "resources")
     public void shouldServeResourcesListExcludingRouteGuardedToolkitFromUnauthorizedCaller() throws Exception
     {
@@ -347,8 +364,10 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.tools/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdFeedExternal")
     public void shouldRefreshTools() throws Exception
     {
         k3po.finish();
@@ -359,8 +378,10 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.refresh.tools.notify/client",
         "${app}/cache.refresh.tools/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldNotifyToolsListChangedAfterRefresh() throws Exception
     {
         k3po.finish();
@@ -371,7 +392,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.notify.tools.list.changed/client",
         "${app}/cache.notify.tools.list.changed/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldRefreshToolsOnListChangedNotification() throws Exception
     {
@@ -383,7 +404,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.notify.tools.list.changed.during.refresh/client",
         "${app}/cache.notify.tools.list.changed.during.refresh/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldNotifyToolsListChangedDuringRefresh() throws Exception
     {
@@ -395,8 +416,10 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.notify.tools.list.changed.after.tools.call/client",
         "${app}/cache.notify.tools.list.changed.after.tools.call/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldEmitOneListChangedAfterAgentInvokesToolsCall() throws Exception
     {
         k3po.finish();
@@ -406,7 +429,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.tools.error/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldRefreshToolsError() throws Exception
     {
@@ -417,7 +440,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.tools.error.retry/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldRetryAfterToolsRefreshError() throws Exception
     {
@@ -431,7 +454,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate.tools.retry.exceeds.max/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldRetryHydrateBeyondOldAttemptsMax() throws Exception
     {
@@ -443,7 +466,7 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.tools.list.during.hydrate/server",
         "${app}/cache.serve.tools.list.during.hydrate/client" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
     public void shouldServeToolsListDuringHydrate() throws Exception
     {
@@ -478,8 +501,10 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.resources/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "resources")
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdFeedExternal")
     public void shouldRefreshResources() throws Exception
     {
         k3po.finish();
@@ -499,7 +524,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.prompts/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "prompts")
     public void shouldRefreshPrompts() throws Exception
     {
@@ -510,7 +535,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate.10k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")
     public void shouldHydrate10k() throws Exception
     {
@@ -521,7 +546,7 @@ public class McpProxyCacheIT
     @Configuration("proxy.cache.yaml")
     @Specification({
         "${app}/cache.hydrate.100k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")
     public void shouldHydrate100k() throws Exception
     {
@@ -617,8 +642,10 @@ public class McpProxyCacheIT
     @Specification({
         "${app}/cache.serve.execute.tool/client",
         "${app}/cache.serve.execute.tool/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyCacheIT::sessionIdB007External")
     public void shouldServeExecuteTool() throws Exception
     {
         k3po.finish();
@@ -669,6 +696,20 @@ public class McpProxyCacheIT
         long affinity)
     {
         String marker = CONTENDED_SESSION_MARKERS[CONTENDED_SESSION_INDEX.getAndIncrement() % CONTENDED_SESSION_MARKERS.length];
-        return "5ca1ab1e-c0de-4a11-feed-%s%08x".formatted(marker, affinity & 0xffff_ffffL);
+        return "5ca1ab1e-c0de-4a11-feed-%s0000003f".formatted(marker);
+    }
+
+    public static String sessionIdFeedExternal(
+        long affinity)
+    {
+        assert affinity == 0L;
+        return "5ca1ab1e-c0de-4a11-feed-00010000003f";
+    }
+
+    public static String sessionIdB007External(
+        long affinity)
+    {
+        assert affinity == 0L;
+        return "5ca1ab1e-c0de-4a11-b007-00010000003f";
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -29,6 +29,7 @@ import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
 import io.aklivity.zilla.runtime.engine.test.annotation.Configuration;
+import io.aklivity.zilla.runtime.engine.test.annotation.Configure;
 
 public class McpProxyIT
 {
@@ -76,7 +77,9 @@ public class McpProxyIT
     @Specification({
         "${app}/lifecycle.shutdown.requests/client",
         "${app}/lifecycle.shutdown.requests/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldShutdownLifecycleRequests() throws Exception
     {
         k3po.finish();
@@ -98,7 +101,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call/client",
         "${app}/tools.call/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallTool() throws Exception
     {
         k3po.finish();
@@ -109,7 +114,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.is.error/client",
         "${app}/tools.call.is.error/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolIsError() throws Exception
     {
         k3po.finish();
@@ -120,7 +127,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.aborted/client",
         "${app}/tools.call.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortCallTool() throws Exception
     {
         k3po.finish();
@@ -131,7 +140,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit.prefixed/client",
         "${app}/tools.call.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldCallToolWithToolkit() throws Exception
     {
         k3po.finish();
@@ -142,7 +151,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit.prefixed.fragmented/client",
         "${app}/tools.call.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldCallToolWithToolkitFragmented() throws Exception
     {
         k3po.finish();
@@ -164,7 +173,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list/client",
         "${app}/tools.list/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListTools() throws Exception
     {
         k3po.finish();
@@ -175,7 +186,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit.prefixed/client",
         "${app}/tools.list.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldListToolsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -186,7 +197,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit.filtered/client",
         "${app}/tools.list.toolkit.filtered/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListToolsFilteredByAllowSet() throws Exception
     {
         k3po.finish();
@@ -197,6 +210,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit.multi.prefixed/client",
         "${app}/tools.list.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListToolsWithToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -217,6 +231,7 @@ public class McpProxyIT
     @Specification({
         "${app}/lifecycle.notify.tools.list.changed.toolkit.multi.prefixed/client",
         "${app}/lifecycle.notify.tools.list.changed.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldNotifyToolsListChangedWithAggregateEventId() throws Exception
     {
         k3po.finish();
@@ -262,6 +277,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.partial.toolkit.multi.prefixed/client",
         "${app}/tools.list.partial.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListToolsWithPartialToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -272,6 +288,7 @@ public class McpProxyIT
     @Specification({
         "${app}/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi.prefixed/client",
         "${app}/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldNotifyToolsListChangedAfterAuthorizeToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -302,7 +319,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get/client",
         "${app}/prompts.get/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldGetPrompt() throws Exception
     {
         k3po.finish();
@@ -313,7 +332,7 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.toolkit.prefixed/client",
         "${app}/prompts.get.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldGetPromptWithToolkit() throws Exception
     {
         k3po.finish();
@@ -324,7 +343,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list/client",
         "${app}/prompts.list/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListPrompts() throws Exception
     {
         k3po.finish();
@@ -335,7 +356,7 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list.toolkit.prefixed/client",
         "${app}/prompts.list.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldListPromptsWithToolkit() throws Exception
     {
         k3po.finish();
@@ -346,6 +367,7 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list.toolkit.multi.prefixed/client",
         "${app}/prompts.list.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListPromptsWithToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -356,7 +378,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read/client",
         "${app}/resources.read/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldReadResource() throws Exception
     {
         k3po.finish();
@@ -367,7 +391,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.subscribe/client",
         "${app}/resources.subscribe/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldSubscribeToResource() throws Exception
     {
         k3po.finish();
@@ -378,7 +404,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.unsubscribe/client",
         "${app}/resources.unsubscribe/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldUnsubscribeFromResource() throws Exception
     {
         k3po.finish();
@@ -389,7 +417,7 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.toolkit.prefixed/client",
         "${app}/resources.read.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldReadResourceWithToolkit() throws Exception
     {
         k3po.finish();
@@ -400,7 +428,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list/client",
         "${app}/resources.list/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListResources() throws Exception
     {
         k3po.finish();
@@ -411,7 +441,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.templates.list/client",
         "${app}/resources.templates.list/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
@@ -422,7 +454,7 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list.toolkit.prefixed/client",
         "${app}/resources.list.toolkit/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldListResourcesWithToolkit() throws Exception
     {
         k3po.finish();
@@ -433,6 +465,7 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list.toolkit.multi.prefixed/client",
         "${app}/resources.list.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListResourcesWithToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -443,7 +476,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.aborted/client",
         "${app}/tools.list.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortToolsList() throws Exception
     {
         k3po.finish();
@@ -454,7 +489,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.canceled/client",
         "${app}/tools.list.canceled/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldListToolsThenCancel() throws Exception
     {
         k3po.finish();
@@ -465,7 +502,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.list.aborted/client",
         "${app}/prompts.list.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortListPrompts() throws Exception
     {
         k3po.finish();
@@ -476,7 +515,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.aborted/client",
         "${app}/prompts.get.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortGetPrompt() throws Exception
     {
         k3po.finish();
@@ -487,7 +528,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.list.aborted/client",
         "${app}/resources.list.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortListResources() throws Exception
     {
         k3po.finish();
@@ -498,7 +541,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.templates.list.aborted/client",
         "${app}/resources.templates.list.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
@@ -509,7 +554,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.aborted/client",
         "${app}/resources.read.aborted/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldAbortReadResource() throws Exception
     {
         k3po.finish();
@@ -520,7 +567,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.10k/client",
         "${app}/tools.call.10k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolWith10kParams() throws Exception
     {
         k3po.finish();
@@ -531,7 +580,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.100k/client",
         "${app}/tools.call.100k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolWith100kParams() throws Exception
     {
         k3po.finish();
@@ -542,7 +593,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.10k/client",
         "${app}/resources.read.10k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldReadResourceWith10kContents() throws Exception
     {
         k3po.finish();
@@ -553,7 +606,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.100k/client",
         "${app}/resources.read.100k/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldReadResourceWith100kContents() throws Exception
     {
         k3po.finish();
@@ -564,7 +619,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.with.progress/client",
         "${app}/tools.call.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolWithProgress() throws Exception
     {
         k3po.finish();
@@ -575,7 +632,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.toolkit.with.progress.prefixed/client",
         "${app}/tools.call.toolkit.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldCallToolWithToolkitWithProgress() throws Exception
     {
         k3po.finish();
@@ -586,7 +643,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.10k.with.progress/client",
         "${app}/tools.call.10k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolWith10kParamsWithProgress() throws Exception
     {
         k3po.finish();
@@ -597,7 +656,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.100k.with.progress/client",
         "${app}/tools.call.100k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolWith100kParamsWithProgress() throws Exception
     {
         k3po.finish();
@@ -608,7 +669,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.10k.with.progress/client",
         "${app}/resources.read.10k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldReadResourceWith10kContentWithProgress() throws Exception
     {
         k3po.finish();
@@ -619,7 +682,9 @@ public class McpProxyIT
     @Specification({
         "${app}/resources.read.100k.with.progress/client",
         "${app}/resources.read.100k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldReadResourceWith100kContentWithProgress() throws Exception
     {
         k3po.finish();
@@ -630,7 +695,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.10k.with.progress/client",
         "${app}/prompts.get.10k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldGetPromptWith10kMessageWithProgress() throws Exception
     {
         k3po.finish();
@@ -641,7 +708,9 @@ public class McpProxyIT
     @Specification({
         "${app}/prompts.get.100k.with.progress/client",
         "${app}/prompts.get.100k.with.progress/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldGetPromptWith100kMessageWithProgress() throws Exception
     {
         k3po.finish();
@@ -652,7 +721,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.elicit.completed.proxied/client",
         "${app}/tools.call.elicit.completed.proxied/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolElicitCompletedProxied() throws Exception
     {
         k3po.finish();
@@ -674,7 +745,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.elicit.declined.proxied/client",
         "${app}/tools.call.elicit.declined.proxied/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolElicitDeclinedProxied() throws Exception
     {
         k3po.finish();
@@ -685,7 +758,9 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.call.elicit.timeout.proxied/client",
         "${app}/tools.call.elicit.timeout.proxied/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    @Configure(name = MCP_SESSION_ID_NAME,
+        value = "io.aklivity.zilla.runtime.binding.mcp.internal.stream.McpProxyIT::sessionIdExternal")
     public void shouldCallToolElicitTimeoutProxied() throws Exception
     {
         k3po.finish();
@@ -696,5 +771,12 @@ public class McpProxyIT
     {
         assert affinity == 0L;
         return "5ca1ab1e-c0de-4a11-5e55-000100000000";
+    }
+
+    public static String sessionIdExternal(
+        long affinity)
+    {
+        assert affinity == 0L;
+        return "5ca1ab1e-c0de-4a11-5e55-00010000003f";
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleIT.java
@@ -53,7 +53,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.server.write.abort/client",
         "${app}/lifecycle.server.write.abort/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleServerWriteAbort() throws Exception
     {
         k3po.finish();
@@ -64,7 +64,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.server.write.close/client",
         "${app}/lifecycle.server.write.close/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleServerWriteClose() throws Exception
     {
         k3po.finish();
@@ -75,7 +75,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.server.read.abort/client",
         "${app}/lifecycle.server.read.abort/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleServerReadAbort() throws Exception
     {
         k3po.finish();
@@ -86,7 +86,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.client.write.abort/client",
         "${app}/lifecycle.client.write.abort/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleClientWriteAbort() throws Exception
     {
         k3po.finish();
@@ -97,7 +97,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.client.write.close/client",
         "${app}/lifecycle.client.write.close/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleClientWriteClose() throws Exception
     {
         k3po.finish();
@@ -108,7 +108,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.client.read.abort/client",
         "${app}/lifecycle.client.read.abort/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldLifecycleClientReadAbort() throws Exception
     {
         k3po.finish();
@@ -119,7 +119,7 @@ public class McpProxyLifecycleIT
     @Specification({
         "${app}/lifecycle.initialize.skip.bearer/client",
         "${app}/lifecycle.initialize.skip.bearer/server" })
-    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
     public void shouldInitializeLifecycleSkippingBearerRejectedRoute() throws Exception
     {
         k3po.finish();
@@ -129,6 +129,6 @@ public class McpProxyLifecycleIT
         long affinity)
     {
         assert affinity == 0L;
-        return "5ca1ab1e-c0de-4a11-b007-000100000000";
+        return "5ca1ab1e-c0de-4a11-b007-00010000003f";
     }
 }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -35,6 +35,7 @@ import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
+import io.aklivity.k3po.runtime.junit.annotation.ScriptProperty;
 import io.aklivity.k3po.runtime.junit.annotation.Specification;
 import io.aklivity.k3po.runtime.junit.rules.K3poRule;
 import io.aklivity.zilla.runtime.engine.test.EngineRule;
@@ -192,6 +193,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.reject.bearer/client",
         "${app}/tools.call.reject.bearer/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldRejectToolsCallWithBearerChallenge() throws Exception
     {
         k3po.finish();
@@ -202,6 +204,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.reject.error/client",
         "${app}/tools.call.reject.error/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldRejectToolsCallWithError() throws Exception
     {
         k3po.finish();
@@ -243,6 +246,7 @@ public class McpServerIT
     @Specification({
         "${net}/lifecycle.shutdown.requests/client",
         "${app}/lifecycle.shutdown.requests/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     @Configure(name = ENGINE_SYNTHETIC_ABORT_NAME, value = "false")
     @Configure(name = ENGINE_DETACH_ON_CLOSE_NAME, value = "false")
     public void shouldShutdownLifecycleRequests() throws Exception
@@ -276,6 +280,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.list.id.last/client",
         "${app}/tools.list/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListToolsWithIdLast() throws Exception
     {
         k3po.finish();
@@ -326,6 +331,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.10k/client",
         "${app}/tools.call.10k/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWith10kParams() throws Exception
     {
         k3po.finish();
@@ -336,6 +342,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.100k/client",
         "${app}/tools.call.100k/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWith100kParams() throws Exception
     {
         k3po.finish();
@@ -346,6 +353,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read.10k/client",
         "${app}/resources.read.10k/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldReadResourceWith10kContents() throws Exception
     {
         k3po.finish();
@@ -356,6 +364,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read.100k/client",
         "${app}/resources.read.100k/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldReadResourceWith100kContents() throws Exception
     {
         k3po.finish();
@@ -366,6 +375,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call/client",
         "${app}/tools.call/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallTool() throws Exception
     {
         k3po.finish();
@@ -376,6 +386,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.timeout/client",
         "${app}/tools.call.timeout/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithTimeout() throws Exception
     {
         k3po.finish();
@@ -386,6 +397,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call/client",
         "${app}/tools.call.resumable/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithUpstreamResumableFlush() throws Exception
     {
         k3po.finish();
@@ -396,6 +408,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.completed/client",
         "${app}/tools.call.elicit.completed/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitCompleted() throws Exception
     {
         k3po.finish();
@@ -406,6 +419,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.after.result/client",
         "${app}/tools.call.elicit.after.result/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitAfterResult() throws Exception
     {
         k3po.finish();
@@ -416,6 +430,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.deferred/client",
         "${app}/tools.call.elicit.deferred/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitDeferred() throws Exception
     {
         k3po.finish();
@@ -426,6 +441,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.completed.context/client",
         "${app}/tools.call.elicit.completed.context/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitCompletedWithContext() throws Exception
     {
         k3po.finish();
@@ -466,6 +482,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.passthrough/client",
         "${app}/tools.call.elicit.passthrough/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitPassthrough() throws Exception
     {
         k3po.finish();
@@ -476,6 +493,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.declined/client",
         "${app}/tools.call.elicit.declined/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitDeclined() throws Exception
     {
         k3po.finish();
@@ -486,6 +504,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.timeout/client",
         "${app}/tools.call.elicit.timeout/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolElicitTimeout() throws Exception
     {
         k3po.finish();
@@ -496,6 +515,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.elicit.reject/client",
         "${app}/tools.call.elicit.reject/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldRejectToolsCallElicitUrlRequired() throws Exception
     {
         k3po.finish();
@@ -506,6 +526,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.list/client",
         "${app}/tools.list/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListTools() throws Exception
     {
         k3po.finish();
@@ -516,6 +537,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.list.security.schemes/client",
         "${app}/tools.list.security.schemes/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListToolsExcludingSecuritySchemes() throws Exception
     {
         k3po.finish();
@@ -526,6 +548,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.list.aborted/client",
         "${app}/tools.list.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortToolsList() throws Exception
     {
         k3po.finish();
@@ -536,6 +559,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.aborted/client",
         "${app}/tools.call.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortCallTool() throws Exception
     {
         k3po.finish();
@@ -546,6 +570,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.list.aborted/client",
         "${app}/prompts.list.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortListPrompts() throws Exception
     {
         k3po.finish();
@@ -556,6 +581,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.get.aborted/client",
         "${app}/prompts.get.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortGetPrompt() throws Exception
     {
         k3po.finish();
@@ -566,6 +592,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.list.aborted/client",
         "${app}/resources.list.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortListResources() throws Exception
     {
         k3po.finish();
@@ -576,6 +603,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.templates.list.aborted/client",
         "${app}/resources.templates.list.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortListResourcesTemplates() throws Exception
     {
         k3po.finish();
@@ -586,6 +614,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read.aborted/client",
         "${app}/resources.read.aborted/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldAbortReadResource() throws Exception
     {
         k3po.finish();
@@ -596,6 +625,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.list.canceled/client",
         "${app}/tools.list.canceled/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListToolsThenCancel() throws Exception
     {
         k3po.finish();
@@ -626,6 +656,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.list/client",
         "${app}/prompts.list/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListPrompts() throws Exception
     {
         k3po.finish();
@@ -636,6 +667,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.list/client",
         "${app}/resources.list/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListResources() throws Exception
     {
         k3po.finish();
@@ -646,6 +678,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.templates.list/client",
         "${app}/resources.templates.list/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldListResourcesTemplates() throws Exception
     {
         k3po.finish();
@@ -656,6 +689,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.get/client",
         "${app}/prompts.get/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldGetPrompt() throws Exception
     {
         k3po.finish();
@@ -666,6 +700,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read/client",
         "${app}/resources.read/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldReadResource() throws Exception
     {
         k3po.finish();
@@ -676,6 +711,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.subscribe/client",
         "${app}/resources.subscribe/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldSubscribeToResource() throws Exception
     {
         k3po.finish();
@@ -686,6 +722,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.unsubscribe/client",
         "${app}/resources.unsubscribe/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldUnsubscribeFromResource() throws Exception
     {
         k3po.finish();
@@ -903,6 +940,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.with.progress/client",
         "${app}/tools.call.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithProgress() throws Exception
     {
         k3po.finish();
@@ -913,6 +951,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.with.progress.suspend/client",
         "${app}/tools.call.with.progress.suspend/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithProgressSuspend() throws Exception
     {
         k3po.finish();
@@ -923,6 +962,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.with.progress.suspended/client",
         "${app}/tools.call.with.progress.suspended/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithProgressSuspended() throws Exception
     {
         k3po.finish();
@@ -933,6 +973,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.with.progress.resume/client",
         "${app}/tools.call.with.progress.resume/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWithProgressResume() throws Exception
     {
         k3po.finish();
@@ -965,6 +1006,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.10k.with.progress/client",
         "${app}/tools.call.10k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWith10kParamsWithProgress() throws Exception
     {
         k3po.finish();
@@ -975,6 +1017,7 @@ public class McpServerIT
     @Specification({
         "${net}/tools.call.100k.with.progress/client",
         "${app}/tools.call.100k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldCallToolWith100kParamsWithProgress() throws Exception
     {
         k3po.finish();
@@ -985,6 +1028,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read.10k.with.progress/client",
         "${app}/resources.read.10k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldReadResourceWith10kContentWithProgress() throws Exception
     {
         k3po.finish();
@@ -995,6 +1039,7 @@ public class McpServerIT
     @Specification({
         "${net}/resources.read.100k.with.progress/client",
         "${app}/resources.read.100k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldReadResourceWith100kContentWithProgress() throws Exception
     {
         k3po.finish();
@@ -1005,6 +1050,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.get.10k.with.progress/client",
         "${app}/prompts.get.10k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldGetPromptWith10kMessageWithProgress() throws Exception
     {
         k3po.finish();
@@ -1015,6 +1061,7 @@ public class McpServerIT
     @Specification({
         "${net}/prompts.get.100k.with.progress/client",
         "${app}/prompts.get.100k.with.progress/server"})
+    @ScriptProperty("affinity \"0000003f\"")
     public void shouldGetPromptWith100kMessageWithProgress() throws Exception
     {
         k3po.finish();

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -125,20 +125,42 @@ public interface EngineContext
         long bindingId);
 
     /**
-     * Allocates a new initial (inbound) stream id for the given binding, selecting
-     * a deterministic worker by {@code Math.floorMod(affinityId, mask.cardinality())}
-     * over the binding's affinity mask. Used to pin per-key application streams to
-     * a specific worker so per-worker session state remains valid across requests
-     * for the same logical key.
+     * Allocates a new initial (inbound) stream id for the given routed binding, pinned to
+     * the worker identified by {@code affinityId} when that worker is local to this engine
+     * node, or selected round-robin over {@code routedId}'s affinity mask otherwise. Used to
+     * pin per-key application streams to a specific worker so per-worker session state
+     * remains valid across requests for the same logical key.
+     * <p>
+     * When redirecting across engine nodes, callers should first resolve {@code routedId}
+     * via {@link #resolveRoutedId(long, long)} so the worker selected here belongs to the
+     * binding the stream will actually be dispatched to.
+     * </p>
      *
-     * @param bindingId   the binding id to associate with the new stream
+     * @param routedId    the routed binding id to associate with the new stream
      * @param affinityId  the affinity value to pin the stream to; same value yields
-     *                     the same worker for a given binding affinity mask
+     *                     the same worker when local to this engine node
      * @return a new unique initial stream id pinned to the worker selected by affinityId
      */
     long supplyInitialId(
-        long bindingId,
+        long routedId,
         long affinityId);
+
+    /**
+     * Resolves the binding id that a stream carrying the given affinity should actually be
+     * routed to, e.g. redirecting to a different binding when the affinity designates a
+     * remote engine node. Identity by default: {@code routedId} unchanged, meaning no
+     * redirection applies.
+     *
+     * @param routedId  the originally configured routed binding id
+     * @param affinity  the affinity value carried by the stream
+     * @return the binding id the stream should actually be routed to
+     */
+    default long resolveRoutedId(
+        long routedId,
+        long affinity)
+    {
+        return routedId;
+    }
 
     /**
      * Returns the reply (outbound) stream id paired with the given initial stream id.

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -541,16 +541,24 @@ public class EngineWorker implements EngineContext, Agent
 
     @Override
     public long supplyInitialId(
-        long bindingId,
+        long routedId,
         long affinityId)
     {
-        final int remoteIndex = resolveRemoteIndex(bindingId, affinityId);
+        final int remoteIndex = resolveRemoteIndex(routedId, affinityId);
 
         initialId += 2L;
         initialId &= mask;
 
         return (((long)remoteIndex << 48) & 0x00ff_0000_0000_0000L) |
                (initialId & 0xff00_0000_7fff_ffffL) | 0x0000_0000_0000_0001L;
+    }
+
+    @Override
+    public long resolveRoutedId(
+        long routedId,
+        long affinity)
+    {
+        return router.resolveRoutedId(routedId, affinity);
     }
 
     @Override
@@ -2181,23 +2189,13 @@ public class EngineWorker implements EngineContext, Agent
     }
 
     private int resolveRemoteIndex(
-        long bindingId,
+        long routedId,
         long affinityId)
     {
-        final Affinity affinity = supplyAffinity(bindingId);
-        final BitSet mask = affinity.mask;
-        final int cardinality = mask.cardinality();
+        final boolean isLocalNode = ((affinityId >>> 24) & 0xffL) == ((long) config.nodeId() & 0xffL);
+        final int index = isLocalNode ? (int)(affinityId & 0x00ff_ffffL) : -1;
 
-        assert cardinality != 0;
-
-        // pick the n-th set bit of the mask, where n = floorMod(affinityId, cardinality)
-        int slot = Math.floorMod(affinityId, cardinality);
-        int remoteIndex = mask.nextSetBit(0);
-        while (slot-- > 0)
-        {
-            remoteIndex = mask.nextSetBit(remoteIndex + 1);
-        }
-        return remoteIndex;
+        return index >= 0 && index < config.workers() ? index : resolveRemoteIndex(routedId);
     }
 
     private Affinity supplyAffinity(

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
@@ -68,4 +68,23 @@ public interface RouterContext
      */
     String supplyLabel(
         int labelId);
+
+    /**
+     * Resolves the binding id that a stream carrying the given affinity should actually be
+     * routed to, e.g. redirecting to a different binding when the affinity designates a
+     * remote node.
+     * <p>
+     * Identity by default: {@code routedId} unchanged, meaning no redirection applies.
+     * </p>
+     *
+     * @param routedId  the originally configured routed binding id
+     * @param affinity  the affinity value carried by the stream
+     * @return the binding id the stream should actually be routed to
+     */
+    default long resolveRoutedId(
+        long routedId,
+        long affinity)
+    {
+        return routedId;
+    }
 }

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await PROMPTS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -86,7 +88,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -107,7 +109,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.100k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -84,7 +86,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -104,7 +106,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await PROMPTS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -86,7 +88,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -107,7 +109,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.10k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -84,7 +86,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -104,7 +106,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 1L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 1L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 1L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -68,7 +70,7 @@ connect await PROMPTS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -90,7 +92,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -112,7 +114,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.credentials/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 1L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -64,7 +66,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -84,7 +86,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -104,7 +106,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await PROMPTS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -83,7 +85,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -104,7 +106,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.error/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -75,7 +77,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -95,7 +97,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -48,7 +50,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -69,7 +71,7 @@ connect await PROMPTS_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -90,7 +92,7 @@ connect await TOOLS_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -111,7 +113,7 @@ connect await RESOURCES_TEMPLATES_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -140,7 +142,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -154,7 +156,7 @@ connect await LIFECYCLE2_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -175,7 +177,7 @@ connect await PROMPTS2_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -196,7 +198,7 @@ connect await TOOLS2_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -217,7 +219,7 @@ connect await RESOURCES_TEMPLATES2_HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.lifecycle.reconnect/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -66,7 +68,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -86,7 +88,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -106,7 +108,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -136,7 +138,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -146,7 +148,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -166,7 +168,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -186,7 +188,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -206,7 +208,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.skip.unauthorized/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -55,7 +57,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -65,7 +67,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.title.collision/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -72,7 +74,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -82,7 +84,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -60,7 +62,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -80,7 +82,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -100,7 +102,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -132,7 +134,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -142,7 +144,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -162,7 +164,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -182,7 +184,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -202,7 +204,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.tools.retry.exceeds.max/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.tools.retry.exceeds.max/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -55,7 +57,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -68,7 +70,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -81,7 +83,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -94,7 +96,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -107,7 +109,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await PROMPTS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -84,7 +86,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -105,7 +107,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -82,7 +84,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -102,7 +104,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -49,7 +51,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(58)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.after.tools.call/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -50,7 +52,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -80,7 +82,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -98,7 +100,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(58)
                               .build()
@@ -122,7 +124,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed.during.refresh/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -52,7 +54,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -72,7 +74,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -96,7 +98,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.notify.tools.list.changed/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -50,7 +52,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -72,7 +74,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.prompts/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -84,7 +86,7 @@ connect await HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -105,7 +107,7 @@ connect await RESOURCES_TEMPLATES_LIST_COMPLETE2
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.resources/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -82,7 +84,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -102,7 +104,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.toolkit.keep.stale.on.failure/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.toolkit.keep.stale.on.failure/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -60,7 +62,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -94,7 +96,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -104,7 +106,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -126,7 +128,7 @@ read await APP1_REFRESHED
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/client.rpt
@@ -28,7 +28,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                               .build()
                           .build()}
 
@@ -42,7 +42,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                                .build()
                            .build()}
 
@@ -63,7 +63,7 @@ connect await TOOLS_LIST_COMPLETE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.contended/server.rpt
@@ -32,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                                .build()
                            .build()}
 write flush
@@ -42,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                               .build()
                           .build()}
 
@@ -62,7 +62,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-000a0000003f")
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -83,7 +85,7 @@ connect await REFRESH_ABORTED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error.retry/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -75,7 +77,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.error/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.notify/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools.notify/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 
@@ -63,7 +65,7 @@ connect await HYDRATED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.refresh.tools/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -62,7 +64,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.execute.tool/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.execute.tool/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("zilla__execute_tool")
                                .contentLength(102)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.execute.tool/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.execute.tool/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list.route.guarded.unauthorized/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.resources.list.route.guarded.unauthorized/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 1L
 
 accept "zilla://streams/app1"
@@ -33,7 +35,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -45,7 +47,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -65,7 +67,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -108,7 +110,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -118,7 +120,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                               .build()
                           .build()}
 
@@ -138,7 +140,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.during.hydrate/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.route.guarded.partial.scope/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.route.guarded.partial.scope/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 1L
 
 accept "zilla://streams/app1"
@@ -33,7 +35,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -43,7 +45,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -89,7 +91,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -99,7 +101,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.route.guarded.unauthorized/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.route.guarded.unauthorized/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 1L
 
 accept "zilla://streams/app1"
@@ -33,7 +35,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -43,7 +45,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -89,7 +91,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -99,7 +101,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000200000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0002".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.security.schemes.filtered/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.security.schemes.filtered/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.toolkit.filtered/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.serve.tools.list.toolkit.filtered/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-feed-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.invalid.input/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.invalid.input/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(52)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.invalid.input/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.invalid.input/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(52)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.no.schema/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.no.schema/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("get_forecast")
                                .contentLength(60)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.no.schema/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.no.schema/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_forecast")
                               .contentLength(60)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.reject.bearer/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.valid.input/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.valid.input/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.valid.input/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.tools.call.valid.input/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.read.abort/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.abort/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.client.write.close/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.skip.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.initialize.skip.bearer/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -64,7 +66,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -110,7 +112,7 @@ write await FIRST_LIST_DONE
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -127,7 +129,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.notify.tools.list.changed.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -58,7 +60,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -96,7 +98,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -117,7 +119,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.read.abort/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.abort/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_OPEN
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.server.write.close/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -49,7 +51,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(25)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.shutdown.requests/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -46,7 +48,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(25)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(60)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.100k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(60)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(60)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.10k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(60)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(25)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(25)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(25)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(25)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsGet()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("weather_prompt")
                                .contentLength(25)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsGet()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("weather_prompt")
                               .contentLength(25)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED_1
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 
@@ -75,7 +77,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 
@@ -89,7 +91,7 @@ connect await LIFECYCLE_INITIALIZED_2
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -76,7 +78,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -86,7 +88,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .promptsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.list/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .promptsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED_1
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 
@@ -75,7 +77,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 
@@ -89,7 +91,7 @@ connect await LIFECYCLE_INITIALIZED_2
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -76,7 +78,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -86,7 +88,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.list/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/image.png")
                                .contentLength(67)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/image.png")
                               .contentLength(67)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/image.png")
                                .contentLength(32)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.100k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/image.png")
                               .contentLength(32)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/image.png")
                                .contentLength(67)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/image.png")
                               .contentLength(67)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/image.png")
                                .contentLength(32)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.10k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/image.png")
                               .contentLength(32)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/readme.txt")
                                .contentLength(33)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/readme.txt")
                               .contentLength(33)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/readme.txt")
                                .contentLength(33)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/readme.txt")
                               .contentLength(33)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesRead()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/readme.txt")
                                .contentLength(33)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesRead()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/readme.txt")
                               .contentLength(33)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.subscribe/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.subscribe/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesSubscribe()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/readme.txt")
                                .contentLength(33)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.subscribe/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.subscribe/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .capabilities("SERVER_RESOURCES_SUBSCRIBE")
                                .build()
                            .build()}
@@ -45,7 +47,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesSubscribe()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/readme.txt")
                               .contentLength(33)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesTemplatesList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.templates.list/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesTemplatesList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.unsubscribe/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.unsubscribe/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .resourcesUnsubscribe()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .uri("file:///data/readme.txt")
                                .contentLength(33)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.unsubscribe/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.unsubscribe/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .capabilities("SERVER_RESOURCES_SUBSCRIBE")
                                .build()
                            .build()}
@@ -45,7 +47,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .resourcesUnsubscribe()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .uri("file:///data/readme.txt")
                               .contentLength(33)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(133440)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(133440)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(133405)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.100k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(133405)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(13440)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(13440)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(13405)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.10k/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(13405)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.after.result/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.after.result/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .timeout(30000)

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.after.result/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.after.result/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.context/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.context/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.context/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.context/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.proxied/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.deferred/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.deferred/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.passthrough/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.passthrough/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.passthrough/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.passthrough/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .timeout(0)

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.proxied/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.is.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.is.error/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.is.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.is.error/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.bearer/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.reject.error/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.resumable/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.timeout/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.timeout/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -32,7 +34,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -47,7 +49,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .timeout(30000)

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.timeout/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.timeout/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -35,7 +37,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -45,7 +47,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .timeout(30000)

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(94)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(94)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(94)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.resume/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(94)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(94)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspend/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(94)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(94)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress.suspended/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(94)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(94)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.with.progress/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(94)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property authorization 0L
 
 connect "zilla://streams/app0"
@@ -31,7 +33,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -46,7 +48,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsCall()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .name("get_weather")
                                .contentLength(59)
                                .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 property authorization 0L
 
@@ -34,7 +36,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -44,7 +46,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsCall()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .name("get_weather")
                               .contentLength(59)
                               .build()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.aborted/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.canceled/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.partial.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.partial.toolkit.multi/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED_1
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.partial.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.partial.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.security.schemes/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.security.schemes/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.security.schemes/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.security.schemes/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.filtered/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.filtered/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.filtered/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.filtered/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app1"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED_1
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 
@@ -75,7 +77,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 
@@ -89,7 +91,7 @@ connect await LIFECYCLE_INITIALIZED_2
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
@@ -30,7 +32,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -40,7 +42,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
                               .build()
                           .build()}
 
@@ -76,7 +78,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -86,7 +88,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b00000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/client.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
@@ -28,7 +30,7 @@ connected
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .lifecycle()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 
@@ -42,7 +44,7 @@ connect await LIFECYCLE_INITIALIZED
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .toolsList()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list/server.rpt
@@ -13,6 +13,8 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property affinity "00000000"
+
 property serverAddress "zilla://streams/app0"
 
 accept ${serverAddress}
@@ -32,7 +34,7 @@ connected
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
                            .lifecycle()
-                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                                .build()
                            .build()}
 write flush
@@ -42,7 +44,7 @@ accepted
 read zilla:begin.ext ${mcp:matchBeginEx()
                           .typeId(zilla:id("mcp"))
                           .toolsList()
-                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
                               .build()
                           .build()}
 

--- a/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
+++ b/specs/engine.spec/src/main/resources/META-INF/zilla/core.idl
@@ -44,6 +44,7 @@ scope core
         struct Begin extends Frame [0x00000001]
         {
             int64 affinity;
+            int64 redirectedId = 0;
             octets extension;
         }
 


### PR DESCRIPTION
## Description

`EngineContext#supplyInitialId(bindingId, affinityId)` is documented to pin a stream to "the worker selected by affinityId", and `EngineContext#affinity()` documents `affinityId` as encoding a node byte plus a 24-bit worker index. Despite that, the implementation resolved the target worker via `Math.floorMod(affinityId, mask.cardinality())` over the binding's tuning mask — discarding the worker index actually embedded in `affinityId` and re-deriving a slot from scratch.

This only happened to select the intended worker when a binding's tuning mask had power-of-two cardinality (`2^24 mod cardinality == 0`). For any other cardinality, once `affinityId` carries a non-zero node byte, the modulo folds the node and worker bits together, and can resolve to the wrong worker — a latent bug that a non-power-of-two worker/core count exposes even without ever leaving a single node.

This PR resolves the worker directly from `affinityId`'s own embedded index when it names a worker local to this engine node (bounds-checked against the configured worker count), falling back to the existing round-robin selection when it doesn't (e.g. the affinity names a different node, or an out-of-range index).

It also closes a related gap in the `Router`/`RouterContext` SPI: today a `Router` can only compose the engine's stream factory, with no way to redirect a stream to a different routed binding before its initial id is minted, short of rewriting frame bytes as they pass through the composed handler. This adds `Router`/`RouterContext#resolveRoutedId(routedId, affinity)` (identity by default) as an explicit hook for that decision, consulted once at mint time.

Finally, `Begin` gains a `redirectedId` field (default `0`). A `REDIRECT`-driven `Begin` can now record the pre-redirect `routedId` for a downstream binding to recover after `routedId` itself has been resolved to the actual dispatch target — without requiring the engine's own dispatch (`handleBeginInitial`) to be router-aware, and without any change needed to existing `Begin` construction call sites (the new field defaults like `Frame`'s existing `timestamp`/`traceId`/`authorization`).

## Test plan

- [x] `./mvnw clean verify -pl runtime/engine -am` — full engine unit + integration test suite passes (`EngineIT`, `EngineContextIT`, `RouterFactoryTest`, etc.)
- [x] `./mvnw clean verify -pl runtime/binding-http -am` — full binding-http test suite passes (397 tests), including both `rfc7230` and `rfc7540` `RedirectIT` classes exercising the changed `onRequestRedirect` path end-to-end through a real engine
- [x] `./mvnw checkstyle:check` / `./mvnw license:check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_