### PR TITLE
fix(common-protobuf): unwrap well-known wrapper types in JSON codec

### DIFF
--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSchema.java
@@ -327,7 +327,12 @@ public final class ProtobufSchema
 
         public ProtobufSchema build()
         {
-            Map<String, ProtobufMessage> resolvedMessages = Map.copyOf(messages);
+            Map<String, ProtobufMessage> withWellKnown = new LinkedHashMap<>(messages);
+            for (String typeName : ProtobufWellKnownTypes.names())
+            {
+                withWellKnown.putIfAbsent(typeName, ProtobufWellKnownTypes.wrapperMessage(typeName));
+            }
+            Map<String, ProtobufMessage> resolvedMessages = Map.copyOf(withWellKnown);
             Map<String, ProtobufEnum> resolvedEnums = Map.copyOf(enums);
             Map<String, ProtobufService> resolvedServices = Map.copyOf(services);
             for (ProtobufMessage message : toRelink)

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufWellKnownTypes.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufWellKnownTypes.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The nine {@code google.protobuf} well-known wrapper message types — {@code StringValue}, {@code BytesValue},
+ * {@code BoolValue}, {@code Int32Value}, {@code UInt32Value}, {@code Int64Value}, {@code UInt64Value},
+ * {@code FloatValue}, {@code DoubleValue}. Each has a wire shape fixed by the protobuf spec itself — always
+ * exactly one field, number 1 named {@code value}, of a fixed corresponding scalar type — so recognizing one
+ * by its fully-qualified name and resolving its shape is a pure lookup, never a schema-import concern; a
+ * schema referencing one of these types by name need not declare or import it.
+ */
+public final class ProtobufWellKnownTypes
+{
+    private static final Map<String, ProtobufType> VALUE_TYPES = Map.of(
+        "google.protobuf.StringValue", ProtobufType.STRING,
+        "google.protobuf.BytesValue", ProtobufType.BYTES,
+        "google.protobuf.BoolValue", ProtobufType.BOOL,
+        "google.protobuf.Int32Value", ProtobufType.INT32,
+        "google.protobuf.UInt32Value", ProtobufType.UINT32,
+        "google.protobuf.Int64Value", ProtobufType.INT64,
+        "google.protobuf.UInt64Value", ProtobufType.UINT64,
+        "google.protobuf.FloatValue", ProtobufType.FLOAT,
+        "google.protobuf.DoubleValue", ProtobufType.DOUBLE);
+
+    /**
+     * The fully-qualified names of all nine well-known wrapper types.
+     */
+    public static Set<String> names()
+    {
+        return VALUE_TYPES.keySet();
+    }
+
+    /**
+     * Whether {@code typeName} is one of the nine well-known wrapper type names.
+     */
+    public static boolean wrapper(
+        String typeName)
+    {
+        return typeName != null && VALUE_TYPES.containsKey(typeName);
+    }
+
+    /**
+     * The synthetic single-field descriptor for the well-known wrapper type named {@code typeName}: field
+     * number 1, named {@code value}, of the type the spec fixes for that wrapper. {@code null} when
+     * {@code typeName} is not one of the nine.
+     */
+    public static ProtobufMessage wrapperMessage(
+        String typeName)
+    {
+        ProtobufType valueType = VALUE_TYPES.get(typeName);
+        return valueType == null
+            ? null
+            : ProtobufMessage.builder(typeName)
+                .field(ProtobufField.builder().number(1).name("value").type(valueType).build())
+                .build();
+    }
+
+    private ProtobufWellKnownTypes()
+    {
+    }
+}

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonGeneratorImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonGeneratorImpl.java
@@ -28,6 +28,7 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufWellKnownTypes;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
 
 /**
@@ -164,7 +165,7 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         if (rootOpened && depth >= 0)
         {
             Scope scope = scopes[depth];
-            if (!scope.mapEntry && scope.message != null)
+            if (!scope.mapEntry && !scope.wrapper && scope.message != null)
             {
                 int separator = scope.openField != -1 || !scope.written.isEmpty() ? 1 : 0;
                 for (ProtobufField field : scope.message.sortedFields())
@@ -551,9 +552,9 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         }
         if (complete)
         {
-            complete = emitDefaults(scope);
+            complete = scope.wrapper ? emitWrapperDefault(scope) : emitDefaults(scope);
         }
-        if (complete && !scope.mapEntry)
+        if (complete && !scope.mapEntry && !scope.wrapper)
         {
             complete = writeEndChecked();
         }
@@ -570,7 +571,7 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         {
             rootOpened = true;
             depth = 0;
-            scopes[0].set(schema.message(messageName), false);
+            scopes[0].set(schema.message(messageName), false, false);
         }
         return rootOpened;
     }
@@ -631,6 +632,10 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
                     width = scope.pendingKey.length() + 3 + separator;
                 }
             }
+            else if (scope.wrapper)
+            {
+                width = 0;
+            }
             else if (scope.message != null)
             {
                 ProtobufField field = scope.message.field(number);
@@ -657,7 +662,7 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         if (!keyDrained && rootOpened && depth >= 0)
         {
             Scope scope = scopes[depth];
-            if (!scope.mapEntry && scope.message != null)
+            if (!scope.mapEntry && !scope.wrapper && scope.message != null)
             {
                 ProtobufField field = scope.message.field(number);
                 if (field != null && !(field.repeated() && scope.openField == number))
@@ -699,6 +704,14 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             {
                 json.writeKey(scope.pendingKey);
             }
+        }
+        else if (scope.wrapper)
+        {
+            // the wrapper's own value field renders exactly where its enclosing field/array-element/map-value
+            // position already put us (see start()) — no key of its own to write
+            scalarField = scope.message.field(number);
+            scalarKey = false;
+            scope.written.set(number);
         }
         else
         {
@@ -748,11 +761,17 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             Scope scope = scopes[depth];
             if (scope.mapEntry)
             {
-                if (json.remaining() >= keyWidth(scope, scope.pendingKey) + 1)
+                ProtobufField field = scope.message.field(number);
+                boolean wrapper = wrapper(field);
+                int braceWidth = wrapper ? 0 : 1;
+                if (json.remaining() >= keyWidth(scope, scope.pendingKey) + braceWidth)
                 {
                     writeKeyChecked(scope.pendingKey);
-                    writeStartObjectChecked();
-                    pushScope(scope.message.field(number).message(), false);
+                    if (!wrapper)
+                    {
+                        writeStartObjectChecked();
+                    }
+                    pushScope(field.message(), false, wrapper);
                     written = true;
                 }
             }
@@ -778,13 +797,15 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
                             scope.openField = number;
                         }
                         scope.written.set(number);
-                        pushScope(field.message(), true);
+                        pushScope(field.message(), true, false);
                         written = true;
                     }
                 }
                 else if (field.repeated())
                 {
-                    if (json.remaining() >= closeWidth + openWidth + 1)
+                    boolean wrapper = wrapper(field);
+                    int braceWidth = wrapper ? 0 : 1;
+                    if (json.remaining() >= closeWidth + openWidth + braceWidth)
                     {
                         if (closesPrior)
                         {
@@ -797,14 +818,19 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
                             scope.openField = number;
                         }
                         scope.written.set(number);
-                        writeStartObjectChecked();
-                        pushScope(field.message(), false);
+                        if (!wrapper)
+                        {
+                            writeStartObjectChecked();
+                        }
+                        pushScope(field.message(), false, wrapper);
                         written = true;
                     }
                 }
                 else
                 {
-                    if (json.remaining() >= closeWidth + keyWidth(scope, key(field)) + 1)
+                    boolean wrapper = wrapper(field);
+                    int braceWidth = wrapper ? 0 : 1;
+                    if (json.remaining() >= closeWidth + keyWidth(scope, key(field)) + braceWidth)
                     {
                         if (closesPrior)
                         {
@@ -812,8 +838,11 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
                         }
                         scope.written.set(number);
                         writeKeyChecked(key(field));
-                        writeStartObjectChecked();
-                        pushScope(field.message(), false);
+                        if (!wrapper)
+                        {
+                            writeStartObjectChecked();
+                        }
+                        pushScope(field.message(), false, wrapper);
                         written = true;
                     }
                 }
@@ -899,6 +928,19 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             }
         }
         return written;
+    }
+
+    // A wrapper message's own presence was already explicit (its enclosing field/element/map-value started
+    // this scope), so unlike a normal composite field's absence, its value field is never itself omitted:
+    // if the wire never wrote it (proto3 omits a default scalar), its bare zero value renders here instead.
+    private boolean emitWrapperDefault(
+        Scope scope)
+    {
+        if (!scope.written.get(1))
+        {
+            emitScalarDefault(scope.message.field(1));
+        }
+        return true;
     }
 
     private void emitScalarDefault(
@@ -1142,7 +1184,8 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
 
     private void pushScope(
         ProtobufMessage message,
-        boolean mapEntry)
+        boolean mapEntry,
+        boolean wrapper)
     {
         depth++;
         if (depth == scopes.length)
@@ -1155,7 +1198,7 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
             }
             scopes = grown;
         }
-        scopes[depth].set(message, mapEntry);
+        scopes[depth].set(message, mapEntry, wrapper);
     }
 
     private void appendUnsigned(
@@ -1222,6 +1265,12 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
         return field.repeated() && message != null && message.mapEntry();
     }
 
+    private static boolean wrapper(
+        ProtobufField field)
+    {
+        return ProtobufWellKnownTypes.wrapper(field.typeName());
+    }
+
     private static String nonFinite(
         double value)
     {
@@ -1243,15 +1292,18 @@ public final class ProtobufJsonGeneratorImpl implements ProtobufGenerator
 
         private ProtobufMessage message;
         private boolean mapEntry;
+        private boolean wrapper;
         private int openField;
         private String pendingKey;
 
         private void set(
             ProtobufMessage message,
-            boolean mapEntry)
+            boolean mapEntry,
+            boolean wrapper)
         {
             this.message = message;
             this.mapEntry = mapEntry;
+            this.wrapper = wrapper;
             this.openField = -1;
             this.pendingKey = null;
             this.written.clear();

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/json/internal/ProtobufJsonParserImpl.java
@@ -29,6 +29,7 @@ import io.aklivity.zilla.runtime.common.protobuf.ProtobufParser;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufParsingException;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufWellKnownTypes;
 import io.aklivity.zilla.runtime.common.protobuf.ProtobufWireType;
 
 /**
@@ -125,7 +126,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     // prefix counts the whole value and stays open until the last chunk
     private int valueRemaining;
     private ProtobufField valueField;
-    private boolean valueClosesMapEntry;
+    private int valueCloseDepth;
 
     private boolean last;
     private boolean primed;
@@ -496,7 +497,14 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         else
         {
             ProtobufField field = frame.field;
-            if (field.composite())
+            if (wrapper(field))
+            {
+                if (token != JsonEvent.VALUE_NULL)
+                {
+                    emitWrapperValue(field, token, 0);
+                }
+            }
+            else if (field.composite())
             {
                 expectStartObject(token);
                 boolean group = field.type() == ProtobufType.GROUP;
@@ -507,7 +515,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             else if (token != JsonEvent.VALUE_NULL)
             {
                 enqueue(ProtobufEvent.FIELD, field, null);
-                emitValue(field, token, false);
+                emitValue(field, token, 0);
             }
             progress = true;
         }
@@ -562,7 +570,18 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             {
                 ProtobufField valueField = frame.message.field(2);
                 frame.mapStep = 0;
-                if (valueField.composite())
+                if (wrapper(valueField))
+                {
+                    if (token == JsonEvent.VALUE_NULL)
+                    {
+                        enqueue(ProtobufEvent.END_MESSAGE, null, null);
+                    }
+                    else
+                    {
+                        emitWrapperValue(valueField, token, 1);
+                    }
+                }
+                else if (valueField.composite())
                 {
                     expectStartObject(token);
                     boolean group = valueField.type() == ProtobufType.GROUP;
@@ -577,7 +596,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
                 else
                 {
                     enqueue(ProtobufEvent.FIELD, valueField, null);
-                    emitValue(valueField, token, true);
+                    emitValue(valueField, token, 1);
                 }
                 progress = true;
             }
@@ -606,6 +625,10 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
             }
             push(Kind.ARRAY, null, field, false, false);
         }
+        else if (wrapper(field))
+        {
+            emitWrapperValue(field, token, 0);
+        }
         else if (field.composite())
         {
             expectStartObject(token);
@@ -617,7 +640,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         else
         {
             enqueue(ProtobufEvent.FIELD, field, null);
-            emitValue(field, token, false);
+            emitValue(field, token, 0);
         }
     }
 
@@ -707,30 +730,61 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     }
 
     // a field value: a string/bytes value begins a bounded streaming run (FIELD already enqueued), every other
-    // scalar decodes whole and enqueues its single VALUE. closesMapEntry defers the map-entry END_MESSAGE until
-    // the (possibly multi-chunk) value finishes
+    // scalar decodes whole and enqueues its single VALUE. closeDepth defers that many END_MESSAGE events (an
+    // enclosing map entry, an enclosing wrapper submessage, or both) until the (possibly multi-chunk) value
+    // finishes
     private void emitValue(
         ProtobufField field,
         JsonEvent token,
-        boolean closesMapEntry)
+        int closeDepth)
     {
         switch (field.type())
         {
         case STRING:
-            beginStringStream(field, parser.getStringView(), closesMapEntry);
+            beginStringStream(field, parser.getStringView(), closeDepth);
             break;
         case BYTES:
-            beginBytesStream(field, parser.getStringView(), closesMapEntry);
+            beginBytesStream(field, parser.getStringView(), closeDepth);
             break;
         default:
             decodeScalar(field, token);
             enqueue(ProtobufEvent.VALUE, field, null);
-            if (closesMapEntry)
-            {
-                enqueue(ProtobufEvent.END_MESSAGE, null, null);
-            }
+            enqueueCloses(closeDepth);
             break;
         }
+    }
+
+    // a wrapper-typed field (one of the nine google.protobuf well-known scalar wrappers) reads a bare JSON
+    // scalar and re-synthesizes the submessage boundary the wire generator still needs — FIELD, START_MESSAGE,
+    // FIELD(value), the value itself, END_MESSAGE — from the one token already in hand; there is no nested
+    // JSON object to open or close for it. extraCloseDepth additionally closes an enclosing map entry once the
+    // value and this wrapper's own END_MESSAGE complete
+    private void emitWrapperValue(
+        ProtobufField field,
+        JsonEvent token,
+        int extraCloseDepth)
+    {
+        ProtobufMessage message = field.message();
+        ProtobufField valueField = message.field(1);
+        enqueue(ProtobufEvent.FIELD, field, null);
+        enqueue(ProtobufEvent.START_MESSAGE, null, message);
+        enqueue(ProtobufEvent.FIELD, valueField, null);
+        emitValue(valueField, token, 1 + extraCloseDepth);
+    }
+
+    private void enqueueCloses(
+        int closeDepth)
+    {
+        for (int i = 0; i < closeDepth; i++)
+        {
+            enqueue(ProtobufEvent.END_MESSAGE, null, null);
+        }
+    }
+
+    private static boolean wrapper(
+        ProtobufField field)
+    {
+        return ProtobufWellKnownTypes.wrapper(field.typeName());
     }
 
     // a map key (FIELD already enqueued, no map-entry END_MESSAGE follows): a string key streams; the other
@@ -742,7 +796,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         switch (keyField.type())
         {
         case STRING:
-            beginStringStream(keyField, text, false);
+            beginStringStream(keyField, text, 0);
             break;
         case BOOL:
             longValue = "true".contentEquals(text) ? 1L : 0L;
@@ -813,7 +867,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private void beginStringStream(
         ProtobufField field,
         CharSequence value,
-        boolean closesMapEntry)
+        int closeDepth)
     {
         valueStreaming = true;
         valueString = true;
@@ -821,7 +875,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         valueCursor = 0;
         valueSourceLength = value.length();
         valueField = field;
-        valueClosesMapEntry = closesMapEntry;
+        valueCloseDepth = closeDepth;
         valueRemaining = utf8Length(value);
         refillStringChunk();
         enqueue(ProtobufEvent.VALUE, field, null);
@@ -832,7 +886,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
     private void beginBytesStream(
         ProtobufField field,
         CharSequence value,
-        boolean closesMapEntry)
+        int closeDepth)
     {
         valueStreaming = true;
         valueString = false;
@@ -840,7 +894,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         valueCursor = 0;
         valueSourceLength = base64SignificantLength(value);
         valueField = field;
-        valueClosesMapEntry = closesMapEntry;
+        valueCloseDepth = closeDepth;
         valueRemaining = base64DecodedLength(value, valueSourceLength);
         refillBytesChunk();
         enqueue(ProtobufEvent.VALUE, field, null);
@@ -848,7 +902,8 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
 
     // drive the in-flight streaming value: when the current chunk is fully drained, stage the next bounded run
     // (resetting the output-pushback cursor) and enqueue another VALUE; when the source is exhausted, close the
-    // run and emit the deferred map-entry END_MESSAGE if any
+    // run and emit the deferred END_MESSAGE events (an enclosing map entry, an enclosing wrapper submessage, or
+    // both) if any
     private boolean streamValueStep()
     {
         if (valueCursor < valueSourceLength)
@@ -867,10 +922,7 @@ public final class ProtobufJsonParserImpl implements ProtobufParser
         {
             valueStreaming = false;
             valueSource = null;
-            if (valueClosesMapEntry)
-            {
-                enqueue(ProtobufEvent.END_MESSAGE, null, null);
-            }
+            enqueueCloses(valueCloseDepth);
         }
         return true;
     }

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufWellKnownTypesTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufWellKnownTypesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+
+/**
+ * A schema referencing one of the nine {@code google.protobuf} well-known wrapper types by name need not
+ * declare or import it — {@link ProtobufSchema.Builder#build()} auto-registers each one's fixed single-field
+ * shape, unless the schema already declares that name itself.
+ */
+public class ProtobufWellKnownTypesTest
+{
+    @Test
+    public void shouldAutoRegisterWrapperMessages()
+    {
+        ProtobufSchema schema = Protobuf.schema().build();
+
+        ProtobufMessage stringValue = schema.message("google.protobuf.StringValue");
+        assertNotNull(stringValue);
+        assertEquals(ProtobufType.STRING, stringValue.field(1).type());
+        assertEquals("value", stringValue.field(1).name());
+
+        assertEquals(ProtobufType.BYTES, schema.message("google.protobuf.BytesValue").field(1).type());
+        assertEquals(ProtobufType.BOOL, schema.message("google.protobuf.BoolValue").field(1).type());
+        assertEquals(ProtobufType.INT32, schema.message("google.protobuf.Int32Value").field(1).type());
+        assertEquals(ProtobufType.UINT32, schema.message("google.protobuf.UInt32Value").field(1).type());
+        assertEquals(ProtobufType.INT64, schema.message("google.protobuf.Int64Value").field(1).type());
+        assertEquals(ProtobufType.UINT64, schema.message("google.protobuf.UInt64Value").field(1).type());
+        assertEquals(ProtobufType.FLOAT, schema.message("google.protobuf.FloatValue").field(1).type());
+        assertEquals(ProtobufType.DOUBLE, schema.message("google.protobuf.DoubleValue").field(1).type());
+    }
+
+    @Test
+    public void shouldPreferExplicitlyDeclaredWrapperMessage()
+    {
+        ProtobufMessage declared = ProtobufMessage.builder("google.protobuf.StringValue")
+            .field(ProtobufField.builder().number(1).name("value").type(ProtobufType.STRING).build())
+            .build();
+
+        ProtobufSchema schema = Protobuf.schema()
+            .message(declared)
+            .build();
+
+        assertSame(declared, schema.message("google.protobuf.StringValue"));
+    }
+
+    @Test
+    public void shouldNotAffectUnrelatedMessages()
+    {
+        ProtobufSchema schema = Protobuf.schema()
+            .message(ProtobufMessage.builder("Person")
+                .field(ProtobufField.builder().number(1).name("name").type(ProtobufType.STRING).build())
+                .build())
+            .build();
+
+        assertNotSame(schema.message("Person"), schema.message("google.protobuf.StringValue"));
+        assertEquals("Person", schema.message("Person").name());
+    }
+
+    @Test
+    public void shouldResolveAndRoundTripUndeclaredWrapperFieldOnWireAlone()
+    {
+        ProtobufSchema schema = Protobuf.schema()
+            .message(ProtobufMessage.builder("Msg")
+                .field(ProtobufField.builder().number(1).name("note").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.StringValue").build())
+                .build())
+            .build();
+
+        assertNotNull(schema.message("Msg").field(1).message(),
+            "field.message() should resolve the auto-registered wrapper without any explicit declaration");
+
+        byte[] original = wire(g ->
+        {
+            g.startMessage(1, 0);
+            g.writeString(1, "hello");
+            g.endMessage();
+        });
+
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, "Msg"))
+            .into(ProtobufSink.of(generator, schema, "Msg"));
+        pipeline.reset();
+
+        assertEquals(ProtobufPipeline.Status.COMPLETED,
+            pipeline.transform(new UnsafeBufferEx(original), 0, original.length));
+
+        byte[] roundTripped = new byte[generator.length()];
+        out.getBytes(0, roundTripped);
+        assertArrayEquals(original, roundTripped);
+    }
+
+    private static byte[] wire(
+        Consumer<ProtobufGenerator> body)
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(buffer, 0, buffer.capacity());
+        body.accept(generator);
+        byte[] bytes = new byte[generator.length()];
+        buffer.getBytes(0, bytes);
+        return bytes;
+    }
+}

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonWrapperTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/json/ProtobufJsonWrapperTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc
+ *
+ * Licensed under the Aklivity Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *   https://www.aklivity.io/aklivity-community-license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.aklivity.zilla.runtime.common.protobuf.json;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
+import io.aklivity.zilla.runtime.common.agrona.buffer.UnsafeBufferEx;
+import io.aklivity.zilla.runtime.common.json.JsonEx;
+import io.aklivity.zilla.runtime.common.protobuf.Protobuf;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufField;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufGenerator;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufMessage;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufPipeline.Status;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSchema;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufSink;
+import io.aklivity.zilla.runtime.common.protobuf.ProtobufType;
+
+/**
+ * Verifies the nine {@code google.protobuf.*Value} well-known wrapper types render to and parse from a bare
+ * JSON scalar per the protobuf JSON mapping spec, instead of leaking their inner {@code value} field as a
+ * nested object.
+ */
+public class ProtobufJsonWrapperTest
+{
+    private final ProtobufSchema schema = newSchema();
+
+    @Test
+    public void shouldRenderWrapperFieldsAsBareScalars()
+    {
+        byte[] wire = wire(g ->
+        {
+            g.startMessage(1, 0);
+            g.writeString(1, "hello");
+            g.endMessage();
+            g.startMessage(2, 0);
+            g.writeInt32(1, 42);
+            g.endMessage();
+            g.startMessage(3, 0);
+            g.writeInt64(1, -7L);
+            g.endMessage();
+            g.startMessage(4, 0);
+            g.writeUInt32(1, 9);
+            g.endMessage();
+            g.startMessage(5, 0);
+            g.writeUInt64(1, 11L);
+            g.endMessage();
+            g.startMessage(6, 0);
+            g.writeBool(1, true);
+            g.endMessage();
+            g.startMessage(7, 0);
+            g.writeFloat(1, 0.5f);
+            g.endMessage();
+            g.startMessage(8, 0);
+            g.writeDouble(1, 1.5);
+            g.endMessage();
+            g.startMessage(9, 0);
+            g.writeBytes(1, new byte[]{1, 2, 3});
+            g.endMessage();
+        });
+
+        assertEquals("{" +
+            "\"note\":\"hello\"," +
+            "\"count\":42," +
+            "\"big\":\"-7\"," +
+            "\"u32\":9," +
+            "\"u64\":\"11\"," +
+            "\"flag\":true," +
+            "\"ratio\":0.5," +
+            "\"precise\":1.5," +
+            "\"data\":\"AQID\"" +
+            "}", toJson("Wrapped", wire));
+    }
+
+    @Test
+    public void shouldOmitAbsentWrapperField()
+    {
+        assertEquals("{}", toJson("Wrapped", new byte[0]));
+    }
+
+    @Test
+    public void shouldRenderExplicitDefaultWrapperValue()
+    {
+        byte[] wire = wire(g ->
+        {
+            g.startMessage(1, 0);
+            g.endMessage();
+            g.startMessage(2, 0);
+            g.endMessage();
+            g.startMessage(3, 0);
+            g.endMessage();
+            g.startMessage(6, 0);
+            g.endMessage();
+            g.startMessage(9, 0);
+            g.endMessage();
+        });
+
+        assertEquals("{\"note\":\"\",\"count\":0,\"big\":\"0\",\"flag\":false,\"data\":\"\"}",
+            toJson("Wrapped", wire));
+    }
+
+    @Test
+    public void shouldRenderRepeatedWrapperFieldAsBareArray()
+    {
+        byte[] wire = wire(g ->
+        {
+            g.startMessage(10, 0);
+            g.writeString(1, "a");
+            g.endMessage();
+            g.startMessage(10, 0);
+            g.writeString(1, "b");
+            g.endMessage();
+        });
+
+        assertEquals("{\"tags\":[\"a\",\"b\"]}", toJson("Wrapped", wire));
+    }
+
+    @Test
+    public void shouldRenderWrapperMapValueAsBareScalar()
+    {
+        byte[] wire = wire(g ->
+        {
+            g.startMessage(11, 0);
+            g.writeString(1, "k");
+            g.startMessage(2, 0);
+            g.writeInt32(1, 5);
+            g.endMessage();
+            g.endMessage();
+        });
+
+        assertEquals("{\"scores\":{\"k\":5}}", toJson("Wrapped", wire));
+    }
+
+    @Test
+    public void shouldRoundTripWrapperFields()
+    {
+        String json = "{" +
+            "\"note\":\"hello\"," +
+            "\"count\":42," +
+            "\"big\":\"-7\"," +
+            "\"u32\":9," +
+            "\"u64\":\"11\"," +
+            "\"flag\":true," +
+            "\"ratio\":0.5," +
+            "\"precise\":1.5," +
+            "\"data\":\"AQID\"" +
+            "}";
+
+        assertEquals(json, roundTrip("Wrapped", json));
+    }
+
+    @Test
+    public void shouldRoundTripRepeatedWrapperField()
+    {
+        assertEquals("{\"tags\":[\"a\",\"b\"]}", roundTrip("Wrapped", "{\"tags\":[\"a\",\"b\"]}"));
+    }
+
+    @Test
+    public void shouldRoundTripWrapperMapValue()
+    {
+        assertEquals("{\"scores\":{\"k\":5}}", roundTrip("Wrapped", "{\"scores\":{\"k\":5}}"));
+    }
+
+    @Test
+    public void shouldOmitNullWrapperValue()
+    {
+        assertEquals("{}", roundTrip("Wrapped", "{\"note\":null}"));
+    }
+
+    @Test
+    public void shouldEncodeWrapperJsonAsExpectedWire()
+    {
+        byte[] expected = wire(g ->
+        {
+            g.startMessage(1, 0);
+            g.writeString(1, "hello");
+            g.endMessage();
+        });
+
+        byte[] actual = toProtobuf("Wrapped", "{\"note\":\"hello\"}");
+
+        assertEquals(toJson("Wrapped", expected), toJson("Wrapped", actual));
+    }
+
+    private String roundTrip(
+        String messageName,
+        String json)
+    {
+        return toJson(messageName, toProtobuf(messageName, json));
+    }
+
+    private String toJson(
+        String messageName,
+        byte[] wire)
+    {
+        Map<String, Object> config = new HashMap<>();
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[8192]);
+        ProtobufGenerator generator = ProtobufJson.generator(JsonEx.createGenerator(), schema, messageName, config);
+        generator.wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(Protobuf.parser(schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        assertEquals(Status.COMPLETED, pipeline.transform(new UnsafeBufferEx(wire), 0, wire.length));
+        generator.flush();
+
+        byte[] bytes = new byte[generator.length()];
+        out.getBytes(0, bytes);
+        return new String(bytes, UTF_8);
+    }
+
+    private byte[] toProtobuf(
+        String messageName,
+        String json)
+    {
+        MutableDirectBufferEx out = new UnsafeBufferEx(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(out, 0, out.capacity());
+        ProtobufPipeline pipeline = Protobuf.stream(ProtobufJson.parser(JsonEx.createParser(), schema, messageName))
+            .into(ProtobufSink.of(generator, schema, messageName));
+        pipeline.reset();
+
+        byte[] in = json.getBytes(UTF_8);
+        assertEquals(Status.COMPLETED, pipeline.transform(new UnsafeBufferEx(in), 0, in.length));
+
+        byte[] bytes = new byte[generator.length()];
+        out.getBytes(0, bytes);
+        return bytes;
+    }
+
+    private static byte[] wire(
+        Consumer<ProtobufGenerator> body)
+    {
+        MutableDirectBufferEx buffer = new UnsafeBufferEx(new byte[8192]);
+        ProtobufGenerator generator = Protobuf.generator().wrap(buffer, 0, buffer.capacity());
+        body.accept(generator);
+        byte[] bytes = new byte[generator.length()];
+        buffer.getBytes(0, bytes);
+        return bytes;
+    }
+
+    // deliberately does not declare any of the nine google.protobuf.*Value messages: ProtobufSchema
+    // auto-registers their fixed single-field shape, so a field referencing one by typeName resolves
+    // without the schema ever declaring or importing it
+    private static ProtobufSchema newSchema()
+    {
+        return Protobuf.schema()
+            .message(ProtobufMessage.builder("ScoresEntry")
+                .mapEntry(true)
+                .field(ProtobufField.builder().number(1).name("key").type(ProtobufType.STRING).build())
+                .field(ProtobufField.builder().number(2).name("value").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.Int32Value").build())
+                .build())
+            .message(ProtobufMessage.builder("Wrapped")
+                .field(ProtobufField.builder().number(1).name("note").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.StringValue").build())
+                .field(ProtobufField.builder().number(2).name("count").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.Int32Value").build())
+                .field(ProtobufField.builder().number(3).name("big").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.Int64Value").build())
+                .field(ProtobufField.builder().number(4).name("u32").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.UInt32Value").build())
+                .field(ProtobufField.builder().number(5).name("u64").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.UInt64Value").build())
+                .field(ProtobufField.builder().number(6).name("flag").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.BoolValue").build())
+                .field(ProtobufField.builder().number(7).name("ratio").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.FloatValue").build())
+                .field(ProtobufField.builder().number(8).name("precise").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.DoubleValue").build())
+                .field(ProtobufField.builder().number(9).name("data").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.BytesValue").build())
+                .field(ProtobufField.builder().number(10).name("tags").type(ProtobufType.MESSAGE)
+                    .typeName("google.protobuf.StringValue").repeated(true).build())
+                .field(ProtobufField.builder().number(11).name("scores").type(ProtobufType.MESSAGE)
+                    .typeName("ScoresEntry").repeated(true).build())
+                .build())
+            .build();
+    }
+}


### PR DESCRIPTION
## Description

The protobuf JSON mapping spec requires the nine `google.protobuf` well-known wrapper types (`StringValue`, `Int32Value`, `Int64Value`, `UInt32Value`, `UInt64Value`, `BoolValue`, `FloatValue`, `DoubleValue`, `BytesValue`) to render as a bare JSON scalar rather than a `{"value": ...}` object. `ProtobufJsonGeneratorImpl` and `ProtobufJsonParserImpl` previously treated every `MESSAGE`/`GROUP` field generically, so a wrapper-typed field leaked its inner `value` field into the JSON shape on both encode and decode.

This adds a shared `ProtobufWellKnownTypes` lookup (their wire shape is spec-fixed: one field, number 1, of a fixed scalar type) used by both JSON codec classes, so a field's `typeName()` alone decides whether to substitute a bare scalar for the nested object — handled as one general concept across all nine, not scoped to any single type. `ProtobufSchema.Builder` also auto-registers each of the nine as a synthetic single-field message when a schema doesn't already declare one under that name, so a field referencing `google.protobuf.StringValue` etc. resolves without any import-resolution machinery, matching the issue's suggested fix shape.

Handles the concept generally: a plain wrapper-typed field, a repeated wrapper-typed field (bare array), and a map value of wrapper type (bare scalar value) all unwrap consistently in both directions, including an explicitly-present-but-default wrapper value rendering its scalar zero value instead of an empty object.

Fixes #2411

## Test plan

- [x] New `ProtobufJsonWrapperTest` covers encode and decode for all nine wrapper types, a repeated wrapper field, a wrapper-valued map, explicit-default rendering, absent-field omission, and null handling
- [x] New `ProtobufWellKnownTypesTest` covers schema auto-registration, explicit-declaration precedence, and a wire-only round trip proving `field.message()` resolves without any explicit declaration
- [x] Full `common-protobuf` module test suite passes (226/226), including checkstyle and license header checks


---
_Generated by [Claude Code](https://claude.ai/code/session_019zS8zhb9myc6iSRxZvMHcp)_