### PR TITLE
test(binding-mcp): model the mcp(client) lifecycle preauthorize challenge

### DIFF
--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.elicit.reauthorize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.elicit.reauthorize/client.rpt
@@ -23,6 +23,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=https%3A%2F%2Freplace.me%2Fcallback")
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.elicit.reauthorize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.elicit.reauthorize/server.rpt
@@ -27,7 +27,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=https%3A%2F%2Freplace.me%2Fcallback")
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.elicit.completed.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/prompts.get.elicit.completed.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.elicit.completed.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/resources.read.elicit.completed.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.preauthorized/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.preauthorized/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.preauthorized/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.preauthorized/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.declined.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.reject.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/client.rpt
@@ -24,6 +24,23 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitCallback()
+                                  .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                  .correlationId("3")
+                                  .build()
+                              .build()}
+
 connected
 
 read zilla:begin.ext ${mcp:matchBeginEx()

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.timeout.guarded/server.rpt
@@ -28,7 +28,24 @@ read zilla:begin.ext ${mcp:matchBeginEx()
                               .build()
                           .build()}
 
+read advise zilla:challenge ${mcp:challengeEx()
+                                  .typeId(zilla:id("mcp"))
+                                  .elicitCreate()
+                                      .id("elicit-1")
+                                      .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                      .correlationId("3")
+                                      .build()
+                              .build()}
+
 connected
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitCallback()
+                                   .url("http://localhost:8080/mcp/auth/callback?code=xyz&state=7f3a9b1c")
+                                   .correlationId("3")
+                                   .build()
+                               .build()}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))


### PR DESCRIPTION
## Description

`develop` is currently red on 8 `McpClientIT` tests (and their spec-level `ApplicationIT` self-consistency counterparts) that all use `client.guarded.yaml`. This reproduces identically on `develop`'s own HEAD in real GitHub Actions CI, so it predates and is unrelated to any other in-flight PR — it's a gap left by #2426 ("defer mcp(client) lifecycle connect until guard decides").

`McpLifecycleStream.proceedWithRequest` now defers connecting south until the configured guard decides, surfacing a `NEEDS_PREAUTHORIZE` answer as an `elicitCreate` challenge on the lifecycle stream itself — the same challenge-then-answer round trip already modeled for per-request guard decisions. The eight k3po scenarios exercising `client.guarded.yaml` predate that lifecycle-level guard check and never modeled it, so their scripts hang waiting on a reply `begin` that never arrives without first answering the challenge.

This adds the `elicitCreate` challenge and its `elicitCallback` answer to each scenario's lifecycle connect, mirroring the existing per-request pattern:
- `tools.call.elicit.reject.guarded`
- `tools.call.elicit.completed.guarded`
- `tools.call.elicit.completed.preauthorized`
- `tools.call.elicit.declined.guarded`
- `tools.call.elicit.timeout.guarded`
- `prompts.get.elicit.completed.guarded`
- `resources.read.elicit.completed.guarded`
- `lifecycle.elicit.reauthorize`

No production code changes — this is purely a test-fixture fix reflecting #2426's intentional new lifecycle-level guard behavior. The connect's own "connected" milestone only fires once the guard finally allows the deferred south connect, so it has to follow the answer rather than precede it as it does for a per-request stream; the paired self-consistency server scripts settle "connected" between the challenge and the answer since they never defer a real south connect (confirmed both orderings are required by testing each in isolation against the real engine vs. the pure two-script self-test).

## Test plan

- [x] `./mvnw clean verify -pl runtime/binding-mcp` — 296 tests, 0 failures (was: 8 failing before this fix, reproducing identically on unmodified `develop`)
- [x] `./mvnw clean verify -pl specs/binding-mcp.spec` — 260 tests, 0 failures
- [x] Confirmed each of the 8 scenarios fails identically on `develop`'s current HEAD before this fix, and passes after, for both the runtime IT and its spec-level self-consistency counterpart

Fixes # (issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_