### PR TITLE
fix(binding-mcp): settle a still-establishing toolkit client on reset/abort

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -1290,7 +1290,11 @@ final class McpProxyLifecycleFactory implements BindingHandler
             settleRequests(traceId);
             doClientAbort(traceId);
             server.clients.remove(routedId, this);
-            if (!(server.hydration && sessionId == null))
+            if (server.hydration && sessionId == null)
+            {
+                settleLifecycle(traceId);
+            }
+            else
             {
                 server.doServerAbort(traceId);
             }
@@ -1338,16 +1342,13 @@ final class McpProxyLifecycleFactory implements BindingHandler
             server.clients.remove(routedId, this);
 
             final boolean bearer = extension.sizeof() > 0;
-            if (!(server.hydration && sessionId == null))
+            if (server.hydration && sessionId == null || bearer)
             {
-                if (bearer)
-                {
-                    settleLifecycle(traceId);
-                }
-                else
-                {
-                    server.doServerReset(traceId, extension);
-                }
+                settleLifecycle(traceId);
+            }
+            else
+            {
+                server.doServerReset(traceId, extension);
             }
         }
     }


### PR DESCRIPTION
## Description

An `mcp(client)`-backed session's south connections toward each routed toolkit are established eagerly and in parallel; the north-facing session's own accept is deferred until every one of them settles (either by opening successfully or by being told to settle explicitly).

`McpLifecycleClient`'s `onClientAbort`/`onClientReset` only told the session to settle when hydration was in progress *and* this client had never opened -- any other combination propagated the abort/reset to the session. That condition had no `else` branch, so exactly that one case did neither: a hydration session's still-establishing toolkit resetting or aborting left the session waiting on a settlement that would now never arrive, wedging the whole hydration attempt indefinitely.

Both handlers now call `settleLifecycle` for that case instead of doing nothing, letting the session proceed without that toolkit; the existing per-kind retry/backoff already re-attempts it once the session is no longer blocked. A caller's own (non-hydration) session and an already-established toolkit's later failure keep propagating exactly as before.

Validated end-to-end against a two-node cluster with a hydration-backed cache: reproduced the wedge (a node became unresponsive to every new session once a toolkit reset mid-establishment), confirmed the fix resolves it (hydration completes and the node stays responsive across repeated fresh restarts), and confirmed `initialize` responses and per-kind cache recovery are unaffected for every other case.

`./mvnw -pl runtime/binding-mcp -am test` passes (178 tests, 0 failures/errors).

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_