### PR TITLE
Expose schema root properties

### DIFF
--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroType.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/AvroType.java
@@ -17,6 +17,8 @@ package io.aklivity.zilla.runtime.common.avro;
 import java.util.List;
 import java.util.function.Predicate;
 
+import jakarta.json.JsonValue;
+
 /**
  * An immutable, read-only node in a compiled Avro type graph. The {@link #kind()} selects which
  * accessors carry meaning; the others return an empty list, {@code null}, or {@code 0}. The graph is
@@ -92,6 +94,14 @@ public interface AvroType
      * The byte count of a {@link AvroKind#FIXED}; {@code 0} otherwise.
      */
     int size();
+
+    /**
+     * The value of an arbitrary member declared on this type's schema object. A field's own members are
+     * not visible here, and a member declared here is not inherited by any field. {@code null} when this
+     * type declares no such key, and when the type is expressed as a union or a bare type name.
+     */
+    JsonValue attribute(
+        String name);
 
     /**
      * The paths of every {@link AvroField} reachable from this type — through record fields,

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroNode.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroNode.java
@@ -50,6 +50,7 @@ final class AvroNode implements AvroType
     final String[][] fieldAliases;
     final JsonValue[] fieldDefaults;
     final JsonObject[] fieldAttributes;
+    JsonObject attributes;
 
     private AvroNode(
         AvroKind kind,
@@ -223,6 +224,13 @@ final class AvroNode implements AvroType
     public int size()
     {
         return size;
+    }
+
+    @Override
+    public JsonValue attribute(
+        String name)
+    {
+        return attributes != null ? attributes.get(name) : null;
     }
 
     static AvroNode ofPrimitive(

--- a/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSchemaCompiler.java
+++ b/runtime/common-avro/src/main/java/io/aklivity/zilla/runtime/common/avro/internal/AvroSchemaCompiler.java
@@ -131,6 +131,7 @@ final class AvroSchemaCompiler
             node = primitive(type, logicalType, precision, scale);
             break;
         }
+        node.attributes = object;
         return node;
     }
 

--- a/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroSchemaTest.java
+++ b/runtime/common-avro/src/test/java/io/aklivity/zilla/runtime/common/avro/AvroSchemaTest.java
@@ -21,10 +21,14 @@ import static io.aklivity.zilla.runtime.common.avro.AvroPipeline.Status.COMPLETE
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 
 import org.junit.jupiter.api.Test;
 
@@ -242,6 +246,19 @@ public class AvroSchemaTest
             new byte[] { 0x02, 0x04, 0x68, 0x69 }, sink));
         assertEquals(2, depth[0]);
         assertEquals(1L, position[0]);
+    }
+
+    @Test
+    public void shouldExposeTypeAttributes()
+    {
+        AvroType type = Avro.schema("""
+            {"type":"record","name":"R","x-owner":"payments","x-labels":["A"],
+            "fields":[{"name":"id","type":"int"}]}""").type();
+
+        assertEquals("payments", ((JsonString) type.attribute("x-owner")).getString());
+        assertEquals(JsonValue.ValueType.ARRAY, type.attribute("x-labels").getValueType());
+        assertEquals("A", type.attribute("x-labels").asJsonArray().getString(0));
+        assertNull(type.attribute("x-missing"));
     }
 
     @Test

--- a/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaAttributeTest.java
+++ b/runtime/common-json/src/test/java/io/aklivity/zilla/runtime/common/json/JsonSchemaAttributeTest.java
@@ -17,6 +17,7 @@ package io.aklivity.zilla.runtime.common.json;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,19 @@ class JsonSchemaAttributeTest
 
         assertNull(schema.attribute("x-flag"));
         assertNull(schema.property("email"));
+    }
+
+    @Test
+    void shouldExposeRootAttribute()
+    {
+        JsonSchema schema = JsonSchema.of("""
+            {"type":"object","x-owner":"payments","x-labels":["A"],
+             "properties":{"email":{"type":"string"}}}""");
+
+        assertEquals("payments", ((JsonString) schema.attribute("x-owner")).getString());
+        assertEquals(JsonValue.ValueType.ARRAY, schema.attribute("x-labels").getValueType());
+        assertEquals("A", schema.attribute("x-labels").asJsonArray().getString(0));
+        assertNull(schema.attribute("x-missing"));
     }
 
     @Test

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufMessage.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufMessage.java
@@ -39,15 +39,18 @@ public final class ProtobufMessage
     private final List<ProtobufField> requiredFields;
     private final Map<Integer, ProtobufField> fieldByNumber;
     private final Map<String, ProtobufField> fieldByJsonName;
+    private final Map<String, ProtobufConstant> options;
 
     private ProtobufMessage(
         String name,
         boolean mapEntry,
-        List<ProtobufField> fields)
+        List<ProtobufField> fields,
+        Map<String, ProtobufConstant> options)
     {
         this.name = name;
         this.mapEntry = mapEntry;
         this.fields = Collections.unmodifiableList(fields);
+        this.options = options;
 
         List<ProtobufField> sorted = new ArrayList<>(fields);
         sorted.sort(Comparator.comparingInt(ProtobufField::number));
@@ -116,6 +119,22 @@ public final class ProtobufMessage
         String jsonNameOrName)
     {
         return fieldByJsonName.get(jsonNameOrName);
+    }
+
+    /**
+     * The value of a message option declared in this message's {@code option ...;} statements, read
+     * from this message only. A field or nested message option is not visible here, and an option
+     * declared here is not inherited by either. {@code null} when this message declares no such option.
+     */
+    public ProtobufConstant option(
+        String name)
+    {
+        return options != null ? options.get(name) : null;
+    }
+
+    Map<String, ProtobufConstant> rawOptions()
+    {
+        return options;
     }
 
     /**
@@ -209,6 +228,7 @@ public final class ProtobufMessage
         private final String name;
         private final List<ProtobufField> fields;
         private boolean mapEntry;
+        private Map<String, ProtobufConstant> options;
 
         private Builder(
             String name)
@@ -231,9 +251,16 @@ public final class ProtobufMessage
             return this;
         }
 
+        public Builder options(
+            Map<String, ProtobufConstant> options)
+        {
+            this.options = options;
+            return this;
+        }
+
         public ProtobufMessage build()
         {
-            return new ProtobufMessage(name, mapEntry, fields);
+            return new ProtobufMessage(name, mapEntry, fields, options);
         }
     }
 }

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlay.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlay.java
@@ -178,7 +178,8 @@ public final class ProtobufOverlay
         ProtobufMessage message,
         Map<String, JsonObject> overlaysByField)
     {
-        ProtobufMessage.Builder builder = ProtobufMessage.builder(message.name()).mapEntry(message.mapEntry());
+        ProtobufMessage.Builder builder = ProtobufMessage.builder(message.name()).mapEntry(message.mapEntry())
+            .options(message.rawOptions());
         for (ProtobufField field : message.fields())
         {
             builder.field(copyField(field, overlaysByField.get(field.name())));

--- a/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
+++ b/runtime/common-protobuf/src/main/java/io/aklivity/zilla/runtime/common/protobuf/internal/ProtobufSourceCompiler.java
@@ -136,6 +136,10 @@ public final class ProtobufSourceCompiler
         for (DraftMessage message : draft.messages)
         {
             ProtobufMessage.Builder builder = ProtobufMessage.builder(message.fullName).mapEntry(message.mapEntry);
+            if (message.options != null)
+            {
+                builder.options(message.options);
+            }
             for (DraftField field : message.fields)
             {
                 builder.field(linkField(field, draft.proto3, names));
@@ -317,6 +321,7 @@ public final class ProtobufSourceCompiler
         private final String fullName;
         private final boolean mapEntry;
         private final List<DraftField> fields;
+        private Map<String, ProtobufConstant> options;
 
         private DraftMessage(
             String fullName,
@@ -436,6 +441,18 @@ public final class ProtobufSourceCompiler
             scope.addLast(name);
         }
 
+        private void addMessageOption(
+            String name,
+            ProtobufConstant value)
+        {
+            DraftMessage message = messages.peek();
+            if (message.options == null)
+            {
+                message.options = new LinkedHashMap<>();
+            }
+            message.options.put(name, value);
+        }
+
         private void exitMessage()
         {
             messages.pop();
@@ -543,6 +560,16 @@ public final class ProtobufSourceCompiler
             Protobuf3Parser.MessageDefContext ctx)
         {
             helper.enterMessage(ctx.messageName().getText());
+        }
+
+        @Override
+        public void enterOptionStatement(
+            Protobuf3Parser.OptionStatementContext ctx)
+        {
+            if (ctx.getParent() instanceof Protobuf3Parser.MessageElementContext)
+            {
+                helper.addMessageOption(ctx.optionName().getText(), toConstant(ctx.constant()));
+            }
         }
 
         @Override
@@ -783,6 +810,16 @@ public final class ProtobufSourceCompiler
             Protobuf2Parser.MessageDefContext ctx)
         {
             helper.enterMessage(ctx.messageName().getText());
+        }
+
+        @Override
+        public void enterOptionStatement(
+            Protobuf2Parser.OptionStatementContext ctx)
+        {
+            if (ctx.getParent() instanceof Protobuf2Parser.MessageElementContext)
+            {
+                helper.addMessageOption(ctx.optionName().getText(), toConstant(ctx.constant()));
+            }
         }
 
         @Override

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufOverlayTest.java
@@ -176,6 +176,24 @@ class ProtobufOverlayTest
     }
 
     @Test
+    void shouldRetainMessageOptionsAcrossOverlay()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "package test;\n" +
+            "message Other {\n" +
+            "  option (acme.owner) = \"payments\";\n" +
+            "  string email = 1;\n" +
+            "}\n");
+        ProtobufOverlay overlay = ProtobufOverlay.of(read(
+            "[{\"field\":\"test.Other.email\",\"options\":{\"acme\":{\"tags\":[\"EMAIL\"]}}}]"));
+
+        ProtobufSchema result = overlay.apply(schema);
+
+        assertEquals(new ProtobufConstant.TextValue("payments"), result.message("test.Other").option("(acme.owner)"));
+    }
+
+    @Test
     void shouldExposeInlineOptionsWhenNoOverlayApplied()
     {
         ProtobufSchema schema = Protobuf.schema(PROTO);

--- a/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
+++ b/runtime/common-protobuf/src/test/java/io/aklivity/zilla/runtime/common/protobuf/ProtobufSourceCompilerTest.java
@@ -222,6 +222,42 @@ public class ProtobufSourceCompilerTest
     }
 
     @Test
+    public void shouldExposeMessageOptions()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto3\";\n" +
+            "package test;\n" +
+            "option java_package = \"io.aklivity.test\";\n" +
+            "message M {\n" +
+            "  option (acme.owner) = \"payments\";\n" +
+            "  option (acme.meta) = { kind: \"A\" level: 2 };\n" +
+            "  string email = 1;\n" +
+            "}\n");
+
+        ProtobufMessage message = schema.message("test.M");
+        assertEquals(new ProtobufConstant.TextValue("payments"), message.option("(acme.owner)"));
+        assertNull(message.option("java_package"));
+        assertNull(message.option("(acme.missing)"));
+
+        ProtobufConstant.MessageValue meta = (ProtobufConstant.MessageValue) message.option("(acme.meta)");
+        assertEquals(new ProtobufConstant.TextValue("A"), meta.fields().get("kind"));
+        assertEquals(new ProtobufConstant.IntegerValue(2), meta.fields().get("level"));
+    }
+
+    @Test
+    public void shouldExposeProto2MessageOption()
+    {
+        ProtobufSchema schema = Protobuf.schema(
+            "syntax = \"proto2\";\n" +
+            "message M {\n" +
+            "  option (acme.owner) = \"payments\";\n" +
+            "  optional string email = 1;\n" +
+            "}\n");
+
+        assertEquals(new ProtobufConstant.TextValue("payments"), schema.message("M").option("(acme.owner)"));
+    }
+
+    @Test
     public void shouldStillRecognizeWellKnownOptionsAlongsideCustomOnes()
     {
         ProtobufSchema schema = Protobuf.schema(


### PR DESCRIPTION
## Description

Schema root metadata should remain available after compilation through APIs that fit each schema format.

This change adds `AvroType.attribute(String)` to return members from Avro type declarations as `JsonValue`. It adds `ProtobufMessage.option(String)` to return message-level options as `ProtobufConstant` for both proto2 and proto3 schemas. Message options are also preserved when overlays rebuild a protobuf message.

The tests cover Avro type attributes, the existing JSON root attribute behavior, protobuf scalar and message-valued options, proto2 and proto3 parsing, and overlay retention.

## Testing

`mvn -pl runtime/common-json,runtime/common-avro,runtime/common-protobuf clean install`

Fixes #2415