### PR TITLE
fix(binding-mcp): flush hydration registrants queued before a real preauthorize challenge

### DIFF
--- a/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
+++ b/runtime/binding-mcp/src/main/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyLifecycleFactory.java
@@ -1205,8 +1205,31 @@ final class McpProxyLifecycleFactory implements BindingHandler
             final long authorization = challenge.authorization();
             final OctetsFW extension = challenge.extension();
 
-            challenged = true;
+            // only a real preauthorize elicitation means this route needs a human to answer --
+            // KIND_RESUME and KIND_SUSPENDED are the south client's own SSE transport resuming
+            // or suspending its long-poll stream, an ordinary occurrence on any healthy
+            // connection and unrelated to authorization, so must not be mistaken for one:
+            // doing so latches this route into interactiveAuthRoutes (via settleLifecycle
+            // below) the moment its stream first happens to suspend, well before any real
+            // elicitation, and hydration then gives up retrying a route that was never
+            // actually stuck on a human
+            final McpChallengeExFW challengeEx = extension.sizeof() > 0
+                ? mcpChallengeExRO.tryWrap(extension.buffer(), extension.offset(), extension.limit())
+                : null;
+            if (challengeEx != null && challengeEx.kind() == McpChallengeExFW.KIND_ELICIT_CREATE)
+            {
+                challenged = true;
+            }
             settleLifecycle(traceId);
+            // a registrant added via register() before this challenge arrived is still
+            // waiting in requests -- unlike onClientBegin/onClientEnd/onClientAbort/onClientReset,
+            // nothing else flushes it. Without this, a list-style registrant (hydration) on a
+            // route whose very first challenge is a real preauthorize elicitation never learns
+            // "no session yet, try again later": it simply waits forever, since no human will
+            // ever answer that elicitation on hydration's behalf. Safe to call unconditionally --
+            // by the time any OTHER challenge kind (RESUME/SUSPENDED) can occur, onClientBegin has
+            // already settled this connect and flushed requests, so this is a no-op then.
+            settleRequests(traceId);
 
             server.doServerChallenge(traceId, authorization, prefixChallengeCorrelationId(extension));
         }

--- a/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
+++ b/runtime/binding-mcp/src/test/java/io/aklivity/zilla/runtime/binding/mcp/internal/stream/McpProxyCacheIT.java
@@ -147,6 +147,25 @@ public class McpProxyCacheIT
         k3po.finish();
     }
 
+    // a hydration list registrant whose route's south connect never reaches Begin/End/Abort/Reset --
+    // only a real preauthorize elicitation CHALLENGE, which no human answers on hydration's behalf --
+    // must still settle (with no session) instead of waiting on it forever: nothing but
+    // onClientChallenge's own settleRequests() call can flush that registrant, since this route's
+    // connect never produces any of the other terminal events that flush it elsewhere. Before that
+    // fix, this route's own kind never reached pending == 0, so cache.populated never became true
+    // and every caller's own initialize blocked on it project-wide, not just this one route
+    @Test
+    @Configuration("proxy.cache.toolkit.multi.yaml")
+    @Specification({
+        "${app}/cache.hydrate.toolkit.multi.challenge.route/server",
+        "${app}/cache.hydrate.toolkit.multi.challenge.route/client" })
+    @ScriptProperty("affinity \"0000003f\"")
+    @Configure(name = MCP_HYDRATE_FILTER_NAME, value = "tools")
+    public void shouldHydrateToolkitMultiSettlingChallengedRoute() throws Exception
+    {
+        k3po.finish();
+    }
+
     @Test
     @Configuration("proxy.cache.toolkit.multi.refresh.yaml")
     @Specification({

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.challenge.route/client.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.challenge.route/client.rpt
@@ -1,0 +1,58 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+connect "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .build()
+                           .build()}
+
+connected
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                              .build()
+                          .build()}
+
+read notify LIFECYCLE_INITIALIZED
+
+connect await LIFECYCLE_INITIALIZED
+        "zilla://streams/app0"
+        option zilla:window 8192
+        option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .toolsList()
+                               .sessionId("5ca1ab1e-c0de-4a11-b007-000100000000")
+                               .build()
+                           .build()}
+
+connected
+
+read  '{"tools":'
+        '['
+          '{"name":"quartz__get_current_time"}'
+        ']'
+      '}'
+read closed
+
+write close

--- a/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.challenge.route/server.rpt
+++ b/specs/binding-mcp.spec/src/main/scripts/io/aklivity/zilla/specs/binding/mcp/streams/application/cache.hydrate.toolkit.multi.challenge.route/server.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2021-2026 Aklivity Inc
+#
+# Licensed under the Aklivity Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   https://www.aklivity.io/aklivity-community-license/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+property affinity "00000000"
+
+accept "zilla://streams/app1"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+read advise zilla:challenge ${mcp:challengeEx()
+                                 .typeId(zilla:id("mcp"))
+                                 .elicitCreate()
+                                     .id("1")
+                                     .url("https://server.example.com/authorize?state=7f3a9b1c&redirect_uri=%s".formatted(http:encodeQuery("https://replace.me/callback")))
+                                     .build()
+                                 .build()}
+
+accept "zilla://streams/app2"
+       option zilla:window 8192
+       option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .lifecycle()
+                              .build()
+                          .build()}
+
+connected
+
+write zilla:begin.ext ${mcp:beginEx()
+                           .typeId(zilla:id("mcp"))
+                           .lifecycle()
+                               .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                               .build()
+                           .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${mcp:matchBeginEx()
+                          .typeId(zilla:id("mcp"))
+                          .toolsList()
+                              .sessionId("5ca1ab1e-c0de-4a11-5e55-000a".concat(affinity))
+                              .build()
+                          .build()}
+
+connected
+
+write flush
+
+write '{"tools":[{"name":"get_current_time"}]}'
+write flush
+
+write close
+
+read closed


### PR DESCRIPTION
## Description

`McpLifecycleClient.onClientChallenge` called `settleLifecycle(traceId)` but never `settleRequests(traceId)`, unlike `onClientBegin`/`onClientEnd`/`onClientAbort`/`onClientReset`, which all flush it. A hydration-mode `McpListClient` registered via `register()` while this connect is still establishing sits in `requests` until flushed — and if the connect's very first event is a real preauthorize elicitation challenge (e.g. a toolkit whose south server requires interactive browser-driven OAuth, which hydration can never complete), nothing ever flushes it. That kind's pending count never reaches zero, `cache.populated` never becomes true, and every real caller's own `initialize` blocks on it indefinitely, project-wide — not just for the affected toolkit.

Also narrows `challenged` to only latch on a real preauthorize elicitation (`McpChallengeExFW.KIND_ELICIT_CREATE`), not any challenge kind. `KIND_RESUME` and `KIND_SUSPENDED` are the south client's own SSE transport resuming or suspending its long-poll stream, an ordinary occurrence on any healthy connection unrelated to authorization — treating them as an elicitation would latch a healthy route into `interactiveAuthRoutes` the moment its SSE stream first happens to suspend, causing hydration to give up retrying a route that was never actually stuck on a human.

This was found while re-verifying [#2443](https://github.com/aklivity/zilla/pull/2443) end-to-end against zilla-plus's `examples/mcp.proxy`: a toolkit requiring interactive OAuth (`everything_connect`) caused every `/mcp` `initialize` call to hang indefinitely, not just requests touching that toolkit.

## Fix

Adds one call — `settleRequests(traceId)` right after `settleLifecycle(traceId)` in `onClientChallenge` — and guards `challenged = true` behind a `KIND_ELICIT_CREATE` check on the challenge's own extension.

## Verification

- `McpProxyCacheIT#shouldHydrateToolkitMultiSettlingChallengedRoute` (new): mirrors `shouldHydrateToolkitMultiSettlingResetRoute`'s two-toolkit shape — one route's south connect issues a real `elicitCreate` challenge and never resolves, the other resolves normally, and the client still receives the second route's tool instead of the whole request hanging.
- Confirmed the new test fails with `TestTimedOut` when `settleRequests(traceId)` is reverted out of `onClientChallenge`, proving it actually exercises the fix.
- Full `binding-mcp` module suite: 178 unit tests, 306 K3PO integration tests (including the new scenario) — all pass. License and checkstyle checks clean.
- Re-ran `zilla-plus`'s `examples/mcp.proxy` `verify.sh` end-to-end against this fix: `cache_hydrated` completed in 11s (previously up to ~300s of backoff retries, or an indefinite hang when a toolkit needing interactive auth was involved) and `everything_connect_echo` completed in 4s.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_