### PR TITLE
fix(examples/mcp.proxy): scope kafka-connect plugin.path to the one connector jar it needs

### DIFF
--- a/examples/mcp.proxy/compose.yaml
+++ b/examples/mcp.proxy/compose.yaml
@@ -247,9 +247,15 @@ services:
   # "kafkaconnect" toolkit -- talks to the same real Kafka broker as the
   # "kafka" toolkit above, storing its own config/offset/status state in
   # three internal compacted topics rather than a separate database.
-  # plugin.path points at the broker distribution's own libs/ directory,
-  # which bundles the FileStreamSource/FileStreamSinkConnector classes this
-  # example's test.sh exercises -- no separate connector plugin download.
+  # plugin.path is scoped to just connect-file-*.jar, copied out of the broker
+  # distribution's own libs/ directory, rather than pointing at that whole
+  # directory -- that jar alone bundles the FileStreamSource/FileStreamSinkConnector
+  # classes this example's test.sh exercises, so no separate connector plugin
+  # download is needed either way. But plugin.path's isolating classloader scans
+  # and isolates every jar it points at, one at a time, before the worker can
+  # start serving requests; pointed at the ~100-jar libs/ directory (the rest of
+  # Kafka's own runtime, not connector plugins), that scan measured ~140s on this
+  # example's stack before this fix, against ~10s scoped to just the one jar.
   kafka-connect:
     image: apache/kafka:4.1.1
     restart: unless-stopped
@@ -288,8 +294,10 @@ services:
         status.storage.replication.factor=1
         listeners=HTTP://0.0.0.0:8083
         rest.advertised.host.name=kafka-connect
-        plugin.path=/opt/kafka/libs
+        plugin.path=/tmp/connect-plugins
         EOF
+        mkdir -p /tmp/connect-plugins
+        cp /opt/kafka/libs/connect-file-*.jar /tmp/connect-plugins/
         echo 'hello from mcp-kafka-connect' > /tmp/kc-source.txt
         exec /opt/kafka/bin/connect-distributed.sh /tmp/connect-distributed.properties
 


### PR DESCRIPTION
## Summary

- `kafka-connect`'s `plugin.path` pointed at the broker distribution's entire `/opt/kafka/libs` directory (~109 jars) — Connect's isolating plugin scanner walks and isolates every jar it points at, one at a time, before the REST server (and this stack's healthcheck target) can come up.
- Scoped `plugin.path` to a directory containing only `connect-file-*.jar`, the one connector class (`FileStreamSourceConnector`/`FileStreamSinkConnector`) this example's `test.sh` actually exercises.

Same fix as [aklivity/zilla-plus#1184](https://github.com/aklivity/zilla-plus/pull/1184), applied to this repo's own copy of the example.

## Measurements

Timed locally from container `Started` to Docker `healthy`, same stack, same host, back to back:

| plugin.path | Started → Healthy |
|---|---|
| `/opt/kafka/libs` (before) | ~144s |
| `/tmp/connect-plugins` (after, containing just `connect-file-*.jar`) | ~9s |

Functionally verified equivalent behavior against the running container: `/connector-plugins` still lists `FileStreamSourceConnector`/`FileStreamSinkConnector`, and a `FileStreamSourceConnector` created via the REST API reached `RUNNING` state for both connector and task before being deleted.

## Test plan

- [x] `docker compose config` validates the changed service
- [x] Manually recreated `kafka-connect` with the new config and confirmed `/connector-plugins` output and a full create/run/delete connector lifecycle work identically to before
- [ ] CI's example verification job

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7N8Z9vABdU8pVPGthRodY)_