### PR TITLE
fix(binding-kafka): use each producer stream's own authorization for cache encode

### DIFF
--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfig.java
@@ -27,7 +27,7 @@ public class TestModelConfig extends ModelConfig
     public final boolean read;
     public final int transformLength;
     public final List<String> fields;
-    public final boolean transformAuthorization;
+    public final List<Long> transformAuthorizations;
 
     public TestModelConfig(
         int length,
@@ -64,7 +64,7 @@ public class TestModelConfig extends ModelConfig
         List<String> fields,
         ValidateConfig validate)
     {
-        this(length, cataloged, read, transformLength, fields, validate, false);
+        this(length, cataloged, read, transformLength, fields, validate, null);
     }
 
     public TestModelConfig(
@@ -74,14 +74,14 @@ public class TestModelConfig extends ModelConfig
         int transformLength,
         List<String> fields,
         ValidateConfig validate,
-        boolean transformAuthorization)
+        List<Long> transformAuthorizations)
     {
         super("test", cataloged, validate);
         this.length = length;
         this.read = read;
         this.transformLength = transformLength;
         this.fields = fields;
-        this.transformAuthorization = transformAuthorization;
+        this.transformAuthorizations = transformAuthorizations;
     }
 
     public static <T> TestModelConfigBuilder<T> builder(

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfig.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfig.java
@@ -27,6 +27,7 @@ public class TestModelConfig extends ModelConfig
     public final boolean read;
     public final int transformLength;
     public final List<String> fields;
+    public final boolean transformAuthorization;
 
     public TestModelConfig(
         int length,
@@ -63,11 +64,24 @@ public class TestModelConfig extends ModelConfig
         List<String> fields,
         ValidateConfig validate)
     {
+        this(length, cataloged, read, transformLength, fields, validate, false);
+    }
+
+    public TestModelConfig(
+        int length,
+        List<CatalogedConfig> cataloged,
+        boolean read,
+        int transformLength,
+        List<String> fields,
+        ValidateConfig validate,
+        boolean transformAuthorization)
+    {
         super("test", cataloged, validate);
         this.length = length;
         this.read = read;
         this.transformLength = transformLength;
         this.fields = fields;
+        this.transformAuthorization = transformAuthorization;
     }
 
     public static <T> TestModelConfigBuilder<T> builder(

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigAdapter.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigAdapter.java
@@ -36,6 +36,7 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
     private static final String TEST = "test";
     private static final String LENGTH = "length";
     private static final String TRANSFORM = "transform";
+    private static final String AUTHORIZATION = "authorization";
     private static final String CAPABILITY = "capability";
     private static final String READ = "read";
     private static final String CATALOG_NAME = "catalog";
@@ -62,8 +63,12 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
             : 0;
 
         int transformLength = object.containsKey(TRANSFORM)
-            ? object.getJsonObject(TRANSFORM).getInt(LENGTH)
+            ? object.getJsonObject(TRANSFORM).getInt(LENGTH, -1)
             : -1;
+
+        boolean transformAuthorization = object.containsKey(TRANSFORM)
+            ? object.getJsonObject(TRANSFORM).getBoolean(AUTHORIZATION, false)
+            : false;
 
         boolean read = object.containsKey(CAPABILITY)
             ? object.getString(CAPABILITY).equals(READ)
@@ -99,6 +104,6 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
 
         ValidateConfig validateConfig = validate.adaptFromJsonObject(object);
 
-        return new TestModelConfig(length, catalogs, read, transformLength, fields, validateConfig);
+        return new TestModelConfig(length, catalogs, read, transformLength, fields, validateConfig, transformAuthorization);
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigAdapter.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigAdapter.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
@@ -36,7 +37,7 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
     private static final String TEST = "test";
     private static final String LENGTH = "length";
     private static final String TRANSFORM = "transform";
-    private static final String AUTHORIZATION = "authorization";
+    private static final String TRANSFORM_AUTHORIZATIONS = "transformAuthorizations";
     private static final String CAPABILITY = "capability";
     private static final String READ = "read";
     private static final String CATALOG_NAME = "catalog";
@@ -66,9 +67,15 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
             ? object.getJsonObject(TRANSFORM).getInt(LENGTH, -1)
             : -1;
 
-        boolean transformAuthorization = object.containsKey(TRANSFORM)
-            ? object.getJsonObject(TRANSFORM).getBoolean(AUTHORIZATION, false)
-            : false;
+        List<Long> transformAuthorizations = null;
+        if (object.containsKey(TRANSFORM_AUTHORIZATIONS))
+        {
+            transformAuthorizations = new LinkedList<>();
+            for (JsonValue item : object.getJsonArray(TRANSFORM_AUTHORIZATIONS))
+            {
+                transformAuthorizations.add(((JsonNumber) item).longValue());
+            }
+        }
 
         boolean read = object.containsKey(CAPABILITY)
             ? object.getString(CAPABILITY).equals(READ)
@@ -104,6 +111,6 @@ public class TestModelConfigAdapter extends ConfigAdapter<ModelConfig, JsonValue
 
         ValidateConfig validateConfig = validate.adaptFromJsonObject(object);
 
-        return new TestModelConfig(length, catalogs, read, transformLength, fields, validateConfig, transformAuthorization);
+        return new TestModelConfig(length, catalogs, read, transformLength, fields, validateConfig, transformAuthorizations);
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigBuilder.java
@@ -34,7 +34,7 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
     private List<CatalogedConfig> catalogs;
     private List<String> fields;
     private ValidateConfig validate;
-    private boolean transformAuthorization;
+    private List<Long> transformAuthorizations;
 
     TestModelConfigBuilder(
         Function<ModelConfig, T> mapper)
@@ -71,9 +71,13 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
     }
 
     public TestModelConfigBuilder<T> transformAuthorization(
-        boolean transformAuthorization)
+        long transformAuthorization)
     {
-        this.transformAuthorization = transformAuthorization;
+        if (transformAuthorizations == null)
+        {
+            transformAuthorizations = new LinkedList<>();
+        }
+        transformAuthorizations.add(transformAuthorization);
         return this;
     }
 
@@ -115,6 +119,6 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
     public T build()
     {
         return mapper.apply(
-            new TestModelConfig(length, catalogs, read, transformLength, fields, validate, transformAuthorization));
+            new TestModelConfig(length, catalogs, read, transformLength, fields, validate, transformAuthorizations));
     }
 }

--- a/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigBuilder.java
+++ b/config/engine.conf/src/test/java/io/aklivity/zilla/config/engine/test/internal/model/config/TestModelConfigBuilder.java
@@ -34,6 +34,7 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
     private List<CatalogedConfig> catalogs;
     private List<String> fields;
     private ValidateConfig validate;
+    private boolean transformAuthorization;
 
     TestModelConfigBuilder(
         Function<ModelConfig, T> mapper)
@@ -66,6 +67,13 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
         int transformLength)
     {
         this.transformLength = transformLength;
+        return this;
+    }
+
+    public TestModelConfigBuilder<T> transformAuthorization(
+        boolean transformAuthorization)
+    {
+        this.transformAuthorization = transformAuthorization;
         return this;
     }
 
@@ -106,6 +114,7 @@ public class TestModelConfigBuilder<T> extends ConfigBuilder<T, TestModelConfigB
     @Override
     public T build()
     {
-        return mapper.apply(new TestModelConfig(length, catalogs, read, transformLength, fields, validate));
+        return mapper.apply(
+            new TestModelConfig(length, catalogs, read, transformLength, fields, validate, transformAuthorization));
     }
 }

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientProduceFactory.java
@@ -269,15 +269,15 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                 final KafkaCache cache = supplyCache.apply(cacheName);
                 final KafkaCacheTopic topic = cache.supplyTopic(topicName);
                 final KafkaCachePartition partition = topic.supplyProducePartition(partitionId, localIndex);
-                final KafkaTopicType topicType = binding.resolveTopicType(topicName);
                 final KafkaCacheClientProduceFan newFan =
                         new KafkaCacheClientProduceFan(routedId, resolvedId, authorization, budget,
-                            partition, cacheRoute, topicName, topicType);
+                            partition, cacheRoute, topicName);
 
                 cacheRoute.clientProduceFansByTopicPartition.put(partitionKey, newFan);
                 fan = newFan;
             }
 
+            final KafkaTopicType topicType = binding.resolveTopicType(topicName);
             final Int2IntHashMap leadersByPartitionId = cacheRoute.supplyLeadersByPartitionId(topicName);
             final int leaderId = leadersByPartitionId.get(partitionId);
             newStream = new KafkaCacheClientProduceStream(
@@ -287,7 +287,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     routedId,
                     initialId,
                     leaderId,
-                    authorization)::onClientMessage;
+                    authorization,
+                    topicType)::onClientMessage;
         }
 
         return newStream;
@@ -507,8 +508,6 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
         private final long routedId;
         private final long authorization;
         private final int partitionId;
-        private final KafkaCacheModel transformKey;
-        private final KafkaCacheModel transformValue;
 
         private long initialId;
         private long replyId;
@@ -545,8 +544,7 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             KafkaCacheClientBudget budget,
             KafkaCachePartition partition,
             KafkaCacheRoute cacheRoute,
-            String topicName,
-            KafkaTopicType topicType)
+            String topicName)
         {
             this.originId = originId;
             this.routedId = routedId;
@@ -556,8 +554,6 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             this.budget = budget;
             this.cacheRoute = cacheRoute;
             this.topicName = topicName;
-            this.transformKey = KafkaCacheModel.encoder(topicType.keyModel, transformBuffer);
-            this.transformValue = KafkaCacheModel.encoder(topicType.valueModel, transformBuffer);
             this.members = new Long2ObjectHashMap<>();
             this.defaultOffset = KafkaOffsetType.LIVE;
             this.cursor = cursorFactory.newCursor(
@@ -718,10 +714,10 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                     assert partitionOffset >= 0 && partitionOffset >= nextOffset
                         : String.format("%d >= 0 && %d >= %d", partitionOffset, partitionOffset, nextOffset);
 
-                    if (partition.writeProduceEntryStart(traceId, routedId, authorization, partitionOffset, stream.segment,
-                        stream.entryMark, stream.valueMark, stream.valueLimit, timestamp, stream.initialId,
+                    if (partition.writeProduceEntryStart(traceId, routedId, stream.authorization, partitionOffset,
+                        stream.segment, stream.entryMark, stream.valueMark, stream.valueLimit, timestamp, stream.initialId,
                         producerId, producerEpoch, sequence, ackMode, key, valueLength,
-                        headers, trailersSizeMax, valueFragment, transformKey, transformValue) == -1)
+                        headers, trailersSizeMax, valueFragment, stream.transformKey, stream.transformValue) == -1)
                     {
                         error = ERROR_INVALID_RECORD;
                         break init;
@@ -737,9 +733,9 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
 
             if (valueFragment != null && error == NO_ERROR)
             {
-                if (partition.writeProduceEntryContinue(traceId, routedId, authorization, flags, stream.segment,
+                if (partition.writeProduceEntryContinue(traceId, routedId, stream.authorization, flags, stream.segment,
                         stream.entryMark, stream.valueMark, stream.valueLimit,
-                        valueFragment, transformValue) == -1)
+                        valueFragment, stream.transformValue) == -1)
                 {
                     error = ERROR_INVALID_RECORD;
                 }
@@ -798,10 +794,10 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
                 assert partitionOffset >= 0 && partitionOffset >= nextOffset
                     : String.format("%d >= 0 && %d >= %d", partitionOffset, partitionOffset, nextOffset);
 
-                partition.writeProduceEntryStart(traceId, routedId, authorization, partitionOffset, stream.segment,
+                partition.writeProduceEntryStart(traceId, routedId, stream.authorization, partitionOffset, stream.segment,
                     stream.entryMark, stream.valueMark, stream.valueLimit, now().toEpochMilli(), stream.initialId,
                     PRODUCE_FLUSH_PRODUCER_ID, PRODUCE_FLUSH_PRODUCER_EPOCH, PRODUCE_FLUSH_SEQUENCE, KafkaAckMode.LEADER_ONLY,
-                    EMPTY_KEY, 0, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, transformKey, transformValue);
+                    EMPTY_KEY, 0, EMPTY_TRAILERS, trailersSizeMax, EMPTY_OCTETS, stream.transformKey, stream.transformValue);
                 stream.partitionOffset = partitionOffset;
                 partitionOffset++;
 
@@ -1236,6 +1232,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
         private final long replyId;
         private final long leaderId;
         private final long authorization;
+        private final KafkaCacheModel transformKey;
+        private final KafkaCacheModel transformValue;
 
         private long partitionOffset = DEFAULT_LATEST_OFFSET;
 
@@ -1260,7 +1258,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             long routedId,
             long initialId,
             long leaderId,
-            long authorization)
+            long authorization,
+            KafkaTopicType topicType)
         {
             this.cursor = cursorFactory.newCursor(
                     cursorFactory
@@ -1277,6 +1276,8 @@ public final class KafkaCacheClientProduceFactory implements BindingHandler
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.leaderId = leaderId;
             this.authorization = authorization;
+            this.transformKey = KafkaCacheModel.encoder(topicType.keyModel, transformBuffer);
+            this.transformValue = KafkaCacheModel.encoder(topicType.valueModel, transformBuffer);
         }
 
         private void onClientMessage(

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheProduceIT.java
@@ -138,6 +138,18 @@ public class CacheProduceIT
     }
 
     @Test
+    @Configuration("cache.value.model.authorization.yaml")
+    @Specification({
+        "${app}/message.values.authorization.distinct/client",
+        "${app}/message.values.authorization.distinct/server"})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @Configure(name = KAFKA_CACHE_SERVER_RECONNECT_DELAY_NAME, value = "1")
+    public void shouldSendMessageValuesAuthorizationDistinct() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("cache.yaml")
     @Specification({
         "${app}/message.key/client",

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
@@ -33,7 +33,9 @@ public class TestModelHandler implements ModelHandler
     private final List<String> fields;
     private final boolean decodeLenient;
     private final boolean encodeLenient;
-    private final boolean transformAuthorization;
+    private final List<Long> transformAuthorizations;
+
+    private int transformAuthorizationIndex;
 
     public TestModelHandler(
         TestModelConfig config)
@@ -43,7 +45,7 @@ public class TestModelHandler implements ModelHandler
         this.fields = config.fields != null ? config.fields : emptyList();
         this.decodeLenient = config.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = config.validate.encode == ValidateMode.LENIENT;
-        this.transformAuthorization = config.transformAuthorization;
+        this.transformAuthorizations = config.transformAuthorizations;
     }
 
     @Override
@@ -51,8 +53,7 @@ public class TestModelHandler implements ModelHandler
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, decodeLenient, envelope, transform,
-            transformAuthorization);
+        return new TestModelPipeline(length, transformLength, fields, decodeLenient, envelope, transform, this);
     }
 
     @Override
@@ -60,7 +61,13 @@ public class TestModelHandler implements ModelHandler
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, encodeLenient, envelope, transform,
-            transformAuthorization);
+        return new TestModelPipeline(length, transformLength, fields, encodeLenient, envelope, transform, this);
+    }
+
+    Long nextTransformAuthorization()
+    {
+        return transformAuthorizations != null && transformAuthorizationIndex < transformAuthorizations.size()
+            ? transformAuthorizations.get(transformAuthorizationIndex++)
+            : null;
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelHandler.java
@@ -33,6 +33,7 @@ public class TestModelHandler implements ModelHandler
     private final List<String> fields;
     private final boolean decodeLenient;
     private final boolean encodeLenient;
+    private final boolean transformAuthorization;
 
     public TestModelHandler(
         TestModelConfig config)
@@ -42,6 +43,7 @@ public class TestModelHandler implements ModelHandler
         this.fields = config.fields != null ? config.fields : emptyList();
         this.decodeLenient = config.validate.decode == ValidateMode.LENIENT;
         this.encodeLenient = config.validate.encode == ValidateMode.LENIENT;
+        this.transformAuthorization = config.transformAuthorization;
     }
 
     @Override
@@ -49,7 +51,8 @@ public class TestModelHandler implements ModelHandler
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, decodeLenient, envelope, transform);
+        return new TestModelPipeline(length, transformLength, fields, decodeLenient, envelope, transform,
+            transformAuthorization);
     }
 
     @Override
@@ -57,6 +60,7 @@ public class TestModelHandler implements ModelHandler
         ModelEnvelope envelope,
         ModelTransform transform)
     {
-        return new TestModelPipeline(length, transformLength, fields, encodeLenient, envelope, transform);
+        return new TestModelPipeline(length, transformLength, fields, encodeLenient, envelope, transform,
+            transformAuthorization);
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
@@ -46,6 +46,8 @@ final class TestModelPipeline implements ModelPipeline
 
     private final DirectBufferEx extractedValue = new UnsafeBufferEx("1234".getBytes(UTF_8));
 
+    private static final int AUTHORIZATION_STAMP_BYTES = 8;
+
     private final int length;
     private final int transformLength;
     private final List<String> fields;
@@ -53,6 +55,7 @@ final class TestModelPipeline implements ModelPipeline
     private final ModelEnvelope envelope;
     private final ModelFieldBridge bridge;
     private final ModelPipelineResult result;
+    private final boolean transformAuthorization;
 
     private int processed;
 
@@ -62,7 +65,8 @@ final class TestModelPipeline implements ModelPipeline
         List<String> fields,
         boolean lenient,
         ModelEnvelope envelope,
-        ModelTransform transform)
+        ModelTransform transform,
+        boolean transformAuthorization)
     {
         this.length = length;
         this.transformLength = transformLength;
@@ -71,6 +75,7 @@ final class TestModelPipeline implements ModelPipeline
         this.envelope = envelope;
         this.bridge = transform != ModelTransform.NONE ? new ModelFieldBridge(transform) : null;
         this.result = new ModelPipelineResult();
+        this.transformAuthorization = transformAuthorization;
     }
 
     @Override
@@ -148,13 +153,19 @@ final class TestModelPipeline implements ModelPipeline
                 status = ModelStatus.UNDERFLOW;
             }
         }
+
+        if (transformAuthorization && status == ModelStatus.COMPLETE)
+        {
+            stampAuthorization(authorization, dst, dstIndex, produced);
+        }
+
         return result.set(status, consumed, produced);
     }
 
     @Override
     public boolean identity()
     {
-        return transformLength < 0;
+        return transformLength < 0 && !transformAuthorization;
     }
 
     @Override
@@ -186,6 +197,21 @@ final class TestModelPipeline implements ModelPipeline
         if (bridge != null)
         {
             bridge.end();
+        }
+    }
+
+    private void stampAuthorization(
+        long authorization,
+        MutableDirectBufferEx dst,
+        int dstIndex,
+        int produced)
+    {
+        final int stamped = Math.min(AUTHORIZATION_STAMP_BYTES, produced);
+        final int stampIndex = dstIndex + produced - stamped;
+        for (int i = 0; i < stamped; i++)
+        {
+            final int shift = (stamped - 1 - i) * Byte.SIZE;
+            dst.putByte(stampIndex + i, (byte) (authorization >>> shift));
         }
     }
 }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/model/TestModelPipeline.java
@@ -39,14 +39,22 @@ import io.aklivity.zilla.runtime.engine.model.ModelTransform;
 // value when an accepted value completes; the same fields are written to the supplied envelope under their
 // own paths, so a caller supplying a real envelope observes what the model surfaced without wiring a
 // transform at all. State lives on the pipeline so interleaved streams stay isolated.
+//
+// When the handler is configured with an ordered `transformAuthorizations` list, each completed value --
+// across every pipeline this handler ever supplies, not just this one -- consumes the next entry from that
+// list as its expected authorization: message order, not pipeline-instance order, is what the list tracks.
+// A completed value whose `authorization` argument doesn't match is rejected, giving callers a way to assert
+// which authorization value actually reached a given encode/decode call without any extra observability
+// machinery -- the mismatch surfaces as an ordinary REJECTED status, same as a length violation. Binding the
+// check to pipeline-construction order instead would miss exactly the bug this exists to catch: a single
+// pipeline instance shared across multiple producers only ever sees one expected value if it were fixed at
+// construction, even though it processes several messages, each with its own authorization.
 final class TestModelPipeline implements ModelPipeline
 {
     private static final int FLAGS_INIT = 0x02;
     private static final int FLAGS_FIN = 0x01;
 
     private final DirectBufferEx extractedValue = new UnsafeBufferEx("1234".getBytes(UTF_8));
-
-    private static final int AUTHORIZATION_STAMP_BYTES = 8;
 
     private final int length;
     private final int transformLength;
@@ -55,7 +63,7 @@ final class TestModelPipeline implements ModelPipeline
     private final ModelEnvelope envelope;
     private final ModelFieldBridge bridge;
     private final ModelPipelineResult result;
-    private final boolean transformAuthorization;
+    private final TestModelHandler handler;
 
     private int processed;
 
@@ -66,7 +74,7 @@ final class TestModelPipeline implements ModelPipeline
         boolean lenient,
         ModelEnvelope envelope,
         ModelTransform transform,
-        boolean transformAuthorization)
+        TestModelHandler handler)
     {
         this.length = length;
         this.transformLength = transformLength;
@@ -75,7 +83,7 @@ final class TestModelPipeline implements ModelPipeline
         this.envelope = envelope;
         this.bridge = transform != ModelTransform.NONE ? new ModelFieldBridge(transform) : null;
         this.result = new ModelPipelineResult();
-        this.transformAuthorization = transformAuthorization;
+        this.handler = handler;
     }
 
     @Override
@@ -154,9 +162,13 @@ final class TestModelPipeline implements ModelPipeline
             }
         }
 
-        if (transformAuthorization && status == ModelStatus.COMPLETE)
+        if (status == ModelStatus.COMPLETE)
         {
-            stampAuthorization(authorization, dst, dstIndex, produced);
+            final Long expectedAuthorization = handler.nextTransformAuthorization();
+            if (expectedAuthorization != null && authorization != expectedAuthorization)
+            {
+                status = ModelStatus.REJECTED;
+            }
         }
 
         return result.set(status, consumed, produced);
@@ -165,7 +177,7 @@ final class TestModelPipeline implements ModelPipeline
     @Override
     public boolean identity()
     {
-        return transformLength < 0 && !transformAuthorization;
+        return transformLength < 0;
     }
 
     @Override
@@ -197,21 +209,6 @@ final class TestModelPipeline implements ModelPipeline
         if (bridge != null)
         {
             bridge.end();
-        }
-    }
-
-    private void stampAuthorization(
-        long authorization,
-        MutableDirectBufferEx dst,
-        int dstIndex,
-        int produced)
-    {
-        final int stamped = Math.min(AUTHORIZATION_STAMP_BYTES, produced);
-        final int stampIndex = dstIndex + produced - stamped;
-        for (int i = 0; i < stamped; i++)
-        {
-            final int shift = (stamped - 1 - i) * Byte.SIZE;
-            dst.putByte(stampIndex + i, (byte) (authorization >>> shift));
         }
     }
 }

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.authorization.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.authorization.yaml
@@ -26,8 +26,7 @@ bindings:
                   value:
                       model: test
                       length: 12
-                      transform:
-                          authorization: true
+                      transformAuthorizations: [2, 0]
         routes:
             - exit: cache0
               when:

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.authorization.yaml
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/config/cache.value.model.authorization.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: test
+bindings:
+    app0:
+        type: kafka
+        kind: cache_client
+        options:
+            topics:
+                - name: test
+                  value:
+                      model: test
+                      length: 12
+                      transform:
+                          authorization: true
+        routes:
+            - exit: cache0
+              when:
+                  - topic: test
+    cache0:
+        type: kafka
+        kind: cache_server
+        routes:
+            - exit: app1
+              when:
+                  - topic: test

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/client.rpt
@@ -1,0 +1,126 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property deltaMillis 0L
+property newTimestamp ${kafka:timestamp() + deltaMillis}
+
+property authorization2 2L
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 177)
+                                 .build()
+                             .build()}
+
+read notify ROUTED_BROKER_CLIENT
+
+connect await ROUTED_BROKER_CLIENT
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 0xb1
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .timestamp(newTimestamp)
+                                  .build()
+                              .build()}
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush
+
+connect await ROUTED_BROKER_CLIENT
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 0xb1
+    option zilla:authorization ${authorization2}
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .timestamp(newTimestamp)
+                                  .build()
+                              .build()}
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .build()
+                              .build()}
+write "Hello, again"
+write flush

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/server.rpt
@@ -95,14 +95,14 @@ read zilla:data.ext ${kafka:matchDataEx()
                              .produce()
                                  .build()
                              .build()}
-read "Hell" [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x02]
+read "Hello, again"
 
 read zilla:data.ext ${kafka:matchDataEx()
                              .typeId(zilla:id("kafka"))
                              .produce()
                                  .build()
                              .build()}
-read "Hell" [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read "Hello, world"
 
 
 

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/produce/message.values.authorization.distinct/server.rpt
@@ -1,0 +1,110 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+    option zilla:update "handshake"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 177)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+write close
+read closed
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .produce()
+                                  .topic("test")
+                                  .partition(0)
+                                  .build()
+                              .build()}
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .produce()
+                                   .topic("test")
+                                   .partition(0)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .produce()
+                                 .build()
+                             .build()}
+read "Hell" [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x02]
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .produce()
+                                 .build()
+                             .build()}
+read "Hell" [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+
+
+
+read option zilla:ack 24
+write flush

--- a/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
+++ b/specs/binding-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/kafka/streams/application/ProduceIT.java
@@ -329,6 +329,13 @@ public class ProduceIT
         k3po.finish();
     }
 
+    // message.values.authorization.distinct has no peer-to-peer counterpart here: k3po itself
+    // (independent of any Zilla engine behavior) cannot correlate a third notify/await-gated
+    // connect to the same accept address in this harness -- confirmed by the pre-existing,
+    // never-covered message.values.parallel scenario failing the identical way peer-to-peer.
+    // The scenario is still fully covered by CacheProduceIT#shouldSendMessageValuesAuthorizationDistinct,
+    // which drives it through a live engine instead.
+
     @Test
     @Specification({
         "${app}/message.header/client",

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/model/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/model/test.schema.patch.json
@@ -66,6 +66,10 @@
                             "length":
                             {
                                 "type": "integer"
+                            },
+                            "authorization":
+                            {
+                                "type": "boolean"
                             }
                         },
                         "additionalProperties": false

--- a/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/model/test.schema.patch.json
+++ b/specs/engine.spec/src/main/scripts/io/aklivity/zilla/specs/engine/schema/model/test.schema.patch.json
@@ -66,10 +66,6 @@
                             "length":
                             {
                                 "type": "integer"
-                            },
-                            "authorization":
-                            {
-                                "type": "boolean"
                             }
                         },
                         "additionalProperties": false
@@ -84,6 +80,14 @@
                         "items":
                         {
                             "type": "string"
+                        }
+                    },
+                    "transformAuthorizations":
+                    {
+                        "type": "array",
+                        "items":
+                        {
+                            "type": "integer"
                         }
                     },
                     "catalog":


### PR DESCRIPTION
## Description

`KafkaCacheClientProduceFan` captured the `authorization` of whichever producer stream first created the per-topic-partition fan, then reused that single value — along with a shared `transformKey`/`transformValue` encoder pair — for every subsequent producer writing to the same partition. `KafkaCacheClientProduceStream` already tracked its own `authorization`, but the encode call sites (`onClientInitialData` ×2, `onClientInitialFlush`) never used it.

This moves `transformKey`/`transformValue` from the fan onto the stream and threads `stream.authorization` through `writeProduceEntryStart`/`writeProduceEntryContinue`, so each message is encoded using the authorization of the producer stream that actually produced it, not the first producer to touch the partition.

To make this observable in an oss-only test, the engine's generic `TestModel` gains an opt-in `transformAuthorizations: [N, M]` config list: an ordered list of the authorization values expected to reach the model, in message-arrival order. Each completed value consumes the next entry from this list (tracked on the shared `ModelHandler`, not the pipeline instance that observed it — a shared/hoisted pipeline handling multiple messages must still be checked against each message's own expected value) and is rejected outright on mismatch, surfacing as an ordinary `REJECTED` → stream `RESET`, the same signal already used by the existing `message.value.rejected`/`message.values.rejected` scenarios. A new k3po scenario (`message.values.authorization.distinct`) drives two producers with distinct authorization values through a live engine and asserts each message reaches the model with its own value, not the other's.

Verified test-first: the new `CacheProduceIT` test fails with a clean, fast rejection (not a hang/timeout) against the pre-fix code, and passes against the fix. Full `ProduceIT` and `CacheProduceIT` suites, `runtime/engine` and `config/engine.conf` unit tests, and checkstyle/license checks all pass with no regressions.

The new scenario's peer-to-peer counterpart is intentionally omitted, with the reasoning documented inline in `ProduceIT.java`: a pre-existing k3po-harness limitation (unrelated to this change, and already present for the never-covered `message.values.parallel` scenario) prevents a third notify/await-gated connect from being peer-verified in this harness.

Fixes #2424


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzxN4tJLhiHQ8ikNeuN8WS)_