### PR TITLE
feat(engine): add RouteableContext#supplyStore

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouteable.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouteable.java
@@ -16,11 +16,13 @@
 package io.aklivity.zilla.runtime.engine.internal.registry;
 
 import java.util.function.Consumer;
+import java.util.function.LongFunction;
 
 import io.aklivity.zilla.config.engine.NamespaceConfig;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 import io.aklivity.zilla.runtime.engine.router.RouteableContext;
+import io.aklivity.zilla.runtime.engine.store.StoreHandler;
 
 final class EngineRouteable implements RouteableContext
 {
@@ -28,17 +30,20 @@ final class EngineRouteable implements RouteableContext
     private final BindingHandler streamFactory;
     private final Consumer<NamespaceConfig> attachComposite;
     private final Consumer<NamespaceConfig> detachComposite;
+    private final LongFunction<StoreHandler> supplyStore;
 
     EngineRouteable(
         Configuration config,
         BindingHandler streamFactory,
         Consumer<NamespaceConfig> attachComposite,
-        Consumer<NamespaceConfig> detachComposite)
+        Consumer<NamespaceConfig> detachComposite,
+        LongFunction<StoreHandler> supplyStore)
     {
         this.config = config;
         this.streamFactory = streamFactory;
         this.attachComposite = attachComposite;
         this.detachComposite = detachComposite;
+        this.supplyStore = supplyStore;
     }
 
     @Override
@@ -65,5 +70,12 @@ final class EngineRouteable implements RouteableContext
         NamespaceConfig composite)
     {
         detachComposite.accept(composite);
+    }
+
+    @Override
+    public StoreHandler supplyStore(
+        long storeId)
+    {
+        return supplyStore.apply(storeId);
     }
 }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -428,7 +428,7 @@ public class EngineWorker implements EngineContext, Agent
 
         this.routerConfig = routerConfig;
         EngineRouteable routeable = new EngineRouteable(config, this::newStream,
-            this::attachComposite, this::detachComposite);
+            this::attachComposite, this::detachComposite, this::supplyStore);
         this.router = router.supply(routeable);
 
         this.bindings = bindings;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouteableContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouteableContext.java
@@ -18,6 +18,7 @@ package io.aklivity.zilla.runtime.engine.router;
 import io.aklivity.zilla.config.engine.NamespaceConfig;
 import io.aklivity.zilla.runtime.engine.Configuration;
 import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
+import io.aklivity.zilla.runtime.engine.store.StoreHandler;
 
 /**
  * Construction-tier context supplied to a {@link Router} during its setup.
@@ -69,4 +70,18 @@ public interface RouteableContext
      */
     void detachComposite(
         NamespaceConfig composite);
+
+    /**
+     * Returns the {@link StoreHandler} for the given store id, previously registered via
+     * the store's {@link io.aklivity.zilla.runtime.engine.store.StoreContext}.
+     * <p>
+     * This includes a store contributed by a synthesized namespace this router itself
+     * attached via {@link #attachComposite(NamespaceConfig)}, once attachment completes.
+     * </p>
+     *
+     * @param storeId  the store id
+     * @return the store handler, or {@code null} if not found
+     */
+    StoreHandler supplyStore(
+        long storeId);
 }


### PR DESCRIPTION
## Summary
- A router can already discover the ids of bindings it injects via `attachComposite` (by scanning the returned `NamespaceConfig`) and resolve labels via `supplyLabelId`/`supplyLabel`, but has no way to obtain a `StoreHandler` for a store it injects the same way.
- Adds `RouteableContext#supplyStore(long storeId)`, mirroring `EngineContext`'s existing capability, so a router-contributed composite namespace's store is as usable to the router as its bindings and labels already are.

## Test plan
- [x] `./mvnw -pl runtime/engine clean install -Dmaven.test.skip=true` — main sources compile cleanly.
- Note: `runtime/engine`'s test compilation currently fails on `develop` HEAD independent of this change (`TestBindingFactory.java` references `VaultAssertion.secretKey`/`.wrap`, which appear to have been removed from `config/engine.conf`'s `TestBindingOptionsConfig` in #2417). Verified via `git stash` that this reproduces identically without this PR's changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_