### PR TITLE
ci(release): move docker buildx registry cache off the zilla image package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,8 +254,8 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         provenance: false
-        cache-from: type=registry,ref=ghcr.io/aklivity/zilla:buildcache
-        cache-to: type=registry,ref=ghcr.io/aklivity/zilla:buildcache,mode=max
+        cache-from: type=registry,ref=ghcr.io/aklivity/zilla-buildcache:latest
+        cache-to: type=registry,ref=ghcr.io/aklivity/zilla-buildcache:latest,mode=max
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}
           ${{ steps.tag.outputs.minor && format('ghcr.io/aklivity/zilla:{0}', steps.tag.outputs.minor) || '' }}
@@ -270,8 +270,8 @@ jobs:
         platforms: linux/amd64
         push: true
         provenance: false
-        cache-from: type=registry,ref=ghcr.io/aklivity/zilla:buildcache-alpine
-        cache-to: type=registry,ref=ghcr.io/aklivity/zilla:buildcache-alpine,mode=max
+        cache-from: type=registry,ref=ghcr.io/aklivity/zilla-buildcache:alpine
+        cache-to: type=registry,ref=ghcr.io/aklivity/zilla-buildcache:alpine,mode=max
         tags: |
           ghcr.io/aklivity/zilla:${{ inputs.version }}-alpine
           ${{ steps.tag.outputs.minor && format('ghcr.io/aklivity/zilla:{0}-alpine', steps.tag.outputs.minor) || '' }}


### PR DESCRIPTION
## Description

The release workflow's `docker/build-push-action` steps use `cache-to: type=registry,...,mode=max` for the multi-arch buildx layer cache. That backend publishes the cache as a real manifest under the given ref, which was landing as extra `buildcache`/`buildcache-alpine` versions inside the public `ghcr.io/aklivity/zilla` package alongside the actual release images.

This moves `cache-from`/`cache-to` for both the main and alpine image builds to a dedicated `ghcr.io/aklivity/zilla-buildcache` package (`:latest` and `:alpine` tags), keeping `ghcr.io/aklivity/zilla` limited to real release versions. `type=registry` is kept rather than switching to `type=gha`, since GitHub Actions cache's per-repo size cap and multi-platform scope collisions were the reason this repo moved to the registry backend in the first place.

Note: the first release run after this merges will create a new `zilla-buildcache` package in GHCR. Its visibility will need to be manually confirmed/set to private in the org's package settings, since new packages don't automatically inherit the source repo's visibility.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPozwovLazfMf5d1ei5MmL)_