### PR TITLE
test(engine): add option zilla:redirectedId to k3po connect/accept

### DIFF
--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaChannelConfig.java
@@ -23,6 +23,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_BYTE_ORDER;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_CAPABILITIES;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_PADDING;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_REDIRECTED_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_SHARED_WINDOW;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_STREAM_ID;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_THROTTLE;
@@ -49,6 +50,7 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     private ZillaThrottleMode throttle = ZillaThrottleMode.STREAM;
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
+    private long redirectedId;
     private byte capabilities;
     private boolean timestamps;
 
@@ -180,6 +182,19 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
     }
 
     @Override
+    public void setRedirectedId(
+        long redirectedId)
+    {
+        this.redirectedId = redirectedId;
+    }
+
+    @Override
+    public long getRedirectedId()
+    {
+        return redirectedId;
+    }
+
+    @Override
     public void setCapabilities(
         byte capabilities)
     {
@@ -253,6 +268,10 @@ public class DefaultZillaChannelConfig extends DefaultChannelConfig implements Z
         else if (OPTION_AFFINITY.getName().equals(key))
         {
             setAffinity(convertToLong(value));
+        }
+        else if (OPTION_REDIRECTED_ID.getName().equals(key))
+        {
+            setRedirectedId(convertToLong(value));
         }
         else if (OPTION_CAPABILITIES.getName().equals(key))
         {

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/DefaultZillaServerChannelConfig.java
@@ -48,6 +48,7 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     private ZillaThrottleMode throttle = ZillaThrottleMode.STREAM;
     private ZillaUpdateMode update = ZillaUpdateMode.STREAM;
     private long affinity;
+    private long redirectedId;
     private byte capabilities;
     private boolean timestamps;
 
@@ -164,6 +165,19 @@ public class DefaultZillaServerChannelConfig extends DefaultServerChannelConfig 
     public long getAffinity()
     {
         return affinity;
+    }
+
+    @Override
+    public void setRedirectedId(
+        long redirectedId)
+    {
+        this.redirectedId = redirectedId;
+    }
+
+    @Override
+    public long getRedirectedId()
+    {
+        return redirectedId;
     }
 
     @Override

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaChannelConfig.java
@@ -55,6 +55,10 @@ public interface ZillaChannelConfig extends ChannelConfig
 
     long getAffinity();
 
+    void setRedirectedId(long redirectedId);
+
+    long getRedirectedId();
+
     void setStreamId(long streamId);
 
     long getStreamId();

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaTarget.java
@@ -256,6 +256,7 @@ final class ZillaTarget implements AutoCloseable
             client.targetAuth(authorization);
 
             final long affinity = clientConfig.getAffinity();
+            final long redirectedId = clientConfig.getRedirectedId();
 
             ChannelBuffer beginExt = client.writeExtBuffer(BEGIN, true);
             final int writableExtBytes = beginExt.readableBytes();
@@ -276,6 +277,7 @@ final class ZillaTarget implements AutoCloseable
                 .traceId(supplyTraceId.getAsLong())
                 .authorization(authorization)
                 .affinity(affinity)
+                .redirectedId(redirectedId)
                 .extension(p -> p.set(beginExtCopy))
                 .build();
 
@@ -384,6 +386,7 @@ final class ZillaTarget implements AutoCloseable
         final long acknowledge = channel.targetAck();
         final int maximum = channel.targetMax();
         final long affinity = channel.getConfig().getAffinity();
+        final long redirectedId = channel.getConfig().getRedirectedId();
 
         final BeginFW begin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .originId(originId)
@@ -395,6 +398,7 @@ final class ZillaTarget implements AutoCloseable
                 .timestamp(channel.timestamp())
                 .traceId(supplyTraceId.getAsLong())
                 .affinity(affinity)
+                .redirectedId(redirectedId)
                 .extension(p -> p.set(beginExtCopy))
                 .build();
 

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
@@ -44,6 +44,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
     public static final TypeInfo<String> OPTION_BYTE_ORDER = new TypeInfo<>("byteorder", String.class);
     public static final TypeInfo<String> OPTION_ALIGNMENT = new TypeInfo<>("alignment", String.class);
     public static final TypeInfo<Long> OPTION_AFFINITY = new TypeInfo<>("affinity", Long.class);
+    public static final TypeInfo<Long> OPTION_REDIRECTED_ID = new TypeInfo<>("redirectedId", Long.class);
     public static final TypeInfo<Byte> OPTION_CAPABILITIES = new TypeInfo<>("capabilities", Byte.class);
     public static final TypeInfo<String> OPTION_TIMESTAMPS = new TypeInfo<>("timestamps", String.class);
     public static final TypeInfo<Integer> OPTION_FLAGS = new TypeInfo<>("flags", Integer.class);
@@ -96,6 +97,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         acceptOptions.add(OPTION_BYTE_ORDER);
         acceptOptions.add(OPTION_ALIGNMENT);
         acceptOptions.add(OPTION_AFFINITY);
+        acceptOptions.add(OPTION_REDIRECTED_ID);
         acceptOptions.add(OPTION_CAPABILITIES);
         acceptOptions.add(OPTION_TIMESTAMPS);
         this.acceptOptions = unmodifiableSet(acceptOptions);
@@ -115,6 +117,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         connectOptions.add(OPTION_BYTE_ORDER);
         connectOptions.add(OPTION_ALIGNMENT);
         connectOptions.add(OPTION_AFFINITY);
+        connectOptions.add(OPTION_REDIRECTED_ID);
         connectOptions.add(OPTION_CAPABILITIES);
         connectOptions.add(OPTION_TIMESTAMPS);
         this.connectOptions = unmodifiableSet(connectOptions);


### PR DESCRIPTION
## Description

The k3po zilla-ext test harness lets `.rpt` scripts set most `Begin` fields directly via `option zilla:<field>` (e.g. `affinity`, `streamId`, `capabilities`), but had no equivalent for `redirectedId` — so no test script could drive or assert a non-default `Begin.redirectedId`, even though the field has existed on the wire type since it was added to `core.idl`. This closes that gap.

- Adds `OPTION_REDIRECTED_ID` (a `Long` option named `redirectedId`) to `ZillaTypeSystem`'s `acceptOptions` and `connectOptions` sets, mirroring the existing `affinity` option.
- Adds `setRedirectedId`/`getRedirectedId` to `ZillaChannelConfig`, with implementations in `DefaultZillaChannelConfig` (wired through `setOption0` so `option zilla:redirectedId <value>` parses) and `DefaultZillaServerChannelConfig`.
- Stamps `.redirectedId(...)` on both `BeginFW` builder call sites in `ZillaTarget` — the outbound connect `Begin` and the reply `Begin` — which previously always left the field at its wire default of `0` regardless of what a script configured.

This is test-harness only (`runtime/engine/src/test/java`); no production code changes.

## Test plan
- [x] `./mvnw compile test-compile checkstyle:check -pl runtime/engine` passes clean
- [x] Verified locally with a `.rpt` script using `option zilla:redirectedId <value>` on both a `connect` and an `accept` block, confirming the resulting wire `Begin.redirectedId` reflects the configured value in both directions

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEncF8TdASSjY9Q113NMkv)_