### PR TITLE
fix(examples/mcp.proxy): send a key with kafka__produce_message in verify.sh

### DIFF
--- a/examples/mcp.proxy/etc/test/verify.sh
+++ b/examples/mcp.proxy/etc/test/verify.sh
@@ -1079,12 +1079,20 @@ fi
 #       this example -- not the engine's `type: test` double specs/ITs use --
 #       proving mcp-kafka's kind:client composite generator (kafka_cache_client
 #       -> kafka_client -> tcp_client) talks to an actual broker end to end
+#
+# a key is required here, not just for realism: a compacted topic always
+# rejects a null-key record, and a rerun against a stack whose broker was left
+# over from an earlier verify.sh run can find "orders" already marked
+# compacted (e.g. by an earlier run's own kafka__alter_topic_configs call) --
+# a keyless produce that passed on a fresh topic then fails only on reuse,
+# which is exactly the kind of rerun-only failure this example's tests
+# should not depend on the topic's history to avoid
 call_kafka_produce() {
   KAFKA_PRODUCE_OUT=$(mcp_run \
       -e JWT_TOKEN="$JWT_FULL" \
       -e MCP_URL="http://zilla:$PORT/mcp" \
       -e CALL_TOOL="kafka__produce_message" \
-      -e CALL_ARGS='{"topic":"orders","value":"hello from mcp-kafka"}' \
+      -e CALL_ARGS='{"topic":"orders","key":"order-1","value":"hello from mcp-kafka"}' \
       tools-list-client 2>&1)
   echo "$KAFKA_PRODUCE_OUT" | grep -q 'Produced record to orders topic'
 }


### PR DESCRIPTION
## Description

`verify.sh`'s `kafka__produce_message` call sent a record with no key. A compacted Kafka topic always rejects a null-key record — and `verify.sh` itself later calls `kafka__alter_topic_configs` to set `orders`' `cleanup.policy` to `compact`. That means a rerun of `verify.sh` against a stack whose broker was left over from an earlier run (rather than a fresh one) finds `orders` already compacted from that earlier run, and the keyless produce call — which passes cleanly on a fresh topic — starts failing purely as an artifact of reusing the stack across runs.

Same fix as [aklivity/zilla-plus#1183](https://github.com/aklivity/zilla-plus/pull/1183) for this repo's own copy of the example.

## Fix

Send a key (`"key":"order-1"`) with the produce call, so it stays valid regardless of the topic's prior compaction state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_