### PR TITLE
fix(guard-jwt): resolve credentials() for a session minted on a different worker

### DIFF
--- a/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
+++ b/runtime/binding-echo/src/test/java/io/aklivity/zilla/runtime/binding/echo/internal/bench/EchoWorker.java
@@ -66,6 +66,13 @@ public class EchoWorker implements EngineContext
     }
 
     @Override
+    public int indexOf(
+        long id)
+    {
+        return 0;
+    }
+
+    @Override
     public Signaler signaler()
     {
         return null;

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaModelWorker.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/cache/bench/KafkaModelWorker.java
@@ -78,6 +78,13 @@ final class KafkaModelWorker implements EngineContext
     }
 
     @Override
+    public int indexOf(
+        long id)
+    {
+        return 0;
+    }
+
+    @Override
     public Signaler signaler()
     {
         return null;

--- a/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
+++ b/runtime/binding-tls/src/test/java/io/aklivity/zilla/runtime/binding/tls/internal/bench/TlsWorker.java
@@ -137,6 +137,13 @@ public class TlsWorker implements EngineContext
     }
 
     @Override
+    public int indexOf(
+        long id)
+    {
+        return 0;
+    }
+
+    @Override
     public Signaler signaler()
     {
         return signaler;

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/EngineContext.java
@@ -98,6 +98,21 @@ public interface EngineContext
     long affinity();
 
     /**
+     * Decodes the worker index encoded into an id minted by {@link #supplyInitialId(long)} or
+     * a similarly-encoded id, regardless of which worker originally minted it.
+     * <p>
+     * Pure decode of the id's own bit layout — safe to call from any worker's {@link EngineContext},
+     * not just the one that minted the id. Used to route a lookup for state that is confined to a
+     * single worker (e.g. a guard's local session cache) back to the worker that actually owns it.
+     * </p>
+     *
+     * @param id  an id minted by this or another worker
+     * @return the zero-based index of the worker that minted the id
+     */
+    int indexOf(
+        long id);
+
+    /**
      * Returns the {@link Signaler} for scheduling time-based and task-based signals on
      * this I/O thread.
      *

--- a/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
+++ b/runtime/engine/src/main/java/io/aklivity/zilla/runtime/engine/internal/registry/EngineWorker.java
@@ -487,6 +487,13 @@ public class EngineWorker implements EngineContext, Agent
     }
 
     @Override
+    public int indexOf(
+        long id)
+    {
+        return indexOfId(id);
+    }
+
+    @Override
     public Signaler signaler()
     {
         return signaler;

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuard.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuard.java
@@ -54,7 +54,7 @@ public final class JwtGuard implements Guard
     public JwtGuardContext supply(
         EngineContext context)
     {
-        JwtGuardContext guard = new JwtGuardContext(config, context);
+        JwtGuardContext guard = new JwtGuardContext(config, context, this);
         contexts[context.index()] = guard;
         return guard;
     }
@@ -147,5 +147,24 @@ public final class JwtGuard implements Guard
         final JwtGuardContext context = contexts[sessionIndex];
         final JwtGuardHandler handler = context != null ? context.handler(guardId) : null;
         return handler != null ? handler.attribute(sessionId, name) : null;
+    }
+
+    // reached from JwtGuardHandler.credentials(...) on a local cache miss, via the credentialer
+    // callback threaded through JwtGuardContext.attach(...) -- unlike verify/identity/attribute above,
+    // sessionIndex here can legitimately fall outside this node's own workers (e.g. a session id
+    // minted before a redirect this node was never part of), so it is bounds-checked rather than
+    // trusted the way the guarded-route-evaluation callers above already are
+    String credentials(
+        int sessionIndex,
+        long guardId,
+        long sessionId)
+    {
+        if (sessionIndex < 0 || sessionIndex >= contexts.length)
+        {
+            return null;
+        }
+        final JwtGuardContext context = contexts[sessionIndex];
+        final JwtGuardHandler handler = context != null ? context.handler(guardId) : null;
+        return handler != null ? handler.credentialsLocal(sessionId) : null;
     }
 }

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardContext.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardContext.java
@@ -14,6 +14,7 @@
  */
 package io.aklivity.zilla.runtime.guard.jwt.internal;
 
+import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 
 import org.agrona.collections.Long2ObjectHashMap;
@@ -29,14 +30,17 @@ final class JwtGuardContext implements GuardContext
     private final Long2ObjectHashMap<JwtGuardHandler> handlersById;
     private final LongSupplier supplyAuthorizedId;
     private final EngineContext context;
+    private final JwtGuard parent;
 
     JwtGuardContext(
         Configuration config,
-        EngineContext context)
+        EngineContext context,
+        JwtGuard parent)
     {
         this.handlersById = new Long2ObjectHashMap<>();
         this.context = context;
         this.supplyAuthorizedId = context::supplyAuthorizedId;
+        this.parent = parent;
     }
 
     @Override
@@ -44,7 +48,9 @@ final class JwtGuardContext implements GuardContext
         GuardConfig guard)
     {
         JwtOptionsConfig options = (JwtOptionsConfig) guard.options;
-        JwtGuardHandler handler = new JwtGuardHandler(options, context, supplyAuthorizedId);
+        long guardId = guard.id;
+        LongFunction<String> credentialer = sessionId -> parent.credentials(context.indexOf(sessionId), guardId, sessionId);
+        JwtGuardHandler handler = new JwtGuardHandler(options, context, supplyAuthorizedId, credentialer);
         handlersById.put(guard.id, handler);
         return handler;
     }

--- a/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
+++ b/runtime/guard-jwt/src/main/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 
 import org.agrona.collections.Long2ObjectHashMap;
@@ -66,11 +67,13 @@ public class JwtGuardHandler implements GuardHandler
     private final JwtEventContext event;
     private final Map<String, String> attributes;
     private final Consumer<Runnable> dispatcher;
+    private final LongFunction<String> credentialer;
 
     public JwtGuardHandler(
         JwtOptionsConfig options,
         EngineContext context,
-        LongSupplier supplyAuthorizedId)
+        LongSupplier supplyAuthorizedId,
+        LongFunction<String> credentialer)
     {
         this.issuer = options.issuer;
         this.audience = options.audience;
@@ -121,6 +124,7 @@ public class JwtGuardHandler implements GuardHandler
         this.event = new JwtEventContext(context);
         this.attributes = options.attributes;
         this.dispatcher = context::dispatch;
+        this.credentialer = credentialer;
     }
 
     @Override
@@ -299,6 +303,18 @@ public class JwtGuardHandler implements GuardHandler
 
     @Override
     public String credentials(
+        long sessionId)
+    {
+        String local = credentialsLocal(sessionId);
+        return local != null ? local : credentialer.apply(sessionId);
+    }
+
+    // local-only lookup, reused by credentials() above as its fast path and by JwtGuard's
+    // cross-worker dispatch (reached via the credentialer callback) once it has already
+    // routed to the specific worker that owns sessionId -- never itself falls back, so a
+    // session that turns out not to be local anywhere simply resolves to null rather than
+    // looping back through the callback that got us here
+    String credentialsLocal(
         long sessionId)
     {
         JwtSession session = sessionsById.get(sessionId);

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardHandlerTest.java
@@ -75,7 +75,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -133,7 +133,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -167,7 +167,7 @@ public class JwtGuardHandlerTest
             .challenge(challenge)
             .identity("username")
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -200,7 +200,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -229,7 +229,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -257,7 +257,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -286,7 +286,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -315,7 +315,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "test issuer");
@@ -337,7 +337,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         long sessionId = guard.reauthorize(0L, 0L, 101L, null);
 
@@ -353,7 +353,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "test issuer");
@@ -377,7 +377,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "not test issuer");
@@ -399,7 +399,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "test issuer");
@@ -421,7 +421,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -446,7 +446,7 @@ public class JwtGuardHandlerTest
             .audience("testAudience")
             .key(RFC7515_RS256_CONFIG)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -473,7 +473,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "test issuer");
@@ -499,7 +499,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -534,7 +534,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -570,7 +570,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -605,7 +605,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -642,7 +642,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -679,7 +679,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -715,7 +715,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -745,7 +745,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 
@@ -781,7 +781,7 @@ public class JwtGuardHandlerTest
             .key(RFC7515_RS256_CONFIG)
             .challenge(challenge)
             .build();
-        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement);
+        JwtGuardHandler guard = new JwtGuardHandler(options, context, new MutableLong(1L)::getAndIncrement, sessionId -> null);
 
         Instant now = Instant.now();
 

--- a/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
+++ b/runtime/guard-jwt/src/test/java/io/aklivity/zilla/runtime/guard/jwt/internal/JwtGuardTest.java
@@ -536,4 +536,89 @@ public class JwtGuardTest
         LongObjectBiFunction<String, String> attributor = guard.attributor(s -> 0, guarded);
         assertEquals(attributor.apply(sessionId, "mail_to"), "recipient@email.address");
     }
+
+    @Test
+    public void shouldResolveCredentialsAcrossWorkers() throws Exception
+    {
+        EngineContext engine0 = Mockito.mock(EngineContext.class);
+        when(engine0.index()).thenReturn(0);
+        when(engine0.supplyAuthorizedId()).thenReturn(1L);
+
+        EngineContext engine1 = Mockito.mock(EngineContext.class);
+        when(engine1.index()).thenReturn(1);
+        when(engine1.indexOf(Mockito.anyLong())).thenReturn(0);
+
+        GuardFactory factory = GuardFactory.instantiate();
+        Guard guard = factory.create("jwt", new Configuration());
+
+        GuardContext context0 = guard.supply(engine0);
+        GuardContext context1 = guard.supply(engine1);
+
+        GuardConfig guardConfig = GenericGuardConfig.builder()
+            .inject(identity())
+            .namespace("test")
+            .name("test0")
+            .type("jwt")
+            .options(JwtOptionsConfig::builder)
+                .inject(identity())
+                .issuer("test issuer")
+                .audience("testAudience")
+                .key(RFC7515_RS256_CONFIG)
+                .build()
+            .build();
+
+        // reauthorize happens on worker 0, the owner; worker 1 never sees the JWT directly
+        GuardHandler handler0 = context0.attach(guardConfig);
+        GuardHandler handler1 = context1.attach(guardConfig);
+
+        Instant now = Instant.now();
+
+        JwtClaims claims = new JwtClaims();
+        claims.setClaim("iss", "test issuer");
+        claims.setClaim("aud", "testAudience");
+        claims.setClaim("sub", "testSubject");
+        claims.setClaim("exp", now.getEpochSecond() + 10L);
+        claims.setClaim("scope", "read:stream");
+
+        String token = sign(claims.toJson(), "test", RFC7515_RS256, "RS256");
+
+        long sessionId = handler0.reauthorize(0L, 0L, 101L, token);
+
+        assertEquals(token, handler1.credentials(sessionId));
+    }
+
+    @Test
+    public void shouldNotResolveCredentialsWhenSessionUnknownEverywhere() throws Exception
+    {
+        EngineContext engine0 = Mockito.mock(EngineContext.class);
+        when(engine0.index()).thenReturn(0);
+
+        EngineContext engine1 = Mockito.mock(EngineContext.class);
+        when(engine1.index()).thenReturn(1);
+        when(engine1.indexOf(Mockito.anyLong())).thenReturn(0);
+
+        GuardFactory factory = GuardFactory.instantiate();
+        Guard guard = factory.create("jwt", new Configuration());
+
+        GuardContext context0 = guard.supply(engine0);
+        GuardContext context1 = guard.supply(engine1);
+
+        GuardConfig guardConfig = GenericGuardConfig.builder()
+            .inject(identity())
+            .namespace("test")
+            .name("test0")
+            .type("jwt")
+            .options(JwtOptionsConfig::builder)
+                .inject(identity())
+                .issuer("test issuer")
+                .audience("testAudience")
+                .key(RFC7515_RS256_CONFIG)
+                .build()
+            .build();
+
+        context0.attach(guardConfig);
+        GuardHandler handler1 = context1.attach(guardConfig);
+
+        assertEquals(null, handler1.credentials(999L));
+    }
 }


### PR DESCRIPTION
## Description

`JwtGuardHandler.credentials(sessionId)` only ever checked its own worker's local `sessionsById` cache, returning `null` whenever the caller's own worker differs from the worker whose `reauthorize(...)` call originally minted that session — a real occurrence any time the mint and the credentials lookup land on different engine workers.

**Root cause**: a JWT guard's session state (`sessionsById`) is confined to the worker that reauthorized it, but nothing routed a `credentials()` call to the worker that actually owns the session — it only ever checked the *calling* worker's own local cache.

**Fix**:
- Adds `EngineContext.indexOf(long id)`: a pure decode of the worker index already encoded into any id minted by `supplyInitialId(...)`/similar, callable from any worker's own `EngineContext` regardless of which worker minted the id.
- `JwtGuardHandler.credentials(sessionId)` now tries its own local cache first (`credentialsLocal`, the existing fast path) and, on a miss, uses `indexOf(sessionId)` to route the lookup through `JwtGuard`'s shared per-worker `contexts[]` array to the specific worker that actually owns the session, calling its handler's local-only `credentialsLocal(sessionId)` directly — never falling back through the callback a second time, so a session that isn't local anywhere simply resolves to `null` rather than looping.
- The three `EngineContext` test/bench doubles (`EchoWorker`, `KafkaModelWorker`, `TlsWorker`) get a matching `indexOf` stub so the interface addition compiles cleanly everywhere it's implemented.

## Verification

- `./mvnw clean install -pl runtime/guard-jwt -am` — clean build.
- `./mvnw test -pl runtime/guard-jwt` — 37/37 tests pass (including new/updated coverage in `JwtGuardHandlerTest`/`JwtGuardTest` for the cross-worker path).
- `./mvnw clean install -pl runtime/binding-echo,runtime/binding-kafka,runtime/binding-tls -am` — confirms the three `EngineContext` test doubles compile cleanly with the new interface method.
- Confirmed these are the only four `EngineContext` implementers in the repo (`grep -r "implements.*EngineContext"`), so no other test double needed updating.

Fixes # (no tracked issue — found while investigating the `binding-mcp` MCP proxy fixes in #2434, where a guard's `credentials()` lookup crossing workers surfaced this as a separate, more general bug in `guard-jwt` itself)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_