### PR TITLE
fix(binding-kafka): decouple cache segment signals from stream identity

### DIFF
--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheClientFetchFactory.java
@@ -608,6 +608,12 @@ public final class KafkaCacheClientFetchFactory implements BindingHandler
             if (KafkaState.closed(state))
             {
                 state = 0;
+                initialSeq = 0;
+                initialAck = 0;
+                initialMax = 0;
+                replySeq = 0;
+                replyAck = 0;
+                replyMax = 0;
             }
 
             if (!KafkaState.initialOpening(state))

--- a/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
+++ b/runtime/binding-kafka/src/main/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/KafkaCacheServerFetchFactory.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
@@ -85,7 +86,6 @@ import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.KafkaFetchF
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.KafkaFlushExFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.KafkaResetExFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.ResetFW;
-import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.SignalFW;
 import io.aklivity.zilla.runtime.binding.kafka.internal.types.stream.WindowFW;
 import io.aklivity.zilla.runtime.common.agrona.buffer.DirectBufferEx;
 import io.aklivity.zilla.runtime.common.agrona.buffer.MutableDirectBufferEx;
@@ -133,7 +133,6 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
     private final FlushFW flushRO = new FlushFW();
     private final ResetFW resetRO = new ResetFW();
     private final WindowFW windowRO = new WindowFW();
-    private final SignalFW signalRO = new SignalFW();
     private final ExtensionFW extensionRO = new ExtensionFW();
     private final KafkaBeginExFW kafkaBeginExRO = new KafkaBeginExFW();
     private final KafkaDataExFW kafkaDataExRO = new KafkaDataExFW();
@@ -602,6 +601,12 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             if (KafkaState.closed(state))
             {
                 state = 0;
+                initialSeq = 0;
+                initialAck = 0;
+                initialMax = 0;
+                replySeq = 0;
+                replyAck = 0;
+                replyMax = 0;
             }
 
             if (!KafkaState.initialOpening(state))
@@ -745,10 +750,6 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             case WindowFW.TYPE_ID:
                 final WindowFW window = windowRO.wrap(buffer, index, index + length);
                 onServerFanoutInitialWindow(window);
-                break;
-            case SignalFW.TYPE_ID:
-                final SignalFW signal = signalRO.wrap(buffer, index, index + length);
-                onServerFanoutInitialSignal(signal);
                 break;
             default:
                 break;
@@ -915,14 +916,16 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                     assert retainId == NO_CANCEL_ID;
 
                     final long retainAt = partition.retainAt(nextHead.segment());
-                    this.retainId = doServerFanoutInitialSignalAt(retainAt, traceId, SIGNAL_SEGMENT_RETAIN);
+                    this.retainId = doServerFanoutSignalAt(retainAt, SIGNAL_SEGMENT_RETAIN,
+                        this::onServerFanoutInitialSignalSegmentRetain);
                 }
 
                 if (deleteId == NO_CANCEL_ID &&
                     partition.cleanupPolicy().delete())
                 {
                     final long deleteAt = partition.deleteAt(nextHead.segment(), retentionMillisMax);
-                    this.deleteId = doServerFanoutInitialSignalAt(deleteAt, traceId, SIGNAL_SEGMENT_DELETE);
+                    this.deleteId = doServerFanoutSignalAt(deleteAt, SIGNAL_SEGMENT_DELETE,
+                        this::onServerFanoutInitialSignalSegmentDelete);
                 }
 
                 IntFunction<KafkaCacheEntryFW> findAncestor =
@@ -996,7 +999,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                             if (compactId == NO_CANCEL_ID)
                             {
                                 this.compactAt = newCompactAt;
-                                this.compactId = doServerFanoutInitialSignalAt(newCompactAt, 0, SIGNAL_SEGMENT_COMPACT);
+                                this.compactId = doServerFanoutSignalAt(newCompactAt, SIGNAL_SEGMENT_COMPACT,
+                                    this::onServerFanoutInitialSignalSegmentCompact);
                             }
                         }
                     }
@@ -1038,8 +1042,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
                                         if (compactId == NO_CANCEL_ID)
                                         {
                                             this.compactAt = newCompactAt;
-                                            this.compactId = doServerFanoutInitialSignalAt(newCompactAt, 0,
-                                                SIGNAL_SEGMENT_COMPACT);
+                                            this.compactId = doServerFanoutSignalAt(newCompactAt, SIGNAL_SEGMENT_COMPACT,
+                                                this::onServerFanoutInitialSignalSegmentCompact);
                                         }
                                     }
                                 }
@@ -1211,35 +1215,15 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             doServerFanoutInitialBeginIfNecessary(traceId);
         }
 
-        private void onServerFanoutInitialSignal(
-            SignalFW signal)
-        {
-            final int signalId = signal.signalId();
-
-            switch (signalId)
-            {
-            case SIGNAL_SEGMENT_RETAIN:
-                onServerFanoutInitialSignalSegmentRetain(signal);
-                break;
-            case SIGNAL_SEGMENT_DELETE:
-                onServerFanoutInitialSignalSegmentDelete(signal);
-                break;
-            case SIGNAL_SEGMENT_COMPACT:
-                onServerFanoutInitialSignalSegmentCompact(signal);
-                break;
-            }
-        }
-
         private void onServerFanoutInitialSignalSegmentRetain(
-            SignalFW signal)
+            int signalId)
         {
             partition.append(partitionOffset + 1);
         }
 
         private void onServerFanoutInitialSignalSegmentDelete(
-            SignalFW signal)
+            int signalId)
         {
-            final long traceId = signal.traceId();
             final long now = currentTimeMillis();
 
             Node segmentNode = partition.sentinel().next();
@@ -1255,7 +1239,8 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             if (segmentNode != partition.sentinel() && segmentNode != partition.head())
             {
                 final long deleteAt = partition.deleteAt(segmentNode.segment(), retentionMillisMax);
-                this.deleteId = doServerFanoutInitialSignalAt(deleteAt, traceId, SIGNAL_SEGMENT_DELETE);
+                this.deleteId = doServerFanoutSignalAt(deleteAt, SIGNAL_SEGMENT_DELETE,
+                    this::onServerFanoutInitialSignalSegmentDelete);
             }
             else
             {
@@ -1264,7 +1249,7 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
         }
 
         private void onServerFanoutInitialSignalSegmentCompact(
-            SignalFW signal)
+            int signalId)
         {
             final long now = currentTimeMillis();
 
@@ -1317,23 +1302,12 @@ public final class KafkaCacheServerFetchFactory implements BindingHandler
             }
         }
 
-        private long doServerFanoutInitialSignalAt(
+        private long doServerFanoutSignalAt(
             long timeMillis,
-            long traceId,
-            int signalId)
+            int signalId,
+            IntConsumer handler)
         {
-            long timerId = NO_CANCEL_ID;
-
-            if (timeMillis <= System.currentTimeMillis())
-            {
-                signaler.signalNow(originId, routedId, initialId, traceId, signalId, 0);
-            }
-            else
-            {
-                timerId = signaler.signalAt(timeMillis, originId, routedId, initialId, timerId, signalId, 0);
-            }
-
-            return timerId;
+            return signaler.signalAt(timeMillis, signalId, handler);
         }
     }
 

--- a/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
+++ b/runtime/binding-kafka/src/test/java/io/aklivity/zilla/runtime/binding/kafka/internal/stream/CacheFetchIT.java
@@ -22,6 +22,7 @@ import static io.aklivity.zilla.runtime.binding.kafka.internal.KafkaConfiguratio
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_BUFFER_SLOT_CAPACITY;
 import static io.aklivity.zilla.runtime.engine.EngineConfiguration.ENGINE_DRAIN_ON_CLOSE;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
 import static org.junit.rules.RuleChain.outerRule;
 
 import org.junit.Before;
@@ -990,5 +991,43 @@ public class CacheFetchIT
     {
         partition.append(1L);
         k3po.finish();
+    }
+
+    @Test
+    @Configuration("cache.options.live.yaml")
+    @Specification({
+        "${app}/delete.segment.after.member.reconnect/client",
+        "${app}/delete.segment.after.member.reconnect/server"})
+    @ScriptProperty("serverAddress \"zilla://streams/app1\"")
+    @Configure(name = KafkaConfigurationTest.KAFKA_CACHE_RETENTION_MILLIS_MAX_NAME, value = "200")
+    @Configure(name = "zilla.binding.kafka.cache.segment.bytes", value = "200")
+    public void shouldDeleteSegmentAfterMemberReconnect() throws Exception
+    {
+        k3po.start();
+        Thread.sleep(250);
+        k3po.notifyBarrier("SEND_MESSAGE_2");
+        k3po.finish();
+
+        int segments = countSegments();
+        final long deadline = System.currentTimeMillis() + SECONDS.toMillis(5);
+        while (segments != 1 && System.currentTimeMillis() < deadline)
+        {
+            Thread.sleep(50);
+            segments = countSegments();
+        }
+
+        assertEquals(1, segments);
+    }
+
+    private int countSegments()
+    {
+        int segments = 0;
+        KafkaCachePartition.Node segmentNode = partition.sentinel().next();
+        while (!segmentNode.sentinel())
+        {
+            segments++;
+            segmentNode = segmentNode.next();
+        }
+        return segments;
     }
 }

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/delete.segment.after.member.reconnect/client.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/delete.segment.after.member.reconnect/client.rpt
@@ -1,0 +1,118 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+connect "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:dataEx()
+                             .typeId(zilla:id("kafka"))
+                             .meta()
+                                 .partition(0, 177)
+                                 .build()
+                             .build()}
+
+read notify ROUTED_BROKER_CLIENT
+
+connect await ROUTED_BROKER_CLIENT
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 0xb1
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -2)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 10, 10)
+                                  .build()
+                              .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .fetch()
+                                 .partition(0, 10, 10)
+                                 .build()
+                             .build()}
+read "Hello, world"
+
+read advised zilla:flush ${kafka:flushEx()
+                                .typeId(zilla:id("kafka"))
+                                .fetch()
+                                    .partition(0, 10, 10)
+                                    .build()
+                                .build()}
+
+read zilla:data.ext ${kafka:matchDataEx()
+                             .typeId(zilla:id("kafka"))
+                             .fetch()
+                                 .partition(0, 20, 20)
+                                 .build()
+                             .build()}
+read "Hello, again"
+
+write close
+read closed
+
+connect await APP1_TEARDOWN_DONE
+        "zilla://streams/app0"
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+    option zilla:affinity 0xb1
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, -1)
+                                   .build()
+                               .build()}
+
+connected
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 31, 30)
+                                  .build()
+                              .build()}

--- a/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/delete.segment.after.member.reconnect/server.rpt
+++ b/specs/binding-kafka.spec/src/main/scripts/io/aklivity/zilla/specs/binding/kafka/streams/application/fetch/delete.segment.after.member.reconnect/server.rpt
@@ -1,0 +1,118 @@
+#
+# Copyright 2021-2026 Aklivity Inc.
+#
+# Aklivity licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newTimestamp1 ${kafka:timestamp()}
+
+property serverAddress "zilla://streams/app0"
+
+accept ${serverAddress}
+    option zilla:window 8192
+    option zilla:transmission "half-duplex"
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .topic("test")
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .meta()
+                                   .topic("test")
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .meta()
+                                  .partition(0, 177)
+                                  .build()
+                              .build()}
+write flush
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, -1)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, 10, 10)
+                                   .build()
+                               .build()}
+write flush
+
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .timestamp(newTimestamp1)
+                                  .partition(0, 10, 10)
+                                  .build()
+                              .build()}
+write "Hello, world"
+write flush
+
+write await SEND_MESSAGE_2
+write zilla:data.ext ${kafka:dataEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .timestamp(newTimestamp1)
+                                  .partition(0, 20, 20)
+                                  .build()
+                              .build()}
+write "Hello, again"
+write flush
+
+read aborted
+write aborted
+
+write notify APP1_TEARDOWN_DONE
+
+accepted
+
+read zilla:begin.ext ${kafka:beginEx()
+                              .typeId(zilla:id("kafka"))
+                              .fetch()
+                                  .topic("test")
+                                  .partition(0, 21)
+                                  .build()
+                              .build()}
+
+connected
+
+write zilla:begin.ext ${kafka:beginEx()
+                               .typeId(zilla:id("kafka"))
+                               .fetch()
+                                   .topic("test")
+                                   .partition(0, 30, 30)
+                                   .build()
+                               .build()}
+write flush


### PR DESCRIPTION
## Description

The `cache_server` binding's local Kafka cache stops evicting segments for a partition once every downstream member has disconnected and a new member later reconnects. The segment retain/delete/compact signals scheduled by `KafkaCacheServerFetchFactory`'s fetch fanout were scheduled with the stream-bound `Signaler` overload, keyed to the fanout's own `initialId`. When the fanout reconnects upstream after going fully idle, its `initialId` is reassigned, silently orphaning any already-scheduled signal and permanently halting segment eviction for that partition.

This switches segment retain/delete/compact scheduling to the callback-based `Signaler.signalAt(timeMillis, signalId, IntConsumer)` overload — the same mechanism already used for `SIGNAL_RECONNECT` — so scheduled signals are immune to stream/`initialId` reassignment across reconnects.

While building an integration test to reproduce and verify this fix, two related bugs surfaced in the same reconnect path:

- Neither the `cache_server` fetch fanout (`KafkaCacheServerFetchFanout`) nor the `cache_client` fetch fanout (`KafkaCacheClientFetchFanout`) reset `initialSeq`/`initialAck`/`initialMax`/`replySeq`/`replyAck`/`replyMax` when reconnecting after going fully idle. Stale sequence state from the prior connection could leak into flow-control frames on the new connection, tripping an assertion and crashing the engine worker thread. Both fanouts now zero these fields alongside the existing `state = 0` reset.

Added `CacheFetchIT.shouldDeleteSegmentAfterMemberReconnect`, a new k3po-driven integration test: a member connects, sends two messages under a tight retention window (creating two segments), disconnects, waits for retention to evict the older segment, then a new member reconnects — asserting exactly one segment remains.

Fixes #2446

## Test plan

- [x] `./mvnw verify -pl runtime/binding-kafka` — full module suite green, including the new `shouldDeleteSegmentAfterMemberReconnect` test
- [x] `./mvnw verify -pl specs/binding-kafka.spec` — spec module green
- [x] New IT verified passing across multiple isolated runs and multiple full-suite runs to rule out flakiness
- [x] `./mvnw checkstyle:check license:check -pl runtime/binding-kafka,specs/binding-kafka.spec` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01GKypSQPRgdzAV1oN5SFUQp)_