### PR TITLE
fix(binding-mcp): preserve request sequence on mcp(client) HttpStream end

### DIFF
--- a/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
+++ b/runtime/binding-http/src/main/java/io/aklivity/zilla/runtime/binding/http/internal/stream/HttpClientFactory.java
@@ -5003,9 +5003,10 @@ public final class HttpClientFactory implements HttpStreamFactory
             assert requestAck <= requestSeq;
             client.requestSharedBudget -= reserved;
 
+            final boolean alreadyClosed = HttpState.initialClosed(state);
             state = HttpState.closeInitial(state);
 
-            if ((streamId & 0x01) == 0x01)
+            if (!alreadyClosed && (streamId & 0x01) == 0x01)
             {
                 final HttpEndExFW endEx = end.extension().get(endExRO::tryWrap);
                 final Array32FW<HttpHeaderFW> trailers = endEx != null ? endEx.trailers() : DEFAULT_TRAILERS;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpAuthorizationResult.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpAuthorizationResult.java
@@ -19,6 +19,6 @@ import io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBearerErro
 public record McpAuthorizationResult(
     long authorization,
     McpBearerError error,
-    boolean owned)
+    Runnable deauthorize)
 {
 }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/config/McpBindingConfig.java
@@ -73,6 +73,10 @@ public final class McpBindingConfig
     private static final String HTTP_HEADER_PATH = ":path";
     private static final String HTTP_HEADER_AUTHORIZATION = "authorization";
 
+    private static final Runnable NOOP = () ->
+    {
+    };
+
     private static final String SCHEME_HTTPS = "https";
     private static final int PORT_HTTP = 80;
     private static final int PORT_HTTPS = 443;
@@ -852,7 +856,7 @@ public final class McpBindingConfig
         HttpBeginExFW httpBeginEx,
         String path)
     {
-        McpAuthorizationResult result = new McpAuthorizationResult(authorization, null, false);
+        McpAuthorizationResult result = new McpAuthorizationResult(authorization, null, NOOP);
         if (guard != null && !isAuthCallbackPath(path))
         {
             final String authorizationHeader = Optional.ofNullable(httpBeginEx.headers()
@@ -877,11 +881,15 @@ public final class McpBindingConfig
                     ? guard.reauthorize(traceId, routedId, initialId, credentials)
                     : GuardHandler.NOT_AUTHORIZED;
 
+                // deauthorize is only ever the real thing here: this reauthorize call is the
+                // one that incremented the session's ref count, so this is the one call site
+                // responsible for eventually decrementing it back -- the transport-level
+                // authorization above is never ours to deauthorize, whatever guard minted it.
                 result = (sessionAuth & GuardHandler.MASK_AUTHORIZED) != 0L
-                    ? new McpAuthorizationResult(sessionAuth, null, true)
+                    ? new McpAuthorizationResult(sessionAuth, null, () -> guard.deauthorize(sessionAuth))
                     : new McpAuthorizationResult(authorization, credentials == null
                         ? McpBearerError.INVALID_REQUEST
-                        : McpBearerError.INVALID_TOKEN, false);
+                        : McpBearerError.INVALID_TOKEN, NOOP);
             }
         }
         return result;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -4702,7 +4702,7 @@ public final class McpClientFactory implements McpStreamFactory
                 encodeSlot == NO_SLOT)
             {
                 state = McpState.closedInitial(state);
-                doEnd(net, originId, routedId, initialId, traceId, authorization);
+                doEnd(net, originId, routedId, initialId, initialSeq, initialAck, initialMax, traceId, authorization);
 
                 cleanupEncodeSlot();
             }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -584,7 +584,7 @@ abstract class McpProxyItemFactory implements BindingHandler
 
             state = McpState.openingInitial(state);
 
-            client.doClientBegin(traceId);
+            client.doClientBegin(traceId, authorization);
 
             final int minInitialMax = toolSchemaId != NO_SCHEMA_ID ? codecBuffer.capacity() : 0;
             flushServerWindow(traceId, 0L, 0, 0L, minInitialMax);
@@ -2094,13 +2094,22 @@ abstract class McpProxyItemFactory implements BindingHandler
         private void driveDelegateBegin(
             long traceId)
         {
+            // the delegate's own initial-side maximum must never advertise less than this outer
+            // execute_tool request already promised the real caller on their one shared reply channel --
+            // restarting at zero let the delegate's own onServerBegin -> flushServerWindow send a second,
+            // smaller WINDOW, regressing what the real caller already recorded and tripping its
+            // monotonic-window assertion. sequence/acknowledge stay at zero (the delegate's own,
+            // self-contained numbering) since this outer request's own first window already advertised
+            // acknowledge=0 too -- there is no divergence to seed there, only maximum ever shrank
+            delegate.initialMax = initialMax;
+
             final BeginFW syntheticBegin = beginRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .originId(originId)
                 .routedId(routedId)
                 .streamId(initialId)
                 .sequence(0L)
                 .acknowledge(0L)
-                .maximum(0)
+                .maximum(initialMax)
                 .traceId(traceId)
                 .authorization(authorization)
                 .affinity(affinity)
@@ -2132,6 +2141,14 @@ abstract class McpProxyItemFactory implements BindingHandler
                 final boolean last = offset + chunk >= bodyLength;
                 final int flags = (first ? DATA_FLAG_INIT : 0) | (last ? DATA_FLAG_FIN : 0);
 
+                // batches every reserved this outer request's own inbound DATA ever aggregated
+                // (initialSeq, the outer's own final total) onto the last synthetic chunk -- not
+                // each chunk, which would recount those same past reserves once per chunk -- so the
+                // delegate's own initialSeq lands exactly on the outer's already-final value once
+                // this loop completes, matching what the real caller's own frames (a later timeout
+                // abort, in particular) will always show from here on
+                final int chunkReserved = last ? (int) (initialSeq - offset) : 0;
+
                 final DataFW syntheticData = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                     .originId(originId)
                     .routedId(routedId)
@@ -2143,7 +2160,7 @@ abstract class McpProxyItemFactory implements BindingHandler
                     .authorization(authorization)
                     .flags(flags)
                     .budgetId(0L)
-                    .reserved(chunk)
+                    .reserved(chunkReserved)
                     .payload(pendingBody, offset, chunk)
                     .build();
                 delegate.onServerMessage(DataFW.TYPE_ID, syntheticData.buffer(), syntheticData.offset(),
@@ -2168,11 +2185,17 @@ abstract class McpProxyItemFactory implements BindingHandler
         private void doDelegateEnd(
             long traceId)
         {
+            // driveDelegateData's own reserved accounting already brought the delegate's initialSeq up to
+            // exactly this outer request's own final initialSeq, so this END's sequence just continues
+            // that same value -- not initialSeq + pendingBodyLength, which double-counts a value the DATA
+            // loop already folded in. From here on the delegate's counter matches exactly what the real
+            // caller's own frames (a later timeout abort, in particular) will show, permanently, since
+            // neither side advances further after this point
             final EndFW syntheticEnd = endRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                 .originId(originId)
                 .routedId(routedId)
                 .streamId(initialId)
-                .sequence((long) pendingBodyLength)
+                .sequence(initialSeq)
                 .acknowledge(0L)
                 .maximum(0)
                 .traceId(traceId)
@@ -2324,9 +2347,10 @@ abstract class McpProxyItemFactory implements BindingHandler
         }
 
         private void doClientBegin(
-            long traceId)
+            long traceId,
+            long authorization)
         {
-            lifecycle.doClientBegin(traceId);
+            lifecycle.doClientBegin(traceId, authorization);
             lifecycle.register(traceId, this);
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -1268,7 +1268,10 @@ final class McpProxyLifecycleFactory implements BindingHandler
             settleRequests(traceId);
             doClientEnd(traceId);
             server.clients.remove(routedId, this);
-            server.doServerEnd(traceId);
+            if (server.clients.isEmpty())
+            {
+                server.doServerEnd(traceId);
+            }
         }
 
         private void onClientAbort(
@@ -1294,7 +1297,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             {
                 settleLifecycle(traceId);
             }
-            else
+            else if (server.clients.isEmpty())
             {
                 server.doServerAbort(traceId);
             }
@@ -1342,11 +1345,12 @@ final class McpProxyLifecycleFactory implements BindingHandler
             server.clients.remove(routedId, this);
 
             final boolean bearer = extension.sizeof() > 0;
+
             if (server.hydration && sessionId == null || bearer)
             {
                 settleLifecycle(traceId);
             }
-            else
+            else if (server.clients.isEmpty())
             {
                 server.doServerReset(traceId, extension);
             }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -305,13 +305,14 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 onDecodeEventId(route.id, eventId);
                 final McpLifecycleClient client = supplyClient(route.id);
                 client.resumeId = eventId;
-                client.doClientBegin(traceId);
+                client.doClientBegin(traceId, authorization);
                 client.doClientResume(traceId, authorization);
             }
         }
 
         private void onServerResumeRoutes(
-            long traceId)
+            long traceId,
+            long authorization)
         {
             for (McpAggregateRoute route : binding.aggregateRoutes)
             {
@@ -319,7 +320,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 if (!clients.containsKey(routedId))
                 {
                     final McpLifecycleClient client = supplyClient(routedId);
-                    client.doClientBegin(traceId);
+                    client.doClientBegin(traceId, authorization);
                 }
             }
         }
@@ -473,13 +474,13 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 {
                     McpAggregateEventId.decode(aggregate,
                         (prefix, eventId) -> onDecodeAggregateEventId(traceId, authorization, prefix, eventId));
-                    onServerResumeRoutes(traceId);
+                    onServerResumeRoutes(traceId, authorization);
                 }
                 else
                 {
                     if (aggregating())
                     {
-                        onServerResumeRoutes(traceId);
+                        onServerResumeRoutes(traceId, authorization);
                     }
                     for (McpLifecycleClient client : clients.values())
                     {
@@ -557,7 +558,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             for (long routeId : routeIds)
             {
                 final McpLifecycleClient client = supplyClient(routeId);
-                client.doClientBegin(traceId);
+                client.doClientBegin(traceId, authorization);
             }
 
             doServerBeginDeferred(traceId);
@@ -928,7 +929,8 @@ final class McpProxyLifecycleFactory implements BindingHandler
         }
 
         void doClientBegin(
-            long traceId)
+            long traceId,
+            long authorization)
         {
             if (!McpState.initialOpening(state))
             {
@@ -936,6 +938,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
                 {
                     authorization = server.binding.routeCacheAuthorization(traceId, routedId);
                 }
+                this.authorization = authorization;
 
                 final int clientCapabilities = server.clientCapabilities;
                 final String authCallback = server.authCallback;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -592,6 +592,7 @@ abstract class McpProxyListFactory implements BindingHandler
             state = McpState.closedReply(state);
             cleanupClientSlot();
             doClientEnd(traceId);
+            server.anySucceeded = true;
             server.onClientClosed(traceId);
         }
 
@@ -1545,6 +1546,8 @@ abstract class McpProxyListFactory implements BindingHandler
 
         private int state;
         private int itemsEmitted;
+        private boolean anySucceeded;
+        private boolean anyErrored;
         private McpListClient client;
 
         private int preludeProgress;
@@ -1784,8 +1787,21 @@ abstract class McpProxyListFactory implements BindingHandler
         private void onClientError(
             long traceId)
         {
-            remaining.clear();
-            doServerAbort(traceId);
+            anyErrored = true;
+            // a route erroring (Abort/Reset/buffer exhaustion) only fails the overall response
+            // when every route that was tried errored and none ever succeeded -- a sole failing
+            // route, or one among several, is otherwise excluded the same way an
+            // unauthorized/skipped route already is, converging to an empty list
+            if (hydration || remaining.isEmpty() && !anySucceeded)
+            {
+                remaining.clear();
+                doServerAbort(traceId);
+            }
+            else
+            {
+                client = null;
+                onNextClient(traceId);
+            }
         }
 
         private void onClientSkip(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyListFactory.java
@@ -363,9 +363,10 @@ abstract class McpProxyListFactory implements BindingHandler
         }
 
         private void doClientBegin(
-            long traceId)
+            long traceId,
+            long authorization)
         {
-            lifecycle.doClientBegin(traceId);
+            lifecycle.doClientBegin(traceId, authorization);
             lifecycle.register(traceId, this);
         }
 
@@ -391,7 +392,7 @@ abstract class McpProxyListFactory implements BindingHandler
                     .build();
 
                 sender = newStream(this::onClientMessage, originId, routedId, initialId,
-                    initialSeq, initialAck, initialMax, traceId, lifecycle.authorization, server.affinity, beginEx);
+                    initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
                 state = McpState.openingInitial(state);
             }
             else
@@ -409,7 +410,7 @@ abstract class McpProxyListFactory implements BindingHandler
                 if (McpState.initialOpening(state))
                 {
                     doEnd(sender, originId, routedId, initialId,
-                        initialSeq, initialAck, initialMax, traceId, lifecycle.authorization);
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
                 }
                 state = McpState.closedInitial(state);
             }
@@ -423,7 +424,7 @@ abstract class McpProxyListFactory implements BindingHandler
                 if (McpState.initialOpening(state))
                 {
                     doAbort(sender, originId, routedId, initialId,
-                        initialSeq, initialAck, initialMax, traceId, lifecycle.authorization);
+                        initialSeq, initialAck, initialMax, traceId, server.authorization);
                 }
                 state = McpState.closedInitial(state);
             }
@@ -437,7 +438,7 @@ abstract class McpProxyListFactory implements BindingHandler
                 if (McpState.initialOpening(state))
                 {
                     doReset(sender, originId, routedId, replyId,
-                        replySeq, replyAck, replyMax, traceId, lifecycle.authorization, emptyRO);
+                        replySeq, replyAck, replyMax, traceId, server.authorization, emptyRO);
                 }
                 state = McpState.closedReply(state);
             }
@@ -452,7 +453,7 @@ abstract class McpProxyListFactory implements BindingHandler
             {
                 state = McpState.openedReply(state);
                 doWindow(sender, originId, routedId, replyId,
-                    replySeq, replyAck, replyMax, traceId, lifecycle.authorization, budgetId, padding);
+                    replySeq, replyAck, replyMax, traceId, server.authorization, budgetId, padding);
             }
         }
 
@@ -731,7 +732,7 @@ abstract class McpProxyListFactory implements BindingHandler
             if (replySlot != NO_SLOT)
             {
                 final MutableDirectBufferEx slot = bufferPool.buffer(replySlot);
-                decode(traceId, lifecycle.authorization, 0L, 0, slot, 0, replySlotOffset);
+                decode(traceId, server.authorization, 0L, 0, slot, 0, replySlotOffset);
             }
         }
 
@@ -1833,7 +1834,7 @@ abstract class McpProxyListFactory implements BindingHandler
                 ? name -> routeConfig.admits(kind, name)
                 : null;
             client = new McpListClient(this, route.resolvedId(), route.prefix(), admits, guard);
-            client.doClientBegin(traceId);
+            client.doClientBegin(traceId, authorization);
         }
 
         private boolean doEncodeFraming(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -471,14 +471,21 @@ public final class McpServerFactory implements McpStreamFactory
                     altSvc);
                 break;
             case "DELETE":
-                newStream = new McpShutdownHandler(
-                    sender,
-                    originId,
-                    routedId,
-                    initialId,
-                    resolvedId,
-                    session,
-                    altSvc)::onNetMessage;
+                if (session == null)
+                {
+                    newStream = new McpRejectHandler(sender, STATUS_400)::onNetBegin;
+                }
+                else
+                {
+                    newStream = new McpShutdownHandler(
+                        sender,
+                        originId,
+                        routedId,
+                        initialId,
+                        resolvedId,
+                        session,
+                        altSvc)::onNetMessage;
+                }
                 break;
             default:
                 newStream = new McpRejectHandler(sender, STATUS_405)::onNetBegin;

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerFactory.java
@@ -20,7 +20,6 @@ import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabiliti
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.McpCapabilities.SERVER_RESOURCES_SUBSCRIBE;
 import static io.aklivity.zilla.runtime.binding.mcp.internal.types.stream.McpBeginExFW.KIND_LIFECYCLE;
 import static io.aklivity.zilla.runtime.engine.buffer.BufferPool.NO_SLOT;
-import static io.aklivity.zilla.runtime.engine.guard.GuardHandler.MASK_AUTHORIZED;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -98,6 +97,10 @@ import io.aklivity.zilla.runtime.engine.concurrent.Signaler;
 
 public final class McpServerFactory implements McpStreamFactory
 {
+    private static final Runnable NOOP = () ->
+    {
+    };
+
     private static final String MCP_PROTOCOL_VERSION = "2025-11-25";
     private static final Set<String> SUPPORTED_PROTOCOL_VERSIONS = Set.of("2025-06-18", MCP_PROTOCOL_VERSION);
 
@@ -446,7 +449,7 @@ public final class McpServerFactory implements McpStreamFactory
                         routedId,
                         initialId,
                         resolvedAuthorization,
-                        authResult.owned(),
+                        authResult.deauthorize(),
                         resolvedId,
                         binding,
                         session,
@@ -462,6 +465,8 @@ public final class McpServerFactory implements McpStreamFactory
                     originId,
                     routedId,
                     initialId,
+                    resolvedAuthorization,
+                    authResult.deauthorize(),
                     binding,
                     session,
                     httpBeginEx,
@@ -501,6 +506,8 @@ public final class McpServerFactory implements McpStreamFactory
         long originId,
         long routedId,
         long initialId,
+        long authorization,
+        Runnable deauthorize,
         McpBindingConfig binding,
         McpLifecycleStream session,
         HttpBeginExFW httpBeginEx,
@@ -528,14 +535,17 @@ public final class McpServerFactory implements McpStreamFactory
         }
         else if (!acceptIncludesEventStream(accept))
         {
+            deauthorize.run();
             newStream = new McpRejectHandler(sender, STATUS_406)::onNetBegin;
         }
         else if (session == null)
         {
+            deauthorize.run();
             newStream = new McpRejectHandler(sender, STATUS_400)::onNetBegin;
         }
         else if (session.eventsUnsupported)
         {
+            deauthorize.run();
             newStream = new McpRejectHandler(sender, STATUS_405)::onNetBegin;
         }
         else
@@ -563,6 +573,7 @@ public final class McpServerFactory implements McpStreamFactory
 
             if (lastEventIdPrefix != null && !lastEventIdPrefix.isEmpty() && resolvedRequest == null)
             {
+                deauthorize.run();
                 newStream = new McpRejectHandler(sender, STATUS_400)::onNetBegin;
             }
             else
@@ -572,6 +583,8 @@ public final class McpServerFactory implements McpStreamFactory
                     originId,
                     routedId,
                     initialId,
+                    authorization,
+                    deauthorize,
                     session,
                     resolvedRequest,
                     resumeEventId,
@@ -1471,10 +1484,8 @@ public final class McpServerFactory implements McpStreamFactory
         private final long initialId;
         private final long replyId;
         private final long authorization;
-        private final boolean guardSessionOwned;
+        private Runnable deauthorize;
         private final long resolvedId;
-
-        private boolean guardSessionDeauthorized;
 
         private McpLifecycleStream session;
 
@@ -1530,7 +1541,7 @@ public final class McpServerFactory implements McpStreamFactory
             long routedId,
             long initialId,
             long authorization,
-            boolean guardSessionOwned,
+            Runnable deauthorize,
             long resolvedId,
             McpBindingConfig binding,
             McpLifecycleStream session,
@@ -1545,7 +1556,7 @@ public final class McpServerFactory implements McpStreamFactory
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
             this.authorization = authorization;
-            this.guardSessionOwned = guardSessionOwned;
+            this.deauthorize = deauthorize;
             this.resolvedId = resolvedId;
             this.binding = binding;
             this.session = session;
@@ -1941,7 +1952,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
-            deauthorizeGuardSession();
+            onNetClosed();
         }
 
         private void doNetAbort(
@@ -1956,7 +1967,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
-            deauthorizeGuardSession();
+            onNetClosed();
         }
 
         private void doNetWindow(
@@ -1990,17 +2001,13 @@ public final class McpServerFactory implements McpStreamFactory
                     initialSeq, initialAck, initialMax, traceId, authorization, extension);
             }
 
-            deauthorizeGuardSession();
+            onNetClosed();
         }
 
-        private void deauthorizeGuardSession()
+        private void onNetClosed()
         {
-            if (!guardSessionDeauthorized &&
-                guardSessionOwned && binding.guard != null && (authorization & MASK_AUTHORIZED) != 0L)
-            {
-                guardSessionDeauthorized = true;
-                binding.guard.deauthorize(authorization);
-            }
+            deauthorize.run();
+            deauthorize = NOOP;
         }
 
         private void flushNetWindow(
@@ -4242,6 +4249,8 @@ public final class McpServerFactory implements McpStreamFactory
         private final long routedId;
         private final long initialId;
         private final long replyId;
+        private final long authorization;
+        private Runnable deauthorize;
         private final McpLifecycleStream session;
 
         private long initialSeq;
@@ -4273,6 +4282,8 @@ public final class McpServerFactory implements McpStreamFactory
             long originId,
             long routedId,
             long initialId,
+            long authorization,
+            Runnable deauthorize,
             McpLifecycleStream session,
             McpRequestStream request,
             String lastEventId,
@@ -4283,6 +4294,8 @@ public final class McpServerFactory implements McpStreamFactory
             this.routedId = routedId;
             this.initialId = initialId;
             this.replyId = supplyReplyId.applyAsLong(initialId);
+            this.authorization = authorization;
+            this.deauthorize = deauthorize;
             this.session = session;
             this.request = request;
             this.lastEventId = lastEventId;
@@ -4337,7 +4350,6 @@ public final class McpServerFactory implements McpStreamFactory
             final long sequence = begin.sequence();
             final long acknowledge = begin.acknowledge();
             final long traceId = begin.traceId();
-            final long authorization = begin.authorization();
 
             initialSeq = sequence;
             initialAck = acknowledge;
@@ -4453,7 +4465,7 @@ public final class McpServerFactory implements McpStreamFactory
 
             state = McpState.closedInitial(state);
 
-            notifySuspendedToSession(traceId, authorization);
+            notifySuspendedToSession(traceId);
 
             doNetAbort(traceId, authorization);
         }
@@ -4493,14 +4505,13 @@ public final class McpServerFactory implements McpStreamFactory
             final long traceId = reset.traceId();
             final long authorization = reset.authorization();
 
-            notifySuspendedToSession(traceId, authorization);
+            notifySuspendedToSession(traceId);
 
             cleanupNet(traceId, authorization);
         }
 
         private void notifySuspendedToSession(
-            long traceId,
-            long authorization)
+            long traceId)
         {
             if (request != null)
             {
@@ -4799,6 +4810,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
+            onNetClosed();
         }
 
         private void doNetAbort(
@@ -4819,6 +4831,7 @@ public final class McpServerFactory implements McpStreamFactory
             }
 
             cleanupEncodeSlot();
+            onNetClosed();
         }
 
         private void doNetReset(
@@ -4831,6 +4844,8 @@ public final class McpServerFactory implements McpStreamFactory
                 doReset(net, originId, routedId, initialId,
                     initialSeq, initialAck, initialMax, traceId, authorization, emptyRO);
             }
+
+            onNetClosed();
         }
 
         private void doNetWindow(
@@ -4908,6 +4923,12 @@ public final class McpServerFactory implements McpStreamFactory
         {
             doNetReset(traceId, authorization);
             doNetAbort(traceId, authorization);
+        }
+
+        private void onNetClosed()
+        {
+            deauthorize.run();
+            deauthorize = NOOP;
         }
 
         private void injectAltSvc(

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -83,6 +83,16 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.yaml")
+    @Specification({
+        "${app}/cache.hydrate.reset/server" })
+    @ScriptProperty({"serverAddress \"zilla://streams/app1\"", "affinity \"0000003f\""})
+    public void shouldHydrateReset() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.credentials.yaml")
     @Specification({
         "${app}/cache.hydrate.credentials/server" })

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -286,6 +286,17 @@ public class McpProxyIT
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
     @Specification({
+        "${app}/tools.list.toolkit.multi.route.error.prefixed/client",
+        "${app}/tools.list.toolkit.multi.route.error/server" })
+    @ScriptProperty("affinity \"0000003f\"")
+    public void shouldListToolsWithToolkitMultiRouteError() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
         "${app}/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi.prefixed/client",
         "${app}/lifecycle.notify.tools.list.changed.after.authorize.toolkit.multi/server" })
     @ScriptProperty("affinity \"0000003f\"")

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -210,7 +210,7 @@ public class McpProxyIT
     @Specification({
         "${app}/tools.list.toolkit.multi.prefixed/client",
         "${app}/tools.list.toolkit.multi/server" })
-    @ScriptProperty("affinity \"0000003f\"")
+    @ScriptProperty({"affinity \"0000003f\"", "authorization 1L"})
     public void shouldListToolsWithToolkitMulti() throws Exception
     {
         k3po.finish();
@@ -307,6 +307,7 @@ public class McpProxyIT
 
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
+    @ScriptProperty("authorization 1L")
     @Specification({
         "${app}/lifecycle.events.resume.aggregate.prefixed/client",
         "${app}/lifecycle.events.resume.aggregate/server" })

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -761,6 +761,31 @@ public class McpServerIT
     }
 
     @Test
+    @Configuration("server.guarded.yaml")
+    @ScriptProperty("authorization 1L")
+    @Specification({
+        "${net}/lifecycle.events.resume/client",
+        "${app}/lifecycle.events.resume/server"})
+    public void shouldDeauthorizeGuardSessionOnResumeClose() throws Exception
+    {
+        // three guarded HTTP requests share this scenario (POST initialize, POST
+        // notifications/initialized, GET/SSE reconnect), each minting its own guard
+        // session on open and releasing it on close -- the GET/SSE reconnect leg is
+        // the one McpEventStream itself is responsible for releasing
+        CountDownLatch deauthorized = new CountDownLatch(3);
+        TestGuardHandler.onDeauthorized = deauthorized::countDown;
+        try
+        {
+            k3po.finish();
+            assertTrue(deauthorized.await(5, SECONDS));
+        }
+        finally
+        {
+            TestGuardHandler.onDeauthorized = null;
+        }
+    }
+
+    @Test
     @Configuration("server.yaml")
     @Specification({
         "${net}/lifecycle.events.resume.reject.bearer/client",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -750,7 +750,8 @@ public class McpServerIT
     }
 
     @Test
-    @Configuration("server.yaml")
+    @Configuration("server.guarded.yaml")
+    @ScriptProperty("authorization 1L")
     @Specification({
         "${net}/lifecycle.events.resume/client",
         "${app}/lifecycle.events.resume/server"})

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpServerIT.java
@@ -800,6 +800,24 @@ public class McpServerIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/lifecycle.shutdown.session.unknown/client"})
+    public void shouldRejectLifecycleShutdownSessionUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
+        "${net}/lifecycle.shutdown.session.missing/client"})
+    public void shouldRejectLifecycleShutdownSessionMissing() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/reject.method.not.allowed/client"})
     public void shouldRejectMethodNotAllowed() throws Exception
     {

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.reset/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.reset/client.rpt
@@ -1,0 +1,116 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .promptsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+read '{"prompts":[]}'
+read closed
+
+write close
+
+read notify PROMPTS_LIST_COMPLETE
+
+connect await PROMPTS_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+write aborted
+
+read notify TOOLS_LIST_COMPLETE
+
+connect await TOOLS_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesTemplatesList()
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resourceTemplates":[]}'
+read closed
+
+write close
+
+read notify RESOURCES_TEMPLATES_LIST_COMPLETE
+
+connect await RESOURCES_TEMPLATES_LIST_COMPLETE
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .resourcesList()
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+read '{"resources":[]}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.reset/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.reset/server.rpt
@@ -1,0 +1,113 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .promptsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"prompts":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+read abort
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesTemplatesList()
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resourceTemplates":[]}'
+write flush
+
+write close
+
+read closed
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .resourcesList()
+                              .sessionId("5ca1ab1e-c0de-4a11-feed-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"resources":[]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate.prefixed/client.rpt
@@ -13,9 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property authorization 1L
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume.aggregate/server.rpt
@@ -13,9 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property authorization 0L
+
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 
@@ -53,6 +56,7 @@ write advise zilla:flush ${mcp:flushEx()
 accept "zilla://streams/app2"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/client.rpt
@@ -13,9 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property authorization 0L
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.events.resume/server.rpt
@@ -14,10 +14,12 @@
 #
 
 property serverAddress "zilla://streams/app0"
+property authorization 0L
 
 accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
@@ -13,9 +13,12 @@
 # specific language governing permissions and limitations under the License.
 #
 
+property authorization 1L
+
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))
@@ -38,6 +41,7 @@ connect await LIFECYCLE_INITIALIZED
         "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
+        option zilla:authorization ${authorization}
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/client.rpt
@@ -18,7 +18,7 @@ property authorization 1L
 connect "zilla://streams/app0"
         option zilla:window 8192
         option zilla:transmission "half-duplex"
-        option zilla:authorization ${authorization}
+        option zilla:authorization 0L
 
 write zilla:begin.ext ${mcp:beginEx()
                            .typeId(zilla:id("mcp"))

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
@@ -14,11 +14,12 @@
 #
 
 property serverAddress "zilla://streams/app0"
+property authorization 1L
 
 accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
-       option zilla:authorization 1L
+       option zilla:authorization 0L
 
 accepted
 
@@ -37,6 +38,11 @@ write zilla:begin.ext ${mcp:beginEx()
                                .build()
                            .build()}
 write flush
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.prefixed/server.rpt
@@ -18,6 +18,7 @@ property serverAddress "zilla://streams/app0"
 accept ${serverAddress}
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization 1L
 
 accepted
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error.prefixed/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"bluesky__get_weather"}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error.prefixed/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error.prefixed/server.rpt
@@ -1,0 +1,62 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{"name":"bluesky__get_weather"}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error/client.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+connect "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_1
+
+connect await LIFECYCLE_INITIALIZED_1
+        "zilla://streams/app1"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"get_weather"}'
+        ']'
+      '}'
+read closed
+
+write close
+
+read notify SERVER_1_DONE
+
+connect await SERVER_1_DONE
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED_2
+
+connect await LIFECYCLE_INITIALIZED_2
+        "zilla://streams/app2"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                               .build()
+                           .build()}
+
+connected
+
+read aborted

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi.route.error/server.rpt
@@ -1,0 +1,97 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":'
+        '['
+          '{"name":"get_weather"}'
+        ']'
+      '}'
+write flush
+
+write close
+
+read closed
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write abort

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.list.toolkit.multi/server.rpt
@@ -14,10 +14,12 @@
 #
 
 property affinity "00000000"
+property authorization 0L
 
 accept "zilla://streams/app1"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 
@@ -64,6 +66,7 @@ read closed
 accept "zilla://streams/app2"
        option zilla:window 8192
        option zilla:transmission "half-duplex"
+       option zilla:authorization ${authorization}
 
 accepted
 

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.events.resume/client.rpt
@@ -26,6 +26,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("content-type", "application/json")
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-11-25")
+                            .header("authorization", "Bearer test-token")
                             .build()}
 
 connected
@@ -59,6 +60,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("accept", "application/json, text/event-stream")
                             .header("mcp-protocol-version", "2025-11-25")
                             .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
+                            .header("authorization", "Bearer test-token")
                             .build()}
 
 connected
@@ -84,6 +86,7 @@ write zilla:begin.ext ${http:beginEx()
                             .header("mcp-protocol-version", "2025-11-25")
                             .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
                             .header("last-event-id", "event-99")
+                            .header("authorization", "Bearer test-token")
                             .build()}
 
 connected

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.missing/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.missing/client.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "DELETE")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .build()}
+
+# TODO: enable once k3po supports `connect aborted` followed by `read zilla:reset.ext`
+#       to assert the extension on the RESET that caused the abort.
+#       Paired peer-side enhancement: a `reject zilla:reset.ext ${...}` primitive
+#       that responds to the inbound BEGIN with a RESET carrying the given
+#       extension without transitioning through `connected`. Both are needed
+#       together so client and server scripts can verify each other.
+# read zilla:reset.ext ${http:resetEx()
+#                            .typeId(zilla:id("http"))
+#                            .header(":status", "400")
+#                            .build()}
+

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.missing/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.missing/server.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "DELETE")
+                           .header(":path", "/mcp")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+# TODO: enable once k3po supports a `reject zilla:reset.ext ${...}` primitive
+#       that responds to the inbound BEGIN with a RESET carrying the given
+#       extension without transitioning through `connected`. Paired client-side
+#       enhancement: `connect aborted` followed by `read zilla:reset.ext ${...}`
+#       to assert the extension on the RESET that caused the abort. Both are
+#       needed together so client and server scripts can verify each other.
+# write zilla:reset.ext ${http:resetEx()
+#                             .typeId(zilla:id("http"))
+#                             .header(":status", "400")
+#                             .build()}
+

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.unknown/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.unknown/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/net0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":method", "DELETE")
+                            .header(":scheme", "http")
+                            .header(":authority", "localhost:8080")
+                            .header(":path", "/mcp")
+                            .header("mcp-protocol-version", "2025-11-25")
+                            .header("mcp-session-id", "5ca1ab1e-c0de-4a11-1057-000000000000")
+                            .build()}
+
+# TODO: enable once k3po supports `connect aborted` followed by `read zilla:reset.ext`
+#       to assert the extension on the RESET that caused the abort.
+#       Paired peer-side enhancement: a `reject zilla:reset.ext ${...}` primitive
+#       that responds to the inbound BEGIN with a RESET carrying the given
+#       extension without transitioning through `connected`. Both are needed
+#       together so client and server scripts can verify each other.
+# read zilla:reset.ext ${http:resetEx()
+#                            .typeId(zilla:id("http"))
+#                            .header(":status", "400")
+#                            .build()}
+

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.unknown/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/lifecycle.shutdown.session.unknown/server.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "DELETE")
+                           .header(":path", "/mcp")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "5ca1ab1e-c0de-4a11-1057-000000000000")
+                           .build()}
+
+# TODO: enable once k3po supports a `reject zilla:reset.ext ${...}` primitive
+#       that responds to the inbound BEGIN with a RESET carrying the given
+#       extension without transitioning through `connected`. Paired client-side
+#       enhancement: `connect aborted` followed by `read zilla:reset.ext ${...}`
+#       to assert the extension on the RESET that caused the abort. Both are
+#       needed together so client and server scripts can verify each other.
+# write zilla:reset.ext ${http:resetEx()
+#                             .typeId(zilla:id("http"))
+#                             .header(":status", "400")
+#                             .build()}
+

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/application/ApplicationIT.java
@@ -1205,4 +1205,22 @@ public class ApplicationIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit.multi.route.error/client",
+        "${app}/tools.list.toolkit.multi.route.error/server"})
+    public void shouldListToolsWithToolkitMultiRouteError() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${app}/tools.list.toolkit.multi.route.error.prefixed/client",
+        "${app}/tools.list.toolkit.multi.route.error.prefixed/server"})
+    public void shouldListToolsWithToolkitMultiRouteErrorPrefixed() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/cache/ProxyCacheIT.java
@@ -56,6 +56,15 @@ public class ProxyCacheIT
 
     @Test
     @Specification({
+        "${app}/cache.hydrate.reset/client",
+        "${app}/cache.hydrate.reset/server" })
+    public void shouldHydrateReset() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/cache.hydrate.credentials/client",
         "${app}/cache.hydrate.credentials/server" })
     public void shouldHydrateWithCredentials() throws Exception

--- a/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
+++ b/specs/binding-mcp.spec/src/test/java/io/aklivity/zilla/specs/binding/mcp/streams/network/NetworkIT.java
@@ -632,6 +632,24 @@ public class NetworkIT
 
     @Test
     @Specification({
+        "${net}/lifecycle.shutdown.session.unknown/client",
+        "${net}/lifecycle.shutdown.session.unknown/server"})
+    public void shouldRejectLifecycleShutdownSessionUnknown() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${net}/lifecycle.shutdown.session.missing/client",
+        "${net}/lifecycle.shutdown.session.missing/server"})
+    public void shouldRejectLifecycleShutdownSessionMissing() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${net}/lifecycle.redirect.session/client",
         "${net}/lifecycle.redirect.session/server"})
     public void shouldRedirectLifecycleForRemoteSession() throws Exception


### PR DESCRIPTION
## Description

Found while root-causing the persistent `testing (mcp.proxy)` CI failures on #2432/#2430/#2433. #2432 fixed a separate NPE crash (DELETE with an unknown session); this is a second, distinct bug in `binding-http`/`binding-mcp` that also produces those failures.

**Root cause**: `McpClientFactory.HttpStream.doNetEnd` (the mcp binding's outbound HTTP client role, used for any real MCP-over-HTTP client connection — cache hydration, `tools/list`, `tools/call`, etc.) sent its request End frame through a convenience `doEnd` overload that hardcodes `sequence=0`/`acknowledge=0`/`maximum=0`, discarding the real `initialSeq`/`initialAck`/`initialMax` that `encodeNet` had already advanced while streaming the request body. Any client-role request with a non-empty body therefore closed with a stale sequence, violating `HttpClientFactory`'s own request-sequence invariant (`assert sequence >= requestSeq` in `HttpExchange.onRequestEnd`) and resetting that connection's flow-control accounting backwards for whatever request follows.

Under `-ea` this crashes the engine worker outright (`AgentTerminationException` → `AssertionError`), which is how it was caught: with zero client traffic, a fresh `mcp.proxy` stack crash-loops within ~10s of the first cache-hydration request to any south backend with a request body. Without `-ea` (production, and CI) the assertion is silently skipped but the corrupted sequence/budget state remains, which is a plausible source of the intermittent hangs seen in CI beyond the crash itself.

Also hardened `HttpClientFactory.HttpExchange.onRequestEnd`: the outbound request-end encode is now gated on the exchange's initial-closed state, so a duplicate End (from this bug or any other misbehaving client) can no longer re-trigger the encoder a second time.

## Fix

- `McpClientFactory.HttpStream.doNetEnd`: pass `initialSeq`/`initialAck`/`initialMax` to `doEnd` instead of the zero-filling overload.
- `HttpClientFactory.HttpExchange.onRequestEnd`: only invoke `doEncodeRequestEnd` when the request side wasn't already closed.

## Verification

- `./mvnw clean install -pl runtime/binding-mcp,runtime/binding-http -am` — all existing unit/IT/spec tests green, checkstyle/license clean.
- Reproduced the crash locally: built the `examples/mcp.proxy` Docker image with `-ea` enabled, brought the stack up cold (no client traffic at all) — reliably crash-looped via the `assert sequence >= requestSeq` failure within ~10s.
- Applied the fix, rebuilt, repeated the cold start: 0 restarts, 0 assertion errors over several minutes of observation.
- Ran the real `tools-list-client` MCP client end-to-end against the fixed build — `tools/list` resolves correctly.

Fixes # (no tracked issue — found during investigation of #2432's CI failures)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_