### PR TITLE
feat(engine): defer RouterContext.attach to run after registry bootstrap

### DIFF
--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/Engine.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -372,6 +373,12 @@ public final class Engine implements Collector, AutoCloseable
         if (!readonly)
         {
             manager.start();
+
+            workers.stream()
+                .map(w -> w.attachRouter(routerConfig))
+                .reduce(CompletableFuture::allOf)
+                .ifPresent(CompletableFuture::join);
+
             Ready.markReady(config.directory());
         }
     }

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineRouterContext.java
@@ -33,10 +33,15 @@ final class EngineRouterContext implements RouterContext
     }
 
     @Override
-    public BindingHandler attach(
-        RouterConfig config)
+    public BindingHandler streamFactory()
     {
         return streamFactory;
+    }
+
+    @Override
+    public void attach(
+        RouterConfig config)
+    {
     }
 
     @Override

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -430,6 +430,7 @@ public class EngineWorker implements EngineContext, Agent
         EngineRouteable routeable = new EngineRouteable(config, this::newStream,
             this::attachComposite, this::detachComposite, this::supplyStore);
         this.router = router.supply(routeable);
+        this.streamFactory = this.router.streamFactory();
 
         this.bindings = bindings;
         this.exporters = exporters;
@@ -993,8 +994,6 @@ public class EngineWorker implements EngineContext, Agent
 
     private void doInit()
     {
-        this.streamFactory = router.attach(routerConfig);
-
         Map<String, BindingContext> bindingsByType = bindings.stream()
             .collect(toMap(Binding::name, b -> b.supply(this), (a, b) -> a, LinkedHashMap::new));
 
@@ -1192,6 +1191,28 @@ public class EngineWorker implements EngineContext, Agent
             writeBindingTypes(registry);
         }
         return detachTask.future();
+    }
+
+    public CompletableFuture<Void> attachRouter(
+        RouterConfig config)
+    {
+        assert thread != Thread.currentThread();
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        dispatch(() ->
+        {
+            try
+            {
+                router.attach(config);
+                future.complete(null);
+            }
+            catch (Throwable ex)
+            {
+                future.completeExceptionally(ex);
+            }
+        });
+
+        return future;
     }
 
     public AgentRunner runner()

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/router/RouterContext.java
@@ -31,13 +31,27 @@ import io.aklivity.zilla.runtime.engine.binding.BindingHandler;
 public interface RouterContext
 {
     /**
-     * Attaches a router configuration to this thread's context, returning the composed
-     * {@link BindingHandler} that will be installed as the engine's stream factory.
+     * Returns this thread's composed {@link BindingHandler}, installed as the engine's
+     * stream factory.
+     * <p>
+     * Available immediately once this context is constructed, independent of {@link #attach},
+     * so the engine can wire it into bindings before any registry-dependent setup has run.
+     * </p>
+     *
+     * @return the composed stream factory
+     */
+    BindingHandler streamFactory();
+
+    /**
+     * Attaches a router configuration to this thread's context.
+     * <p>
+     * Called once this thread's namespace registry reflects the engine's bootstrap
+     * configuration, so implementations may safely attach synthesized namespaces here.
+     * </p>
      *
      * @param config  the router configuration to activate
-     * @return a {@link BindingHandler} that the engine installs as its stream factory
      */
-    BindingHandler attach(
+    void attach(
         RouterConfig config);
 
     /**

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterContext.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/router/TestRouterContext.java
@@ -34,10 +34,15 @@ public final class TestRouterContext implements RouterContext
     }
 
     @Override
-    public BindingHandler attach(
-        RouterConfig config)
+    public BindingHandler streamFactory()
     {
         return streamFactory;
+    }
+
+    @Override
+    public void attach(
+        RouterConfig config)
+    {
     }
 
     @Override


### PR DESCRIPTION
## Description

`RouterContext.attach(RouterConfig)` ran as the first statement of `EngineWorker.doInit()` — before this worker's own `EngineRegistry` is constructed, and before `EngineManager` has processed any namespace. Its contract already lets an implementation attach a synthesized composite namespace via `RouteableContext.attachComposite()` as part of that same call (`RouteableContext`'s own javadoc: "Attaches a synthesized `NamespaceConfig` to the engine alongside operator-authored namespaces"), which reads and mutates per-worker registry state that doesn't exist yet at that point in engine bootstrap.

Every existing `RouterContext` implementation (`EngineRouterContext`, the test router, and a real composite-synthesizing router built against this SPI) already builds its stream factory once, at construction time in `Router#supply(RouteableContext)`, and `attach()` just returns that value unchanged — `RouterConfig` itself goes unused in every implementation. So the stream factory returned by `attach()` never actually depended on `attach()` running early during `doInit()`; only bindings' own construction-time capture of `EngineContext#streamFactory()` did (every binding factory does `this.streamFactory = context.streamFactory();` in its own constructor, called from `doInit()`).

This splits the two concerns:
- `RouterContext#streamFactory()` (new) — returns the already-constructed stream factory. `EngineWorker` sources this immediately after `Router#supply(RouteableContext)` returns, in its own constructor — independent of when `attach()` runs.
- `RouterContext#attach(RouterConfig)` — now `void`. `EngineWorker.doInit()` no longer calls it. Instead, `Engine#start()` calls it once per worker, dispatched onto that worker's own thread (mirroring the existing `EngineWorker#attach(NamespaceConfig)` pattern), only after `EngineManager#start()` has run the engine's bootstrap config through to completion — so any registry-dependent setup a router's `attach()` performs (like attaching a composite namespace) now runs with the registry and `EngineManager`'s live configuration already in place.

No behavior change for any existing router: `EngineRouterContext#attach()` becomes an empty no-op, matching what it always effectively did.

## Test plan

- [x] `./mvnw checkstyle:check -pl runtime/engine` — 0 violations
- [x] `./mvnw clean verify -pl runtime/engine` — 228 unit tests + 210 integration tests, 0 failures/errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_