### PR TITLE
fix(binding-mqtt, binding-mqtt-kafka): prevent engine crash on MQTT CONNECT with Will message

### DIFF
--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -3019,13 +3019,15 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             int limit,
             Flyweight extension)
         {
+            if (kafka != null)
+            {
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, buffer, offset, limit, extension);
 
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, buffer, offset, limit, extension);
+                initialSeq += reserved;
 
-            initialSeq += reserved;
-
-            assert initialSeq - padding <= initialAck + initialMax;
+                assert initialSeq - padding <= initialAck + initialMax;
+            }
         }
 
         protected final void doKafkaData(
@@ -3037,12 +3039,15 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             OctetsFW payload,
             Flyweight extension)
         {
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, payload, extension);
+            if (kafka != null)
+            {
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, payload, extension);
 
-            initialSeq += reserved;
+                initialSeq += reserved;
 
-            assert initialSeq <= initialAck + initialMax;
+                assert initialSeq <= initialAck + initialMax;
+            }
         }
 
         protected void doKafkaData(
@@ -3055,17 +3060,20 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             Flyweight payload,
             Flyweight extension)
         {
-            final DirectBufferEx buffer = payload.buffer();
-            final int offset = payload.offset();
-            final int limit = payload.limit();
-            final int length = limit - offset;
+            if (kafka != null)
+            {
+                final DirectBufferEx buffer = payload.buffer();
+                final int offset = payload.offset();
+                final int limit = payload.limit();
+                final int length = limit - offset;
 
-            doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
-                traceId, authorization, budgetId, flags, reserved, buffer, offset, length, extension);
+                doData(kafka, originId, routedId, initialId, initialSeq, initialAck, initialMax,
+                    traceId, authorization, budgetId, flags, reserved, buffer, offset, length, extension);
 
-            initialSeq += reserved;
+                initialSeq += reserved;
 
-            assert initialSeq - padding <= initialAck + initialMax;
+                assert initialSeq - padding <= initialAck + initialMax;
+            }
         }
 
         private void doKafkaFlush(

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -277,6 +277,17 @@ public class MqttKafkaSessionProxyIT
 
     @Test
     @Configuration("proxy.yaml")
+    @Configure(name = WILL_AVAILABLE_NAME, value = "false")
+    @Specification({
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/client",
+        "${kafka}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSkipWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
     @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
     @Specification({
         "${mqtt}/session.will.message.abort.deliver.will.retain/client",

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -3561,6 +3561,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             final int willQos = decodeWillQos(connectFlags);
             final boolean willFlagSet = isSetWillFlag(connectFlags);
 
+            decode:
             if (willFlagSet && MqttState.initialOpened(session.state))
             {
                 int publishedWillSize = 0;
@@ -3588,6 +3589,12 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                     final MqttWillMessageFW will = willMessageBuilder.build();
                     final int headerSize = willMessageBuilder.sizeof();
+
+                    if (!session.hasSessionWindow(headerSize))
+                    {
+                        break decode;
+                    }
+
                     int payloadSize = Math.min(limit - offset, session.initialBudget() - headerSize);
 
                     final OctetsFW payload = payloadRO.wrap(buffer, offset, offset + payloadSize);

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -190,6 +190,16 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.header.exceeds.window/client",
+        "${app}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.disconnect.with.will.message/client",
         "${app}/session.will.message.abort/server"})
     public void shouldCloseSessionDisconnectWithWill() throws Exception

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/client.rpt
@@ -1,0 +1,49 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect
+        "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-messages")
+                                   .build()
+                               .build()}
+
+connected
+
+write await SESSION_META_STREAMS_OPENED
+write abort
+
+
+connect
+        "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-retained")
+                                   .build()
+                               .build()}
+
+connected
+
+write await SESSION_META_STREAMS_OPENED
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/server.rpt
@@ -1,0 +1,51 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-messages")
+                                   .build()
+                               .build()}
+
+connected
+
+read aborted
+
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-retained")
+                                   .build()
+                               .build()}
+
+connected
+
+# partition metadata is still outstanding, no session state stream exists yet
+write notify SESSION_META_STREAMS_OPENED
+
+# no will signal and no expiry signal are produced,
+# the session was never established
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/client.rpt
@@ -1,0 +1,38 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# session stays half-duplex, the session reply stream is only opened once the
+# qos2 session state stream has been established
+connect "zilla://streams/mqtt0"
+         option zilla:window 8192
+         option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .expiry(1)
+                              .publishQosMax(2)
+                              .capabilities("REDIRECT")
+                              .clientId("client-1")
+                              .build()
+                           .build()}
+
+connected
+
+# abort while the qos2 partition metadata is still being negotiated,
+# no session state stream has been established yet
+write await SESSION_META_STREAMS_OPENED
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/server.rpt
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/mqtt0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .expiry(1)
+                                .publishQosMax(2)
+                                .capabilities("REDIRECT")
+                                .clientId("client-1")
+                                .build()
+                             .build()}
+
+connected
+
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
@@ -749,6 +749,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/session.will.message.qos2.abort.before.session.established/client",
+        "${kafka}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSkipWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/session.will.message.will.id.mismatch.skip.delivery/client",
         "${kafka}/session.will.message.will.id.mismatch.skip.delivery/server"})
     public void shouldNotSendWillMessageOnWillIdMismatch() throws Exception

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
@@ -632,6 +632,17 @@ public class MqttIT
 
     @Test
     @Specification({
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/client",
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSkipWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("SESSION_META_STREAMS_OPENED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mqtt}/publish.qos1/client",
         "${mqtt}/publish.qos1/server"})
     public void shouldPublishQoS1Message() throws Exception

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/client.rpt
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 32
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+read zilla:data.empty
+
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/server.rpt
@@ -1,0 +1,52 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+# window is smaller than the encoded will message header (44 bytes for topic
+# "wills/one"), so the will message must remain deferred instead of being
+# written with a negative payload size
+
+accept "zilla://streams/app0"
+        option zilla:window 32
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write zilla:data.empty
+write flush
+
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/client.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x2f]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x0c] "will payload"                       # will payload
+
+read  [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/server.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0x2f]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x0c] "will payload"                       # will payload
+
+write [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+read aborted

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -121,6 +121,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.header.exceeds.window/client",
+        "${app}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -129,6 +129,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.header.exceeds.window/client",
+        "${net}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({


### PR DESCRIPTION
Fixes #2428

Two independent bugs combined to let a single MQTT client with a Last Will and Testament crash the whole engine (and in production, segfault the JVM):

1. **binding-mqtt**: `onDecodeConnectWillPayload` computed a payload size from `session.initialBudget() - headerSize` with no floor. When the session stream's granted window is smaller than the encoded will-message header alone, this goes negative and corrupts a subsequent `OctetsFW.wrap()` call, throwing an uncaught `IndexOutOfBoundsException` that terminates the engine worker. Fixed by checking `session.hasSessionWindow(headerSize)` first, mirroring the existing SUBSCRIBE-to-session-state-sync pattern in the same file.
2. **binding-mqtt-kafka**: `KafkaSessionStream.doKafkaData` had no `kafka != null` guard, unlike every sibling method (`doKafkaEnd`/`doKafkaAbort`/`doKafkaReset`/`doKafkaWindow`). Reachable independently of bug 1 whenever a client negotiates QoS 2 with Will + Clean Start and aborts before the Kafka-side session stream is established — `sendWillSignal` then NPEs on the unattached stream. This also amplified bug 1's crash into a full JVM crash, since it fired again during the engine's forced teardown.

Both fixes are minimal and follow existing idiomatic patterns in their respective files. Each has a new failing-first k3po spec scenario (confirmed to reproduce the exact production stack traces pre-fix) plus full regression coverage on both modules — see the two commits for details.

## Test plan
- [x] New k3po scenario for bug 1 (`session.will.message.header.exceeds.window`) fails pre-fix with the reported `IndexOutOfBoundsException`, passes post-fix
- [x] New k3po scenario for bug 2 (`session.will.message.qos2.abort.before.session.established`) fails pre-fix with the reported NPE, passes post-fix
- [x] Full regression suite green on `runtime/binding-mqtt`, `runtime/binding-mqtt-kafka`, `specs/binding-mqtt.spec`, `specs/binding-mqtt-kafka.spec`
- [x] `checkstyle:check` clean on all four modules