### PR TITLE
feat(model-core): expose the pipeline's authorization to transform stages

### DIFF
--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/ext/BytesController.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/ext/BytesController.java
@@ -28,6 +28,22 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 public interface BytesController
 {
     /**
+     * Returns the authorization in effect for the value currently being transformed.
+     * <p>
+     * A mediating stage may override this to scope the authorization further for a nested composition; a
+     * non-mediating stage passes its own through, so this reflects the authorization the pipeline received
+     * for the current value unless some stage along the way has narrowed it. The default is {@code 0L},
+     * for a pipeline that never received one.
+     * </p>
+     *
+     * @return the authorization in effect for the current value
+     */
+    default long authorization()
+    {
+        return 0L;
+    }
+
+    /**
      * Returns the metadata travelling alongside the value being transformed, addressed by name rather than
      * by position within the value. The default is {@link ModelEnvelope#NONE}, in force when the caller
      * driving the pipeline supplied no envelope, so a stage reads an empty envelope rather than no

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/ext/StringController.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/ext/StringController.java
@@ -28,6 +28,22 @@ import io.aklivity.zilla.runtime.engine.model.ModelStatus;
 public interface StringController
 {
     /**
+     * Returns the authorization in effect for the value currently being transformed.
+     * <p>
+     * A mediating stage may override this to scope the authorization further for a nested composition; a
+     * non-mediating stage passes its own through, so this reflects the authorization the pipeline received
+     * for the current value unless some stage along the way has narrowed it. The default is {@code 0L},
+     * for a pipeline that never received one.
+     * </p>
+     *
+     * @return the authorization in effect for the current value
+     */
+    default long authorization()
+    {
+        return 0L;
+    }
+
+    /**
      * Returns the metadata travelling alongside the value being transformed, addressed by name rather than
      * by position within the value. The default is {@link ModelEnvelope#NONE}, in force when the caller
      * driving the pipeline supplied no envelope, so a stage reads an empty envelope rather than no

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BytesExtModelPipeline.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/BytesExtModelPipeline.java
@@ -95,6 +95,12 @@ final class BytesExtModelPipeline extends CoreExtModelPipeline
     private final class Control implements BytesController
     {
         @Override
+        public long authorization()
+        {
+            return BytesExtModelPipeline.this.authorization();
+        }
+
+        @Override
         public ModelEnvelope envelope()
         {
             return BytesExtModelPipeline.this.envelope();

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipeline.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipeline.java
@@ -70,6 +70,7 @@ abstract class CoreExtModelPipeline implements ModelPipeline
     private int reported;
     private String diagnostic;
     private boolean withheld;
+    private long authorization;
 
     CoreExtModelPipeline(
         CoreModelHandler handler,
@@ -107,6 +108,7 @@ abstract class CoreExtModelPipeline implements ModelPipeline
             reset();
         }
 
+        this.authorization = authorization;
         target = dst;
         targetAt = dstIndex;
         targetLimit = dstLimit;
@@ -215,6 +217,11 @@ abstract class CoreExtModelPipeline implements ModelPipeline
     protected final ModelEnvelope envelope()
     {
         return envelope;
+    }
+
+    protected final long authorization()
+    {
+        return authorization;
     }
 
     protected final void consumed(

--- a/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringExtModelPipeline.java
+++ b/runtime/model-core/src/main/java/io/aklivity/zilla/runtime/model/core/internal/StringExtModelPipeline.java
@@ -95,6 +95,12 @@ final class StringExtModelPipeline extends CoreExtModelPipeline
     private final class Control implements StringController
     {
         @Override
+        public long authorization()
+        {
+            return StringExtModelPipeline.this.authorization();
+        }
+
+        @Override
         public ModelEnvelope envelope()
         {
             return StringExtModelPipeline.this.envelope();

--- a/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipelineTest.java
+++ b/runtime/model-core/src/test/java/io/aklivity/zilla/runtime/model/core/internal/CoreExtModelPipelineTest.java
@@ -297,6 +297,19 @@ public class CoreExtModelPipelineTest
         assertSame(envelope, envelopes.observed);
     }
 
+    @Test
+    public void shouldReachAuthorizationFromStage()
+    {
+        Authorizations authorizations = new Authorizations();
+        ModelHandler handler = handler(mock(EngineContext.class), stage(authorizations));
+        ModelPipeline pipeline = handler.supplyDecoder(ModelEnvelope.NONE, ModelTransform.NONE);
+        UnsafeBufferEx dst = new UnsafeBufferEx(new byte[16]);
+
+        pipeline.transform(0L, 0L, 42L, FLAGS_COMPLETE, buffer("abc"), 0, 3, dst, 0, dst.capacity());
+
+        assertEquals(42L, authorizations.observed);
+    }
+
     private static ModelPipeline decoder(
         BytesModelExtHandler... exts)
     {
@@ -435,6 +448,24 @@ public class CoreExtModelPipelineTest
             BytesSink sink)
         {
             observed = control.envelope();
+            return sink.transform(control, source, event);
+        }
+    }
+
+    // reads the authorization in force and remembers it, so a test can assert a stage reaches the
+    // authorization the pipeline received through its control handle
+    private static final class Authorizations implements BytesTransform
+    {
+        private long observed;
+
+        @Override
+        public ModelStatus transform(
+            BytesController control,
+            BytesSource source,
+            BytesEvent event,
+            BytesSink sink)
+        {
+            observed = control.authorization();
             return sink.transform(control, source, event);
         }
     }


### PR DESCRIPTION
## Description

`BytesController`/`StringController` had no way for a `BytesTransform`/`StringTransform` to observe the authorization in effect for the value it is transforming, unlike `AvroController`'s own `authorization()` (and `JsonController`'s, added for parity in #2410) — so a bytes/string model extension could not gate any part of its behavior on the caller's authorization the way an avro or json extension already can.

`CoreExtModelPipeline.transform` already receives `authorization` as a parameter on every call (it's just never stored or exposed). This change:

- Stores it on `CoreExtModelPipeline` and exposes a `protected final authorization()` accessor, mirroring the existing `envelope()` plumbing.
- Adds a default `authorization()` method (returning `0L`) to both `BytesController` and `StringController`, matching `AvroController`'s contract and `JsonController`'s javadoc.
- Wires the delegating override into each pipeline's `Control` inner class (`BytesExtModelPipeline`, `StringExtModelPipeline`).

No dependencies required for this change.

## Test plan

- New unit test `shouldReachAuthorizationFromStage` in `CoreExtModelPipelineTest`, mirroring the existing `shouldReachMetadataEnvelopeFromStage` test — drives a stage that reads `control.authorization()` and asserts it observes the value passed into `transform(...)`.
- `./mvnw clean install -pl runtime/model-core -am` green: 107 unit tests + 23 ITs, checkstyle clean, JaCoCo coverage met.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BM4DuDAs8Xs73PHYnA9866)_