### PR TITLE
feat(common-feature): add @Internal, a permanent non-overridable visibility gate

### DIFF
--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/factory/FactoryTest.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/factory/FactoryTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.aklivity.zilla.runtime.common.feature.Incubating;
+import io.aklivity.zilla.runtime.common.feature.Internal;
 
 public class FactoryTest
 {
@@ -48,6 +49,20 @@ public class FactoryTest
 
         assertThat(instances.contains(stable), equalTo(instancesByType.containsKey("stable")));
         assertThat(instances.contains(incubating), equalTo(instancesByType.containsKey("incubating")));
+    }
+
+    @Test
+    public void shouldFilterInternalIdenticallyToMapOverload()
+    {
+        TestFactorySpi stable = new TestFactorySpi("stable");
+        InternalTestFactorySpi internal = new InternalTestFactorySpi("internal");
+        List<TestFactorySpi> provided = List.of(stable, internal);
+
+        List<TestFactorySpi> instances = Factory.instantiate(provided);
+        Map<String, TestFactorySpi> instancesByType = new TestFactory().map(provided);
+
+        assertThat(instances.contains(stable), equalTo(instancesByType.containsKey("stable")));
+        assertThat(instances.contains(internal), equalTo(instancesByType.containsKey("internal")));
     }
 
     private static final class TestFactory extends Factory
@@ -80,6 +95,16 @@ public class FactoryTest
     private static final class IncubatingTestFactorySpi extends TestFactorySpi
     {
         private IncubatingTestFactorySpi(
+            String type)
+        {
+            super(type);
+        }
+    }
+
+    @Internal
+    private static final class InternalTestFactorySpi extends TestFactorySpi
+    {
+        private InternalTestFactorySpi(
             String type)
         {
             super(type);

--- a/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
+++ b/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/FeatureFilter.java
@@ -26,6 +26,7 @@ public final class FeatureFilter
     }
 
     private static final boolean INCUBATOR_ENABLED = incubatorEnabled();
+    private static final boolean INTERNAL_ENABLED = internalEnabled();
     private static final Predicate<Object> FEATURE_ENABLED = FeatureFilter::featureEnabled;
 
     public static <S> Iterable<S> filter(
@@ -37,15 +38,14 @@ public final class FeatureFilter
     private static boolean featureEnabled(
         Object feature)
     {
-        return INCUBATOR_ENABLED ||
-            !feature.getClass().isAnnotationPresent(Incubating.class);
+        return featureEnabled(feature.getClass());
     }
 
     public static boolean featureEnabled(
         Class<?> feature)
     {
-        return INCUBATOR_ENABLED ||
-            !feature.isAnnotationPresent(Incubating.class);
+        return (INCUBATOR_ENABLED || !feature.isAnnotationPresent(Incubating.class)) &&
+            (INTERNAL_ENABLED || !feature.isAnnotationPresent(Internal.class));
     }
 
     public static boolean isIncubatorEnabled()
@@ -53,14 +53,29 @@ public final class FeatureFilter
         return INCUBATOR_ENABLED;
     }
 
+    public static boolean isInternalEnabled()
+    {
+        return INTERNAL_ENABLED;
+    }
+
     private static boolean incubatorEnabled()
     {
-        final Module module = FeatureFilter.class.getModule();
         final String override = System.getProperty("zilla.incubator.enabled");
 
-        return override != null ? Boolean.parseBoolean(override) : module == null ||
-            module.getDescriptor() == null || "develop-SNAPSHOT".equals(
-                module.getDescriptor().version().map(ModuleDescriptor.Version::toString)
-                    .orElse("develop-SNAPSHOT"));
+        return override != null ? Boolean.parseBoolean(override) : isDevelopSnapshot();
+    }
+
+    private static boolean internalEnabled()
+    {
+        return isDevelopSnapshot();
+    }
+
+    private static boolean isDevelopSnapshot()
+    {
+        final Module module = FeatureFilter.class.getModule();
+
+        return module == null || module.getDescriptor() == null || "develop-SNAPSHOT".equals(
+            module.getDescriptor().version().map(ModuleDescriptor.Version::toString)
+                .orElse("develop-SNAPSHOT"));
     }
 }

--- a/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/Internal.java
+++ b/runtime/common-feature/src/main/java/io/aklivity/zilla/runtime/common/feature/Internal.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.common.feature;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE })
+public @interface Internal
+{
+}

--- a/runtime/common-feature/src/test/java/io/aklivity/zilla/runtime/common/feature/FeatureFilterTest.java
+++ b/runtime/common-feature/src/test/java/io/aklivity/zilla/runtime/common/feature/FeatureFilterTest.java
@@ -44,8 +44,32 @@ class FeatureFilterTest
         assertEquals(FeatureFilter.isIncubatorEnabled() ? 2L : 1L, filtered);
     }
 
+    @Test
+    void shouldReportIsInternalEnabledConsistentlyWithFeatureEnabled()
+    {
+        boolean internalEnabled = FeatureFilter.isInternalEnabled();
+
+        assertEquals(internalEnabled, FeatureFilter.featureEnabled(InternalFeature.class));
+        assertTrue(FeatureFilter.featureEnabled(StableFeature.class));
+    }
+
+    @Test
+    void shouldFilterInternalConsistentlyWithIsInternalEnabled()
+    {
+        List<Object> providers = List.of(new StableFeature(), new InternalFeature());
+
+        long filtered = StreamSupport.stream(FeatureFilter.filter(providers).spliterator(), false).count();
+
+        assertEquals(FeatureFilter.isInternalEnabled() ? 2L : 1L, filtered);
+    }
+
     @Incubating
     private static final class IncubatingFeature
+    {
+    }
+
+    @Internal
+    private static final class InternalFeature
     {
     }
 


### PR DESCRIPTION
## Description

`common-feature`'s visibility gate currently has one maturity axis: `@Incubating`, which hides a feature from a real release's config schema and runtime SPI loading, but always leaves a supported escape hatch — `zilla.incubator.enabled` (or the `ZILLA_INCUBATOR_ENABLED` env var it's mapped from) lets it be turned back on even in a tagged release.

There's no way today to express the opposite maturity: a feature that must never be reachable in a real release, under any configuration, with no supported override at all. `@Internal` adds that second axis.

`@Internal` is filtered through the exact same `FeatureFilter`/`Factory.instantiate()` machinery `@Incubating` already uses (so every existing ServiceLoader-based lookup — `BindingFactory`, `GuardFactory`, `VaultFactory`, `CatalogFactory`, `ExporterFactory`, `StoreFactory`, `RouterFactory`, `MetricGroupFactory`, `EventFormatter(Factory)`, and `EngineInfo`'s config-schema aggregation — picks it up automatically, with zero changes needed at any call site). The one deliberate difference: it has no system-property override branch. Its only "on" switch is the same unnamed-module/`develop-SNAPSHOT` fallback `@Incubating` already falls back to, which is why it stays free during ordinary Maven-run unit/integration tests (Surefire and Failsafe both execute before `moditect-maven-plugin` ever adds a module descriptor to the built jar) while remaining permanently unreachable in a fully packaged, module-path release build.

While extending `FeatureFilter.featureEnabled(Class<?>)` to check both annotations, also removed the pre-existing exact duplication between its `Object` and `Class<?>` overloads by having the former delegate to the latter.

## Test plan

- `FeatureFilterTest` — two new tests mirroring the existing `@Incubating` coverage exactly (`shouldReportIsInternalEnabledConsistentlyWithFeatureEnabled`, `shouldFilterInternalConsistentlyWithIsInternalEnabled`), plus a private `@Internal`-annotated fixture class.
- `FactoryTest` (`config/engine.conf`) — a new `shouldFilterInternalIdenticallyToMapOverload` test mirroring the existing `@Incubating` one, covering the actual `Factory.instantiate()` integration point.
- Verified `./mvnw test -pl runtime/common-feature` and `./mvnw verify -pl config/engine.conf` both pass (checkstyle, license, JaCoCo coverage all green).
- Verified the full `runtime/engine` unit test suite (228 tests) still passes unchanged, confirming the stricter `featureEnabled` check doesn't affect any of its other callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEncF8TdASSjY9Q113NMkv)_