### PR TITLE
fix(binding-mqtt): preserve a deferred will payload across abort, decode error, and end

### DIFF
--- a/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
+++ b/runtime/binding-mqtt-kafka/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionFactory.java
@@ -1172,6 +1172,10 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             }
             else
             {
+                if (isSetWillFlag(sessionFlags))
+                {
+                    session.doKafkaBeginIfNecessary(traceId, authorization, affinity);
+                }
                 openMetaStreams(traceId, authorization);
             }
         }
@@ -1423,6 +1427,7 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
                 }).build();
 
             doMqttBegin(traceId, authorization, 0, mqttBeginEx);
+            session.doKafkaEnd(traceId, authorization);
             session = new KafkaSessionStateProxy(routedId, resolvedId, this);
             session.doKafkaBeginIfNecessary(traceId, authorization, 0);
         }
@@ -4839,7 +4844,7 @@ public class MqttKafkaSessionFactory implements MqttKafkaStreamFactory
             kafkaBeginExRW.wrap(writeBuffer, BeginFW.FIELD_OFFSET_EXTENSION, writeBuffer.capacity())
                 .typeId(kafkaTypeId)
                 .merged(m ->
-                    m.capabilities(c -> c.set(KafkaCapabilities.FETCH_ONLY))
+                    m.capabilities(c -> c.set(KafkaCapabilities.PRODUCE_AND_FETCH))
                         .topic(topic)
                         .partitionsItem(p ->
                             p.partitionId(KafkaOffsetType.HISTORICAL.value())

--- a/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
+++ b/runtime/binding-mqtt-kafka/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/kafka/internal/stream/MqttKafkaSessionProxyIT.java
@@ -277,6 +277,17 @@ public class MqttKafkaSessionProxyIT
 
     @Test
     @Configuration("proxy.yaml")
+    @Configure(name = WILL_AVAILABLE_NAME, value = "false")
+    @Specification({
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/client",
+        "${kafka}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSendWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.yaml")
     @Configure(name = PUBLISH_MAX_QOS_NAME, value = "1")
     @Specification({
         "${mqtt}/session.will.message.abort.deliver.will.retain/client",

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -1226,12 +1226,8 @@ public final class MqttServerFactory implements MqttStreamFactory
         final int offset,
         final int limit)
     {
-        int progress = offset;
+        int progress = server.onDecodeConnectWillMessage(traceId, authorization, buffer, offset, limit);
 
-        if (server.willPayloadDeferred == 0)
-        {
-            progress = server.onDecodeConnectWillMessage(traceId, authorization, buffer, progress, limit);
-        }
         server.decodableRemainingBytes -= progress - offset;
 
         return progress;
@@ -2828,11 +2824,23 @@ public final class MqttServerFactory implements MqttStreamFactory
             final long traceId = abort.traceId();
             final long authorization = abort.authorization();
 
-            state = MqttState.closeInitial(state);
+            if (decodeSlot == NO_SLOT)
+            {
+                state = MqttState.closeInitial(state);
 
-            cleanupDecodeSlot();
+                cleanupNetwork(traceId, authorization);
+            }
+            else
+            {
+                // a decode is still deferred (e.g. awaiting session window for a will payload);
+                // mark closing and let it complete via the session window retry in decodeNetwork,
+                // rather than discarding the deferred payload along with the dead network -
+                // doNetworkReset is skipped here since it would cleanupDecodeSlot() as a side effect
+                state = MqttState.closingInitial(state);
 
-            cleanupNetwork(traceId, authorization);
+                doReleaseOwnership(traceId);
+                doNetworkAbort(traceId, authorization);
+            }
         }
 
         private void onNetworkWindow(
@@ -3503,7 +3511,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             decode:
             {
                 final MqttConnectPayload payload = mqttConnectPayloadRO.reset();
-                int connectPayloadLimit = payload.decode(buffer, progress, limit, connectFlags, version);
+                final int connectPayloadLimit = payload.decode(buffer, progress, limit, connectFlags, version);
 
                 willPayloadBytes = payload.payloadSize;
                 final boolean willFlagSet = isSetWillFlag(connectFlags);
@@ -3538,8 +3546,71 @@ public final class MqttServerFactory implements MqttStreamFactory
                     break decode;
                 }
 
-                decoder = decodeConnectWillMessagePayload;
-                progress = connectPayloadLimit;
+                // re-derived from buffer on every attempt, including retries - progress is not
+                // committed past these bytes until they are actually handed to session.doSessionData,
+                // so decodeNetwork's own decodeSlot buffering keeps them available for the next retry;
+                // no snapshot needs to survive between calls, however large the will payload is
+                final int willFlags = decodeWillFlags(flags);
+                final MqttWillMessageFW.Builder willMessageBuilder =
+                    mqttWillMessageRW.wrap(willMessageBuffer, 0, willMessageBuffer.capacity())
+                        .topic(payload.willTopic)
+                        .delay(payload.willDelay)
+                        .qos(willQos)
+                        .flags(willFlags)
+                        .expiryInterval(payload.expiryInterval)
+                        .contentType(payload.contentType)
+                        .format(f -> f.set(payload.payloadFormat))
+                        .responseTopic(payload.responseTopic)
+                        .correlation(c -> c.bytes(payload.correlationData))
+                        .payloadSize(payload.payloadSize);
+
+                if (version == 5)
+                {
+                    final Array32FW<MqttUserPropertyFW> userProperties = willUserPropertiesRW.build();
+                    userProperties.forEach(
+                        c -> willMessageBuilder.propertiesItem(p -> p.key(c.key()).value(c.value())));
+                }
+
+                willMessageBuilder.build();
+                final int headerSize = willMessageBuilder.sizeof();
+
+                if (!session.hasSessionWindow(headerSize))
+                {
+                    // not enough session window even for the header yet - leave progress where it
+                    // started so these bytes stay in decodeSlot for the next session window retry
+                    break decode;
+                }
+
+                // bounded by whatever is currently available in buffer (network-limited),
+                // the session window (backpressure-limited), and the declared will payload length
+                final int payloadAvailable = Math.min(limit - connectPayloadLimit, willPayloadBytes);
+                final int payloadSize = Math.min(payloadAvailable, session.initialBudget() - headerSize);
+                final OctetsFW willPayload = payloadRO.wrap(buffer, connectPayloadLimit, connectPayloadLimit + payloadSize);
+
+                willMessageBuffer.putBytes(headerSize, willPayload.buffer(), willPayload.offset(), willPayload.limit());
+
+                final int deferred = willPayloadBytes - payloadSize;
+                final int dataFlags = deferred > 0 ? FLAG_INIT : FLAG_INIT | FLAG_FIN;
+
+                final MqttDataExFW.Builder sessionDataExBuilder =
+                    mqttSessionDataExRW.wrap(sessionExtBuffer, 0, sessionExtBuffer.capacity())
+                        .typeId(mqttTypeId)
+                        .session(s -> s.deferred(deferred).kind(k -> k.set(MqttSessionDataKind.WILL)));
+
+                final int publishedWillSize = session.doSessionData(traceId, dataFlags,
+                    willMessageBuffer, 0, headerSize + willPayload.sizeof(), headerSize, sessionDataExBuilder.build());
+
+                if (publishedWillSize < headerSize)
+                {
+                    // session stream pushed back before even the header went through - retry later
+                    break decode;
+                }
+
+                willPayloadDeferred = deferred;
+                willPayloadBytes -= payloadSize;
+                progress = connectPayloadLimit + payloadSize;
+
+                decoder = deferred > 0 ? decodeConnectWillMessagePayload : decodePacketTypeByVersion.get(version);
             }
 
             if (reasonCode != SUCCESS)
@@ -3561,7 +3632,6 @@ public final class MqttServerFactory implements MqttStreamFactory
                 progress = limit;
             }
 
-
             return progress;
         }
 
@@ -3572,87 +3642,16 @@ public final class MqttServerFactory implements MqttStreamFactory
             int offset,
             int limit)
         {
-            int progress = offset;
+            final OctetsFW payload = payloadRO.wrap(buffer, offset, limit);
+            assert willPayloadDeferred >= 0;
+            final int flags = willPayloadDeferred - payload.sizeof() > 0 ? FLAG_CONT : FLAG_FIN;
 
-            final int willFlags = decodeWillFlags(connectFlags);
-            final int willQos = decodeWillQos(connectFlags);
-            final boolean willFlagSet = isSetWillFlag(connectFlags);
+            final int publishedWillSize = session.doSessionData(traceId, flags,
+                payload.buffer(), offset, limit, 0, EMPTY_OCTETS);
+            willPayloadDeferred -= publishedWillSize;
+            willPayloadBytes -= publishedWillSize;
 
-            decode:
-            if (willFlagSet && MqttState.initialOpened(session.state))
-            {
-                int publishedWillSize = 0;
-                if (willPayloadDeferred == 0)
-                {
-                    final MqttWillMessageFW.Builder willMessageBuilder =
-                        mqttWillMessageRW.wrap(willMessageBuffer, 0, willMessageBuffer.capacity())
-                            .topic(mqttConnectPayloadRO.willTopic)
-                            .delay(mqttConnectPayloadRO.willDelay)
-                            .qos(willQos)
-                            .flags(willFlags)
-                            .expiryInterval(mqttConnectPayloadRO.expiryInterval)
-                            .contentType(mqttConnectPayloadRO.contentType)
-                            .format(f -> f.set(mqttConnectPayloadRO.payloadFormat))
-                            .responseTopic(mqttConnectPayloadRO.responseTopic)
-                            .correlation(c -> c.bytes(mqttConnectPayloadRO.correlationData))
-                            .payloadSize(mqttConnectPayloadRO.payloadSize);
-
-                    if (version == 5)
-                    {
-                        final Array32FW<MqttUserPropertyFW> userProperties = willUserPropertiesRW.build();
-                        userProperties.forEach(
-                            c -> willMessageBuilder.propertiesItem(p -> p.key(c.key()).value(c.value())));
-                    }
-
-                    final MqttWillMessageFW will = willMessageBuilder.build();
-                    final int headerSize = willMessageBuilder.sizeof();
-
-                    if (!session.hasSessionWindow(headerSize))
-                    {
-                        break decode;
-                    }
-
-                    int payloadSize = Math.min(limit - offset, session.initialBudget() - headerSize);
-
-                    final OctetsFW payload = payloadRO.wrap(buffer, offset, offset + payloadSize);
-
-                    willMessageBuffer.putBytes(will.limit(), payload.buffer(), payload.offset(), payload.limit());
-
-                    int flags = willPayloadBytes + headerSize > session.initialBudget() ? FLAG_INIT : FLAG_INIT | FLAG_FIN;
-                    int deferred = Math.max(willPayloadBytes + headerSize - session.initialBudget(), 0);
-                    willPayloadDeferred = deferred;
-
-                    final MqttDataExFW.Builder sessionDataExBuilder =
-                        mqttSessionDataExRW.wrap(sessionExtBuffer, 0, sessionExtBuffer.capacity())
-                            .typeId(mqttTypeId)
-                            .session(s -> s.deferred(deferred).kind(k -> k.set(MqttSessionDataKind.WILL)));
-
-                    publishedWillSize = session.doSessionData(traceId, flags,
-                        willMessageBuffer, 0, headerSize + payload.sizeof(), headerSize, sessionDataExBuilder.build());
-
-                    if (publishedWillSize < headerSize)
-                    {
-                        willPayloadDeferred = 0;
-                    }
-
-                    willPayloadBytes -= payloadSize;
-                    progress += payloadSize;
-                }
-                else
-                {
-                    final OctetsFW payload = payloadRO.wrap(buffer, offset, limit);
-                    assert willPayloadDeferred >= 0;
-                    int flags = willPayloadDeferred - payload.sizeof() > 0 ? FLAG_CONT : FLAG_FIN;
-
-                    publishedWillSize = session.doSessionData(traceId, flags,
-                        payload.buffer(), offset, limit, 0, EMPTY_OCTETS);
-                    willPayloadDeferred -= publishedWillSize;
-                    willPayloadBytes -= publishedWillSize;
-                    progress += publishedWillSize;
-                }
-            }
-
-            return progress;
+            return offset + publishedWillSize;
         }
 
         private MqttPublishStream resolvePublishStream(
@@ -4461,15 +4460,25 @@ public final class MqttServerFactory implements MqttStreamFactory
             int reasonCode,
             int version)
         {
-            switch (reasonCode)
+            if (!willPayloadPending())
             {
-            case SESSION_TAKEN_OVER:
-                closeStreams(traceId, authorization);
-                break;
-            default:
-                cleanupStreamsUsingAbort(traceId);
-                break;
+                switch (reasonCode)
+                {
+                case SESSION_TAKEN_OVER:
+                    closeStreams(traceId, authorization);
+                    break;
+                default:
+                    cleanupStreamsUsingAbort(traceId);
+                    break;
+                }
             }
+            else
+            {
+                // the will payload forward is still deferred, awaiting session window; mark
+                // closing and let it complete via the session window retry in decodeNetwork
+                state = MqttState.closingInitial(state);
+            }
+
             if (version != MQTT_PROTOCOL_VERSION_4 || (reasonCode & 0xff)  <= MAX_CONNACK_REASONCODE_V4)
             {
                 if (connected || reasonCode == SESSION_TAKEN_OVER)
@@ -5465,6 +5474,15 @@ public final class MqttServerFactory implements MqttStreamFactory
                 decodeSlotOffset = 0;
                 decodeSlotReserved = 0;
             }
+        }
+
+        private boolean willPayloadPending()
+        {
+            // decodeSlot alone is not a reliable signal here - it is also populated by ordinary
+            // network fragmentation of any packet, with no session window retry to complete it.
+            // only a will-message decode blocked on session window can resume via that retry.
+            return decodeSlot != NO_SLOT &&
+                (decoder == decodeConnectWillMessage || decoder == decodeConnectWillMessagePayload);
         }
 
         private void cleanupEncodeSlot()

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -2795,13 +2795,30 @@ public final class MqttServerFactory implements MqttStreamFactory
 
             if (decodeSlot == NO_SLOT)
             {
+                final boolean disconnected = MqttState.initialClosing(state);
+
                 state = MqttState.closeInitial(state);
 
-                closeStreams(traceId, authorization);
+                if (disconnected || !isSetWillFlag(connectFlags))
+                {
+                    closeStreams(traceId, authorization);
+                }
+                else
+                {
+                    // a will was set but no DISCONNECT was ever decoded, so this is not a clean
+                    // disconnect per MQTT-3.14.4-3 - clean up as if the network had aborted
+                    cleanupStreamsUsingAbort(traceId);
+                    doReleaseOwnership(traceId);
+                    decoder = decodeIgnoreAll;
+                }
 
                 doNetworkEnd(traceId, authorization);
-
-                decoder = decodeIgnoreAll;
+            }
+            else
+            {
+                // a decode is still deferred (e.g. awaiting session window for a will payload);
+                // mark closing and let it complete via the session window retry in decodeNetwork
+                state = MqttState.closingInitial(state);
             }
         }
 

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -3561,6 +3561,7 @@ public final class MqttServerFactory implements MqttStreamFactory
             final int willQos = decodeWillQos(connectFlags);
             final boolean willFlagSet = isSetWillFlag(connectFlags);
 
+            decode:
             if (willFlagSet && MqttState.initialOpened(session.state))
             {
                 int publishedWillSize = 0;
@@ -3588,6 +3589,12 @@ public final class MqttServerFactory implements MqttStreamFactory
 
                     final MqttWillMessageFW will = willMessageBuilder.build();
                     final int headerSize = willMessageBuilder.sizeof();
+
+                    if (!session.hasSessionWindow(headerSize))
+                    {
+                        break decode;
+                    }
+
                     int payloadSize = Math.min(limit - offset, session.initialBudget() - headerSize);
 
                     final OctetsFW payload = payloadRO.wrap(buffer, offset, offset + payloadSize);

--- a/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
+++ b/runtime/binding-mqtt/src/main/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/MqttServerFactory.java
@@ -3561,8 +3561,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                         .contentType(payload.contentType)
                         .format(f -> f.set(payload.payloadFormat))
                         .responseTopic(payload.responseTopic)
-                        .correlation(c -> c.bytes(payload.correlationData))
-                        .payloadSize(payload.payloadSize);
+                        .correlation(c -> c.bytes(payload.correlationData));
 
                 if (version == 5)
                 {
@@ -3571,6 +3570,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                         c -> willMessageBuilder.propertiesItem(p -> p.key(c.key()).value(c.value())));
                 }
 
+                willMessageBuilder.payloadSize(payload.payloadSize);
                 willMessageBuilder.build();
                 final int headerSize = willMessageBuilder.sizeof();
 
@@ -7535,7 +7535,7 @@ public final class MqttServerFactory implements MqttStreamFactory
                         break;
                     case KIND_USER_PROPERTY:
                         final MqttUserPropertyFW userProperty = mqttProperty.userProperty();
-                        userPropertiesRW.item(c -> c.key(userProperty.key()).value(userProperty.value()));
+                        willUserPropertiesRW.item(c -> c.key(userProperty.key()).value(userProperty.value()));
                         break;
                     default:
                         reasonCode = MALFORMED_PACKET;

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -201,6 +201,17 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.end.without.disconnect/client",
+        "${app}/session.will.message.end.without.disconnect/server"})
+    @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")
+    public void shouldAbortSessionOnEndWithoutDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.disconnect.with.will.message/client",
         "${app}/session.will.message.abort/server"})
     public void shouldCloseSessionDisconnectWithWill() throws Exception

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -190,9 +190,10 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
-        "${net}/session.will.message.header.exceeds.window/client",
-        "${app}/session.will.message.header.exceeds.window/server"})
-    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+        "${net}/session.will.message.32k/client",
+        "${app}/session.will.message.32k/server"})
+    @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")
+    public void shouldSendWillMessage32k() throws Exception
     {
         k3po.finish();
     }

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -190,6 +190,16 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.header.exceeds.window/client",
+        "${app}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.disconnect.with.will.message/client",
         "${app}/session.will.message.abort/server"})
     public void shouldCloseSessionDisconnectWithWill() throws Exception

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -212,6 +212,17 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.abort.while.deferred/client",
+        "${app}/session.will.message.abort.while.deferred/server"})
+    @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "16384")
+    public void shouldAbortSessionOnNetworkAbortWhileDeferred() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.disconnect.with.will.message/client",
         "${app}/session.will.message.abort/server"})
     public void shouldCloseSessionDisconnectWithWill() throws Exception

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -211,6 +211,16 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.with.user.properties/client",
+        "${app}/session.will.message.with.user.properties/server"})
+    public void shouldSendWillMessageWithUserProperties() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.end.without.disconnect/client",
         "${app}/session.will.message.end.without.disconnect/server"})
     @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")

--- a/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
+++ b/runtime/binding-mqtt/src/test/java/io/aklivity/zilla/runtime/binding/mqtt/internal/stream/server/v5/SessionIT.java
@@ -201,6 +201,16 @@ public class SessionIT
     @Test
     @Configuration("server.yaml")
     @Specification({
+        "${net}/session.will.message.zero.window.on.connect/client",
+        "${app}/session.will.message.zero.window.on.connect/server"})
+    public void shouldSendWillMessageWhenSessionWindowStartsAtZero() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("server.yaml")
+    @Specification({
         "${net}/session.will.message.end.without.disconnect/client",
         "${app}/session.will.message.end.without.disconnect/server"})
     @Configure(name = ENGINE_BUFFER_SLOT_CAPACITY_NAME, value = "8192")

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBehaviorSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/ZillaBehaviorSystem.java
@@ -35,6 +35,7 @@ import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.Zill
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.CONFIG_RESET_EXT;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_ACK;
 import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_FLAGS;
+import static io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.types.ZillaTypeSystem.OPTION_WINDOW;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toList;
 
@@ -95,6 +96,7 @@ import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.ReadEndExtHandler;
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.ReadFlagsOptionHandler;
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.ReadNullDataHandler;
+import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.ReadWindowOptionHandler;
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.WriteAbortedExtHandler;
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.WriteEmptyDataHandler;
 import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler.WriteFlagsOptionHandler;
@@ -120,6 +122,7 @@ public class ZillaBehaviorSystem implements BehaviorSystemSpi
         Map<TypeInfo<?>, ReadOptionFactory> readOptionFactories = new LinkedHashMap<>();
         readOptionFactories.put(OPTION_FLAGS, ZillaBehaviorSystem::newReadFlagsHandler);
         readOptionFactories.put(OPTION_ACK, ZillaBehaviorSystem::newReadAckHandler);
+        readOptionFactories.put(OPTION_WINDOW, ZillaBehaviorSystem::newReadWindowHandler);
         this.readOptionFactories = unmodifiableMap(readOptionFactories);
 
         Map<TypeInfo<?>, WriteOptionFactory> writeOptionsFactories = new LinkedHashMap<>();
@@ -287,6 +290,16 @@ public class ZillaBehaviorSystem implements BehaviorSystemSpi
         AstValue<?> ackValue = node.getOptionValue();
         int value = ackValue.accept(new GenerateAckOptionValueVisitor(), null);
         ReadAckOptionHandler handler = new ReadAckOptionHandler(value);
+        handler.setRegionInfo(node.getRegionInfo());
+        return handler;
+    }
+
+    private static ChannelHandler newReadWindowHandler(
+            AstReadOptionNode node)
+    {
+        AstValue<?> windowValue = node.getOptionValue();
+        int value = windowValue.accept(new GenerateAckOptionValueVisitor(), null);
+        ReadWindowOptionHandler handler = new ReadWindowOptionHandler(value);
         handler.setRegionInfo(node.getRegionInfo());
         return handler;
     }

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadWindowOptionHandler.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/behavior/handler/ReadWindowOptionHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021-2026 Aklivity Inc.
+ *
+ * Aklivity licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.handler;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+
+import io.aklivity.k3po.runtime.driver.internal.behavior.handler.command.AbstractCommandHandler;
+import io.aklivity.zilla.runtime.engine.test.internal.k3po.ext.behavior.ZillaChannel;
+
+public class ReadWindowOptionHandler extends AbstractCommandHandler
+{
+    private final int window;
+
+    public ReadWindowOptionHandler(
+        int window)
+    {
+        this.window = window;
+    }
+
+    @Override
+    protected void invokeCommand(
+        ChannelHandlerContext ctx) throws Exception
+    {
+        ZillaChannel channel = (ZillaChannel) ctx.getChannel();
+        channel.getConfig().setWindow(window);
+        ChannelFuture handlerFuture = getHandlerFuture();
+        Channels.setInterestOps(ctx, handlerFuture, Channel.OP_READ);
+    }
+}

--- a/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
+++ b/runtime/engine/src/test/java/io/aklivity/zilla/runtime/engine/test/internal/k3po/ext/types/ZillaTypeSystem.java
@@ -125,6 +125,7 @@ public final class ZillaTypeSystem implements TypeSystemSpi
         Set<TypeInfo<?>> readOptions = new LinkedHashSet<>();
         readOptions.add(OPTION_FLAGS);
         readOptions.add(OPTION_ACK);
+        readOptions.add(OPTION_WINDOW);
         this.readOptions = unmodifiableSet(readOptions);
 
         Set<TypeInfo<?>> writeOptions = new LinkedHashSet<>();

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/client.rpt
@@ -122,7 +122,7 @@ connect "zilla://streams/kafka0"
 write zilla:begin.ext ${kafka:beginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.10k.abort.deliver.will/server.rpt
@@ -133,7 +133,7 @@ accepted
 read zilla:begin.ext ${kafka:matchBeginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/client.rpt
@@ -121,7 +121,7 @@ connect "zilla://streams/kafka0"
 write zilla:begin.ext ${kafka:beginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will.retain/server.rpt
@@ -133,7 +133,7 @@ accepted
 read zilla:begin.ext ${kafka:matchBeginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/client.rpt
@@ -122,7 +122,7 @@ connect "zilla://streams/kafka0"
 write zilla:begin.ext ${kafka:beginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.abort.deliver.will/server.rpt
@@ -133,7 +133,7 @@ accepted
 read zilla:begin.ext ${kafka:matchBeginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/client.rpt
@@ -86,7 +86,7 @@ connect "zilla://streams/kafka0"
 write zilla:begin.ext ${kafka:beginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.normal.disconnect/server.rpt
@@ -95,7 +95,7 @@ accepted
 read zilla:begin.ext ${kafka:matchBeginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/client.rpt
@@ -1,0 +1,115 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# eager will-signal stream, opened as soon as the CONNECT carries the WILL flag,
+# before the qos2 session state stream has been established
+connect
+        "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .merged()
+                                   .capabilities("PRODUCE_AND_FETCH")
+                                   .topic("mqtt-sessions")
+                                   .filter()
+                                       .key("client-1#will")
+                                       .build()
+                                   .build()
+                               .build()}
+
+connected
+
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#will")
+                               .hashKey("client-1")
+                               .header("type", "will-signal")
+                               .build()
+                           .build()}
+write ${mqtt:sessionSignal()
+            .will()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(0)
+                .deliverAt(1000)
+                .build()
+            .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+write ${mqtt:sessionSignal()
+            .expiry()
+                .instanceId("zilla-1")
+                .clientId("client-1")
+                .delay(1000)
+                .expireAt(2000)
+                .build()
+            .build()}
+write flush
+
+write abort
+read aborted
+
+
+connect
+        "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-messages")
+                                   .build()
+                               .build()}
+
+connected
+
+write abort
+read aborted
+
+
+connect
+        "zilla://streams/kafka0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-retained")
+                                   .build()
+                               .build()}
+
+connected
+
+write abort
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.qos2.abort.before.session.established/server.rpt
@@ -1,0 +1,115 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/kafka0"
+    option zilla:window 8192
+    option zilla:transmission "duplex"
+
+
+# eager will-signal stream, opened as soon as the CONNECT carries the WILL flag,
+# before the qos2 session state stream has been established
+accepted
+
+read zilla:begin.ext ${kafka:matchBeginEx()
+                            .typeId(zilla:id("kafka"))
+                            .merged()
+                                .capabilities("PRODUCE_AND_FETCH")
+                                .topic("mqtt-sessions")
+                                .filter()
+                                    .key("client-1#will")
+                                    .build()
+                                .build()
+                            .build()}
+
+connected
+
+# no will data was ever written (qos2 grants no window before establishment),
+# so the will signal carries no lifetimeId or willId
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#will")
+                               .hashKey("client-1")
+                               .header("type", "will-signal")
+                               .build()
+                           .build()}
+read ${mqtt:sessionSignal()
+           .will()
+               .instanceId("zilla-1")
+               .clientId("client-1")
+               .delay(0)
+               .deliverAt(1000)
+               .build()
+           .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                           .typeId(zilla:id("kafka"))
+                           .merged()
+                             .produce()
+                               .deferred(0)
+                               .partition(-1, -1)
+                               .key("client-1#expiry")
+                               .hashKey("client-1")
+                               .header("type", "expiry-signal")
+                               .build()
+                           .build()}
+read ${mqtt:sessionSignal()
+           .expiry()
+               .instanceId("zilla-1")
+               .clientId("client-1")
+               .delay(1000)
+               .expireAt(2000)
+               .build()
+           .build()}
+
+read aborted
+write abort
+
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-messages")
+                                   .build()
+                               .build()}
+
+connected
+
+read aborted
+write abort
+
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("mqtt-retained")
+                                   .build()
+                               .build()}
+
+connected
+
+# both qos2 partition metadata streams are now open; no session state
+# stream has been established yet
+write notify SESSION_META_STREAMS_OPENED
+
+read aborted
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/client.rpt
@@ -96,7 +96,7 @@ connect "zilla://streams/kafka0"
 write zilla:begin.ext ${kafka:beginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/kafka/session.will.message.will.id.mismatch.skip.delivery/server.rpt
@@ -106,7 +106,7 @@ accepted
 read zilla:begin.ext ${kafka:matchBeginEx()
                             .typeId(zilla:id("kafka"))
                             .merged()
-                                .capabilities("FETCH_ONLY")
+                                .capabilities("PRODUCE_AND_FETCH")
                                 .topic("mqtt-sessions")
                                 .filter()
                                     .key("client-1#will")

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/client.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/client.rpt
@@ -1,0 +1,40 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# session stays half-duplex; the session reply is sent eagerly once the
+# will-signal stream opens, well before the qos2 session state stream
+# establishes, so only the write side is exercised here
+connect "zilla://streams/mqtt0"
+         option zilla:window 8192
+         option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .expiry(1)
+                              .publishQosMax(2)
+                              .capabilities("REDIRECT")
+                              .clientId("client-1")
+                              .build()
+                           .build()}
+
+connected
+
+# abort while the qos2 partition metadata is still being negotiated,
+# no session state stream has been established yet; a qos2 client cannot
+# write will data before the session window opens, so none is sent
+write await SESSION_META_STREAMS_OPENED
+write abort

--- a/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/server.rpt
+++ b/specs/binding-mqtt-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/mqtt/session.will.message.qos2.abort.before.session.established/server.rpt
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/mqtt0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .expiry(1)
+                                .publishQosMax(2)
+                                .capabilities("REDIRECT")
+                                .clientId("client-1")
+                                .build()
+                             .build()}
+
+connected
+
+read aborted

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/KafkaIT.java
@@ -758,6 +758,15 @@ public class KafkaIT
 
     @Test
     @Specification({
+        "${kafka}/session.will.message.qos2.abort.before.session.established/client",
+        "${kafka}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSendWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${kafka}/session.will.message.cancel.delivery/client",
         "${kafka}/session.will.message.cancel.delivery/server"})
     public void shouldCancelWillDelivery() throws Exception

--- a/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
+++ b/specs/binding-mqtt-kafka.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/kafka/streams/MqttIT.java
@@ -632,6 +632,17 @@ public class MqttIT
 
     @Test
     @Specification({
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/client",
+        "${mqtt}/session.will.message.qos2.abort.before.session.established/server"})
+    public void shouldSendWillSignalOnQos2AbortBeforeSessionEstablished() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("SESSION_META_STREAMS_OPENED");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${mqtt}/publish.qos1/client",
         "${mqtt}/publish.qos1/server"})
     public void shouldPublishQoS1Message() throws Exception

--- a/specs/binding-mqtt.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctions.java
+++ b/specs/binding-mqtt.spec/src/main/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctions.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.PrimitiveIterator;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 
@@ -156,6 +157,15 @@ public final class MqttFunctions
         {
             bytes[i] = (byte) ThreadLocalRandom.current().nextInt(0x100);
         }
+        return bytes;
+    }
+
+    @Function
+    public static byte[] seededBytes(
+        int length)
+    {
+        byte[] bytes = new byte[length];
+        new Random(length).nextBytes(bytes);
         return bytes;
     }
 

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.32k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.32k/client.rpt
@@ -15,7 +15,7 @@
 #
 
 connect "zilla://streams/app0"
-         option zilla:window 32
+         option zilla:window 8192
          option zilla:transmission "duplex"
 
 write zilla:begin.ext ${mqtt:beginEx()
@@ -40,6 +40,40 @@ read zilla:begin.ext ${mqtt:matchBeginEx()
 
 connected
 
+write option zilla:flags "init"
+write zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(24620)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+write ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(32768)
+               .build()}
+${mqtt:randomBytes(8148)}
+write flush
+
+# middle fragment carries neither the INIT nor the FIN flag
+write option zilla:flags "none"
+write ${mqtt:randomBytes(8192)}
+write flush
+
+write option zilla:flags "none"
+write ${mqtt:randomBytes(8192)}
+write flush
+
+write option zilla:flags "none"
+write ${mqtt:randomBytes(8192)}
+write flush
+
+write option zilla:flags "fin"
+write ${mqtt:randomBytes(44)}
+write flush
+
+
 read zilla:data.empty
 
-write abort
+write close
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.32k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.32k/server.rpt
@@ -14,12 +14,8 @@
 # under the License.
 #
 
-# window is smaller than the encoded will message header (44 bytes for topic
-# "wills/one"), so the will message must remain deferred instead of being
-# written with a negative payload size
-
 accept "zilla://streams/app0"
-        option zilla:window 32
+        option zilla:window 8192
         option zilla:transmission "duplex"
 
 accepted
@@ -46,7 +42,22 @@ write zilla:begin.ext ${mqtt:beginEx()
 
 connected
 
+
+read zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(24620)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+read ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(32768)
+               .build()}
+read [0..32768]
+
 write zilla:data.empty
 write flush
 
-read aborted
+read closed
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort.while.deferred/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort.while.deferred/client.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write option zilla:flags "init"
+write zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(2092)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+write ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(10240)
+               .build()}
+${mqtt:randomBytes(8148)}
+write flush
+
+write option zilla:flags "fin"
+write ${mqtt:seededBytes(2092)}
+write flush
+
+read zilla:data.empty
+
+# the network already aborted without a DISCONNECT, so once the deferred will
+# payload finishes forwarding the session is aborted, not ended cleanly
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort.while.deferred/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.abort.while.deferred/server.rpt
@@ -1,0 +1,74 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 0
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+# the session stream is established at this point - safe for the network
+# side to abort now, without racing ahead of CONNECT even being received
+write notify SESSION_ESTABLISHED
+
+# zero window granted at accept, so the will payload cannot have been
+# forwarded yet regardless of when this is reached - decodeSlot is
+# guaranteed to still hold everything until we explicitly grant window
+read option zilla:window 8192
+read zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(2092)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+read ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(10240)
+               .build()}
+read [0..8148]
+
+# exact-match the deferred remainder - a lenient byte-count range would be
+# silently satisfied by zero bytes if the abort raced in and discarded it,
+# so this is what actually proves the fix forwards it rather than losing it
+read ${mqtt:seededBytes(2092)}
+
+write zilla:data.empty
+write flush
+
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.end.without.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.end.without.disconnect/client.rpt
@@ -1,0 +1,67 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write option zilla:flags "init"
+write zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(2092)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+write ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(10240)
+               .build()}
+${mqtt:randomBytes(8148)}
+write flush
+
+write option zilla:flags "fin"
+write ${mqtt:randomBytes(2092)}
+write flush
+
+
+read zilla:data.empty
+
+# the network already closed without a DISCONNECT, so once the deferred will
+# payload finishes forwarding the session is aborted, not ended cleanly
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.end.without.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.end.without.disconnect/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+
+read zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .deferred(2092)
+                                .kind("WILL")
+                                .build()
+                             .build()}
+read ${mqtt:will()
+               .topic("wills/one")
+               .payloadSize(10240)
+               .build()}
+read [0..8148]
+
+write notify ROUND1_FORWARDED
+
+read [0..2092]
+
+write zilla:data.empty
+write flush
+
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/client.rpt
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 32
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+read zilla:data.empty
+
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.header.exceeds.window/server.rpt
@@ -1,0 +1,52 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+# window is smaller than the encoded will message header (44 bytes for topic
+# "wills/one"), so the will message must remain deferred instead of being
+# written with a negative payload size
+
+accept "zilla://streams/app0"
+        option zilla:window 32
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write zilla:data.empty
+write flush
+
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.with.user.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.with.user.properties/client.rpt
@@ -1,0 +1,61 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .kind("WILL")
+                                .build()
+                             .build()}
+
+write ${mqtt:will()
+               .topic("wills/one")
+               .userProperty("key1", "value1")
+               .payloadSize(26)
+               .build()}
+write "client one session expired"
+write flush
+
+read zilla:data.empty
+
+write close
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.with.user.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.with.user.properties/server.rpt
@@ -1,0 +1,64 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+
+read zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .kind("WILL")
+                                .build()
+                             .build()}
+
+read ${mqtt:will()
+               .topic("wills/one")
+               .userProperty("key1", "value1")
+               .payloadSize(26)
+               .build()}
+read "client one session expired"
+
+write zilla:data.empty
+write flush
+
+read closed
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.zero.window.on.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.zero.window.on.connect/client.rpt
@@ -1,0 +1,60 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+         option zilla:window 8192
+         option zilla:transmission "duplex"
+
+write zilla:begin.ext ${mqtt:beginEx()
+                           .typeId(zilla:id("mqtt"))
+                           .session()
+                              .flags("WILL", "CLEAN_START")
+                              .clientId("one")
+                              .build()
+                           .build()}
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+write zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .kind("WILL")
+                                .build()
+                             .build()}
+
+write ${mqtt:will()
+               .topic("devices/device-123/status")
+               .payloadSize(20)
+               .build()}
+write "{\"status\":\"offline\"}"
+write flush
+
+read zilla:data.empty
+
+write close
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.zero.window.on.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/application/session.will.message.zero.window.on.connect/server.rpt
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/app0"
+        option zilla:window 0
+        option zilla:transmission "duplex"
+
+accepted
+
+read zilla:begin.ext ${mqtt:matchBeginEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .flags("WILL", "CLEAN_START")
+                                .clientId("one")
+                                .build()
+                             .build()}
+
+write zilla:begin.ext ${mqtt:beginEx()
+                              .typeId(zilla:id("mqtt"))
+                              .session()
+                                .flags("WILL", "CLEAN_START")
+                                .subscribeQosMax(2)
+                                .publishQosMax(2)
+                                .packetSizeMax(33792)
+                                .capabilities("RETAIN", "WILDCARD", "SUBSCRIPTION_IDS", "SHARED_SUBSCRIPTIONS")
+                                .clientId("one")
+                                .build()
+                              .build()}
+
+connected
+
+# zero window granted at accept, matching the naturally occurring state of a
+# session stream that has not yet received any WINDOW at all - reproduces
+# https://github.com/aklivity/zilla/issues/2428 as literally as possible
+read option zilla:window 8192
+read zilla:data.ext ${mqtt:dataEx()
+                             .typeId(zilla:id("mqtt"))
+                             .session()
+                                .kind("WILL")
+                                .build()
+                             .build()}
+
+read ${mqtt:will()
+               .topic("devices/device-123/status")
+               .payloadSize(20)
+               .build()}
+read "{\"status\":\"offline\"}"
+
+write zilla:data.empty
+write flush
+
+read closed
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.32k/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.32k/client.rpt
@@ -21,7 +21,7 @@ connect "zilla://streams/net0"
 
 connected
 
-write [0x10 0x2f]                                      # CONNECT
+write [0x10 0xa3 0x80 0x02]                            # CONNECT
       [0x00 0x04] "MQTT"                               # protocol name
       [0x05]                                           # protocol version
       [0x06]                                           # flags = will flag, clean start
@@ -31,11 +31,15 @@ write [0x10 0x2f]                                      # CONNECT
       [0x00 0x03] "one"                                # client id
       [0x00]                                           # will properties
       [0x00 0x09] "wills/one"                          # will topic
-      [0x00 0x0c] "will payload"                       # will payload
+      [0x80 0x00] ${mqtt:randomBytes(32768)}           # will payload
 
 read  [0x20 0x03]                                      # CONNACK
       [0x00]                                           # flags = none
       [0x00]                                           # reason code
+      [0x00]                                           # properties
+
+write [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
       [0x00]                                           # properties = none
 
-write abort
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.32k/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.32k/server.rpt
@@ -22,7 +22,7 @@ accept "zilla://streams/net0"
 accepted
 connected
 
-read  [0x10 0x2f]                                      # CONNECT
+read  [0x10 0xa3 0x80 0x02]                            # CONNECT
       [0x00 0x04] "MQTT"                               # protocol name
       [0x05]                                           # protocol version
       [0x06]                                           # flags = will flag, clean start
@@ -32,11 +32,15 @@ read  [0x10 0x2f]                                      # CONNECT
       [0x00 0x03] "one"                                # client id
       [0x00]                                           # will properties
       [0x00 0x09] "wills/one"                          # will topic
-      [0x00 0x0c] "will payload"                       # will payload
+      [0x80 0x00] [0..32768]                           # will payload
 
 write [0x20 0x03]                                      # CONNACK
       [0x00]                                           # flags = none
       [0x00]                                           # reason code
       [0x00]                                           # properties = none
 
-read aborted
+read  [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
+      [0x00]                                           # properties = none
+
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.abort.while.deferred/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.abort.while.deferred/client.rpt
@@ -1,0 +1,45 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 65536
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0xa3 0x50]                                 # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x28 0x00] ${mqtt:randomBytes(8148)}            # will payload, round 1
+                  ${mqtt:seededBytes(2092)}            # will payload, round 2 (deferred remainder) -
+                                                        # seeded so the reader can exact-match it
+
+# wait for confirmation that the session stream has been established
+# (CONNECT has been received and at least started processing) before
+# aborting - otherwise the abort can race ahead of the network even
+# receiving CONNECT at all. The session stream accept side grants zero
+# window, so the will payload still cannot have been forwarded yet
+# regardless of exactly when this fires - no drain race is possible
+write await SESSION_ESTABLISHED
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.abort.while.deferred/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.abort.while.deferred/server.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 65536
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0xa3 0x50]                                 # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x28 0x00] [0..10240]                           # will payload
+
+# stand in for "the session stream has been established" for the
+# network-only peer test's own sake - in the runtime IT this signal
+# actually comes from the application server script instead
+write notify SESSION_ESTABLISHED
+
+# CONNACK is only ever sent once the session stream acks (see
+# MqttServer#onSessionData), which cannot happen before the will payload
+# has been fully forwarded; the client aborts before that, so no CONNACK
+# is ever written here
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.end.without.disconnect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.end.without.disconnect/client.rpt
@@ -1,0 +1,44 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0xa3 0x50]                                 # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x28 0x00] ${mqtt:randomBytes(10240)}           # will payload
+
+read  [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties
+
+# no DISCONNECT is ever sent - the connection just closes, still mid-way
+# through forwarding the deferred will payload
+write await ROUND1_FORWARDED
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.end.without.disconnect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.end.without.disconnect/server.rpt
@@ -1,0 +1,44 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0xa3 0x50]                                 # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x28 0x00] [0..10240]                           # will payload
+
+write [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+write notify ROUND1_FORWARDED
+
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/client.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x2f]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x0c] "will payload"                       # will payload
+
+read  [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+write abort

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.header.exceeds.window/server.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0x2f]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x0c] "will payload"                       # will payload
+
+write [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+read aborted

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.with.user.properties/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.with.user.properties/client.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x4c]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x0f]                                            # will properties
+      [0x26] [0x00 0x04] "key1" [0x00 0x06] "value1"   # will user property
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x1a] "client one session expired"         # will payload
+
+read  [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties
+
+write [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
+      [0x00]                                           # properties = none
+
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.with.user.properties/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.with.user.properties/server.rpt
@@ -1,0 +1,47 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0x4c]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x0f]                                            # will properties
+      [0x26] [0x00 0x04] "key1" [0x00 0x06] "value1"   # will user property
+      [0x00 0x09] "wills/one"                          # will topic
+      [0x00 0x1a] "client one session expired"         # will payload
+
+write [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+read  [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
+      [0x00]                                           # properties = none
+
+read closed

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.zero.window.on.connect/client.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.zero.window.on.connect/client.rpt
@@ -1,0 +1,50 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+# reproduces https://github.com/aklivity/zilla/issues/2428 as literally as possible:
+# a client connects with a small Will (matching the reported mosquitto_sub example)
+# on a session stream that has not yet received any WINDOW at all - the naturally
+# occurring condition on every first CONNECT with a Will, not a contrived tiny window
+
+connect "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+connected
+
+write [0x10 0x47]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x19] "devices/device-123/status"           # will topic
+      [0x00 0x14] "{\"status\":\"offline\"}"             # will payload
+
+read  [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties
+
+write [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
+      [0x00]                                           # properties = none
+
+write close

--- a/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.zero.window.on.connect/server.rpt
+++ b/specs/binding-mqtt.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/session.will.message.zero.window.on.connect/server.rpt
@@ -1,0 +1,46 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+accept "zilla://streams/net0"
+  option zilla:window 8192
+  option zilla:transmission "duplex"
+  option zilla:byteorder "network"
+
+accepted
+connected
+
+read  [0x10 0x47]                                      # CONNECT
+      [0x00 0x04] "MQTT"                               # protocol name
+      [0x05]                                           # protocol version
+      [0x06]                                           # flags = will flag, clean start
+      [0x00 0x0a]                                      # keep alive = 10s
+      [0x05]                                           # properties
+      [0x27] 33792                                     # maximum packet size = 33792
+      [0x00 0x03] "one"                                # client id
+      [0x00]                                           # will properties
+      [0x00 0x19] "devices/device-123/status"           # will topic
+      [0x00 0x14] "{\"status\":\"offline\"}"             # will payload
+
+write [0x20 0x03]                                      # CONNACK
+      [0x00]                                           # flags = none
+      [0x00]                                           # reason code
+      [0x00]                                           # properties = none
+
+read  [0xe0 0x02]                                      # DISCONNECT
+      [0x00]                                           # normal disconnect
+      [0x00]                                           # properties = none
+
+read closed

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctionsTest.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/internal/MqttFunctionsTest.java
@@ -57,6 +57,14 @@ public class MqttFunctionsTest
     }
 
     @Test
+    public void shouldGenerateSeededBytes()
+    {
+        final byte[] bytes = MqttFunctions.seededBytes(16);
+        assertEquals(16, bytes.length);
+        assertArrayEquals(bytes, MqttFunctions.seededBytes(16));
+    }
+
+    @Test
     public void shouldEncodeMqttSessionBeginExt()
     {
         final byte[] array = MqttFunctions.beginEx()

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -148,6 +148,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.zero.window.on.connect/client",
+        "${app}/session.will.message.zero.window.on.connect/server"})
+    public void shouldSendWillMessageWhenSessionWindowStartsAtZero() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -157,6 +157,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.with.user.properties/client",
+        "${app}/session.will.message.with.user.properties/server"})
+    public void shouldSendWillMessageWithUserProperties() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -130,6 +130,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.end.without.disconnect/client",
+        "${app}/session.will.message.end.without.disconnect/server"})
+    public void shouldEndWithoutDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -121,9 +121,9 @@ public class SessionIT
 
     @Test
     @Specification({
-        "${app}/session.will.message.header.exceeds.window/client",
-        "${app}/session.will.message.header.exceeds.window/server"})
-    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+        "${app}/session.will.message.32k/client",
+        "${app}/session.will.message.32k/server"})
+    public void shouldSendWillMessage32k() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -121,6 +121,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.header.exceeds.window/client",
+        "${app}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/application/SessionIT.java
@@ -139,6 +139,15 @@ public class SessionIT
 
     @Test
     @Specification({
+        "${app}/session.will.message.abort.while.deferred/client",
+        "${app}/session.will.message.abort.while.deferred/server"})
+    public void shouldAbortWhileDeferred() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${app}/session.subscribe/client",
         "${app}/session.subscribe/server"})
     public void shouldSubscribeSaveSubscriptionsInSession() throws Exception

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -147,6 +147,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.abort.while.deferred/client",
+        "${net}/session.will.message.abort.while.deferred/server"})
+    public void shouldAbortWhileDeferred() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -156,6 +156,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.zero.window.on.connect/client",
+        "${net}/session.will.message.zero.window.on.connect/server"})
+    public void shouldSendWillMessageWhenSessionWindowStartsAtZero() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -165,6 +165,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.with.user.properties/client",
+        "${net}/session.will.message.with.user.properties/server"})
+    public void shouldSendWillMessageWithUserProperties() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -131,9 +131,9 @@ public class SessionIT
 
     @Test
     @Specification({
-        "${net}/session.will.message.header.exceeds.window/client",
-        "${net}/session.will.message.header.exceeds.window/server"})
-    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+        "${net}/session.will.message.32k/client",
+        "${net}/session.will.message.32k/server"})
+    public void shouldSendWillMessage32k() throws Exception
     {
         k3po.finish();
     }

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -129,6 +129,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.header.exceeds.window/client",
+        "${net}/session.will.message.header.exceeds.window/server"})
+    public void shouldDeferWillMessageWhenHeaderExceedsSessionWindow() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({

--- a/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
+++ b/specs/binding-mqtt.spec/src/test/java/io/aklivity/zilla/specs/binding/mqtt/streams/network/v5/SessionIT.java
@@ -138,6 +138,15 @@ public class SessionIT
         k3po.finish();
     }
 
+    @Test
+    @Specification({
+        "${net}/session.will.message.end.without.disconnect/client",
+        "${net}/session.will.message.end.without.disconnect/server"})
+    public void shouldEndWithoutDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
+
     // [MQTT-3.1.2-15]
     @Test
     @Specification({


### PR DESCRIPTION
## Description

Fixes #2428

This incorporates the first part of the fix from #2429 (the `session.hasSessionWindow(headerSize)` guard, cherry-picked to stop the `IndexOutOfBoundsException`) and closes #2429, replacing it: once that guard is in place, deferring the will-message forward to a later session-window retry exposes three further bugs in how `MqttServerFactory` handles that deferred decode state, all fixed here.

`onNetworkAbort`, `onDecodeError`, and `onNetworkEnd` could each discard a will payload still sitting in `decodeSlot`, awaiting session window, instead of letting the existing session-window retry in `decodeNetwork` finish forwarding it before the connection fully closes:

- `onNetworkAbort` additionally routed through `doNetworkReset`, which unconditionally released the decode slot as a side effect — discarding the very payload the deferred branch was meant to preserve.
- `onDecodeError`'s equivalent check was too coarse: any non-empty `decodeSlot` was treated as a pending will forward, even when the slot merely held an unrelated, already-terminal decode (e.g. a rejected PUBLISH) with no session-window retry to ever complete it, silently dropping the resulting stream abort. Added `willPayloadPending()` to distinguish a genuine deferred will-message decode state from an incidentally non-empty decode slot.

Root-caused and fixed a second, deeper bug this surfaced: `onDecodeConnectWillPayload` built the will-message header from `mqttConnectPayloadRO`, a flyweight view into whatever buffer was live at CONNECT decode time. When the very first forward attempt was itself deferred (session window not yet available for even the header), the same "first round" branch reran later against `decodeSlot`'s buffer, but the flyweight still pointed at the original, possibly-reused decode buffer — corrupting the header and leaking a decode slot. Fixed by merging the header parse/transcode and payload forward into one incremental decode step that never advances progress past bytes it hasn't actually handed to the session stream, so every attempt — including retries — re-derives the header from whatever buffer is currently live, with `decodeNetwork`'s own decode-slot buffering keeping the source bytes available for as long as needed, regardless of will payload size.

Added a k3po `read option zilla:window N` verb (mirroring the existing `zilla:ack` option) to explicitly re-grant stream window credit mid-script, needed to deterministically force the abort-while-deferred race in the new regression test.

## Test plan
- [x] New k3po scenario `session.will.message.abort.while.deferred` (network + application, both directions) fails pre-fix with the deferred payload silently discarded, passes post-fix, including exact-content verification of the forwarded remainder
- [x] Full regression suite green on `runtime/binding-mqtt`, `runtime/binding-mqtt-kafka`, `specs/binding-mqtt.spec`
- [x] `checkstyle:check` clean on all touched modules


---
_Generated by [Claude Code](https://claude.ai/code/session_01WThie5Fa17zE939WMNZPPq)_