### PR TITLE
feat(engine): embed cluster node id into worker-scoped ids

### DIFF
--- a/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
+++ b/incubator/command-dump/src/main/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/zilla.lua
@@ -122,6 +122,8 @@ add_field("acknowledge", ProtoField.int64("zilla.acknowledge", "Acknowledge", ba
 add_field("maximum", ProtoField.int32("zilla.maximum", "Maximum", base.DEC))
 add_field("timestamp", ProtoField.uint64("zilla.timestamp", "Timestamp", base.HEX))
 add_field("trace_id", ProtoField.uint64("zilla.trace_id", "Trace ID", base.HEX))
+add_field("trace_id_node", ProtoField.uint8("zilla.trace_id.node", "Node", base.DEC))
+add_field("trace_id_worker", ProtoField.uint8("zilla.trace_id.worker", "Worker", base.DEC))
 add_field("authorization", ProtoField.uint64("zilla.authorization", "Authorization", base.HEX))
 
 -- begin frame
@@ -575,7 +577,10 @@ function zilla_protocol.dissector(buffer, pinfo, tree)
     subtree:add_le(fields.acknowledge, slice_acknowledge)
     subtree:add_le(fields.maximum, slice_maximum)
     subtree:add_le(fields.timestamp, slice_timestamp)
-    subtree:add_le(fields.trace_id, slice_trace_id)
+    local trace_id_subtree = subtree:add(zilla_protocol, slice_trace_id, "Trace ID")
+    trace_id_subtree:add_le(fields.trace_id, slice_trace_id)
+    trace_id_subtree:add_le(fields.trace_id_node, buffer(frame_offset + 62, 1))
+    trace_id_subtree:add_le(fields.trace_id_worker, buffer(frame_offset + 63, 1))
     subtree:add_le(fields.authorization, slice_authorization)
 
     pinfo.cols.protocol = zilla_protocol.name

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpLinkNetworkIT_shouldExchangeAttachAsReceiver.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -53,7 +56,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -83,7 +89,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -117,7 +126,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -151,7 +163,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -192,7 +207,10 @@ Zilla Frame
     Acknowledge: 8
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -226,7 +244,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -267,7 +288,10 @@ Zilla Frame
     Acknowledge: 8
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -301,7 +325,10 @@ Zilla Frame
     Acknowledge: 8
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -342,7 +369,10 @@ Zilla Frame
     Acknowledge: 30
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -376,7 +406,10 @@ Zilla Frame
     Acknowledge: 8
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -417,7 +450,10 @@ Zilla Frame
     Acknowledge: 30
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -451,7 +487,10 @@ Zilla Frame
     Acknowledge: 30
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -492,7 +531,10 @@ Zilla Frame
     Acknowledge: 57
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -526,7 +568,10 @@ Zilla Frame
     Acknowledge: 30
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -567,7 +612,10 @@ Zilla Frame
     Acknowledge: 59
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -601,7 +649,10 @@ Zilla Frame
     Acknowledge: 57
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000011
+    Trace ID
+        Trace ID: 0x8000000000000011
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -642,7 +693,10 @@ Zilla Frame
     Acknowledge: 99
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000012
+    Trace ID
+        Trace ID: 0x8000000000000012
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -676,7 +730,10 @@ Zilla Frame
     Acknowledge: 59
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000013
+    Trace ID
+        Trace ID: 0x8000000000000013
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -717,7 +774,10 @@ Zilla Frame
     Acknowledge: 108
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000014
+    Trace ID
+        Trace ID: 0x8000000000000014
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -751,7 +811,10 @@ Zilla Frame
     Acknowledge: 99
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000015
+    Trace ID
+        Trace ID: 0x8000000000000015
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -792,7 +855,10 @@ Zilla Frame
     Acknowledge: 99
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000016
+    Trace ID
+        Trace ID: 0x8000000000000016
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -822,7 +888,10 @@ Zilla Frame
     Acknowledge: 127
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000017
+    Trace ID
+        Trace ID: 0x8000000000000017
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -856,7 +925,10 @@ Zilla Frame
     Acknowledge: 108
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000018
+    Trace ID
+        Trace ID: 0x8000000000000018
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/AmqpStreamApplicationIT_shouldConnectAsReceiverOnly.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -62,7 +65,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -101,7 +107,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -135,7 +144,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -169,7 +181,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -199,7 +214,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/FileSystemApplicationIT_shouldReadFileExtensionOnly.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -80,7 +83,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -114,7 +120,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -144,7 +153,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -201,7 +213,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -231,7 +246,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/GrpcServerStreamRpcApplicationIT_shouldEstablishServerStreamRpc.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -79,7 +82,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -113,7 +119,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -153,7 +162,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -183,7 +195,10 @@ Zilla Frame
     Acknowledge: 13
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -217,7 +232,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -247,7 +265,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -281,7 +302,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -321,7 +345,10 @@ Zilla Frame
     Acknowledge: 14
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -355,7 +382,10 @@ Zilla Frame
     Acknowledge: 14
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -395,7 +425,10 @@ Zilla Frame
     Acknowledge: 14
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -425,7 +458,10 @@ Zilla Frame
     Acknowledge: 28
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationApplicationIT_shouldChallengeCredentialsHeader.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000001
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -84,7 +87,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -118,7 +124,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000001
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -148,7 +157,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -204,7 +216,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -238,7 +253,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -278,7 +296,10 @@ Zilla Frame
     Acknowledge: 19
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -312,7 +333,10 @@ Zilla Frame
     Acknowledge: 19
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Extension: http
         Stream Type ID: 0x4620b68a
@@ -356,7 +380,10 @@ Zilla Frame
     Acknowledge: 19
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -396,7 +423,10 @@ Zilla Frame
     Acknowledge: 19
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -426,7 +456,10 @@ Zilla Frame
     Acknowledge: 120
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/Http2AuthorizationNetworkIT_shouldChallengeCredentialsHeader.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -53,7 +56,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -83,7 +89,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -117,7 +126,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -151,7 +163,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -192,7 +207,10 @@ Zilla Frame
     Acknowledge: 24
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -226,7 +244,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -267,7 +288,10 @@ Zilla Frame
     Acknowledge: 27
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -301,7 +325,10 @@ Zilla Frame
     Acknowledge: 24
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -342,7 +369,10 @@ Zilla Frame
     Acknowledge: 45
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -376,7 +406,10 @@ Zilla Frame
     Acknowledge: 27
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -417,7 +450,10 @@ Zilla Frame
     Acknowledge: 36
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -451,7 +487,10 @@ Zilla Frame
     Acknowledge: 45
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -492,7 +531,10 @@ Zilla Frame
     Acknowledge: 45
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -533,7 +575,10 @@ Zilla Frame
     Acknowledge: 54
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -567,7 +612,10 @@ Zilla Frame
     Acknowledge: 112
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -601,7 +649,10 @@ Zilla Frame
     Acknowledge: 36
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000011
+    Trace ID
+        Trace ID: 0x8000000000000011
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -642,7 +693,10 @@ Zilla Frame
     Acknowledge: 36
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000012
+    Trace ID
+        Trace ID: 0x8000000000000012
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -683,7 +737,10 @@ Zilla Frame
     Acknowledge: 36
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000013
+    Trace ID
+        Trace ID: 0x8000000000000013
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -724,7 +781,10 @@ Zilla Frame
     Acknowledge: 36
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000014
+    Trace ID
+        Trace ID: 0x8000000000000014
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -765,7 +825,10 @@ Zilla Frame
     Acknowledge: 106
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000015
+    Trace ID
+        Trace ID: 0x8000000000000015
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -799,7 +862,10 @@ Zilla Frame
     Acknowledge: 134
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000016
+    Trace ID
+        Trace ID: 0x8000000000000016
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -833,7 +899,10 @@ Zilla Frame
     Acknowledge: 244
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000017
+    Trace ID
+        Trace ID: 0x8000000000000017
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -867,7 +936,10 @@ Zilla Frame
     Acknowledge: 257
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000018
+    Trace ID
+        Trace ID: 0x8000000000000018
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -901,7 +973,10 @@ Zilla Frame
     Acknowledge: 112
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000019
+    Trace ID
+        Trace ID: 0x8000000000000019
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -931,7 +1006,10 @@ Zilla Frame
     Acknowledge: 257
     Maximum: 40000
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000001a
+    Trace ID
+        Trace ID: 0x800000000000001a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeApplicationIT_shouldReceiveTopicConfigInfo.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -66,7 +69,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -100,7 +106,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -143,7 +152,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -177,7 +189,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -230,7 +245,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -264,7 +282,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -294,7 +315,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaDescribeConfigsNetworkIT_shouldReceiveTopicConfigInfo.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -53,7 +56,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -83,7 +89,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -117,7 +126,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -151,7 +163,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -192,7 +207,10 @@ Zilla Frame
     Acknowledge: 50
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -226,7 +244,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -267,7 +288,10 @@ Zilla Frame
     Acknowledge: 59
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -301,7 +325,10 @@ Zilla Frame
     Acknowledge: 50
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -331,7 +358,10 @@ Zilla Frame
     Acknowledge: 59
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaFetchApplicationIT_shouldRequestPartitionOffset.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -60,7 +63,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -94,7 +100,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -131,7 +140,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -165,7 +177,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -214,7 +229,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -248,7 +266,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
     Redirected ID: 0x0000000000000000
@@ -299,7 +320,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -329,7 +353,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -363,7 +390,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -414,7 +444,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -444,7 +477,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -478,7 +514,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -508,7 +547,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaGroupApplicationIT_shouldHandleRebalanceSyncGroup.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -74,7 +77,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -108,7 +114,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -159,7 +168,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -210,7 +222,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -244,7 +259,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -283,7 +301,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -317,7 +338,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -368,7 +392,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -407,7 +434,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -441,7 +471,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -480,7 +513,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -514,7 +550,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -544,7 +583,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaInitProducerIdApplicationIT_shouldGenerateNewProducerId.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -59,7 +62,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -93,7 +99,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -129,7 +138,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -163,7 +175,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -193,7 +208,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMergedApplicationIT_shouldFetchMergedFilterSync.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -98,7 +101,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -132,7 +138,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -207,7 +216,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -277,7 +289,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 16
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -311,7 +326,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -341,7 +359,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 16
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaMetaApplicationIT_shouldReceiveTopicPartitionInfo.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -60,7 +63,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -94,7 +100,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -131,7 +140,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -165,7 +177,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -217,7 +232,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -251,7 +269,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -281,7 +302,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetCommitApplicationIT_shouldUpdateTopicPartitionOffset.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -70,7 +73,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -104,7 +110,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -160,7 +169,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -190,7 +202,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -224,7 +239,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -254,7 +272,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -284,7 +305,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaOffsetFetchApplicationIT_shouldFetchTopicOffsetInfo.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -71,7 +74,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -105,7 +111,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -135,7 +144,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -169,7 +181,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -222,7 +237,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -256,7 +274,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -286,7 +307,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/KafkaProduceApplicationIT_shouldSendMessageValueWithProducerId.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -60,7 +63,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -94,7 +100,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -131,7 +140,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -165,7 +177,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -214,7 +229,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -248,7 +266,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
     Redirected ID: 0x0000000000000000
@@ -296,7 +317,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -326,7 +350,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -360,7 +387,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -408,7 +438,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -438,7 +471,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -472,7 +508,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -531,7 +570,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -561,7 +603,10 @@ Zilla Frame
     Acknowledge: 12
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -595,7 +640,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishApplicationIT_shouldSendOneMessage.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -74,7 +77,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -125,7 +131,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -159,7 +168,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -193,7 +205,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -232,7 +247,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -266,7 +284,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -296,7 +317,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -326,7 +350,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -369,7 +396,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -399,7 +429,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -433,7 +466,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -467,7 +503,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -530,7 +569,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -560,7 +602,10 @@ Zilla Frame
     Acknowledge: 7
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -594,7 +639,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttPublishNetworkIT_shouldSendOneMessage.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -53,7 +56,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -83,7 +89,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -117,7 +126,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -151,7 +163,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -192,7 +207,10 @@ Zilla Frame
     Acknowledge: 26
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -226,7 +244,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -267,7 +288,10 @@ Zilla Frame
     Acknowledge: 5
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -301,7 +325,10 @@ Zilla Frame
     Acknowledge: 26
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -342,7 +369,10 @@ Zilla Frame
     Acknowledge: 26
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -372,7 +402,10 @@ Zilla Frame
     Acknowledge: 85
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -406,7 +439,10 @@ Zilla Frame
     Acknowledge: 5
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/MqttSubscribeApplicationIT_shouldReceiveOneMessage.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -74,7 +77,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -125,7 +131,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -159,7 +168,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -193,7 +205,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -232,7 +247,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -266,7 +284,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -312,7 +333,10 @@ Zilla Frame
     Acknowledge: 28
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -346,7 +370,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -386,7 +413,10 @@ Zilla Frame
     Acknowledge: 28
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -420,7 +450,10 @@ Zilla Frame
     Acknowledge: 28
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -450,7 +483,10 @@ Zilla Frame
     Acknowledge: 28
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -480,7 +516,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -533,7 +572,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -563,7 +605,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -597,7 +642,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -631,7 +679,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000011
+    Trace ID
+        Trace ID: 0x8000000000000011
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -702,7 +753,10 @@ Zilla Frame
     Acknowledge: 7
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000012
+    Trace ID
+        Trace ID: 0x8000000000000012
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -736,7 +790,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000013
+    Trace ID
+        Trace ID: 0x8000000000000013
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -766,7 +823,10 @@ Zilla Frame
     Acknowledge: 7
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000014
+    Trace ID
+        Trace ID: 0x8000000000000014
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/ProxyApplicationIT_shouldConnectLocalClientSendsBeginExt.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -66,7 +69,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -100,7 +106,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -130,7 +139,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -160,7 +172,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -190,7 +205,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/SseDataApplicationIT_shouldReceiveNonEmptyData.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -68,7 +71,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -98,7 +104,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -132,7 +141,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -166,7 +178,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -216,7 +231,10 @@ Zilla Frame
     Acknowledge: 12
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -250,7 +268,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -280,7 +301,10 @@ Zilla Frame
     Acknowledge: 12
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsApplicationIT_shouldEstablishConnection.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -65,7 +68,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -95,7 +101,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -129,7 +138,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -163,7 +175,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -193,7 +208,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/TlsNetworkIT_shouldEstablishConnection.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -53,7 +56,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -83,7 +89,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -117,7 +126,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -151,7 +163,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -192,7 +207,10 @@ Zilla Frame
     Acknowledge: 337
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -226,7 +244,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -267,7 +288,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000008
+    Trace ID
+        Trace ID: 0x8000000000000008
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -308,7 +332,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000009
+    Trace ID
+        Trace ID: 0x8000000000000009
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -349,7 +376,10 @@ Zilla Frame
     Acknowledge: 127
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000a
+    Trace ID
+        Trace ID: 0x800000000000000a
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -383,7 +413,10 @@ Zilla Frame
     Acknowledge: 133
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000b
+    Trace ID
+        Trace ID: 0x800000000000000b
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -417,7 +450,10 @@ Zilla Frame
     Acknowledge: 2355
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000c
+    Trace ID
+        Trace ID: 0x800000000000000c
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -451,7 +487,10 @@ Zilla Frame
     Acknowledge: 337
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000d
+    Trace ID
+        Trace ID: 0x800000000000000d
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -492,7 +531,10 @@ Zilla Frame
     Acknowledge: 337
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000e
+    Trace ID
+        Trace ID: 0x800000000000000e
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -533,7 +575,10 @@ Zilla Frame
     Acknowledge: 337
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x800000000000000f
+    Trace ID
+        Trace ID: 0x800000000000000f
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -574,7 +619,10 @@ Zilla Frame
     Acknowledge: 343
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000010
+    Trace ID
+        Trace ID: 0x8000000000000010
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -608,7 +656,10 @@ Zilla Frame
     Acknowledge: 433
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000011
+    Trace ID
+        Trace ID: 0x8000000000000011
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -642,7 +693,10 @@ Zilla Frame
     Acknowledge: 473
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000012
+    Trace ID
+        Trace ID: 0x8000000000000012
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -676,7 +730,10 @@ Zilla Frame
     Acknowledge: 2355
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000013
+    Trace ID
+        Trace ID: 0x8000000000000013
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Flags: 0x03
         .... ...1 = FIN: Set (1)
@@ -717,7 +774,10 @@ Zilla Frame
     Acknowledge: 2355
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000014
+    Trace ID
+        Trace ID: 0x8000000000000014
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -747,7 +807,10 @@ Zilla Frame
     Acknowledge: 4488
     Maximum: 65536
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000015
+    Trace ID
+        Trace ID: 0x8000000000000015
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentChallenge.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -68,7 +71,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -98,7 +104,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -132,7 +141,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -166,7 +178,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
 
 Frame 6: 206 bytes on wire (1648 bits), 206 bytes captured (1648 bits)
@@ -194,7 +209,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0
@@ -224,7 +242,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000007
+    Trace ID
+        Trace ID: 0x8000000000000007
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Reserved: 0

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/WsAdvisoryApplicationIT_shouldReceiveClientSentRedirect.txt
@@ -23,7 +23,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000001
+    Trace ID
+        Trace ID: 0x8000000000000001
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -68,7 +71,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 0
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000002
+    Trace ID
+        Trace ID: 0x8000000000000002
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x0000000000000000
     Redirected ID: 0x0000000000000000
@@ -98,7 +104,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000003
+    Trace ID
+        Trace ID: 0x8000000000000003
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -132,7 +141,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000004
+    Trace ID
+        Trace ID: 0x8000000000000004
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Budget ID: 0x0000000000000000
     Padding: 0
@@ -166,7 +178,10 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000005
+    Trace ID
+        Trace ID: 0x8000000000000005
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
     Affinity: 0x00000000000000b1
     Extension: ws
@@ -210,6 +225,9 @@ Zilla Frame
     Acknowledge: 0
     Maximum: 8192
     Timestamp: 0x0000000000000000
-    Trace ID: 0x8000000000000006
+    Trace ID
+        Trace ID: 0x8000000000000006
+        Node: 0
+        Worker: 128
     Authorization: 0x0000000000000000
 

--- a/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/golden.lua
+++ b/incubator/command-dump/src/test/resources/io/aklivity/zilla/runtime/command/dump/internal/airline/golden.lua
@@ -122,6 +122,8 @@ add_field("acknowledge", ProtoField.int64("zilla.acknowledge", "Acknowledge", ba
 add_field("maximum", ProtoField.int32("zilla.maximum", "Maximum", base.DEC))
 add_field("timestamp", ProtoField.uint64("zilla.timestamp", "Timestamp", base.HEX))
 add_field("trace_id", ProtoField.uint64("zilla.trace_id", "Trace ID", base.HEX))
+add_field("trace_id_node", ProtoField.uint8("zilla.trace_id.node", "Node", base.DEC))
+add_field("trace_id_worker", ProtoField.uint8("zilla.trace_id.worker", "Worker", base.DEC))
 add_field("authorization", ProtoField.uint64("zilla.authorization", "Authorization", base.HEX))
 
 -- begin frame
@@ -4060,7 +4062,10 @@ function zilla_protocol.dissector(buffer, pinfo, tree)
     subtree:add_le(fields.acknowledge, slice_acknowledge)
     subtree:add_le(fields.maximum, slice_maximum)
     subtree:add_le(fields.timestamp, slice_timestamp)
-    subtree:add_le(fields.trace_id, slice_trace_id)
+    local trace_id_subtree = subtree:add(zilla_protocol, slice_trace_id, "Trace ID")
+    trace_id_subtree:add_le(fields.trace_id, slice_trace_id)
+    trace_id_subtree:add_le(fields.trace_id_node, buffer(frame_offset + 62, 1))
+    trace_id_subtree:add_le(fields.trace_id_worker, buffer(frame_offset + 63, 1))
     subtree:add_le(fields.authorization, slice_authorization)
 
     pinfo.cols.protocol = zilla_protocol.name

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -183,11 +183,6 @@ public class EngineWorker implements EngineContext, Agent
 
     private static final int SHIFT_SIZE = 56;
 
-    // Sits directly below the local worker index (bits 56-63), forming one contiguous
-    // 16-bit (node, worker) pair at the top of every id sharing this worker's `initial`/
-    // `mask` (initialId, promiseId, traceId, budgetId, authorizedId, this.affinityId) --
-    // the same field width as EngineConfiguration's own node.id byte, so every such id is
-    // cluster-wide unique, not just unique within this node.
     private static final int NODE_SHIFT_SIZE = 48;
 
     private static final int SIGNAL_TASK_QUEUED = 1;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -183,6 +183,13 @@ public class EngineWorker implements EngineContext, Agent
 
     private static final int SHIFT_SIZE = 56;
 
+    // Sits directly below the local worker index (bits 56-63), forming one contiguous
+    // 16-bit (node, worker) pair at the top of every id sharing this worker's `initial`/
+    // `mask` (initialId, promiseId, traceId, budgetId, authorizedId, this.affinityId) --
+    // the same field width as EngineConfiguration's own node.id byte, so every such id is
+    // cluster-wide unique, not just unique within this node.
+    private static final int NODE_SHIFT_SIZE = 48;
+
     private static final int SIGNAL_TASK_QUEUED = 1;
 
     private final FrameFW frameRO = new FrameFW();
@@ -403,7 +410,7 @@ public class EngineWorker implements EngineContext, Agent
 
         final BufferPool bufferPool = bufferPoolLayout.bufferPool();
 
-        final long initial = ((long) index) << SHIFT_SIZE;
+        final long initial = (((long) index) << SHIFT_SIZE) | ((config.nodeId() & 0xffL) << NODE_SHIFT_SIZE);
         final long mask = initial | (-1L >>> RESERVED_SIZE);
 
         this.mask = mask;
@@ -463,6 +470,12 @@ public class EngineWorker implements EngineContext, Agent
         long indexedId)
     {
         return (int) (indexedId >> SHIFT_SIZE);
+    }
+
+    public static int nodeOfId(
+        long indexedId)
+    {
+        return (int) ((indexedId >>> NODE_SHIFT_SIZE) & 0xffL);
     }
 
     @Override


### PR DESCRIPTION
## Description

`EngineWorker` mints `initialId`, `promiseId`, `traceId`, `budgetId`, `authorizedId`, and its own `affinityId` counter from one shared `initial`/`mask` pair that previously encoded only this node's local worker index (top byte, bits 56-63). Every such id was therefore unique only *within one engine instance* — a `traceId` minted on one node's worker 2 can numerically collide with one minted on a different node's worker 2.

That matters once a `RouterContext` implementation fans work out across physical nodes (the SPI already supports this — `RouteableContext#attachComposite`/`supplyStore`, `RouterContext#resolveRoutedId`) rather than only across local workers: any consumer of `traceId`/`budgetId`/etc. for cross-node trace or log correlation (`zilla dump` output included, once a stream has been forwarded to a different node and back) can't disambiguate two ids that happen to share the same local worker index on different nodes.

This folds `EngineConfiguration`'s own `node.id` byte into the same `initial` value, immediately below the existing worker-index byte (bits 48-55, previously always zero) — forming one contiguous 16-bit (node, worker) pair. Every id derived from `initial`/`mask` becomes cluster-wide unique as a result, with:
- no change to the existing per-worker counter width (still 31 bits via the unchanged `RESERVED_SIZE`)
- no change to `indexOfId`'s existing local-dispatch semantics (guard verifier/identifier/attributor routing, `BudgetId#ownerIndex` resolution) — both still read only the unmoved worker-index byte
- a new `nodeOfId` alongside the existing `indexOfId`, for symmetry

`node.id` defaults to `0`, so this is a no-op for every single-node deployment — verified via the full `runtime/engine` unit + integration test suite (438 tests, 0 failures) and `checkstyle:check` (0 violations), both green before and after this change.

## Test plan

- [x] `./mvnw checkstyle:check -pl runtime/engine` — 0 violations
- [x] `./mvnw clean install -pl runtime/engine -am -DskipTests=false` — full unit + IT suite green (228 unit tests, 210 integration tests, 0 failures/errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_