### PR TITLE
fix(binding-mcp): resolve lifecycle preauthorize races between connect and requests

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -2899,6 +2899,14 @@ public final class McpClientFactory implements McpStreamFactory
             {
                 final String sid = sessionId;
                 final int caps = serverCapabilities;
+
+                // the south handshake has now genuinely finished -- this session is ready to
+                // carry other south-bound traffic before its own reply is dispatched, since
+                // doAppBegin below can synchronously cascade into a request that was waiting
+                // on this exact connect to settle (e.g. the proxy layer's settleRequests(),
+                // called from the same reply it is about to receive)
+                pendingConnect = false;
+
                 doAppBegin(traceId, authorization, mcpBeginExRW
                     .wrap(codecBuffer, 0, codecBuffer.capacity())
                     .typeId(mcpTypeId)
@@ -2908,10 +2916,6 @@ public final class McpClientFactory implements McpStreamFactory
                     .build());
                 touch();
                 scheduleKeepalive(traceId);
-
-                // the south handshake has now genuinely finished -- only now is this session
-                // actually ready to carry other south-bound traffic
-                pendingConnect = false;
             }
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -2517,7 +2517,9 @@ public final class McpClientFactory implements McpStreamFactory
 
             if ((sessionId & GuardHandler.MASK_AUTHORIZED) != 0L)
             {
-                pendingConnect = false;
+                // pendingConnect stays true until the south handshake actually finishes (see
+                // onNetEnd) -- the guard has decided, but this session is not yet ready to carry
+                // other south-bound traffic
                 credentials = guard.credentials(sessionId);
                 guardSessionId = sessionId;
                 resumeDeferredConnect(acquireTraceId, acquireAuthorization);
@@ -2550,16 +2552,19 @@ public final class McpClientFactory implements McpStreamFactory
                     .build();
                 doAppChallenge(acquireTraceId, acquireAuthorization, challengeEx);
 
+                // still pendingConnect: a request whose own proceedWithRequest observes this
+                // rejects rather than independently asking the same guard the same question
                 return;
             }
 
-            pendingConnect = false;
             if (!binding.needsCredentials)
             {
+                // pendingConnect stays true until the south handshake finishes -- see onNetEnd
                 resumeDeferredConnect(acquireTraceId, acquireAuthorization);
             }
             else
             {
+                pendingConnect = false;
                 doAppReset(acquireTraceId, acquireAuthorization);
                 doAppAbort(acquireTraceId, acquireAuthorization);
             }
@@ -2831,10 +2836,11 @@ public final class McpClientFactory implements McpStreamFactory
             {
                 deauthorizeGuardSession();
                 guardSessionId = sessionId;
+                credentials = binding.guard.credentials(sessionId);
 
                 if (pendingConnect)
                 {
-                    pendingConnect = false;
+                    // pendingConnect stays true until the south handshake finishes -- see onNetEnd
                     resumeDeferredConnect(acquireTraceId, acquireAuthorization);
                     return;
                 }
@@ -2902,6 +2908,10 @@ public final class McpClientFactory implements McpStreamFactory
                     .build());
                 touch();
                 scheduleKeepalive(traceId);
+
+                // the south handshake has now genuinely finished -- only now is this session
+                // actually ready to carry other south-bound traffic
+                pendingConnect = false;
             }
         }
 
@@ -3145,6 +3155,15 @@ public final class McpClientFactory implements McpStreamFactory
             long authorization,
             McpBeginExFW mcpBeginEx)
         {
+            // the session's own connect is already asking the guard this same question; a request
+            // landing here cannot be for a caller that legitimately learned this session id yet
+            if (session.pendingConnect)
+            {
+                doAppReset(traceId, authorization);
+                doAppAbort(traceId, authorization);
+                return false;
+            }
+
             doAppBegin(traceId, authorization, null);
 
             final GuardHandler guard = session.binding.guard;
@@ -3163,10 +3182,6 @@ public final class McpClientFactory implements McpStreamFactory
                 }
             }
 
-            // the asynchronous overload completes on a later turn in every case, whether the
-            // guard decides locally or has to reach an authorization server for an outbound
-            // token exchange, so there is one path here: hold the request and buffer its body
-            // until the decision arrives
             acquireTraceId = traceId;
             acquireAuthorization = authorization;
             guard.reauthorize(traceId, session.binding.id, authorization, null, acquireCompletion);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientFactory.java
@@ -1535,6 +1535,23 @@ public final class McpClientFactory implements McpStreamFactory
         return colon < 0 ? id : id.substring(colon + 1);
     }
 
+    // the JSON-RPC id decoder accepts either a string or number id but only keeps the token
+    // text, not which one it was; this re-derives it from the token's own shape so a reverse
+    // elicitation response can echo the id back as the same JSON type it originally arrived as
+    private static boolean isJsonRpcNumericId(
+        String id)
+    {
+        boolean numeric = id != null && !id.isEmpty();
+        for (int i = 0; numeric && i < id.length(); i++)
+        {
+            final char ch = id.charAt(i);
+            final boolean digit = ch >= '0' && ch <= '9';
+            final boolean sign = i == 0 && ch == '-' && id.length() > 1;
+            numeric = digit || sign;
+        }
+        return numeric;
+    }
+
     @Override
     public int originTypeId()
     {
@@ -6363,6 +6380,7 @@ public final class McpClientFactory implements McpStreamFactory
         private final String sessionId;
         private final String protocolVersion;
         private final String requestId;
+        private final boolean numericRequestId;
         private final String action;
         private final McpBindingConfig binding;
         private final int contentLength;
@@ -6391,12 +6409,14 @@ public final class McpClientFactory implements McpStreamFactory
             this.sessionId = mcp.transportSessionId();
             this.protocolVersion = mcp.protocolVersion();
             this.requestId = requestId;
+            this.numericRequestId = isJsonRpcNumericId(requestId);
             this.action = action;
             this.originId = mcp.routedId;
             this.routedId = mcp.resolvedId;
             this.affinity = mcp.affinity;
             this.binding = mcp.binding();
-            this.contentLength = JSON_RPC_ELICIT_RESPONSE_PREFIX.length() + requestId.length() +
+            final int idQuotes = numericRequestId ? 0 : 2;
+            this.contentLength = JSON_RPC_ELICIT_RESPONSE_PREFIX.length() + idQuotes + requestId.length() +
                 JSON_RPC_ELICIT_RESPONSE_MIDDLE.length() + action.length() + JSON_RPC_ELICIT_RESPONSE_SUFFIX.length();
         }
 
@@ -6432,7 +6452,15 @@ public final class McpClientFactory implements McpStreamFactory
         {
             int codecLength = 0;
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_ELICIT_RESPONSE_PREFIX);
+            if (!numericRequestId)
+            {
+                codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, "\"");
+            }
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, requestId);
+            if (!numericRequestId)
+            {
+                codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, "\"");
+            }
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_ELICIT_RESPONSE_MIDDLE);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, action);
             codecLength += codecBuffer.putStringWithoutLengthAscii(codecLength, JSON_RPC_ELICIT_RESPONSE_SUFFIX);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -498,6 +498,9 @@ public final class McpProxyCacheHydrater
             case AbortFW.TYPE_ID:
                 onAbort(abortRO.wrap(buffer, index, index + length));
                 break;
+            case ResetFW.TYPE_ID:
+                onReset(resetRO.wrap(buffer, index, index + length));
+                break;
             default:
                 break;
             }
@@ -525,6 +528,16 @@ public final class McpProxyCacheHydrater
             AbortFW abort)
         {
             settle(abort.traceId(), true);
+        }
+
+        // a cancelled hydration fetch (e.g. the south server rejecting a concurrent
+        // request while another is already in flight on the same session) resets the
+        // initial side rather than ending or aborting the reply -- without this, the
+        // route never settles and the whole kind's cache never becomes ready
+        private void onReset(
+            ResetFW reset)
+        {
+            settle(reset.traceId(), true);
         }
 
         private void settle(

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheHydrater.java
@@ -375,13 +375,26 @@ public final class McpProxyCacheHydrater
                 pending = routes.size();
                 for (McpRoutePrefix route : routes)
                 {
-                    final long authorization = binding.routeCacheAuthorization(traceId, route.resolvedId());
                     final List<String> routeScopes = flattenRoles(route.route().roles);
                     final McpListRouteSink sink = new McpListRouteSink(this, route.prefix().asString(), routeScopes);
                     sinks.add(sink);
-                    sink.server = listFactory.newHydrationList(
-                        handler.lifecycle, sink::onMessage, authorization,
-                        bufferPool.slotCapacity(), route, traceId);
+                    if (handler.lifecycle.needsInteractiveAuth(route.resolvedId()))
+                    {
+                        // this route's own south connect already settled without a session -- a
+                        // preauthorize challenge only a real, interactive caller can answer, so
+                        // dialing again would just repeat the same unanswerable challenge; treat
+                        // it as permanently empty for hydration instead
+                        sink.settled = true;
+                        sink.failed = true;
+                        onRouteSettled(sink, traceId);
+                    }
+                    else
+                    {
+                        final long authorization = binding.routeCacheAuthorization(traceId, route.resolvedId());
+                        sink.server = listFactory.newHydrationList(
+                            handler.lifecycle, sink::onMessage, authorization,
+                            bufferPool.slotCapacity(), route, traceId);
+                    }
                 }
             }
         }

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyItemFactory.java
@@ -2380,9 +2380,24 @@ abstract class McpProxyItemFactory implements BindingHandler
                     initialSeq, initialAck, initialMax, traceId, server.authorization, server.affinity, beginEx);
                 state = McpState.openingInitial(state);
             }
+            else if (lifecycle.resolved)
+            {
+                // resetting the initial side alone is a no-op once this request's own (small)
+                // body already arrived and closed it -- which is the common case -- so the
+                // caller would otherwise never learn this call failed; aborting the reply too
+                // closes the stream regardless of which side is still open
+                server.doServerReset(traceId);
+                server.doServerAbort(traceId);
+            }
             else
             {
-                server.doServerReset(traceId);
+                // this connect has only issued a preauthorize challenge so far, still awaiting
+                // an interactive answer -- and the caller of this very request may be the one
+                // about to provide it (the challenge is relayed to the same session), so wait
+                // for the real outcome instead of failing now; added directly rather than via
+                // register(), which would just re-fire onLifecycleSettled synchronously since
+                // settled is already latched true
+                lifecycle.awaitResolution(this);
             }
         }
 

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -870,6 +870,16 @@ final class McpProxyLifecycleFactory implements BindingHandler
         // transient reason (a reset, a rejected concurrent request, a network hiccup), which
         // stays retriable exactly as before this route existed
         private boolean challenged;
+        // true once this connect has reached a genuine conclusion -- a session obtained, or a
+        // real abort/reset -- as opposed to merely having issued a preauthorize challenge that
+        // is still awaiting an interactive answer. register()/settled still answer a mere
+        // challenge immediately (a list-style registrant wants that: skip this route for now,
+        // pick it up later via a toolsListChanged-style notification); a registrant for whom
+        // "no session yet" is not an acceptable answer -- e.g. a specific tool call that cannot
+        // partially succeed -- checks this field instead, to tell a challenge still awaiting its
+        // own caller's answer apart from a connect that has truly given up (see McpClient in
+        // McpProxyItemFactory)
+        boolean resolved;
         String sessionId;
         long authorization;
         private String resumeId;
@@ -995,6 +1005,16 @@ final class McpProxyLifecycleFactory implements BindingHandler
             {
                 requests.add(request);
             }
+        }
+
+        // re-queues a registrant that was told "settled" while this connect had merely
+        // issued a preauthorize challenge, not yet reached a real disposition -- added
+        // directly rather than through register(), since settled is already latched true
+        // and asking again there would just re-fire onLifecycleSettled synchronously
+        void awaitResolution(
+            McpRouteRequest request)
+        {
+            requests.add(request);
         }
 
         private void settleRequests(
@@ -1274,6 +1294,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
 
             state = McpState.openedReply(state);
 
+            resolved = true;
             settleLifecycle(traceId);
 
             if (resumeId != null || server.resumePending)
@@ -1325,6 +1346,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             assert replyAck <= replySeq;
 
             state = McpState.closedReply(state);
+            resolved = true;
             settleRequests(traceId);
             doClientAbort(traceId);
             server.clients.remove(routedId, this);
@@ -1375,6 +1397,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             assert initialAck <= initialSeq;
 
             state = McpState.closedInitial(state);
+            resolved = true;
             settleRequests(traceId);
             doClientReset(traceId);
             server.clients.remove(routedId, this);

--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -26,6 +26,7 @@ import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 
 import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.collections.LongHashSet;
 
 import io.aklivity.zilla.runtime.binding.mcp.internal.McpConfiguration;
 import io.aklivity.zilla.runtime.binding.mcp.internal.config.McpAggregateEventId;
@@ -219,6 +220,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
         private final boolean hydration;
         private final Long2ObjectHashMap<McpLifecycleClient> clients;
         private final Long2ObjectHashMap<String> eventIds;
+        private final LongHashSet interactiveAuthRoutes;
 
         private int state;
         private boolean resumePending;
@@ -263,12 +265,25 @@ final class McpProxyLifecycleFactory implements BindingHandler
             this.eventIds = binding.aggregateRoutes.length > 0
                 ? new Long2ObjectHashMap<>()
                 : null;
+            this.interactiveAuthRoutes = new LongHashSet();
         }
 
         McpLifecycleClient supplyClient(
             long routedId)
         {
             return clients.computeIfAbsent(routedId, id -> new McpLifecycleClient(this, id));
+        }
+
+        // true once this route's own south connect has settled without ever obtaining a
+        // session -- the only way that happens is a preauthorize challenge that only a real,
+        // interactive caller can answer, so a hydration retry would just repeat the same
+        // unanswerable challenge; tracked here rather than on McpLifecycleClient because that
+        // per-attempt object is discarded (removed from clients) as soon as its south connect
+        // closes, well before the next hydration retry gets a chance to ask
+        boolean needsInteractiveAuth(
+            long routedId)
+        {
+            return interactiveAuthRoutes.contains(routedId);
         }
 
         private boolean aggregating()
@@ -850,6 +865,11 @@ final class McpProxyLifecycleFactory implements BindingHandler
         private MessageConsumer sender;
         private int state;
         private boolean settled;
+        // true once an actual preauthorize challenge (elicitation) arrived on this south
+        // connect -- as opposed to settling without a session for some other, ordinary
+        // transient reason (a reset, a rejected concurrent request, a network hiccup), which
+        // stays retriable exactly as before this route existed
+        private boolean challenged;
         String sessionId;
         long authorization;
         private String resumeId;
@@ -1165,6 +1185,7 @@ final class McpProxyLifecycleFactory implements BindingHandler
             final long authorization = challenge.authorization();
             final OctetsFW extension = challenge.extension();
 
+            challenged = true;
             settleLifecycle(traceId);
 
             server.doServerChallenge(traceId, authorization, prefixChallengeCorrelationId(extension));
@@ -1213,6 +1234,10 @@ final class McpProxyLifecycleFactory implements BindingHandler
             if (!settled)
             {
                 settled = true;
+                if (server.hydration && sessionId == null && challenged)
+                {
+                    server.interactiveAuthRoutes.add(routedId);
+                }
                 server.onClientLifecycleOpened(traceId);
             }
         }
@@ -1236,6 +1261,13 @@ final class McpProxyLifecycleFactory implements BindingHandler
             {
                 sessionId = beginEx.lifecycle().sessionId().asString();
                 server.binding.recordServerCapabilities(routedId, beginEx.lifecycle().capabilities());
+            }
+
+            if (sessionId != null)
+            {
+                // a session was obtained after all (e.g. a human completed the interactive
+                // auth this route previously needed) -- hydration retries can resume
+                server.interactiveAuthRoutes.remove(routedId);
             }
 
             doClientWindow(traceId, 0L, 0);

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -188,6 +188,16 @@ public class McpClientIT
     @Test
     @Configuration("client.yaml")
     @Specification({
+        "${app}/tools.call.elicit.completed.proxied.string.id/client",
+        "${net}/tools.call.elicit.completed.proxied.string.id/server"})
+    public void shouldCallToolElicitCompletedProxiedStringId() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("client.yaml")
+    @Specification({
         "${app}/tools.call.elicit.declined.proxied/client",
         "${net}/tools.call.elicit.declined.proxied/server"})
     public void shouldCallToolElicitDeclinedProxied() throws Exception

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpClientIT.java
@@ -216,6 +216,16 @@ public class McpClientIT
     }
 
     @Test
+    @Configuration("client.guarded.yaml")
+    @Specification({
+        "${app}/tools.call.concurrent.lifecycle.preauthorize/client",
+        "${net}/tools.call.concurrent.lifecycle.preauthorize/server"})
+    public void shouldCallToolConcurrentWithLifecyclePreauthorize() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("client.yaml")
     @Specification({
         "${app}/lifecycle.timeout.rejected/client",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -136,6 +136,18 @@ public class McpProxyCacheIT
     }
 
     @Test
+    @Configuration("proxy.cache.toolkit.multi.yaml")
+    @Specification({
+        "${app}/cache.hydrate.toolkit.multi.reset.route/server",
+        "${app}/cache.hydrate.toolkit.multi.reset.route/client" })
+    @ScriptProperty("affinity \"0000003f\"")
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldHydrateToolkitMultiSettlingResetRoute() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
     @Configuration("proxy.cache.toolkit.multi.refresh.yaml")
     @Specification({
         "${app}/cache.refresh.toolkit.keep.stale.on.failure/server",

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyIT.java
@@ -307,6 +307,17 @@ public class McpProxyIT
 
     @Test
     @Configuration("proxy.toolkit.multi.yaml")
+    @Specification({
+        "${app}/lifecycle.hold.tools.call.after.authorize.toolkit.multi.prefixed/client",
+        "${app}/lifecycle.hold.tools.call.after.authorize.toolkit.multi/server" })
+    @ScriptProperty("affinity \"0000003f\"")
+    public void shouldHoldToolCallOpenThroughOutstandingLifecycleChallenge() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Configuration("proxy.toolkit.multi.yaml")
     @ScriptProperty("authorization 1L")
     @Specification({
         "${app}/lifecycle.events.resume.aggregate.prefixed/client",

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.reset.route/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.reset.route/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"quartz__get_current_time"}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.reset.route/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.reset.route/server.rpt
@@ -1,0 +1,101 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:reset.ext ${mcp:resetEx()
+                           .typeId(zilla:id("mcp"))
+                           .error()
+                               .code(-32603)
+                               .message("concurrent request rejected")
+                               .build()
+                           .build()}
+
+read abort
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":[{"name":"get_current_time"}]}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.hold.tools.call.after.authorize.toolkit.multi.prefixed/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.hold.tools.call.after.authorize.toolkit.multi.prefixed/client.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                              .build()
+                          .build()}
+
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                        .build()
+                                    .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .name("quartz__get_current_time")
+                               .contentLength(50)
+                               .build()
+                           .build()}
+
+write notify TOOLS_CALL_SENT
+
+connected
+
+write '{'
+        '"name":"quartz__get_current_time",'
+        '"arguments":{}'
+      '}'
+
+read  '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "It is currently 12:00:00 UTC"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.hold.tools.call.after.authorize.toolkit.multi/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/lifecycle.hold.tools.call.after.authorize.toolkit.multi/server.rpt
@@ -1,0 +1,106 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+read advise zilla:challenge ${mcp:challengeEx()
+                                 .typeId(zilla:id("mcp"))
+                                 .elicitCreate()
+                                     .id("1")
+                                     .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                     .build()
+                                 .build()}
+
+write await TOOLS_CALL_SENT
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsCall()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000b".concat(affinity))
+                              .name("get_current_time")
+                              .contentLength(42)
+                              .build()
+                          .build()}
+
+connected
+
+read  '{'
+        '"name":"get_current_time",'
+        '"arguments":{}'
+      '}'
+
+write flush
+
+write '{'
+        '"content":'
+        '['
+          '{'
+            '"type": "text",'
+            '"text": "It is currently 12:00:00 UTC"'
+          '}'
+        '],'
+        '"isError": false'
+      '}'
+write flush
+
+write close
+
+read closed

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.concurrent.lifecycle.preauthorize/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.concurrent.lifecycle.preauthorize/client.rpt
@@ -1,0 +1,52 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .authCallback("http://localhost:8080/mcp/auth/callback")
+                               .build()
+                           .build()}
+
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("http://localhost:8080/mcp/auth/callback")))
+                                        .correlationId("3")
+                                        .build()
+                                    .build()}
+
+write notify CONNECT_CHALLENGED
+
+connect await CONNECT_CHALLENGED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000100000000")
+                               .name("get_weather")
+                               .contentLength(59)
+                               .build()
+                           .build()}
+
+connect aborted

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied.string.id/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/tools.call.elicit.completed.proxied.string.id/client.rpt
@@ -1,0 +1,100 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsCall()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-0001".concat(affinity))
+                               .name("get_weather")
+                               .contentLength(59)
+                               .build()
+                           .build()}
+
+connected
+
+write '{'
+        '"name":"get_weather",'
+        '"arguments":'
+        '{'
+          '"location": "New York"'
+        '}'
+      '}'
+
+write advised zilla:challenge ${mcp:matchChallengeEx()
+                                    .typeId(zilla:id("mcp"))
+                                    .elicitCreate()
+                                        .id("elicit-1")
+                                        .url("https://server.example.com/authorize?state=7f3a9b1c")
+                                        .message("Open the link to authorize access.")
+                                        .correlationId("elicit-token-9f3a")
+                                        .build()
+                                    .build()}
+
+write advise zilla:flush ${mcp:flushEx()
+                              .typeId(zilla:id("mcp"))
+                              .elicitResponse()
+                                  .correlationId("elicit-token-9f3a")
+                                  .action("ACCEPT")
+                                  .build()
+                              .build()}
+
+read advised zilla:flush ${mcp:matchFlushEx()
+                               .typeId(zilla:id("mcp"))
+                               .elicitComplete()
+                                   .id("elicit-1")
+                                   .build()
+                               .build()}
+
+read '{'
+       '"content":'
+       '['
+         '{'
+           '"type": "text",'
+           '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+         '}'
+       '],'
+       '"isError": false'
+     '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.concurrent.lifecycle.preauthorize/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.concurrent.lifecycle.preauthorize/server.rpt
@@ -1,0 +1,18 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied.string.id/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/network/tools.call.elicit.completed.proxied.string.id/server.rpt
@@ -1,0 +1,173 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+accept "zilla://streams/net0"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "application/json")
+                            .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
+                            .build()}
+write flush
+
+write '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"prompts":{"listChanged":true},"resources":{"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"zilla","version":"1.0"}}}'
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close
+
+accepted
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("content-type", "application/json")
+                           .header("accept", "application/json, text/event-stream")
+                           .header("mcp-protocol-version", "2025-11-25")
+                           .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
+                           .header("content-length", "115")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_weather","arguments":{"location": "New York"}}}'
+
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "200")
+                            .header("content-type", "text/event-stream")
+                            .build()}
+write flush
+
+write 'id: 2:1\n'
+write 'data: {'
+        '"jsonrpc":"2.0",'
+        '"id":"elicit-token-9f3a",'
+        '"method":"elicitation/create",'
+        '"params":'
+        '{'
+          '"mode":"url",'
+          '"elicitationId":"elicit-1",'
+          '"url":"https://server.example.com/authorize?state=7f3a9b1c",'
+          '"message":"Open the link to authorize access."'
+        '}'
+      '}\n'
+write '\n'
+write flush
+write notify ELICIT_CREATED
+
+write await ELICIT_RESPONDED
+
+write 'data: {'
+        '"jsonrpc":"2.0",'
+        '"method":"notifications/elicitation/complete",'
+        '"params":'
+        '{'
+          '"elicitationId":"elicit-1"'
+        '}'
+      '}\n'
+write '\n'
+write flush
+
+write 'data: {'
+        '"jsonrpc":"2.0",'
+        '"id":2,'
+        '"result":'
+        '{'
+          '"content":'
+          '['
+            '{'
+              '"type": "text",'
+              '"text": "Current weather in New York:\\nTemperature: 72°F\\nConditions: Partly cloudy"'
+            '}'
+          '],'
+          '"isError": false'
+        '}'
+      '}\n'
+write '\n'
+write flush
+
+write close
+
+accepted
+
+read await ELICIT_CREATED
+
+read zilla:begin.ext ${http:matchBeginEx()
+                           .typeId(zilla:id("http"))
+                           .header(":method", "POST")
+                           .header(":path", "/mcp")
+                           .header("mcp-session-id", "5ca1ab1e-c0de-4a11-b0a7-000100000000")
+                           .build()}
+
+connected
+
+read '{"jsonrpc":"2.0","id":"elicit-token-9f3a","result":{"action":"accept"}}'
+read closed
+
+write zilla:begin.ext ${http:beginEx()
+                            .typeId(zilla:id("http"))
+                            .header(":status", "202")
+                            .build()}
+write flush
+
+write close
+write notify ELICIT_RESPONDED


### PR DESCRIPTION
## Description

`McpRequestStream.proceedWithRequest` (in `binding-mcp`'s `kind: client`) asked `binding.guard` the same preauthorize question that the session's own `McpLifecycleStream` connect was already asking, whenever a request landed while that connect's guard decision was still outstanding. Since both streams share the same `binding.guard`, this minted a second, independent elicitation for what is really one guard decision. An external OAuth callback can only ever resolve one of the two correlation ids, so whichever elicitation didn't win hangs indefinitely — the reported symptom being that the browser completes the login successfully but the original tool call still times out.

A request cannot legitimately belong to a caller that has already learned the session id at this point, since the reply carrying it is withheld until the connect itself settles — so this is a protocol violation, not a normal timing overlap to absorb. `McpRequestStream.proceedWithRequest` now rejects such a request outright instead of starting a redundant elicitation. The check runs before the reply-side `doAppBegin`, so a request that's about to be rejected never opens a reply it's only going to abort.

Two related fixes landed alongside it, in the same code path:
- `pendingConnect` now clears once the south handshake actually finishes (`onNetEnd`), not merely once the guard decision resolves — the window a racing request needs to be rejected in extends through the full handshake, not just the guard round trip. This also has to happen *before* the reply-side `doAppBegin` is dispatched, not after: `doAppBegin` can synchronously cascade through a composing proxy layer into a request that was queued waiting on this exact connect to settle, and that request needs to see `pendingConnect` already false by the time it's redispatched from within that same call.
- `McpLifecycleStream.onReauthorized`'s success branch now also refreshes `credentials` via `guard.credentials(sessionId)`, matching the pattern already used on the other decision branches on this path (previously only `guardSessionId` was set there).

A third, unrelated bug surfaced while verifying this fix end-to-end against a real OAuth authorization-code + DCR flow (as opposed to the simpler url-mode elicitation the original report used): `McpClientFactory` relays a south server's own reverse `elicitation/create` request north to the real caller, then relays the caller's answer back south as a JSON-RPC response. The id decoder accepts either a JSON string or number id but only keeps the token text, discarding which one it was, so the response encoder had no way to know whether to quote the id when echoing it back. It always wrote it unquoted, which happens to be correct only when the original id was a number. For a south server whose reverse-request id is a non-numeric string (e.g. the `everything` MCP reference server), this produced invalid JSON (`"id":dfdca290` instead of `"id":"dfdca290"`), which the server rejected with a parse error, silently stalling that connection with no further retry. Fixed by re-deriving the type from the id token's own shape at the point it's re-serialized, since that's the only signal left by then.

Continued end-to-end verification against `zilla-plus`'s `examples/mcp.proxy` (real browser-driven authorization-code + DCR login, `everything` MCP reference server behind `kind: proxy` toolkit routing and cache hydration) surfaced three further bugs in the same lifecycle/proxy machinery, fixed here as well:

- **`McpProxyListFactory` cache hydration never settling on a cancelled fetch.** `McpListRouteSink.onMessage` handled BEGIN/DATA/END/ABORT but had no RESET case, so a cancelled hydration fetch (e.g. a south peer whose transport only serves one in-flight request per session, rejecting a concurrent one) never called `settle()`. The route's kind never reached `pending == 0`, `McpProxyCache.markAttempted` never fired, and `cache.populated` stayed false forever — blocking every client's own `initialize`, not just callers of the affected toolkit, since `register()` gates on that flag.
- **Hydration retrying a route that can only ever be answered by a human.** A cache-hydration route whose south connect receives an actual preauthorize challenge (elicitation) can never be satisfied automatically — only a real, interactive caller can answer it. Retrying such a route on every hydration cycle just re-triggers `guard.preauthorize()` repeatedly, minting a fresh elicitation each time; those compete with a real caller's own in-flight elicitation for the same toolkit. Tracked per-route on `McpLifecycleServer` (not on the per-attempt `McpLifecycleClient`, which is discarded as soon as its south connect closes, well before the next retry), scoped to an actual CHALLENGE frame so a route guarded by a plain, non-interactive guard (e.g. `authn_jwt`) that settles without a session for an ordinary transient reason stays retriable.
- **A `tools/call` (or `prompts/get`/`resources/read` etc.) racing an outstanding lifecycle challenge on its own toolkit route hanging forever.** `McpProxyItemFactory`'s `McpClient` answered its route registration as soon as the toolkit's `McpLifecycleClient` went settled, which happens the instant a preauthorize challenge is issued — well before the human answers it. With no session yet at that point, the failure branch called `doServerReset` alone, a no-op once the call's own (small) request body had already arrived and closed its initial side. The caller never learned the call had failed and the request hung indefinitely. Fixed by distinguishing "merely challenged, still awaiting an interactive answer" from "genuinely resolved" via a new `resolved` field on `McpLifecycleClient`, set only on a real session or a real abort/reset — not on a mere challenge; `McpClient` now re-queues itself while unresolved (the caller of this very request may be the one about to answer the challenge, since it's relayed to the same session) and, once genuinely resolved without a session, calls `doServerAbort` alongside `doServerReset` so the caller is actually notified. `McpProxyListFactory`'s own list-style registrants are intentionally unaffected — they still get an immediate "no session yet" answer on a mere challenge (skip this route for now, pick it up later via a `toolsListChanged` notification), which is the correct behavior for a partial list result.

Fixes #(issue)

## Test plan

- Added `McpClientIT.shouldCallToolConcurrentWithLifecyclePreauthorize`, with paired `binding-mcp.spec` scripts, modeling a `tools/call` that arrives for a session whose connect-level preauthorize elicitation is still outstanding — asserts it is rejected rather than minting a second elicitation.
- Added `McpClientIT.shouldCallToolElicitCompletedProxiedStringId`, with paired `binding-mcp.spec` scripts, modeling a reverse `elicitation/create` whose id is a non-numeric string — asserts the accept response is re-serialized with the id correctly quoted (the existing `shouldCallToolElicitCompletedProxied` test continues to assert a numeric id is echoed back unquoted).
- Verified locally end-to-end against `aklivity/zilla-plus`'s `examples/mcp.proxy`: built this branch as `develop-SNAPSHOT`, built a local `zilla-plus` Docker image against it, and drove the full OAuth authorization-code + DCR + real-browser login flow through the `everything` MCP reference server — the tool call that previously hung for 150s now completes end-to-end in ~4s. Full `mcp.proxy` `verify.sh` suite passes end to end (115 assertions, 0 failures).
- `./mvnw -pl specs/binding-mcp.spec,runtime/binding-mcp clean verify checkstyle:check license:check` — 303 tests, 0 failures, 0 checkstyle violations, license check clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_