### PR TITLE
docs(readme): fix release badge to use GitHub releases, scoped to 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Zilla is made available under the [Aklivity Community License](./LICENSE-Aklivit
 [community-join]: https://www.aklivity.io/slack
 [artifact-hub-shield]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/zilla
 [artifact-hub]: https://artifacthub.io/packages/helm/zilla/zilla
-[release-latest-image]: https://img.shields.io/github/v/tag/aklivity/zilla?label=release
+[release-latest-image]: https://img.shields.io/github/v/release/aklivity/zilla?label=release&sort=semver&filter=1.*
 [release-latest]: https://github.com/aklivity/zilla/pkgs/container/zilla
 [zilla-roadmap]: https://github.com/orgs/aklivity/projects/4/views/1
 


### PR DESCRIPTION
## Description

Same issue as the `develop` branch (see #2441): the README's "release" badge used `github/v/tag/aklivity/zilla`, which reads from raw git tags. This repo's git-flow release process tags every version, including in-progress release candidates, so the badge could show an unreleased rc as the "release" instead of the latest finished version.

Switched to `github/v/release/aklivity/zilla` with `sort=semver`, same as the `develop` fix. Additionally scoped it with `filter=1.*`, since `github/v/release` reads from the repo's overall Releases list (not branch-scoped) — without a filter, this branch's badge would show the repo's overall highest semver release (currently `2.3.0` on `develop`) instead of the latest release in the `1.x` line that this branch and its README actually track.



---
_Generated by [Claude Code](https://claude.ai/code/session_01TPozwovLazfMf5d1ei5MmL)_